### PR TITLE
fix: box::pin build_agent_factory awaits to fix large_futures on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   Self-learning/heuristic auto-promotion and reload trust-assignment are intentionally out of
   scope for this change — see the PR description.
 
+### Fixed
+
+- `src/serve`: boxed all 17 `build_agent_factory(...).await` call sites in `agent_factory.rs`
+  and `handlers.rs` with `Box::pin(...)` to resolve `clippy::large_futures` (16456-byte future,
+  over the 16384-byte threshold) that only triggered on macOS/aarch64 due to platform-specific
+  stack layout differences (#6163). Same fix pattern as #3521: move the large future onto the
+  heap rather than tuning its size. No behavior change.
+
 ### Testing
 
 - `zeph-llm`: reduced the discoverability of bypassing the Claude no-prefill funnel introduced

--- a/src/serve/agent_factory.rs
+++ b/src/serve/agent_factory.rs
@@ -850,7 +850,7 @@ mod tests {
             quality_pipeline: None,
         };
 
-        let build_agent = build_agent_factory(deps, session_id.clone(), cid).await;
+        let build_agent = Box::pin(build_agent_factory(deps, session_id.clone(), cid)).await;
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
         let _agent = build_agent(channel);
 
@@ -941,7 +941,7 @@ mod tests {
             quality_pipeline: None,
         };
 
-        let build_agent = build_agent_factory(deps, session_id.clone(), cid).await;
+        let build_agent = Box::pin(build_agent_factory(deps, session_id.clone(), cid)).await;
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
         let mut agent = build_agent(channel);
 
@@ -1051,7 +1051,7 @@ mod tests {
             quality_pipeline: None,
         };
 
-        let build_agent = build_agent_factory(deps, session_id.clone(), cid).await;
+        let build_agent = Box::pin(build_agent_factory(deps, session_id.clone(), cid)).await;
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
         let mut agent = build_agent(channel);
 
@@ -1150,7 +1150,7 @@ mod tests {
             quality_pipeline: None,
         };
 
-        let build_agent = build_agent_factory(deps, session_id.clone(), cid).await;
+        let build_agent = Box::pin(build_agent_factory(deps, session_id.clone(), cid)).await;
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
         let mut agent = build_agent(channel);
 
@@ -1248,7 +1248,7 @@ mod tests {
             quality_pipeline: None,
         };
 
-        let build_agent = build_agent_factory(deps, session_id.clone(), cid).await;
+        let build_agent = Box::pin(build_agent_factory(deps, session_id.clone(), cid)).await;
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
         let mut agent = build_agent(channel);
 
@@ -1343,7 +1343,7 @@ mod tests {
             quality_pipeline: None,
         };
 
-        let build_agent = build_agent_factory(deps, session_id.clone(), cid).await;
+        let build_agent = Box::pin(build_agent_factory(deps, session_id.clone(), cid)).await;
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
         let mut agent = build_agent(channel);
 
@@ -1461,8 +1461,8 @@ mod tests {
             crate::agent_setup::PolicyGatePieces::default(),
         );
 
-        let build_agent_a = build_agent_factory(deps.clone(), session_id_a, cid_a).await;
-        let build_agent_b = build_agent_factory(deps, session_id_b, cid_b).await;
+        let build_agent_a = Box::pin(build_agent_factory(deps.clone(), session_id_a, cid_a)).await;
+        let build_agent_b = Box::pin(build_agent_factory(deps, session_id_b, cid_b)).await;
         let (channel_a, _handle_a) = zeph_core::LoopbackChannel::pair(8);
         let (channel_b, _handle_b) = zeph_core::LoopbackChannel::pair(8);
         let agent_a = build_agent_a(channel_a);
@@ -1534,7 +1534,7 @@ mod tests {
             policy_gate_pieces,
         );
 
-        let build_agent = build_agent_factory(deps, session_id, cid).await;
+        let build_agent = Box::pin(build_agent_factory(deps, session_id, cid)).await;
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
         let agent = build_agent(channel);
 
@@ -1704,7 +1704,7 @@ mod tests {
             ..Default::default()
         };
 
-        let build_agent = build_agent_factory(deps, session_id, cid).await;
+        let build_agent = Box::pin(build_agent_factory(deps, session_id, cid)).await;
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
         let agent = build_agent(channel);
         let executor = agent.tool_executor_arc();
@@ -1782,7 +1782,7 @@ mod tests {
             ..Default::default()
         };
 
-        let build_agent = build_agent_factory(deps, session_id, cid).await;
+        let build_agent = Box::pin(build_agent_factory(deps, session_id, cid)).await;
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
         let agent = build_agent(channel);
         let executor = agent.tool_executor_arc();
@@ -1845,7 +1845,7 @@ mod tests {
             crate::agent_setup::PolicyGatePieces::default(),
         );
 
-        let build_agent = build_agent_factory(deps, session_id, cid).await;
+        let build_agent = Box::pin(build_agent_factory(deps, session_id, cid)).await;
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
         let agent = build_agent(channel);
 
@@ -1901,7 +1901,7 @@ mod tests {
             crate::agent_setup::PolicyGatePieces::default(),
         );
 
-        let build_agent = build_agent_factory(deps, session_id, cid).await;
+        let build_agent = Box::pin(build_agent_factory(deps, session_id, cid)).await;
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
         let agent = build_agent(channel);
 
@@ -1976,7 +1976,7 @@ mod tests {
             .create_conversation()
             .await
             .unwrap();
-        let build_agent = build_agent_factory(serve_deps, session_id, cid).await;
+        let build_agent = Box::pin(build_agent_factory(serve_deps, session_id, cid)).await;
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
         let agent = build_agent(channel);
 

--- a/src/serve/handlers.rs
+++ b/src/serve/handlers.rs
@@ -60,8 +60,12 @@ async fn reactivate_session(
     let meta = store.get(session_id.as_str()).await.ok().flatten()?;
     let conversation_id = meta.conversation_id.map(zeph_memory::ConversationId)?;
 
-    let build_agent =
-        build_agent_factory(state.deps.clone(), session_id.clone(), conversation_id).await;
+    let build_agent = Box::pin(build_agent_factory(
+        state.deps.clone(),
+        session_id.clone(),
+        conversation_id,
+    ))
+    .await;
     let (handle, _blocking_handle) = SessionActor::spawn(
         &state.supervisor,
         &state.registry,
@@ -127,8 +131,12 @@ pub(super) async fn create_session_handler(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
-    let build_agent =
-        build_agent_factory(state.deps.clone(), session_id.clone(), conversation_id).await;
+    let build_agent = Box::pin(build_agent_factory(
+        state.deps.clone(),
+        session_id.clone(),
+        conversation_id,
+    ))
+    .await;
     let (handle, _blocking_handle) = SessionActor::spawn(
         &state.supervisor,
         &state.registry,
@@ -418,8 +426,12 @@ pub(super) async fn fork_session_handler(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
-    let build_agent =
-        build_agent_factory(state.deps.clone(), new_id.clone(), conversation_id).await;
+    let build_agent = Box::pin(build_agent_factory(
+        state.deps.clone(),
+        new_id.clone(),
+        conversation_id,
+    ))
+    .await;
     let (handle, _blocking_handle) = SessionActor::spawn(
         &state.supervisor,
         &state.registry,


### PR DESCRIPTION
## Summary

- `cargo clippy --profile ci` fails on macOS/aarch64 with 17 `clippy::large_futures` errors, all citing `build_agent_factory(...).await` call sites in `src/serve/agent_factory.rs` (14 sites, test module) and `src/serve/handlers.rs` (3 sites: `reactivate_session`, `create_session_handler`, `fork_session_handler`). The future is 16456 bytes, just over the lint's fixed 16384-byte threshold; platform-specific async state-machine layout differences mean Linux CI stays under the threshold for the same source.
- Same fix pattern as the closed issue #3521 (PR #3530): `Box::pin(...)` each flagged call site to move the future onto the heap, resolving the lint deterministically regardless of platform ABI differences. No behavior change — pure heap-allocation wrapper.

Closes #6163

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing,deep-link" -- -D warnings` — 0 errors (was 17 `large_futures` errors)
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13209 passed, 35 skipped
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — 0 errors
- [x] Verified zero stray unboxed `build_agent_factory(` call sites remain workspace-wide
- [x] Verified no `#[allow(clippy::large_futures)]` suppression used