### PR TITLE
fix(orchestration): enforce NetworkScope::Deny for spawned sub-agents and RunInline tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-orchestration`/`zeph-subagent`/`zeph-core`: `TaskNode::network_scope: Deny` was
+  advisory-only — the field was never read at dispatch time, so a planner-emitted
+  `network_scope: Deny` silently left a task's network egress unrestricted (spec
+  `069-threat-model` OQ-1, #6030). Now enforced on both dispatch paths via the new
+  `NetworkDenyToolExecutor`, which blocks `bash` invocations of `curl`, `wget`, `nc`,
+  `ncat`, `netcat`, and any call to the native `web_scrape`/`fetch` tool:
+  - Spawned sub-agents: `handle_scheduler_spawn_action` sets the new
+    `SpawnContext::network_denied` flag; `build_filtered_executor` wraps the sub-agent's
+    tool executor when set — sibling tasks and the parent agent's own executor are
+    unaffected.
+  - `RunInline` tasks: `handle_run_inline_action` temporarily wraps the parent agent's own
+    `tool_executor` for the duration of that single inline turn (there is no per-task
+    executor to wrap independently, since `RunInline` shares the parent's tool loop),
+    restoring it afterward.
+
+  Known gap: MCP-provided tools are not inspected and may still perform their own HTTP
+  egress. This is a best-effort tool/command-identity block, not a sandbox-level
+  guarantee — see `specs/069-threat-model/spec.md` INVARIANT-5.
 - `zeph-skills`/`src/acp.rs`/`src/serve/`: `SkillOrchestra`'s RL routing head lost learned
   updates under concurrent ACP/`/sessions` agents (#5974). `#5921` wired `RoutingHead`
   persistence into `spawn_acp_agent` and `build_agent_factory`, but each session independently

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -19,6 +19,25 @@ fn lookahead_effective_depth(fidelity: Option<&zeph_config::FidelityConfig>) -> 
     fidelity.map_or(0, |c| if c.enabled { c.lookahead_depth } else { 0 })
 }
 
+/// Returns `true` if `task` carries `NetworkScope::Deny`, in which case the spawned
+/// sub-agent's tool executor must be wrapped with `NetworkDenyToolExecutor` (spec
+/// `069-threat-model` OQ-1). `Inherit`, `Allow`, and `None` all return `false` — only an
+/// explicit `Deny` restricts network egress; the default/non-Deny path is unaffected.
+///
+/// Fails open (`false`) when `task` is `None` — a graph-desync task-lookup miss cannot be
+/// distinguished from a genuinely scope-less task here, so this logs at `debug` for
+/// observability rather than assuming `Deny` (consistent with the product's
+/// network-allow-by-default model).
+fn network_denied_for_task(task: Option<&zeph_orchestration::TaskNode>) -> bool {
+    if task.is_none() {
+        tracing::debug!("network_denied_for_task: task lookup missed, defaulting to not-denied");
+    }
+    matches!(
+        task.and_then(|t| t.network_scope),
+        Some(zeph_orchestration::NetworkScope::Deny)
+    )
+}
+
 /// Save a graph snapshot to persistent storage with a 5-second timeout.
 ///
 /// Fail-open: errors and timeouts are logged at `warn!` level and do not abort
@@ -88,11 +107,9 @@ impl<C: crate::channel::Channel> Agent<C> {
         spawn_counter: &mut usize,
         task_count: usize,
     ) -> (bool, bool, Option<zeph_orchestration::GraphStatus>) {
-        let task_title = scheduler
-            .graph()
-            .tasks
-            .get(task_id.index())
-            .map_or("unknown", |t| t.title.as_str());
+        let task = scheduler.graph().tasks.get(task_id.index());
+        let task_title = task.map_or("unknown", |t| t.title.as_str());
+        let network_denied = network_denied_for_task(task);
 
         let provider = self.provider.clone();
         let tool_executor = Arc::clone(&self.tool_executor);
@@ -101,7 +118,8 @@ impl<C: crate::channel::Channel> Agent<C> {
         let event_tx = scheduler.event_sender();
         let task_supervisor = Arc::clone(&self.runtime.lifecycle.task_supervisor);
 
-        let spawn_ctx = self.build_spawn_context(&cfg);
+        let mut spawn_ctx = self.build_spawn_context(&cfg);
+        spawn_ctx.network_denied = network_denied;
 
         let mgr = self
             .services
@@ -193,11 +211,9 @@ impl<C: crate::channel::Channel> Agent<C> {
         task_count: usize,
         cancel_token: &CancellationToken,
     ) {
-        let task_title = scheduler
-            .graph()
-            .tasks
-            .get(task_id.index())
-            .map_or("unknown", |t| t.title.as_str());
+        let task = scheduler.graph().tasks.get(task_id.index());
+        let task_title = task.map_or("unknown", |t| t.title.as_str());
+        let network_denied = network_denied_for_task(task);
         self.channel
             .send_status_best_effort(&format!(
                 "Executing task {spawn_counter}/{task_count} (inline): {task_title}..."
@@ -215,6 +231,27 @@ impl<C: crate::channel::Channel> Agent<C> {
             .tasks
             .get(task_id.index())
             .and_then(|t| t.execution_environment.clone());
+
+        // NetworkScope::Deny (spec 069-threat-model OQ-1, #6030 S1 follow-up): unlike a
+        // spawned sub-agent, a `RunInline` task executes inside this agent's own tool loop
+        // and shares `self.tool_executor` directly (see `run_inline_tool_loop`'s dispatch
+        // via `self.tool_executor.execute_tool_call_erased`). There is no per-spawn
+        // executor to wrap, so temporarily replace `self.tool_executor` with a
+        // `NetworkDenyToolExecutor` for the duration of this single inline turn, then
+        // restore it unconditionally. Safe because `Agent<C>` methods take `&mut self`:
+        // no concurrent task can observe or race the swap, and any sub-agent already
+        // spawned holds its own `Arc` clone taken before this point, so it is unaffected.
+        let prev_executor = network_denied.then(|| {
+            tracing::warn!(
+                %task_id,
+                "RunInline task carries NetworkScope::Deny — wrapping tool_executor for this turn"
+            );
+            let prev = Arc::clone(&self.tool_executor);
+            self.tool_executor = Arc::new(zeph_subagent::NetworkDenyToolExecutor::new(Arc::clone(
+                &prev,
+            )));
+            prev
+        });
 
         let event_tx = scheduler.event_sender();
         let max_iter = self.tool_orchestrator.max_iterations;
@@ -238,6 +275,9 @@ impl<C: crate::channel::Channel> Agent<C> {
         };
         // Restore prior env (supports nested RunInline, though unusual in practice).
         self.services.orchestration.task_execution_env = prev_task_env;
+        if let Some(prev) = prev_executor {
+            self.tool_executor = prev;
+        }
 
         let event = zeph_orchestration::TaskEvent {
             task_id,
@@ -799,7 +839,7 @@ impl<C: crate::channel::Channel> Agent<C> {
 
 #[cfg(test)]
 mod tests {
-    use super::lookahead_effective_depth;
+    use super::{lookahead_effective_depth, network_denied_for_task};
 
     #[test]
     fn fidelity_none_returns_zero() {
@@ -824,5 +864,44 @@ mod tests {
             ..zeph_config::FidelityConfig::default()
         };
         assert_eq!(lookahead_effective_depth(Some(&cfg)), 4);
+    }
+
+    // ── network_denied_for_task (issue #6030) ──────────────────────────────
+
+    fn task_with_scope(
+        scope: Option<zeph_orchestration::NetworkScope>,
+    ) -> zeph_orchestration::TaskNode {
+        let mut node = zeph_orchestration::TaskNode::new(0, "t", "d");
+        node.network_scope = scope;
+        node
+    }
+
+    #[test]
+    fn no_task_returns_false() {
+        assert!(!network_denied_for_task(None));
+    }
+
+    #[test]
+    fn missing_network_scope_returns_false() {
+        let node = task_with_scope(None);
+        assert!(!network_denied_for_task(Some(&node)));
+    }
+
+    #[test]
+    fn inherit_scope_returns_false() {
+        let node = task_with_scope(Some(zeph_orchestration::NetworkScope::Inherit));
+        assert!(!network_denied_for_task(Some(&node)));
+    }
+
+    #[test]
+    fn allow_scope_returns_false() {
+        let node = task_with_scope(Some(zeph_orchestration::NetworkScope::Allow));
+        assert!(!network_denied_for_task(Some(&node)));
+    }
+
+    #[test]
+    fn deny_scope_returns_true() {
+        let node = task_with_scope(Some(zeph_orchestration::NetworkScope::Deny));
+        assert!(network_denied_for_task(Some(&node)));
     }
 }

--- a/crates/zeph-core/src/agent/tests/inline_tool_loop_tests.rs
+++ b/crates/zeph-core/src/agent/tests/inline_tool_loop_tests.rs
@@ -212,6 +212,77 @@ async fn provider_error_is_propagated() {
     assert!(result.is_err());
 }
 
+// Regression test for #6030 S1 (critic finding): `handle_run_inline_action` wraps
+// `self.tool_executor` with `NetworkDenyToolExecutor` for the duration of a single inline
+// turn when the task carries `NetworkScope::Deny`, since `RunInline` tasks share the
+// parent agent's own tool loop (no per-spawn executor to wrap, unlike spawned sub-agents).
+// This test exercises that exact mechanism directly against `run_inline_tool_loop` — the
+// same call `handle_run_inline_action` awaits — proving the `fetch` tool call never
+// reaches the inner executor once wrapped.
+#[tokio::test]
+async fn network_deny_wrapped_executor_blocks_fetch_before_reaching_inner() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    struct FlaggingExecutor {
+        called: Arc<AtomicBool>,
+    }
+
+    impl ToolExecutor for FlaggingExecutor {
+        async fn execute(&self, _response: &str) -> Result<Option<ToolOutput>, ToolError> {
+            Ok(None)
+        }
+
+        async fn execute_tool_call(
+            &self,
+            _call: &ToolCall,
+        ) -> Result<Option<ToolOutput>, ToolError> {
+            self.called.store(true, Ordering::SeqCst);
+            Ok(Some(ToolOutput {
+                tool_name: "fetch".into(),
+                summary: "should not be reached".into(),
+                blocks_executed: 1,
+                filter_stats: None,
+                diff: None,
+                streamed: false,
+                terminal_id: None,
+                locations: None,
+                raw_response: None,
+                claim_source: None,
+            }))
+        }
+
+        zeph_tools::tool_executor_no_inner_defaults!();
+    }
+
+    let (mock, _counter) = MockProvider::default().with_tool_use(vec![
+        tool_use_response("call-1", "fetch"),
+        ChatResponse::Text("done".into()),
+    ]);
+    let provider = AnyProvider::Mock(mock);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let called = Arc::new(AtomicBool::new(false));
+    let executor = FlaggingExecutor {
+        called: called.clone(),
+    };
+
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+    // Simulate the swap `handle_run_inline_action` performs when `network_denied_for_task`
+    // returns `true` for the dispatched task.
+    agent.tool_executor = Arc::new(zeph_subagent::NetworkDenyToolExecutor::new(
+        agent.tool_executor.clone(),
+    ));
+
+    let result = agent.run_inline_tool_loop("fetch a url", 10).await;
+
+    assert_eq!(result.unwrap(), "done");
+    assert!(
+        !called.load(Ordering::SeqCst),
+        "fetch tool call must be blocked before reaching the inner executor"
+    );
+}
+
 // Regression test for issue #2542: elicitation deadlock in run_inline_tool_loop.
 //
 // The real deadlock scenario: MCP tool sends an elicitation event and then blocks

--- a/crates/zeph-orchestration/src/graph.rs
+++ b/crates/zeph-orchestration/src/graph.rs
@@ -311,8 +311,20 @@ pub enum ExecutionMode {
 
 /// Controls network access for a task node during orchestrated execution.
 ///
-/// **Advisory only** — this field is not yet read at runtime. See the
-/// `TODO(enforcement)` on the `Deny` variant and `specs/069-threat-model/spec.md §5`.
+/// **`Deny` is enforced as a best-effort tool/command-identity block, not a sandbox
+/// boundary.** Both dispatch paths (`handle_scheduler_spawn_action` for spawned
+/// sub-agents, and `handle_run_inline_action` for `RunInline` tasks) wrap the task's tool
+/// executor with `zeph_subagent::NetworkDenyToolExecutor` when this field is `Deny`, which
+/// blocks:
+/// - `bash` invocations of network commands (`curl`, `wget`, `nc`, `ncat`, `netcat`)
+/// - any call to the native `web_scrape`/`fetch` tool
+///
+/// **Known gap**: MCP-provided tools are not inspected and may still perform their own
+/// HTTP egress. Obfuscated shell commands (`eval`, `bash -c` payloads, variable expansion,
+/// `/dev/tcp`, language-runtime one-liners) also bypass the `bash` check — this is the same
+/// pre-existing class of limitation documented on `ShellExecutor`'s own blocklist. See
+/// `specs/069-threat-model/spec.md` INVARIANT-5 for the full enforcement boundary and
+/// residual risk.
 ///
 /// # Examples
 ///
@@ -335,9 +347,12 @@ pub enum NetworkScope {
     Inherit,
     /// Explicitly allow network egress (shell network commands + scrape/fetch) for this task.
     Allow,
-    /// Deny all network egress for this task regardless of global config.
-    // TODO(enforcement): wire to spawned sub-agent launch in handle_scheduler_spawn_action.
-    // See scheduler_loop.rs spawn_for_task — it does not thread per-task scope today.
+    /// Deny network egress for this task via `bash` network commands and the
+    /// `web_scrape`/`fetch` tool, regardless of global config.
+    ///
+    /// This is a best-effort tool/command-identity block enforced via
+    /// `NetworkDenyToolExecutor`, not a full network-egress guarantee — MCP-provided
+    /// tools and obfuscated shell commands are not covered. See the type-level doc above.
     Deny,
 }
 
@@ -418,7 +433,8 @@ pub struct TaskNode {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token_budget_cents: Option<f64>,
 
-    /// Per-task network egress policy. Advisory only for spawned sub-agents.
+    /// Per-task network egress policy. Enforced (best-effort) for both spawned
+    /// sub-agents and `RunInline` tasks.
     ///
     /// `None` / `Inherit` = inherit the executor/global `allow_network` default.
     /// See [`NetworkScope`] for enforcement caveats and `specs/069-threat-model/spec.md §5`.

--- a/crates/zeph-subagent/src/filter.rs
+++ b/crates/zeph-subagent/src/filter.rs
@@ -324,6 +324,145 @@ impl ErasedToolExecutor for PlanModeExecutor {
     zeph_tools::erased_tool_executor_forward!(inner);
 }
 
+// ── Network egress denial ─────────────────────────────────────────────────────
+
+/// Tool IDs that are pure network-egress tools — any call is blocked outright, no command
+/// inspection needed (unlike `bash`, which is dual-use).
+///
+/// `web_scrape`/`fetch` are the native `WebScrapeExecutor` tool IDs (see `zeph-tools`
+/// `scrape.rs`) — the tool an LLM reaches for by default to retrieve a URL, and therefore
+/// the highest-likelihood egress vector for a `Deny`-scoped task (#6030 critic finding S2).
+const NETWORK_ONLY_TOOL_IDS: &[&str] = &["web_scrape", "fetch"];
+
+/// Blocks network-egress tool calls for a single sub-agent spawn.
+///
+/// Wraps an [`ErasedToolExecutor`] and rejects two classes of call with
+/// [`ToolError::Blocked`]:
+/// - Any call to a network-only tool (`web_scrape`, `fetch`) — blocked unconditionally,
+///   since these tools have no non-network purpose.
+/// - `bash` tool calls whose command matches [`zeph_tools::NETWORK_COMMANDS`] (`curl`,
+///   `wget`, `nc`, `ncat`, `netcat`).
+///
+/// All other tool calls pass through unchanged. **Known gap**: MCP-provided tools (which may
+/// perform their own HTTP egress) are not inspected — see `specs/069-threat-model/spec.md`
+/// INVARIANT-5. This is a best-effort, tool/command-identity block, not a sandbox boundary.
+///
+/// Installed by `build_filtered_executor` (`crate::manager::spawn`) when the spawning
+/// task carries `NetworkScope::Deny` (spec `069-threat-model` OQ-1). Unlike mutating
+/// [`ShellConfig`](zeph_tools::ShellConfig)'s `allow_network` field directly, this
+/// wrapper scopes the restriction to a single spawn without affecting the shared
+/// `tool_executor` used by the parent agent and sibling tasks.
+pub struct NetworkDenyToolExecutor {
+    inner: Arc<dyn ErasedToolExecutor>,
+    blocklist: Vec<String>,
+}
+
+impl NetworkDenyToolExecutor {
+    /// Wrap `inner`, blocking network-egress tool calls for every call.
+    #[must_use]
+    pub fn new(inner: Arc<dyn ErasedToolExecutor>) -> Self {
+        Self {
+            inner,
+            blocklist: zeph_tools::NETWORK_COMMANDS
+                .iter()
+                .map(|s| (*s).to_owned())
+                .collect(),
+        }
+    }
+
+    /// Returns `Err` if `call` targets a network-only tool (`web_scrape`, `fetch`) or is a
+    /// `bash` invocation whose command matches the network-command blocklist; `Ok(())`
+    /// otherwise.
+    fn check_call(&self, call: &ToolCall) -> Result<(), ToolError> {
+        let tool_id = normalize_tool_id(call.tool_id.as_str());
+
+        if NETWORK_ONLY_TOOL_IDS.contains(&tool_id.as_str()) {
+            tracing::warn!(
+                tool_id = %tool_id,
+                "network egress denied for sub-agent task (NetworkScope::Deny)"
+            );
+            return Err(ToolError::Blocked { command: tool_id });
+        }
+
+        if tool_id != "bash" {
+            return Ok(());
+        }
+        let Some(command) = call.params.get("command").and_then(|v| v.as_str()) else {
+            return Ok(());
+        };
+        if let Some(matched) = zeph_tools::check_blocklist(command, &self.blocklist) {
+            tracing::warn!(
+                command = %matched,
+                "network egress denied for sub-agent task (NetworkScope::Deny)"
+            );
+            return Err(ToolError::Blocked { command: matched });
+        }
+        Ok(())
+    }
+}
+
+impl ErasedToolExecutor for NetworkDenyToolExecutor {
+    fn execute_erased<'a>(
+        &'a self,
+        response: &'a str,
+    ) -> Pin<Box<dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a>>
+    {
+        self.inner.execute_erased(response)
+    }
+
+    fn execute_confirmed_erased<'a>(
+        &'a self,
+        response: &'a str,
+    ) -> Pin<Box<dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a>>
+    {
+        self.inner.execute_confirmed_erased(response)
+    }
+
+    fn tool_definitions_erased(&self) -> Vec<ToolDef> {
+        self.inner.tool_definitions_erased()
+    }
+
+    fn execute_tool_call_erased<'a>(
+        &'a self,
+        call: &'a ToolCall,
+    ) -> Pin<Box<dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a>>
+    {
+        if let Err(e) = self.check_call(call) {
+            return Box::pin(std::future::ready(Err(e)));
+        }
+        Box::pin(self.inner.execute_tool_call_erased(call))
+    }
+
+    fn execute_tool_call_confirmed_erased<'a>(
+        &'a self,
+        call: &'a ToolCall,
+    ) -> Pin<Box<dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a>>
+    {
+        if let Err(e) = self.check_call(call) {
+            return Box::pin(std::future::ready(Err(e)));
+        }
+        Box::pin(self.inner.execute_tool_call_confirmed_erased(call))
+    }
+
+    fn set_skill_env(&self, env: Option<HashMap<String, String>>) {
+        self.inner.set_skill_env(env);
+    }
+
+    fn set_effective_trust(&self, level: zeph_tools::SkillTrustLevel) {
+        self.inner.set_effective_trust(level);
+    }
+
+    fn is_tool_retryable_erased(&self, tool_id: &str) -> bool {
+        self.inner.is_tool_retryable_erased(tool_id)
+    }
+
+    fn requires_confirmation_erased(&self, call: &ToolCall) -> bool {
+        self.inner.requires_confirmation_erased(call)
+    }
+
+    zeph_tools::erased_tool_executor_forward!(inner);
+}
+
 // ── Skill filtering ───────────────────────────────────────────────────────────
 
 /// Filter skills from a registry according to a [`SkillFilter`].
@@ -983,6 +1122,112 @@ mod tests {
         let defs = exec.tool_definitions_erased();
         assert_eq!(defs.len(), 2);
         assert!(!defs.iter().any(|d| d.id == "dangerous"));
+    }
+
+    // ── NetworkDenyToolExecutor tests (issue #6030) ────────────────────────
+
+    fn bash_call(command: &str) -> ToolCall {
+        let mut params = serde_json::Map::new();
+        params.insert("command".into(), serde_json::Value::from(command));
+        ToolCall {
+            tool_id: "bash".into(),
+            params,
+            caller_id: None,
+            context: None,
+            tool_call_id: String::new(),
+            skill_name: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn network_deny_blocks_curl() {
+        let exec = NetworkDenyToolExecutor::new(stub_box(&["bash"]));
+        let res = exec
+            .execute_tool_call_erased(&bash_call("curl https://evil.example"))
+            .await;
+        assert_matches!(res, Err(ToolError::Blocked { .. }));
+    }
+
+    #[tokio::test]
+    async fn network_deny_blocks_wget_and_nc() {
+        let exec = NetworkDenyToolExecutor::new(stub_box(&["bash"]));
+        assert!(
+            exec.execute_tool_call_erased(&bash_call("wget https://evil.example"))
+                .await
+                .is_err()
+        );
+        assert!(
+            exec.execute_tool_call_erased(&bash_call("nc -l 4444"))
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn network_deny_permits_non_network_bash() {
+        let exec = NetworkDenyToolExecutor::new(stub_box(&["bash"]));
+        let res = exec.execute_tool_call_erased(&bash_call("ls -la")).await;
+        assert!(res.is_ok(), "non-network command must pass through");
+    }
+
+    #[tokio::test]
+    async fn network_deny_ignores_non_bash_tools() {
+        let exec = NetworkDenyToolExecutor::new(stub_box(&["web"]));
+        let call = ToolCall {
+            tool_id: "web".into(),
+            params: serde_json::Map::default(),
+            caller_id: None,
+            context: None,
+            tool_call_id: String::new(),
+            skill_name: None,
+        };
+        let res = exec.execute_tool_call_erased(&call).await;
+        assert!(res.is_ok(), "non-bash tool calls must not be inspected");
+    }
+
+    #[tokio::test]
+    async fn network_deny_confirmed_path_also_enforces() {
+        let exec = NetworkDenyToolExecutor::new(stub_box(&["bash"]));
+        let res = exec
+            .execute_tool_call_confirmed_erased(&bash_call("curl https://evil.example"))
+            .await;
+        assert_matches!(res, Err(ToolError::Blocked { .. }));
+    }
+
+    fn tool_call(tool_id: &str) -> ToolCall {
+        ToolCall {
+            tool_id: tool_id.into(),
+            params: serde_json::Map::default(),
+            caller_id: None,
+            context: None,
+            tool_call_id: String::new(),
+            skill_name: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn network_deny_blocks_web_scrape_unconditionally() {
+        let exec = NetworkDenyToolExecutor::new(stub_box(&["web_scrape"]));
+        let res = exec
+            .execute_tool_call_erased(&tool_call("web_scrape"))
+            .await;
+        assert_matches!(res, Err(ToolError::Blocked { .. }));
+    }
+
+    #[tokio::test]
+    async fn network_deny_blocks_fetch_unconditionally() {
+        let exec = NetworkDenyToolExecutor::new(stub_box(&["fetch"]));
+        let res = exec.execute_tool_call_erased(&tool_call("fetch")).await;
+        assert_matches!(res, Err(ToolError::Blocked { .. }));
+    }
+
+    #[tokio::test]
+    async fn network_deny_blocks_fetch_confirmed_path_too() {
+        let exec = NetworkDenyToolExecutor::new(stub_box(&["fetch"]));
+        let res = exec
+            .execute_tool_call_confirmed_erased(&tool_call("fetch"))
+            .await;
+        assert_matches!(res, Err(ToolError::Blocked { .. }));
     }
 
     // ── #1184: PlanModeExecutor + disallowed_tools catalog test ───────────

--- a/crates/zeph-subagent/src/lib.rs
+++ b/crates/zeph-subagent/src/lib.rs
@@ -65,7 +65,7 @@ pub use durable::{
     resolve_durable_promise, try_replay_durable_subagent,
 };
 pub use error::SubAgentError;
-pub use filter::{FilteredToolExecutor, PlanModeExecutor, filter_skills};
+pub use filter::{FilteredToolExecutor, NetworkDenyToolExecutor, PlanModeExecutor, filter_skills};
 pub use fleet::{FleetRegistry, FleetSessionInfo, FleetSessionStatus, SharedFleetRegistry};
 pub use grants::{Grant, GrantKind, GrantedSecret, PermissionGrants, SecretRequest};
 pub use hooks::{

--- a/crates/zeph-subagent/src/manager/mod.rs
+++ b/crates/zeph-subagent/src/manager/mod.rs
@@ -138,6 +138,26 @@ pub struct SpawnContext {
     ///
     /// `None` when `durable.enabled && durable.subagent` is false (plain spawn/collect path).
     pub durable_resolver: Option<DurableResolverSeat>,
+
+    /// Deny network egress for this sub-agent's `bash` tool calls.
+    ///
+    /// Set by the orchestration layer when the spawning `TaskNode` carries
+    /// `network_scope: NetworkScope::Deny` (spec `069-threat-model` OQ-1). When `true`,
+    /// `build_filtered_executor` wraps the tool executor with
+    /// [`NetworkDenyToolExecutor`](crate::NetworkDenyToolExecutor), which blocks `bash`
+    /// invocations of `curl`, `wget`, `nc`, `ncat`, and `netcat` for this spawn only —
+    /// sibling tasks and the parent agent's own executor are unaffected.
+    ///
+    /// # Caller responsibility for nested spawns
+    ///
+    /// Like [`max_trust_level`][Self::max_trust_level], this field does **not** propagate
+    /// automatically. A sub-agent that itself spawns a grandchild must copy this field
+    /// from its own received `SpawnContext` into the grandchild's `SpawnContext`, or the
+    /// grandchild spawns with network access regardless of the original task's scope.
+    ///
+    /// `false` (the default) imposes no restriction beyond the executor/global
+    /// `allow_network` default.
+    pub network_denied: bool,
 }
 
 /// Live status snapshot of a running sub-agent.

--- a/crates/zeph-subagent/src/manager/spawn.rs
+++ b/crates/zeph-subagent/src/manager/spawn.rs
@@ -23,7 +23,7 @@ use crate::agent_loop::{AgentLoopArgs, run_agent_loop};
 use crate::cwd_guard::CwdRestoreGuard;
 use crate::def::{MemoryScope, PermissionMode, SubAgentDef, ToolPolicy};
 use crate::error::SubAgentError;
-use crate::filter::{self, FilteredToolExecutor, PlanModeExecutor};
+use crate::filter::{self, FilteredToolExecutor, NetworkDenyToolExecutor, PlanModeExecutor};
 use crate::fleet::{FleetSessionInfo, FleetSessionStatus};
 use crate::grants::{GrantedSecret, PermissionGrants, SecretRequest};
 use crate::hooks::fire_hooks;
@@ -143,10 +143,19 @@ pub(crate) fn build_filtered_executor(
     permission_mode: PermissionMode,
     def: &SubAgentDef,
     memory_dir: Option<PathBuf>,
+    network_denied: bool,
 ) -> FilteredToolExecutor {
     let base: Arc<dyn ErasedToolExecutor> = match memory_dir {
         Some(dir) => Arc::new(MemoryAwareExecutor::new(tool_executor, dir)),
         None => tool_executor,
+    };
+    // NetworkScope::Deny (spec 069-threat-model OQ-1): wrap innermost so the restriction
+    // applies regardless of permission mode, and does not depend on FilteredToolExecutor's
+    // tool-level allow/deny policy.
+    let base: Arc<dyn ErasedToolExecutor> = if network_denied {
+        Arc::new(NetworkDenyToolExecutor::new(base))
+    } else {
+        base
     };
     if permission_mode == PermissionMode::Plan {
         let plan_inner = Arc::new(PlanModeExecutor::new(base));
@@ -563,6 +572,7 @@ impl SubAgentManager {
 
         apply_def_config_defaults(&mut def, config)?;
         apply_constraint_propagation(&mut def, &ctx);
+        let network_denied = ctx.network_denied;
 
         let active = self
             .agents
@@ -664,7 +674,13 @@ impl SubAgentManager {
                 .push("set_working_directory".to_string());
         }
 
-        let executor = build_filtered_executor(tool_executor, permission_mode, &def, memory_dir);
+        let executor = build_filtered_executor(
+            tool_executor,
+            permission_mode,
+            &def,
+            memory_dir,
+            network_denied,
+        );
 
         if let Some(cap) = ctx.max_trust_level {
             executor.set_effective_trust(cap);
@@ -1051,7 +1067,9 @@ impl SubAgentManager {
         let agent_hooks = def.hooks.clone();
         let agent_name_clone = def.name.clone();
 
-        let executor = build_filtered_executor(tool_executor, permission_mode, &def, None);
+        let network_denied = spawn_context.is_some_and(|ctx| ctx.network_denied);
+        let executor =
+            build_filtered_executor(tool_executor, permission_mode, &def, None, network_denied);
 
         if let Some(ctx) = spawn_context
             && let Some(cap) = ctx.max_trust_level
@@ -1246,5 +1264,148 @@ impl SubAgentManager {
             .join_handle = Some(wrapped_join);
 
         Ok(handle_id)
+    }
+}
+
+#[cfg(test)]
+mod build_filtered_executor_tests {
+    //! Regression tests for issue #6030 (`NetworkScope::Deny` enforcement): verify
+    //! `build_filtered_executor` installs `NetworkDenyToolExecutor` exactly when
+    //! `network_denied` is `true`, and leaves the default path unaffected otherwise.
+
+    use super::*;
+    use crate::def::SubAgentDef;
+
+    /// Minimal `bash`-only stub executor that always succeeds.
+    struct StubBashExecutor;
+
+    impl ErasedToolExecutor for StubBashExecutor {
+        fn execute_erased<'a>(
+            &'a self,
+            _response: &'a str,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a,
+            >,
+        > {
+            Box::pin(std::future::ready(Ok(None)))
+        }
+
+        fn execute_confirmed_erased<'a>(
+            &'a self,
+            _response: &'a str,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a,
+            >,
+        > {
+            Box::pin(std::future::ready(Ok(None)))
+        }
+
+        fn tool_definitions_erased(&self) -> Vec<zeph_tools::registry::ToolDef> {
+            use zeph_tools::registry::InvocationHint;
+            vec![zeph_tools::registry::ToolDef {
+                id: "bash".into(),
+                description: "stub".into(),
+                schema: schemars::Schema::default(),
+                invocation: InvocationHint::ToolCall,
+                output_schema: None,
+                server_id: None,
+            }]
+        }
+
+        fn execute_tool_call_erased<'a>(
+            &'a self,
+            call: &'a ToolCall,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a,
+            >,
+        > {
+            let result = Ok(Some(ToolOutput {
+                tool_name: zeph_common::ToolName::new(call.tool_id.as_str()),
+                summary: "ok".into(),
+                blocks_executed: 1,
+                filter_stats: None,
+                diff: None,
+                streamed: false,
+                terminal_id: None,
+                locations: None,
+                raw_response: None,
+                claim_source: None,
+            }));
+            Box::pin(std::future::ready(result))
+        }
+
+        fn is_tool_retryable_erased(&self, _tool_id: &str) -> bool {
+            false
+        }
+
+        zeph_tools::erased_tool_executor_no_inner_defaults!();
+    }
+
+    fn bash_call(command: &str) -> ToolCall {
+        let mut params = serde_json::Map::new();
+        params.insert("command".into(), serde_json::Value::from(command));
+        ToolCall {
+            tool_id: "bash".into(),
+            params,
+            caller_id: None,
+            context: None,
+            tool_call_id: String::new(),
+            skill_name: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn network_denied_true_blocks_network_egress() {
+        let def = SubAgentDef::for_test("net-denied");
+        let exec = build_filtered_executor(
+            Arc::new(StubBashExecutor),
+            PermissionMode::Default,
+            &def,
+            None,
+            true,
+        );
+        let res = exec
+            .execute_tool_call_erased(&bash_call("curl https://evil.example"))
+            .await;
+        assert!(res.is_err(), "network_denied=true must block curl");
+    }
+
+    #[tokio::test]
+    async fn network_denied_false_permits_network_egress() {
+        let def = SubAgentDef::for_test("net-allowed");
+        let exec = build_filtered_executor(
+            Arc::new(StubBashExecutor),
+            PermissionMode::Default,
+            &def,
+            None,
+            false,
+        );
+        let res = exec
+            .execute_tool_call_erased(&bash_call("curl https://example.com"))
+            .await;
+        assert!(
+            res.is_ok(),
+            "network_denied=false (default) must not restrict network commands"
+        );
+    }
+
+    #[tokio::test]
+    async fn network_denied_true_permits_non_network_bash() {
+        let def = SubAgentDef::for_test("net-denied-2");
+        let exec = build_filtered_executor(
+            Arc::new(StubBashExecutor),
+            PermissionMode::Default,
+            &def,
+            None,
+            true,
+        );
+        let res = exec.execute_tool_call_erased(&bash_call("ls -la")).await;
+        assert!(
+            res.is_ok(),
+            "network_denied=true must not block non-network commands"
+        );
     }
 }

--- a/crates/zeph-tools/src/lib.rs
+++ b/crates/zeph-tools/src/lib.rs
@@ -153,8 +153,8 @@ pub use search_code::{
 pub use shadow_probe::{ProbeGate, ProbeOutcome, ShadowProbeExecutor};
 pub use shell::background::{BackgroundCompletion, BackgroundRunSnapshot, RunId};
 pub use shell::{
-    DEFAULT_BLOCKED_COMMANDS, SHELL_INTERPRETERS, SafeFixSuggestion, ShellExecutor,
-    ShellOutputEnvelope, ShellPolicyHandle, check_blocklist, deobfuscate_command,
+    DEFAULT_BLOCKED_COMMANDS, NETWORK_COMMANDS, SHELL_INTERPRETERS, SafeFixSuggestion,
+    ShellExecutor, ShellOutputEnvelope, ShellPolicyHandle, check_blocklist, deobfuscate_command,
     effective_shell_command, is_blocked_rm_worktrees,
 };
 pub use tool_filter::ToolFilter;

--- a/crates/zeph-tools/src/shell/mod.rs
+++ b/crates/zeph-tools/src/shell/mod.rs
@@ -206,7 +206,13 @@ pub fn effective_shell_command<'a>(binary: &str, args: &'a [String]) -> Option<&
     args.get(pos + 1).map(String::as_str)
 }
 
-const NETWORK_COMMANDS: &[&str] = &["curl", "wget", "nc ", "ncat", "netcat"];
+/// Shell commands that perform outbound network egress.
+///
+/// Used both to derive [`ShellConfig::allow_network`]'s effective blocklist entries here,
+/// and by [`check_blocklist`] callers outside this module (e.g. `zeph-subagent`'s
+/// `NetworkDenyToolExecutor`) that need to block network egress for a single sub-agent
+/// spawn without mutating the shared executor's global policy.
+pub const NETWORK_COMMANDS: &[&str] = &["curl", "wget", "nc ", "ncat", "netcat"];
 
 /// Effective command-restriction policy held inside a `ShellExecutor`.
 ///

--- a/specs/069-threat-model/spec.md
+++ b/specs/069-threat-model/spec.md
@@ -164,7 +164,7 @@ Each tree starts from an adversarial goal and branches to leaf attack steps.
 | 2.2.1 Prompt → ShellExecutor | VIGIL tripwire; `ScopedToolExecutor`; Seatbelt sandbox | **Low** |
 | 2.2.2 MCP tool name collision | Collision detection in `zeph-mcp`; `normalize_tool_id` | **Low** |
 | 2.2.3 Seatbelt profile bypass | Deny-first profile; audited by `SeatbeltProfile` | **Medium** — depends on profile completeness |
-| 2.2.4 Spawned sub-agent scope (§5) | **None today** — `network_scope` advisory only | **High** — uncontrolled path |
+| 2.2.4 Spawned sub-agent scope (§5) | `NetworkDenyToolExecutor` blocks `curl`/`wget`/`nc`/`ncat`/`netcat` in `bash` calls, and unconditionally blocks the `web_scrape`/`fetch` tool, for both spawned sub-agents and `RunInline` tasks (OQ-1, resolved) | **Medium** — detection is tool/command-identity matching, not sandbox-level; MCP-provided tools and obfuscated shell commands are not covered |
 | 2.3.1 SSRF direct | `SsrfGuard` + `ScrapeConfig` allowlist | **Low** — if allowlist is configured |
 | 2.3.2 SSRF via redirect | `SsrfGuard` (initial URL only) | **Medium** — redirect not re-validated |
 | 2.3.3 DNS rebinding | No connect-time IP re-validation | **High** — no current control |
@@ -181,12 +181,16 @@ Each tree starts from an adversarial goal and branches to leaf attack steps.
 
 The following paths have **no or weak controls** today:
 
-### 4.1 Per-task network egress is not bounded by orchestration
+### 4.1 Per-task network egress is bounded by orchestration on a best-effort basis (RESOLVED, OQ-1)
 
-The orchestration planner can annotate a task with `network_scope: Deny`, but this field
-is **advisory only** — the spawned sub-agent's `ShellConfig.allow_network` is set by the
-runner's global config, not per the task node. Issue #3934 introduces the types and the
-spec annotation; runner enforcement is a follow-up (see §5 and §7).
+The orchestration planner can annotate a task with `network_scope: Deny`. This is now
+enforced on both dispatch paths: `handle_scheduler_spawn_action` (spawned sub-agents) and
+`handle_run_inline_action` (`RunInline` tasks — the latter by temporarily wrapping the
+parent agent's own `tool_executor` for the duration of that inline turn, then restoring
+it) both wrap the task's tool executor with `NetworkDenyToolExecutor`, which blocks
+network-egress `bash` commands (`curl`/`wget`/`nc`/`ncat`/`netcat`) and the native
+`web_scrape`/`fetch` tool (OQ-1, resolved, #6030). Residual gap: MCP-provided tools are not
+inspected and may still perform their own HTTP egress — see §5.2.
 
 ### 4.2 Asset-sensitivity is not propagated to planner tool scoping
 
@@ -226,23 +230,32 @@ and graph-wide on `OrchestrationConfig::default_asset_sensitivity`.
 
 ### 5.2 Enforcement caveat (MANDATORY — read before using these types)
 
-> **Advisory only — not enforced for spawned sub-agents.**
+> **`NetworkScope::Deny` is enforced (best-effort) on both dispatch paths;
+> `AssetSensitivity` remains advisory everywhere.**
 >
-> The `RunInline` path (scheduler_loop.rs `tick_once`) reads `TaskNode::execution_environment`
-> to configure the inline executor. `NetworkScope` and `AssetSensitivity` follow the same
-> advisory pattern as `token_budget_cents` (warn-only, pre-v1.0.0).
+> `handle_scheduler_spawn_action` (spawned sub-agents) reads `TaskNode::network_scope` and
+> sets `SpawnContext::network_denied` accordingly; `build_filtered_executor` wraps the
+> sub-agent's tool executor with `NetworkDenyToolExecutor` when `Deny` (OQ-1, resolved,
+> #6030). `handle_run_inline_action` (`RunInline` path, `scheduler_loop.rs`) reads the same
+> field and, when `Deny`, temporarily replaces the parent agent's own `self.tool_executor`
+> with a `NetworkDenyToolExecutor`-wrapped copy for the duration of that single inline turn,
+> restoring it afterward — `RunInline` tasks share the parent's tool loop, so there is no
+> per-task executor to wrap independently.
 >
-> The spawned sub-agent path (`handle_scheduler_spawn_action` → `spawn_for_task`) builds its
-> context via `build_spawn_context(&cfg)` and does **NOT** read per-task scope fields.
-> A planner-emitted `network_scope: Deny` is silently ignored for spawned tasks until the
-> runner wiring described in §7 is implemented.
+> `NetworkDenyToolExecutor` blocks two classes of call: `bash` invocations of `curl`,
+> `wget`, `nc`, `ncat`, `netcat`; and any call to the native `web_scrape`/`fetch` tool
+> (blocked unconditionally — no command inspection needed, since these tools have no
+> non-network purpose). **Known gap**: MCP-provided tools are not inspected.
+>
+> `AssetSensitivity` follows the same advisory pattern as `token_budget_cents` (warn-only,
+> pre-v1.0.0) on both paths — `TaskNode::network_scope` enforcement does not extend to
+> `asset_sensitivity` (OQ-2 open).
 
-<!-- TODO(critic): NetworkScope/AssetSensitivity are advisory in this PR; spawned sub-agent
-enforcement (handle_scheduler_spawn_action / spawn_for_task) is deferred.
-See scheduler_loop.rs handle_scheduler_spawn_action and spawn_for_task. -->
-
-This means: **do not treat `network_scope: Deny` as a security guarantee** in the current
-implementation. It is a planner annotation for future enforcement only.
+This means: **`network_scope: Deny` is a best-effort tool/command-identity block, not a
+sandbox-level guarantee** — it does not protect against obfuscated or subshell-embedded
+shell commands the underlying blocklist heuristic misses (see §2.2.3), nor against MCP
+tools performing their own HTTP egress. `asset_sensitivity` remains a planner annotation
+for future enforcement only (OQ-2).
 
 ### 5.3 Planner JSON schema exposure
 
@@ -272,9 +285,13 @@ tracked as a finding in §4.4.)*
 **INVARIANT-4 (Memory-write-gate):** All writes to Qdrant and the graph entity store MUST
 pass through `MemoryWriteGate` scoring. `NEVER` bypass the write gate for "trusted" inputs.
 
-**INVARIANT-5 (NetworkScope-advisory):** `network_scope: Deny` on a `TaskNode` is an advisory
-annotation only. `NEVER` document or represent it as a security enforcement boundary until
-runner wiring in §7 is complete.
+**INVARIANT-5 (NetworkScope-enforcement-scope):** `network_scope: Deny` on a `TaskNode` is
+enforced for both spawned sub-agents and `RunInline` tasks via `NetworkDenyToolExecutor`
+(OQ-1, resolved), which blocks `bash` network commands and the native `web_scrape`/`fetch`
+tool. This is a best-effort tool/command-identity block, not a sandbox boundary — it does
+not cover obfuscated shell commands, subshell embedding beyond what the underlying
+blocklist heuristic catches, or MCP tool calls performing their own HTTP egress. `NEVER`
+represent it as a hard security boundary.
 
 **INVARIANT-6 (AssetSensitivity-advisory):** `asset_sensitivity: Confidential` on a `TaskNode`
 does NOT cause the dispatcher to tighten the tool allow-list in the current implementation.
@@ -289,7 +306,7 @@ MCP client MUST emit an `EgressEvent` with a non-empty `ToolCall.skill_egress_at
 
 | # | Question | Tracked by |
 |---|----------|-----------|
-| OQ-1 | Wire `network_scope: Deny` to `ShellConfig.allow_network` in `handle_scheduler_spawn_action` and `build_spawn_context`. Requires threading per-task scope through `SchedulerAction::Spawn`. | Follow-up issue after #3934 |
+| OQ-1 | ~~Wire `network_scope: Deny` to `ShellConfig.allow_network` in `handle_scheduler_spawn_action` and `build_spawn_context`.~~ **Resolved** (#6030): both `handle_scheduler_spawn_action` (spawned sub-agents, via `SpawnContext::network_denied`) and `handle_run_inline_action` (`RunInline` tasks, via a temporary swap of `self.tool_executor`) wrap the task's tool executor with `NetworkDenyToolExecutor` instead of mutating the shared `ShellConfig` directly (avoids affecting sibling tasks / the parent agent outside the wrapped call). Blocks `bash` network commands and the native `web_scrape`/`fetch` tool. Remaining known gap: MCP-provided tools are not inspected. | #6030 |
 | OQ-2 | Wire `asset_sensitivity ≥ Confidential` to auto-tighten `ScopedToolExecutor` allow-list at dispatch time. | Follow-up issue after #3934 |
 | OQ-3 | Re-validate HTTP target IP after each redirect in `WebScrapeExecutor` to close SSRF-via-redirect (§4.4 / 2.3.2). | See `010-security/spec.md` |
 | OQ-4 | Add connect-time IP validation (DNS rebinding guard, §4.4 / 2.3.3). | See `010-security/spec.md` |


### PR DESCRIPTION
## Summary

`TaskNode::network_scope: Deny` was advisory-only — never read at dispatch time, so a planner-emitted `Deny` silently left a task's network egress unrestricted (`specs/069-threat-model/spec.md` OQ-1, flagged High risk).

- Adds `NetworkDenyToolExecutor`, a per-spawn decorator (same shape as the existing `FilteredToolExecutor`/`PlanModeExecutor`) that blocks `bash` invocations of `curl`/`wget`/`nc`/`ncat`/`netcat` and the native `web_scrape`/`fetch` tool.
- Wired into both dispatch paths:
  - Spawned sub-agents: `handle_scheduler_spawn_action` sets `SpawnContext::network_denied`; `build_filtered_executor` wraps only that spawn's executor — sibling tasks and the parent's own executor are unaffected.
  - `RunInline` tasks: `handle_run_inline_action` temporarily wraps the parent agent's own `tool_executor` for the duration of the inline turn (there's no per-task executor to wrap independently since `RunInline` shares the parent's tool loop), restoring it afterward.
- `specs/069-threat-model/spec.md` (§3, §4.1, §5.2, INVARIANT-5, OQ-1) updated to match what's actually enforced.

Known gap (documented, not silently missing): MCP-provided tools are not inspected and may still perform their own HTTP egress — this is a best-effort tool/command-identity block, not a sandbox-level guarantee.

Went through an internal security-chain review: an adversarial critique pass caught two real gaps in the first implementation (RunInline silently ignoring `Deny`, and native `web_scrape`/`fetch` fully bypassing the bash-only check) — both were fixed and independently re-verified before this PR, see `CHANGELOG.md` for the full description.

Closes #6030

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13194 passed, 0 failed, 35 skipped
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links"`)
- [x] New unit tests: `NetworkDenyToolExecutor` blocks curl/wget/nc bash calls and web_scrape/fetch unconditionally (unconfirmed + confirmed paths), permits non-network bash; `build_filtered_executor` wiring; `network_denied_for_task` scope mapping; RunInline swap proven against the real `run_inline_tool_loop`
- [ ] Live session verification (requires a planner-spawned/inline task with a manually-injected `network_scope: Deny` — the planner does not emit the field yet, tracked as OQ-6); playbook scenario added at `.local/testing/playbooks/orchestration.md` for when that's unblocked