### PR TITLE
fix: convert 9 remaining Display impls from write_str to pad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   Known gap: MCP-provided tools are not inspected and may still perform their own HTTP
   egress. This is a best-effort tool/command-identity block, not a sandbox-level
   guarantee — see `specs/069-threat-model/spec.md` INVARIANT-5.
+
+- `zeph-config`/`zeph-memory`/`zeph-experiments`/`zeph-common`/`zeph-index`: 9 `Display`
+  impls (`ProviderKind`, `MemoryTier`, `ContentFidelity`, `EntityType`, `SourceKind`,
+  `ParameterKind`, `ExperimentSource`, `EdgeType`, `Lang`) used `Formatter::write_str`,
+  which silently ignores width/fill/align flags from the caller's format spec — only
+  `Formatter::pad` respects them. Switched all 9 to `f.pad(...)`, closing off the same
+  latent width-spec bug already fixed for `SessionKind`/`SessionStatus`/`SessionChannel`
+  in #6060 (#6066).
+
 - `zeph-skills`/`src/acp.rs`/`src/serve/`: `SkillOrchestra`'s RL routing head lost learned
   updates under concurrent ACP/`/sessions` agents (#5974). `#5921` wired `RoutingHead`
   persistence into `spawn_acp_agent` and `build_agent_factory`, but each session independently

--- a/crates/zeph-common/src/memory.rs
+++ b/crates/zeph-common/src/memory.rs
@@ -312,7 +312,7 @@ impl EdgeType {
 
 impl fmt::Display for EdgeType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
+        f.pad(self.as_str())
     }
 }
 
@@ -761,7 +761,22 @@ pub trait ContextMemoryBackend: Send + Sync {
 
 #[cfg(test)]
 mod tests {
-    use super::MemoryRoute;
+    use super::{EdgeType, MemoryRoute};
+
+    /// Locks in the `f.pad` fix (#6066): `f.write_str` ignores width/fill/align flags.
+    /// `f.pad` must reproduce the same padding a plain `&str` would get under an
+    /// identical width specifier.
+    #[test]
+    fn edge_type_display_respects_width() {
+        assert_eq!(
+            format!("{:<10}", EdgeType::Causal),
+            format!("{:<10}", "causal")
+        );
+        assert_eq!(
+            format!("{:>10}", EdgeType::Semantic),
+            format!("{:>10}", "semantic")
+        );
+    }
 
     #[test]
     fn memory_route_serde_roundtrip() {

--- a/crates/zeph-config/src/providers/llm.rs
+++ b/crates/zeph-config/src/providers/llm.rs
@@ -130,7 +130,7 @@ impl ProviderKind {
 
 impl std::fmt::Display for ProviderKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
+        f.pad(self.as_str())
     }
 }
 

--- a/crates/zeph-config/src/providers/tests.rs
+++ b/crates/zeph-config/src/providers/tests.rs
@@ -982,3 +982,18 @@ fn validate_cocoon_pricing_valid_passes() {
     });
     assert!(e.validate().is_ok());
 }
+
+/// Locks in the `f.pad` fix (#6066): `f.write_str` ignores width/fill/align flags, so
+/// width-specifier `format!` calls used to render unpadded text. `f.pad` must reproduce
+/// the same padding a plain `&str` would get under an identical width specifier.
+#[test]
+fn provider_kind_display_respects_width() {
+    assert_eq!(
+        format!("{:<12}", ProviderKind::Claude),
+        format!("{:<12}", "claude")
+    );
+    assert_eq!(
+        format!("{:>12}", ProviderKind::Compatible),
+        format!("{:>12}", "compatible")
+    );
+}

--- a/crates/zeph-experiments/src/types.rs
+++ b/crates/zeph-experiments/src/types.rs
@@ -132,7 +132,7 @@ impl ParameterKind {
 
 impl std::fmt::Display for ParameterKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
+        f.pad(self.as_str())
     }
 }
 
@@ -283,7 +283,7 @@ impl ExperimentSource {
 
 impl std::fmt::Display for ExperimentSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
+        f.pad(self.as_str())
     }
 }
 
@@ -381,6 +381,33 @@ mod tests {
         assert_eq!(ExperimentSource::Scheduled.as_str(), "scheduled");
         assert_eq!(ExperimentSource::Manual.to_string(), "manual");
         assert_eq!(ExperimentSource::Scheduled.to_string(), "scheduled");
+    }
+
+    /// Locks in the `f.pad` fix (#6066): `f.write_str` ignores width/fill/align flags.
+    /// `f.pad` must reproduce the same padding a plain `&str` would get under an
+    /// identical width specifier.
+    #[test]
+    fn parameter_kind_display_respects_width() {
+        assert_eq!(
+            format!("{:<20}", ParameterKind::TopK),
+            format!("{:<20}", "top_k")
+        );
+        assert_eq!(
+            format!("{:>20}", ParameterKind::SimilarityThreshold),
+            format!("{:>20}", "similarity_threshold")
+        );
+    }
+
+    #[test]
+    fn experiment_source_display_respects_width() {
+        assert_eq!(
+            format!("{:<12}", ExperimentSource::Manual),
+            format!("{:<12}", "manual")
+        );
+        assert_eq!(
+            format!("{:>12}", ExperimentSource::Scheduled),
+            format!("{:>12}", "scheduled")
+        );
     }
 
     #[test]

--- a/crates/zeph-index/src/languages.rs
+++ b/crates/zeph-index/src/languages.rs
@@ -297,7 +297,7 @@ impl Lang {
 
 impl std::fmt::Display for Lang {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.id())
+        f.pad(self.id())
     }
 }
 
@@ -454,5 +454,17 @@ mod tests {
             assert!(!lang.id().is_empty());
             assert_eq!(lang.to_string(), lang.id());
         }
+    }
+
+    /// Locks in the `f.pad` fix (#6066): `f.write_str` ignores width/fill/align flags.
+    /// `f.pad` must reproduce the same padding a plain `&str` would get under an
+    /// identical width specifier.
+    #[test]
+    fn lang_display_respects_width() {
+        assert_eq!(format!("{:<12}", Lang::Rust), format!("{:<12}", "rust"));
+        assert_eq!(
+            format!("{:>12}", Lang::TypeScript),
+            format!("{:>12}", "typescript")
+        );
     }
 }

--- a/crates/zeph-memory/src/graph/types.rs
+++ b/crates/zeph-memory/src/graph/types.rs
@@ -58,7 +58,7 @@ impl EntityType {
 
 impl fmt::Display for EntityType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
+        f.pad(self.as_str())
     }
 }
 
@@ -623,6 +623,21 @@ mod tests {
             let s = et.to_string();
             assert_eq!(s.parse::<EntityType>().unwrap(), et);
         }
+    }
+
+    /// Locks in the `f.pad` fix (#6066): `f.write_str` ignores width/fill/align flags.
+    /// `f.pad` must reproduce the same padding a plain `&str` would get under an
+    /// identical width specifier.
+    #[test]
+    fn entity_type_display_respects_width() {
+        assert_eq!(
+            format!("{:<15}", EntityType::Person),
+            format!("{:<15}", "person")
+        );
+        assert_eq!(
+            format!("{:>15}", EntityType::Organization),
+            format!("{:>15}", "organization")
+        );
     }
 
     #[test]

--- a/crates/zeph-memory/src/optical_forgetting.rs
+++ b/crates/zeph-memory/src/optical_forgetting.rs
@@ -76,7 +76,7 @@ impl ContentFidelity {
 
 impl std::fmt::Display for ContentFidelity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
+        f.pad(self.as_str())
     }
 }
 
@@ -411,6 +411,21 @@ mod tests {
     #[test]
     fn content_fidelity_unknown_string_errors() {
         assert!("unknown".parse::<ContentFidelity>().is_err());
+    }
+
+    /// Locks in the `f.pad` fix (#6066): `f.write_str` ignores width/fill/align flags.
+    /// `f.pad` must reproduce the same padding a plain `&str` would get under an
+    /// identical width specifier.
+    #[test]
+    fn content_fidelity_display_respects_width() {
+        assert_eq!(
+            format!("{:<15}", ContentFidelity::Full),
+            format!("{:<15}", "Full")
+        );
+        assert_eq!(
+            format!("{:>15}", ContentFidelity::SummaryOnly),
+            format!("{:>15}", "SummaryOnly")
+        );
     }
 
     #[test]

--- a/crates/zeph-memory/src/store/trust.rs
+++ b/crates/zeph-memory/src/store/trust.rs
@@ -34,7 +34,7 @@ impl SourceKind {
 
 impl std::fmt::Display for SourceKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
+        f.pad(self.as_str())
     }
 }
 
@@ -598,6 +598,21 @@ mod tests {
     #[test]
     fn source_kind_display_file() {
         assert_eq!(SourceKind::File.to_string(), "file");
+    }
+
+    /// Locks in the `f.pad` fix (#6066): `f.write_str` ignores width/fill/align flags.
+    /// `f.pad` must reproduce the same padding a plain `&str` would get under an
+    /// identical width specifier.
+    #[test]
+    fn source_kind_display_respects_width() {
+        assert_eq!(
+            format!("{:<10}", SourceKind::Local),
+            format!("{:<10}", "local")
+        );
+        assert_eq!(
+            format!("{:>10}", SourceKind::Bundled),
+            format!("{:>10}", "bundled")
+        );
     }
 
     #[test]

--- a/crates/zeph-memory/src/types.rs
+++ b/crates/zeph-memory/src/types.rs
@@ -44,7 +44,7 @@ impl MemoryTier {
 
 impl std::fmt::Display for MemoryTier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
+        f.pad(self.as_str())
     }
 }
 
@@ -222,6 +222,21 @@ mod tests {
     #[test]
     fn memory_tier_unknown_string_errors() {
         assert!("unknown".parse::<MemoryTier>().is_err());
+    }
+
+    /// Locks in the `f.pad` fix (#6066): `f.write_str` ignores width/fill/align flags.
+    /// `f.pad` must reproduce the same padding a plain `&str` would get under an
+    /// identical width specifier.
+    #[test]
+    fn memory_tier_display_respects_width() {
+        assert_eq!(
+            format!("{:<10}", MemoryTier::Working),
+            format!("{:<10}", "working")
+        );
+        assert_eq!(
+            format!("{:>10}", MemoryTier::Semantic),
+            format!("{:>10}", "semantic")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `SessionKind`/`SessionStatus`/`SessionChannel` were fixed in #6060 for a latent bug: `Formatter::write_str` silently ignores width/fill/align flags from the caller's format spec, while `Formatter::pad` respects them. The fix scoped itself to those 3 confirmed-live instances, leaving 8 other flagged sites for a follow-up pass (per #6015's own text).
- Converts the remaining 9 instances of this pattern from `f.write_str(...)` to `f.pad(...)`: `ProviderKind`, `MemoryTier`, `ContentFidelity`, `EntityType`, `SourceKind`, `ParameterKind`, `ExperimentSource`, `EdgeType` (the 8 originally named in the issue), plus `Lang` (`crates/zeph-index/src/languages.rs`) — a 9th same-class site found during adversarial review that used `f.id()` instead of `f.as_str()`, so it wasn't caught by the issue's own grep pattern. Fixing it now closes the anti-pattern crate-wide, matching the issue's stated goal, instead of leaving it for yet another follow-up.
- Adds width-spec regression tests for all 9 types, mirroring the precedent test pattern from #6060 — each asserts `format!("{:<N}", value)` / `format!("{:>N}", value)` actually pads, which fails under the old `write_str` behavior and passes under `pad`.

This is a preventive/tech-debt fix — no confirmed live width-spec call site exists for these types today (verified in the issue and re-verified during review), so the change closes off the anti-pattern before it can cause a visible rendering bug.

Closes #6066

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (13186 passed, 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] 9 new width-spec regression tests added and passing, verified with a negative-control check (reverting one `pad` back to `write_str` makes the corresponding test fail)