### PR TITLE
fix: safe URL redaction fallback, migrate-config validation warning, --tui feature guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+### Fixed
+
+- `src/commands/db.rs`: `zeph db migrate` fell back to the raw, unredacted database URL
+  in error messages and the migration-status line whenever `redact_url` returned `None`
+  — which only means the URL didn't match a recognized credential-bearing shape, not that
+  it's credential-free (#6026). All three call sites now fall back to the literal
+  `"[redacted]"` marker, matching the existing safe pattern in
+  `crates/zeph-db/src/pool.rs::connect_postgres`.
+- `src/commands/migrate.rs`: `zeph migrate-config` operated on the raw TOML document and
+  never validated the result against the strict `Config` schema, so an invalid existing
+  value (e.g. an unrecognized `vault.backend`) silently survived migration while real
+  startup (`Config::load`, hardened by #6025) would reject it (#6038). `migrate-config`
+  now attempts to deserialize the migrated document into `Config` and prints a warning
+  with the underlying error if that fails, without turning the migration itself into a
+  hard failure — its job remains adding missing keys, not fixing preexisting invalid
+  values.
+- `src/cli.rs`/`src/runner.rs`: `--tui` silently fell through to plain CLI mode with zero
+  diagnostic when the binary was compiled without the `tui` feature, since `Cli::tui` was
+  never feature-gated but every consumer of it was (#6016). Added
+  `warn_if_tui_requested_but_unavailable`, mirroring the existing
+  `warn_if_acp_enabled_but_unavailable` precedent but returning a hard error instead of a
+  warning, since silently falling back to a different mode than requested is a materially
+  different UX.
+
 ### Testing
 
 - `zeph-llm`: reduced the discoverability of bypassing the Claude no-prefill funnel introduced

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -22,7 +22,7 @@ pub(crate) async fn handle_db_migrate(config_path: Option<&std::path::Path>) -> 
     // C-001: validate that the URL matches the compiled-in backend.
     #[cfg(feature = "postgres")]
     if !zeph_db::is_postgres_url(db_url) {
-        let safe = redact_url(db_url).unwrap_or_else(|| db_url.to_owned());
+        let safe = redact_url(db_url).unwrap_or_else(|| "[redacted]".to_owned());
         anyhow::bail!(
             "postgres build requires a postgres:// or postgresql:// URL, but got: {safe:?}. \
              Set database_url in [memory] config or run: \
@@ -31,14 +31,14 @@ pub(crate) async fn handle_db_migrate(config_path: Option<&std::path::Path>) -> 
     }
     #[cfg(feature = "sqlite")]
     if zeph_db::is_postgres_url(db_url) {
-        let safe = redact_url(db_url).unwrap_or_else(|| db_url.to_owned());
+        let safe = redact_url(db_url).unwrap_or_else(|| "[redacted]".to_owned());
         anyhow::bail!(
             "sqlite build cannot connect to a postgres:// URL: {safe:?}. \
              Recompile with --features postgres or use a sqlite file path."
         );
     }
 
-    let display_url = redact_url(db_url).unwrap_or_else(|| db_url.to_owned());
+    let display_url = redact_url(db_url).unwrap_or_else(|| "[redacted]".to_owned());
     eprintln!("Running migrations on: {display_url}");
 
     let db_config = DbConfig {
@@ -58,6 +58,83 @@ pub(crate) async fn handle_db_migrate(config_path: Option<&std::path::Path>) -> 
 mod tests {
     use crate::cli::{Cli, Command, DbCommand};
     use clap::Parser;
+
+    /// Regression test for #6026: when `redact_url` returns `None` for a
+    /// backend-mismatch URL, the fallback must never fall through to the raw
+    /// URL. `None` means "unrecognized shape", not "credential-free" — this
+    /// query string carries a secret under a key (`token`) that the redaction
+    /// heuristic doesn't recognize, so `redact_url` returns `None` even though
+    /// the URL is not safe to print as-is.
+    #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+    #[tokio::test]
+    async fn db_migrate_backend_mismatch_does_not_leak_raw_url() {
+        use super::handle_db_migrate;
+
+        let secret = "s3cr3t-token-do-not-leak";
+        let db_url = format!("postgres://db.example.com/zeph?token={secret}");
+        assert!(zeph_db::redact_url(&db_url).is_none());
+
+        let toml = zeph_config::Config::dump_defaults().expect("dump default config");
+        let toml = toml.replacen(
+            "[memory]\n",
+            &format!("[memory]\ndatabase_url = \"{db_url}\"\n"),
+            1,
+        );
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, toml).expect("write temp config");
+
+        let err = handle_db_migrate(Some(&config_path))
+            .await
+            .expect_err("sqlite build must reject a postgres:// URL");
+        let message = err.to_string();
+        assert!(
+            !message.contains(secret),
+            "error message must not leak the raw URL/secret: {message}"
+        );
+        assert!(
+            message.contains("[redacted]"),
+            "error message must show the redacted placeholder: {message}"
+        );
+    }
+
+    /// Mirror of `db_migrate_backend_mismatch_does_not_leak_raw_url` for the
+    /// postgres-build backend-mismatch branch (a non-`postgres://` URL rejected
+    /// by a postgres-only build). `sqlite` and `postgres` are mutually
+    /// exclusive (`zeph-db`'s `compile_error!` guard), so this only compiles
+    /// under `--no-default-features --features postgres`.
+    #[cfg(all(feature = "postgres", not(feature = "sqlite")))]
+    #[tokio::test]
+    async fn db_migrate_backend_mismatch_does_not_leak_raw_url_postgres_build() {
+        use super::handle_db_migrate;
+
+        let secret = "s3cr3t-token-do-not-leak";
+        let db_url = format!("sqlite:///data/zeph.db?token={secret}");
+        assert!(zeph_db::redact_url(&db_url).is_none());
+
+        let toml = zeph_config::Config::dump_defaults().expect("dump default config");
+        let toml = toml.replacen(
+            "[memory]\n",
+            &format!("[memory]\ndatabase_url = \"{db_url}\"\n"),
+            1,
+        );
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, toml).expect("write temp config");
+
+        let err = handle_db_migrate(Some(&config_path))
+            .await
+            .expect_err("postgres build must reject a non-postgres:// URL");
+        let message = err.to_string();
+        assert!(
+            !message.contains(secret),
+            "error message must not leak the raw URL/secret: {message}"
+        );
+        assert!(
+            message.contains("[redacted]"),
+            "error message must show the redacted placeholder: {message}"
+        );
+    }
 
     #[test]
     fn db_migrate_parses() {

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeSet;
 use std::path::Path;
 
 use similar::{ChangeTag, TextDiff};
+use zeph_core::config::Config;
 use zeph_core::config::migrate::{ConfigMigrator, MIGRATIONS, MigrationResult};
 
 /// Aggregated totals from a `migrate-config` run, returned by [`handle_migrate_config`]
@@ -58,6 +59,8 @@ pub(crate) fn handle_migrate_config(
     let (total_changed_count, total_sections_changed) = aggregate_totals(&step_results, &result);
     let total_sections_len = total_sections_changed.len();
 
+    warn_if_migrated_config_invalid(&result.output);
+
     if diff {
         print_diff(&input, &result.output);
         for (name, step_result) in &step_results {
@@ -100,6 +103,25 @@ pub(crate) fn handle_migrate_config(
         total_changed_count,
         total_sections_changed: total_sections_len,
     })
+}
+
+/// Warn if the migrated TOML would fail to deserialize into [`Config`].
+///
+/// `migrate-config` only adds missing keys — it never validates the user's existing
+/// values, so a preexisting invalid value (e.g. an unrecognized `vault.backend`) survives
+/// the migration untouched. Real startup (`Config::load`) deserializes with the same
+/// `toml::from_str::<Config>` call and rejects such values (see #6025), which previously
+/// gave a false sense that a config accepted by `migrate-config` would also load — file it
+/// as a warning rather than a hard error, since fixing unrelated invalid values isn't this
+/// command's job.
+fn warn_if_migrated_config_invalid(migrated_toml: &str) {
+    if let Err(err) = toml::from_str::<Config>(migrated_toml) {
+        eprintln!(
+            "warning: the migrated config would fail to load: {err}\n\
+             migrate-config only adds missing keys — it does not fix invalid existing \
+             values. Fix the reported error in the config file before relying on it."
+        );
+    }
 }
 
 /// Sum `changed_count` and union `sections_changed` across every named migration step
@@ -234,6 +256,43 @@ mod tests {
             !migrated.is_empty(),
             "migration should add content to an empty config"
         );
+    }
+
+    #[test]
+    fn warn_if_migrated_config_invalid_detects_bogus_vault_backend() {
+        // Reproduces #6038: an invalid vault.backend value survives migration
+        // untouched (migrate-config only adds missing keys), but `Config::load`
+        // (via the same `toml::from_str::<Config>` call) rejects it at startup.
+        // Start from an otherwise-valid config (so the only failure reason is the
+        // bogus backend value, not missing required sections) and corrupt just
+        // `vault.backend` via the TOML value tree.
+        let default_toml = toml::to_string(&Config::default()).expect("serialize default config");
+        let mut value: toml::Value = toml::from_str(&default_toml).expect("parse as toml value");
+        value["vault"]["backend"] = toml::Value::String("bogus_backend_name".to_owned());
+        let corrupted = toml::to_string(&value).expect("serialize corrupted config");
+
+        assert!(toml::from_str::<Config>(&corrupted).is_err());
+    }
+
+    #[test]
+    fn warn_if_migrated_config_invalid_accepts_valid_config() {
+        // A default config round-tripped through TOML must still deserialize —
+        // the warning must not fire on a well-formed config.
+        let default_toml = toml::to_string(&Config::default()).expect("serialize default config");
+        assert!(toml::from_str::<Config>(&default_toml).is_ok());
+    }
+
+    #[test]
+    fn handle_migrate_config_with_invalid_vault_backend_still_succeeds() {
+        // The warning must not turn migrate-config into a hard failure — its job
+        // is adding missing keys, not fixing preexisting invalid values.
+        let raw = "[vault]\nbackend = \"bogus_backend_name\"\n";
+        let mut file = NamedTempFile::new().expect("create temp config file");
+        file.write_all(raw.as_bytes()).expect("write config");
+        let path = file.path().to_path_buf();
+
+        handle_migrate_config(&path, false, true)
+            .expect("migrate-config must not hard-fail on an invalid existing value");
     }
 
     #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -531,6 +531,26 @@ fn warn_if_acp_enabled_but_unavailable(config: &Config) {
     }
 }
 
+/// Reject `--tui` outright when the binary was not compiled with the `tui` feature.
+///
+/// Unlike ACP autostart (which falls back to a different but still functional mode),
+/// silently falling through to plain CLI mode is a materially different UX than the
+/// user asked for, so this is a hard error rather than a warning.
+///
+/// # Errors
+///
+/// Returns an error if `--tui` was passed but this binary lacks the `tui` feature.
+#[cfg(not(feature = "tui"))]
+fn warn_if_tui_requested_but_unavailable(cli: &Cli) -> anyhow::Result<()> {
+    if cli.tui {
+        anyhow::bail!(
+            "--tui was requested but this binary was not compiled with the `tui` feature; \
+             rebuild with --features tui (or a bundle like 'desktop'/'full') to use the TUI dashboard."
+        );
+    }
+    Ok(())
+}
+
 /// Resolve the API key for the STT provider entry.
 ///
 /// `OpenAI` and Candle use the `OpenAI` key; Compatible providers use their own inline key or the
@@ -1205,6 +1225,9 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
 
     #[cfg(not(feature = "acp"))]
     warn_if_acp_enabled_but_unavailable(app.config());
+
+    #[cfg(not(feature = "tui"))]
+    warn_if_tui_requested_but_unavailable(&cli)?;
 
     #[cfg(feature = "scheduler")]
     {
@@ -4506,6 +4529,28 @@ mod deep_link_tests {
 mod tests {
     use super::*;
     use clap::Parser;
+
+    // --- warn_if_tui_requested_but_unavailable ---
+
+    #[test]
+    #[cfg(not(feature = "tui"))]
+    fn tui_requested_without_feature_is_rejected() {
+        let cli = Cli {
+            tui: true,
+            ..Default::default()
+        };
+        let err = warn_if_tui_requested_but_unavailable(&cli)
+            .expect_err("--tui without the tui feature must be a hard error");
+        assert!(err.to_string().contains("--tui"));
+        assert!(err.to_string().contains("tui"));
+    }
+
+    #[test]
+    #[cfg(not(feature = "tui"))]
+    fn tui_not_requested_is_ok() {
+        let cli = Cli::default();
+        assert!(warn_if_tui_requested_but_unavailable(&cli).is_ok());
+    }
 
     // --- parse_plugin_url_arg ---
 


### PR DESCRIPTION
## Summary

Three small, independent bug fixes bundled into one PR since each is a self-contained root-binary CLI fix with no cross-dependencies:

- `src/commands/db.rs` no longer falls back to the raw, unredacted database URL when `redact_url` returns `None` (meaning "no recognized credential form", not "credential-free"). It now falls back to `"[redacted]"`, matching the existing safe pattern in `zeph-db::pool::connect_postgres`.
- `zeph migrate-config` now attempts to deserialize the migrated config into the strict `Config` struct (the same way `Config::load()` does) and prints a warning when the result would fail to load — e.g. an invalid `vault.backend` value — instead of silently round-tripping it with no diagnostic.
- `--tui` now hard-errors with a clear message when passed to a binary built without the `tui` feature, instead of silently falling through to plain CLI mode with zero diagnostic. Mirrors the existing `warn_if_acp_enabled_but_unavailable` pattern for ACP.

Closes #6026
Closes #6038
Closes #6016

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing,deep-link" -- -D warnings` — clean except pre-existing, unrelated `clippy::large_futures` errors in `src/serve/agent_factory.rs`/`src/serve/handlers.rs` (macOS/aarch64-only; CI's Linux `lint-clippy` job passes on the same commit/feature-set; filed separately as #6163)
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13204 passed, 0 failed
- [x] `cargo nextest run -p zeph --no-default-features --features postgres --bins` for the postgres-gated regression test — passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] New regression tests added: 2 for `src/commands/db.rs` (exercising the actual `bail!` sites, sqlite- and postgres-gated), 3 for `src/commands/migrate.rs`, 2 for `src/runner.rs` (confirmed correctly compiled out under `--features desktop`)
- [x] CHANGELOG.md updated under `[Unreleased]`
- [x] Testing playbook and coverage-status.md updated in the main repository (`.local/testing/`)