### PR TITLE
fix: wire remaining 5 memory-maintenance loops into ACP/daemon/serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 ### Added
 
+- **Memory**: wired the five remaining memory-maintenance loops — guidelines
+  (`mem-guidelines`), tree-consolidation (`mem-tree-consolidation`), hebbian-consolidation
+  (`mem-hebbian-consolidation`), episodic-consolidation (`mem-episodic-consolidation`), and
+  optical-forgetting (`mem-optical-forgetting`) — into `src/acp.rs` (`build_acp_deps`),
+  `src/daemon.rs` (`run_daemon`), and `src/serve/deps.rs` (`spawn_memory_maintenance_loops`),
+  matching the CLI/TUI path (`src/runner.rs`) and the first five loops wired by #5978. Each new
+  loop is gated by its own `[memory.*] enabled` config flag, exactly as in `runner.rs`; ACP and
+  `/sessions*`-created agents pass `None` for the hebbian loop's status sender since neither
+  entry point has a status-sender handle in scope, while the daemon reuses its own
+  `status_tx` (#5979).
 - **Skills**: `[skills.trust] require_integrity_check_on_promote` (default `true`) automatically
   arms the per-invocation BLAKE3 integrity re-check (`requires_trust_check`) whenever a skill is
   promoted to `trusted`/`verified`, at both the CLI (`zeph skill trust`) and in-session

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -642,11 +642,13 @@ async fn build_acp_deps(
 
     let config = app.config();
 
-    // #5914: memory maintenance loops — mirrors src/runner.rs's CLI/TUI wiring so ACP sessions
-    // (standalone `--acp` and the ACP half of `serve-sessions --acp`) get the same ongoing
-    // eviction/tier-promotion/scene-consolidation/consolidation/forgetting sweeps instead of an
-    // ever-growing, never-maintained memory store. Spawned once per connection (shared across
-    // all sessions on `acp_mem_supervisor`), matching runner.rs's once-per-process cadence.
+    // #5914/#5979: memory maintenance loops — mirrors src/runner.rs's CLI/TUI wiring so ACP
+    // sessions (standalone `--acp` and the ACP half of `serve-sessions --acp`) get the same
+    // ongoing eviction/tier-promotion/scene-consolidation/consolidation/forgetting/guidelines/
+    // tree-consolidation/hebbian-consolidation/episodic-consolidation/optical-forgetting sweeps
+    // instead of an ever-growing, never-maintained memory store. Spawned once per connection
+    // (shared across all sessions on `acp_mem_supervisor`), matching runner.rs's
+    // once-per-process cadence.
     {
         let store = std::sync::Arc::new(memory.sqlite().clone());
         let embedding = memory.embedding_store().cloned();
@@ -769,6 +771,144 @@ async fn build_acp_deps(
                     cancel.clone(),
                 )
             },
+        });
+    }
+    if config.memory.compression_guidelines.enabled {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let guidelines_provider = app
+            .build_guidelines_provider()
+            .unwrap_or_else(|| provider.clone());
+        let token_counter = std::sync::Arc::clone(&memory.token_counter);
+        let guidelines_cfg = config.memory.compression_guidelines.clone();
+        let cancel = acp_mem_supervisor.cancellation_token();
+        acp_mem_supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
+            name: "mem-guidelines",
+            restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_guidelines_updater(
+                    store.clone(),
+                    guidelines_provider.clone(),
+                    token_counter.clone(),
+                    guidelines_cfg.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    if config.memory.tree.enabled {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let tree_provider = app
+            .build_tree_consolidation_provider()
+            .unwrap_or_else(|| provider.clone());
+        let tree_cfg = zeph_memory::TreeConsolidationConfig {
+            enabled: config.memory.tree.enabled,
+            sweep_interval_secs: config.memory.tree.sweep_interval_secs,
+            batch_size: config.memory.tree.batch_size,
+            similarity_threshold: config.memory.tree.similarity_threshold,
+            max_level: config.memory.tree.max_level,
+            min_cluster_size: config.memory.tree.min_cluster_size,
+            embed_timeout_secs: config.memory.semantic.embed_timeout_secs,
+        };
+        let cancel = acp_mem_supervisor.cancellation_token();
+        acp_mem_supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
+            name: "mem-tree-consolidation",
+            restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_tree_consolidation_loop(
+                    store.clone(),
+                    tree_provider.clone(),
+                    tree_cfg.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    if config.memory.hebbian.enabled && config.memory.hebbian.consolidation_interval_secs > 0 {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let hebbian_consolidation_cfg = zeph_memory::HebbianConsolidationConfig {
+            consolidation_interval_secs: config.memory.hebbian.consolidation_interval_secs,
+            consolidation_threshold: config.memory.hebbian.consolidation_threshold,
+            max_candidates_per_sweep: config.memory.hebbian.max_candidates_per_sweep,
+            consolidation_cooldown_secs: config.memory.hebbian.consolidation_cooldown_secs,
+            consolidation_prompt_timeout_secs: config
+                .memory
+                .hebbian
+                .consolidation_prompt_timeout_secs,
+            consolidation_max_neighbors: config.memory.hebbian.consolidation_max_neighbors,
+        };
+        let hebbian_provider = app
+            .build_hebbian_consolidation_provider()
+            .unwrap_or_else(|| provider.clone());
+        let cancel = acp_mem_supervisor.cancellation_token();
+        acp_mem_supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
+            name: "mem-hebbian-consolidation",
+            restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::spawn_hebbian_consolidation_loop(
+                    store.clone(),
+                    hebbian_consolidation_cfg.clone(),
+                    hebbian_provider.clone(),
+                    None,
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    if config.memory.episodic_consolidation.enabled {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let ep_cfg = zeph_memory::EpisodicConsolidationConfig {
+            enabled: config.memory.episodic_consolidation.enabled,
+            consolidation_provider: config
+                .memory
+                .episodic_consolidation
+                .consolidation_provider
+                .clone(),
+            interval_secs: config.memory.episodic_consolidation.interval_secs,
+            batch_size: config.memory.episodic_consolidation.batch_size,
+            min_age_secs: config.memory.episodic_consolidation.min_age_secs,
+            dedup_jaccard_threshold: config.memory.episodic_consolidation.dedup_jaccard_threshold,
+        };
+        let ep_provider = app
+            .build_episodic_consolidation_provider()
+            .unwrap_or_else(|| provider.clone());
+        let ep_qdrant = memory.embedding_store().cloned();
+        let cancel = acp_mem_supervisor.cancellation_token();
+        acp_mem_supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
+            name: "mem-episodic-consolidation",
+            restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_episodic_consolidation_loop(
+                    store.clone(),
+                    ep_provider.clone(),
+                    ep_cfg.clone(),
+                    ep_qdrant.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    if config.memory.optical_forgetting.enabled {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let optical_provider = app
+            .build_optical_forgetting_provider()
+            .unwrap_or_else(|| provider.clone());
+        let optical_cfg = config.memory.optical_forgetting.clone();
+        let forgetting_floor = config.memory.forgetting.forgetting_floor;
+        let cancel = acp_mem_supervisor.cancellation_token();
+        tracing::info_span!("acp.memory.optical_forgetting.startup").in_scope(|| {
+            acp_mem_supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
+                name: "mem-optical-forgetting",
+                restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
+                factory: move || {
+                    zeph_memory::start_optical_forgetting_loop(
+                        store.clone(),
+                        optical_provider.clone(),
+                        optical_cfg.clone(),
+                        forgetting_floor,
+                        cancel.clone(),
+                    )
+                },
+            });
         });
     }
 
@@ -3805,15 +3945,18 @@ mod tests {
         );
     }
 
-    /// Regression test confirming the five #5914 memory-maintenance loops (eviction,
-    /// tier-promotion, scene-consolidation, consolidation, forgetting) are actually
-    /// registered on the ACP connection's own `TaskSupervisor`: `build_acp_deps` previously
-    /// spawned none of them, unlike the CLI path (`src/runner.rs`). Reconstructs the same
-    /// `TaskDescriptor`/`supervisor.spawn` block `build_acp_deps` now runs (falling back
-    /// directly to the primary provider where production uses `app.build_scene_provider()`/
-    /// `app.build_consolidation_provider()`, since this test has no `AppBuilder` to resolve a
-    /// named override from) and asserts every expected task name is present in the connection
-    /// supervisor's snapshot.
+    /// Regression test confirming all ten memory-maintenance loops (eviction, tier-promotion,
+    /// scene-consolidation, consolidation, forgetting — #5914; plus guidelines,
+    /// tree-consolidation, hebbian-consolidation, episodic-consolidation, optical-forgetting —
+    /// #5979) are actually registered on the ACP connection's own `TaskSupervisor`:
+    /// `build_acp_deps` previously spawned none of them, unlike the CLI path (`src/runner.rs`).
+    /// Reconstructs the same `TaskDescriptor`/`supervisor.spawn` block `build_acp_deps` now runs
+    /// (falling back directly to the primary provider where production uses
+    /// `app.build_scene_provider()`/`app.build_consolidation_provider()`/etc., since this test
+    /// has no `AppBuilder` to resolve a named override from, and passing `None` for the hebbian
+    /// status sender since `build_acp_deps` has no status-sender handle in scope either) and
+    /// asserts every expected task name is present in the connection supervisor's snapshot. The
+    /// five #5979 loops are config-gated, so the config below explicitly enables each.
     #[tokio::test]
     #[allow(clippy::too_many_lines)]
     async fn acp_memory_maintenance_loops_registered_on_connection_supervisor() {
@@ -3830,7 +3973,12 @@ mod tests {
             .await
             .unwrap(),
         );
-        let config = zeph_core::config::Config::default();
+        let mut config = zeph_core::config::Config::default();
+        config.memory.compression_guidelines.enabled = true;
+        config.memory.tree.enabled = true;
+        config.memory.hebbian.enabled = true;
+        config.memory.episodic_consolidation.enabled = true;
+        config.memory.optical_forgetting.enabled = true;
         let cancel = tokio_util::sync::CancellationToken::new();
         let supervisor = zeph_common::TaskSupervisor::new(cancel);
 
@@ -3954,6 +4102,137 @@ mod tests {
                 },
             });
         }
+        {
+            let store = std::sync::Arc::new(memory.sqlite().clone());
+            let guidelines_provider = mock_provider.clone();
+            let token_counter = std::sync::Arc::clone(&memory.token_counter);
+            let guidelines_cfg = config.memory.compression_guidelines.clone();
+            let cancel = supervisor.cancellation_token();
+            supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
+                name: "mem-guidelines",
+                restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
+                factory: move || {
+                    zeph_memory::start_guidelines_updater(
+                        store.clone(),
+                        guidelines_provider.clone(),
+                        token_counter.clone(),
+                        guidelines_cfg.clone(),
+                        cancel.clone(),
+                    )
+                },
+            });
+        }
+        {
+            let store = std::sync::Arc::new(memory.sqlite().clone());
+            let tree_provider = mock_provider.clone();
+            let tree_cfg = zeph_memory::TreeConsolidationConfig {
+                enabled: config.memory.tree.enabled,
+                sweep_interval_secs: config.memory.tree.sweep_interval_secs,
+                batch_size: config.memory.tree.batch_size,
+                similarity_threshold: config.memory.tree.similarity_threshold,
+                max_level: config.memory.tree.max_level,
+                min_cluster_size: config.memory.tree.min_cluster_size,
+                embed_timeout_secs: config.memory.semantic.embed_timeout_secs,
+            };
+            let cancel = supervisor.cancellation_token();
+            supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
+                name: "mem-tree-consolidation",
+                restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
+                factory: move || {
+                    zeph_memory::start_tree_consolidation_loop(
+                        store.clone(),
+                        tree_provider.clone(),
+                        tree_cfg.clone(),
+                        cancel.clone(),
+                    )
+                },
+            });
+        }
+        {
+            let store = std::sync::Arc::new(memory.sqlite().clone());
+            let hebbian_consolidation_cfg = zeph_memory::HebbianConsolidationConfig {
+                consolidation_interval_secs: config.memory.hebbian.consolidation_interval_secs,
+                consolidation_threshold: config.memory.hebbian.consolidation_threshold,
+                max_candidates_per_sweep: config.memory.hebbian.max_candidates_per_sweep,
+                consolidation_cooldown_secs: config.memory.hebbian.consolidation_cooldown_secs,
+                consolidation_prompt_timeout_secs: config
+                    .memory
+                    .hebbian
+                    .consolidation_prompt_timeout_secs,
+                consolidation_max_neighbors: config.memory.hebbian.consolidation_max_neighbors,
+            };
+            let hebbian_provider = mock_provider.clone();
+            let cancel = supervisor.cancellation_token();
+            supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
+                name: "mem-hebbian-consolidation",
+                restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
+                factory: move || {
+                    zeph_memory::spawn_hebbian_consolidation_loop(
+                        store.clone(),
+                        hebbian_consolidation_cfg.clone(),
+                        hebbian_provider.clone(),
+                        None,
+                        cancel.clone(),
+                    )
+                },
+            });
+        }
+        {
+            let store = std::sync::Arc::new(memory.sqlite().clone());
+            let ep_cfg = zeph_memory::EpisodicConsolidationConfig {
+                enabled: config.memory.episodic_consolidation.enabled,
+                consolidation_provider: config
+                    .memory
+                    .episodic_consolidation
+                    .consolidation_provider
+                    .clone(),
+                interval_secs: config.memory.episodic_consolidation.interval_secs,
+                batch_size: config.memory.episodic_consolidation.batch_size,
+                min_age_secs: config.memory.episodic_consolidation.min_age_secs,
+                dedup_jaccard_threshold: config
+                    .memory
+                    .episodic_consolidation
+                    .dedup_jaccard_threshold,
+            };
+            let ep_provider = mock_provider.clone();
+            let ep_qdrant = memory.embedding_store().cloned();
+            let cancel = supervisor.cancellation_token();
+            supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
+                name: "mem-episodic-consolidation",
+                restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
+                factory: move || {
+                    zeph_memory::start_episodic_consolidation_loop(
+                        store.clone(),
+                        ep_provider.clone(),
+                        ep_cfg.clone(),
+                        ep_qdrant.clone(),
+                        cancel.clone(),
+                    )
+                },
+            });
+        }
+        {
+            let store = std::sync::Arc::new(memory.sqlite().clone());
+            let optical_provider = mock_provider.clone();
+            let optical_cfg = config.memory.optical_forgetting.clone();
+            let forgetting_floor = config.memory.forgetting.forgetting_floor;
+            let cancel = supervisor.cancellation_token();
+            tracing::info_span!("acp.memory.optical_forgetting.startup").in_scope(|| {
+                supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
+                    name: "mem-optical-forgetting",
+                    restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
+                    factory: move || {
+                        zeph_memory::start_optical_forgetting_loop(
+                            store.clone(),
+                            optical_provider.clone(),
+                            optical_cfg.clone(),
+                            forgetting_floor,
+                            cancel.clone(),
+                        )
+                    },
+                });
+            });
+        }
 
         let names: std::collections::HashSet<String> = supervisor
             .snapshot()
@@ -3966,6 +4245,11 @@ mod tests {
             "mem-scene-consolidation",
             "mem-consolidation",
             "mem-forgetting",
+            "mem-guidelines",
+            "mem-tree-consolidation",
+            "mem-hebbian-consolidation",
+            "mem-episodic-consolidation",
+            "mem-optical-forgetting",
         ] {
             assert!(
                 names.contains(expected),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -466,9 +466,11 @@ pub(crate) async fn run_daemon(
         });
     }
 
-    // #5914: memory maintenance loops — mirrors src/runner.rs's CLI/TUI wiring so the daemon
-    // (A2A) entry point gets the same ongoing eviction/tier-promotion/scene-consolidation/
-    // consolidation/forgetting sweeps instead of an ever-growing, never-maintained memory store.
+    // #5914/#5979: memory maintenance loops — mirrors src/runner.rs's CLI/TUI wiring so the
+    // daemon (A2A) entry point gets the same ongoing eviction/tier-promotion/
+    // scene-consolidation/consolidation/forgetting/guidelines/tree-consolidation/
+    // hebbian-consolidation/episodic-consolidation/optical-forgetting sweeps instead of an
+    // ever-growing, never-maintained memory store.
     {
         let store = std::sync::Arc::new(memory.sqlite().clone());
         let embedding = memory.embedding_store().cloned();
@@ -591,6 +593,145 @@ pub(crate) async fn run_daemon(
                     cancel.clone(),
                 )
             },
+        });
+    }
+    if config.memory.compression_guidelines.enabled {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let guidelines_provider = app
+            .build_guidelines_provider()
+            .unwrap_or_else(|| provider.clone());
+        let token_counter = std::sync::Arc::clone(&memory.token_counter);
+        let guidelines_cfg = config.memory.compression_guidelines.clone();
+        let cancel = mem_supervisor.cancellation_token();
+        mem_supervisor.spawn(zeph_common::TaskDescriptor {
+            name: "mem-guidelines",
+            restart: zeph_common::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_guidelines_updater(
+                    store.clone(),
+                    guidelines_provider.clone(),
+                    token_counter.clone(),
+                    guidelines_cfg.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    if config.memory.tree.enabled {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let tree_provider = app
+            .build_tree_consolidation_provider()
+            .unwrap_or_else(|| provider.clone());
+        let tree_cfg = zeph_memory::TreeConsolidationConfig {
+            enabled: config.memory.tree.enabled,
+            sweep_interval_secs: config.memory.tree.sweep_interval_secs,
+            batch_size: config.memory.tree.batch_size,
+            similarity_threshold: config.memory.tree.similarity_threshold,
+            max_level: config.memory.tree.max_level,
+            min_cluster_size: config.memory.tree.min_cluster_size,
+            embed_timeout_secs: config.memory.semantic.embed_timeout_secs,
+        };
+        let cancel = mem_supervisor.cancellation_token();
+        mem_supervisor.spawn(zeph_common::TaskDescriptor {
+            name: "mem-tree-consolidation",
+            restart: zeph_common::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_tree_consolidation_loop(
+                    store.clone(),
+                    tree_provider.clone(),
+                    tree_cfg.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    if config.memory.hebbian.enabled && config.memory.hebbian.consolidation_interval_secs > 0 {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let hebbian_consolidation_cfg = zeph_memory::HebbianConsolidationConfig {
+            consolidation_interval_secs: config.memory.hebbian.consolidation_interval_secs,
+            consolidation_threshold: config.memory.hebbian.consolidation_threshold,
+            max_candidates_per_sweep: config.memory.hebbian.max_candidates_per_sweep,
+            consolidation_cooldown_secs: config.memory.hebbian.consolidation_cooldown_secs,
+            consolidation_prompt_timeout_secs: config
+                .memory
+                .hebbian
+                .consolidation_prompt_timeout_secs,
+            consolidation_max_neighbors: config.memory.hebbian.consolidation_max_neighbors,
+        };
+        let hebbian_provider = app
+            .build_hebbian_consolidation_provider()
+            .unwrap_or_else(|| provider.clone());
+        let status_tx_clone = status_tx.clone();
+        let cancel = mem_supervisor.cancellation_token();
+        mem_supervisor.spawn(zeph_common::TaskDescriptor {
+            name: "mem-hebbian-consolidation",
+            restart: zeph_common::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::spawn_hebbian_consolidation_loop(
+                    store.clone(),
+                    hebbian_consolidation_cfg.clone(),
+                    hebbian_provider.clone(),
+                    Some(status_tx_clone.clone()),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    if config.memory.episodic_consolidation.enabled {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let ep_cfg = zeph_memory::EpisodicConsolidationConfig {
+            enabled: config.memory.episodic_consolidation.enabled,
+            consolidation_provider: config
+                .memory
+                .episodic_consolidation
+                .consolidation_provider
+                .clone(),
+            interval_secs: config.memory.episodic_consolidation.interval_secs,
+            batch_size: config.memory.episodic_consolidation.batch_size,
+            min_age_secs: config.memory.episodic_consolidation.min_age_secs,
+            dedup_jaccard_threshold: config.memory.episodic_consolidation.dedup_jaccard_threshold,
+        };
+        let ep_provider = app
+            .build_episodic_consolidation_provider()
+            .unwrap_or_else(|| provider.clone());
+        let ep_qdrant = memory.embedding_store().cloned();
+        let cancel = mem_supervisor.cancellation_token();
+        mem_supervisor.spawn(zeph_common::TaskDescriptor {
+            name: "mem-episodic-consolidation",
+            restart: zeph_common::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_episodic_consolidation_loop(
+                    store.clone(),
+                    ep_provider.clone(),
+                    ep_cfg.clone(),
+                    ep_qdrant.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    if config.memory.optical_forgetting.enabled {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let optical_provider = app
+            .build_optical_forgetting_provider()
+            .unwrap_or_else(|| provider.clone());
+        let optical_cfg = config.memory.optical_forgetting.clone();
+        let forgetting_floor = config.memory.forgetting.forgetting_floor;
+        let cancel = mem_supervisor.cancellation_token();
+        tracing::info_span!("daemon.memory.optical_forgetting.startup").in_scope(|| {
+            mem_supervisor.spawn(zeph_common::TaskDescriptor {
+                name: "mem-optical-forgetting",
+                restart: zeph_common::RestartPolicy::RunOnce,
+                factory: move || {
+                    zeph_memory::start_optical_forgetting_loop(
+                        store.clone(),
+                        optical_provider.clone(),
+                        optical_cfg.clone(),
+                        forgetting_floor,
+                        cancel.clone(),
+                    )
+                },
+            });
         });
     }
 
@@ -2492,21 +2633,29 @@ mod tests {
         );
     }
 
-    /// Regression test confirming the five #5914 memory-maintenance loops (eviction,
-    /// tier-promotion, scene-consolidation, consolidation, forgetting) are actually
-    /// registered on the daemon's own `TaskSupervisor`: `run_daemon` previously spawned none
-    /// of them, unlike the CLI path (`src/runner.rs`). Reconstructs the same
-    /// `TaskDescriptor`/`supervisor.spawn` block `run_daemon` now runs (falling back directly
-    /// to the primary provider where production uses `app.build_scene_provider()`/
-    /// `app.build_consolidation_provider()`, since this test has no `AppBuilder` to resolve a
-    /// named override from) and asserts every expected task name is present in the daemon's
-    /// memory supervisor snapshot.
+    /// Regression test confirming all ten memory-maintenance loops (eviction, tier-promotion,
+    /// scene-consolidation, consolidation, forgetting — #5914; plus guidelines,
+    /// tree-consolidation, hebbian-consolidation, episodic-consolidation, optical-forgetting —
+    /// #5979) are actually registered on the daemon's own `TaskSupervisor`: `run_daemon`
+    /// previously spawned none of them, unlike the CLI path (`src/runner.rs`). Reconstructs the
+    /// same `TaskDescriptor`/`supervisor.spawn` block `run_daemon` now runs (falling back
+    /// directly to the primary provider where production uses `app.build_scene_provider()`/
+    /// `app.build_consolidation_provider()`/etc., since this test has no `AppBuilder` to resolve
+    /// a named override from, and passing `None` for the hebbian status sender since this test
+    /// has no `status_tx` from `app.build_provider()`) and asserts every expected task name is
+    /// present in the daemon's memory supervisor snapshot. The five #5979 loops are
+    /// config-gated, so the config below explicitly enables each.
     #[tokio::test]
     #[allow(clippy::too_many_lines)]
     async fn daemon_memory_maintenance_loops_registered_on_mem_supervisor() {
         let mock_provider = mock_provider();
         let memory = make_daemon_test_memory().await;
-        let config = Config::default();
+        let mut config = Config::default();
+        config.memory.compression_guidelines.enabled = true;
+        config.memory.tree.enabled = true;
+        config.memory.hebbian.enabled = true;
+        config.memory.episodic_consolidation.enabled = true;
+        config.memory.optical_forgetting.enabled = true;
         let cancel = tokio_util::sync::CancellationToken::new();
         let supervisor = zeph_common::TaskSupervisor::new(cancel);
 
@@ -2630,6 +2779,137 @@ mod tests {
                 },
             });
         }
+        {
+            let store = std::sync::Arc::new(memory.sqlite().clone());
+            let guidelines_provider = mock_provider.clone();
+            let token_counter = std::sync::Arc::clone(&memory.token_counter);
+            let guidelines_cfg = config.memory.compression_guidelines.clone();
+            let cancel = supervisor.cancellation_token();
+            supervisor.spawn(zeph_common::TaskDescriptor {
+                name: "mem-guidelines",
+                restart: zeph_common::RestartPolicy::RunOnce,
+                factory: move || {
+                    zeph_memory::start_guidelines_updater(
+                        store.clone(),
+                        guidelines_provider.clone(),
+                        token_counter.clone(),
+                        guidelines_cfg.clone(),
+                        cancel.clone(),
+                    )
+                },
+            });
+        }
+        {
+            let store = std::sync::Arc::new(memory.sqlite().clone());
+            let tree_provider = mock_provider.clone();
+            let tree_cfg = zeph_memory::TreeConsolidationConfig {
+                enabled: config.memory.tree.enabled,
+                sweep_interval_secs: config.memory.tree.sweep_interval_secs,
+                batch_size: config.memory.tree.batch_size,
+                similarity_threshold: config.memory.tree.similarity_threshold,
+                max_level: config.memory.tree.max_level,
+                min_cluster_size: config.memory.tree.min_cluster_size,
+                embed_timeout_secs: config.memory.semantic.embed_timeout_secs,
+            };
+            let cancel = supervisor.cancellation_token();
+            supervisor.spawn(zeph_common::TaskDescriptor {
+                name: "mem-tree-consolidation",
+                restart: zeph_common::RestartPolicy::RunOnce,
+                factory: move || {
+                    zeph_memory::start_tree_consolidation_loop(
+                        store.clone(),
+                        tree_provider.clone(),
+                        tree_cfg.clone(),
+                        cancel.clone(),
+                    )
+                },
+            });
+        }
+        {
+            let store = std::sync::Arc::new(memory.sqlite().clone());
+            let hebbian_consolidation_cfg = zeph_memory::HebbianConsolidationConfig {
+                consolidation_interval_secs: config.memory.hebbian.consolidation_interval_secs,
+                consolidation_threshold: config.memory.hebbian.consolidation_threshold,
+                max_candidates_per_sweep: config.memory.hebbian.max_candidates_per_sweep,
+                consolidation_cooldown_secs: config.memory.hebbian.consolidation_cooldown_secs,
+                consolidation_prompt_timeout_secs: config
+                    .memory
+                    .hebbian
+                    .consolidation_prompt_timeout_secs,
+                consolidation_max_neighbors: config.memory.hebbian.consolidation_max_neighbors,
+            };
+            let hebbian_provider = mock_provider.clone();
+            let cancel = supervisor.cancellation_token();
+            supervisor.spawn(zeph_common::TaskDescriptor {
+                name: "mem-hebbian-consolidation",
+                restart: zeph_common::RestartPolicy::RunOnce,
+                factory: move || {
+                    zeph_memory::spawn_hebbian_consolidation_loop(
+                        store.clone(),
+                        hebbian_consolidation_cfg.clone(),
+                        hebbian_provider.clone(),
+                        None,
+                        cancel.clone(),
+                    )
+                },
+            });
+        }
+        {
+            let store = std::sync::Arc::new(memory.sqlite().clone());
+            let ep_cfg = zeph_memory::EpisodicConsolidationConfig {
+                enabled: config.memory.episodic_consolidation.enabled,
+                consolidation_provider: config
+                    .memory
+                    .episodic_consolidation
+                    .consolidation_provider
+                    .clone(),
+                interval_secs: config.memory.episodic_consolidation.interval_secs,
+                batch_size: config.memory.episodic_consolidation.batch_size,
+                min_age_secs: config.memory.episodic_consolidation.min_age_secs,
+                dedup_jaccard_threshold: config
+                    .memory
+                    .episodic_consolidation
+                    .dedup_jaccard_threshold,
+            };
+            let ep_provider = mock_provider.clone();
+            let ep_qdrant = memory.embedding_store().cloned();
+            let cancel = supervisor.cancellation_token();
+            supervisor.spawn(zeph_common::TaskDescriptor {
+                name: "mem-episodic-consolidation",
+                restart: zeph_common::RestartPolicy::RunOnce,
+                factory: move || {
+                    zeph_memory::start_episodic_consolidation_loop(
+                        store.clone(),
+                        ep_provider.clone(),
+                        ep_cfg.clone(),
+                        ep_qdrant.clone(),
+                        cancel.clone(),
+                    )
+                },
+            });
+        }
+        {
+            let store = std::sync::Arc::new(memory.sqlite().clone());
+            let optical_provider = mock_provider.clone();
+            let optical_cfg = config.memory.optical_forgetting.clone();
+            let forgetting_floor = config.memory.forgetting.forgetting_floor;
+            let cancel = supervisor.cancellation_token();
+            tracing::info_span!("daemon.memory.optical_forgetting.startup").in_scope(|| {
+                supervisor.spawn(zeph_common::TaskDescriptor {
+                    name: "mem-optical-forgetting",
+                    restart: zeph_common::RestartPolicy::RunOnce,
+                    factory: move || {
+                        zeph_memory::start_optical_forgetting_loop(
+                            store.clone(),
+                            optical_provider.clone(),
+                            optical_cfg.clone(),
+                            forgetting_floor,
+                            cancel.clone(),
+                        )
+                    },
+                });
+            });
+        }
 
         let names: std::collections::HashSet<String> = supervisor
             .snapshot()
@@ -2642,6 +2922,11 @@ mod tests {
             "mem-scene-consolidation",
             "mem-consolidation",
             "mem-forgetting",
+            "mem-guidelines",
+            "mem-tree-consolidation",
+            "mem-hebbian-consolidation",
+            "mem-episodic-consolidation",
+            "mem-optical-forgetting",
         ] {
             assert!(
                 names.contains(expected),

--- a/src/serve/deps.rs
+++ b/src/serve/deps.rs
@@ -465,11 +465,12 @@ pub(crate) async fn assemble_serve_deps(
     })
 }
 
-/// Spawns the five ongoing memory-maintenance sweeps (#5914) shared by every `/sessions*` agent:
-/// eviction, tier-promotion, scene-consolidation, consolidation, and forgetting. Extracted from
-/// [`assemble_serve_deps`] to keep that function under clippy's `too_many_lines`; mirrors the
-/// equivalent block in `src/runner.rs`'s CLI/TUI path, `src/acp.rs`'s `build_acp_deps`, and
-/// `src/daemon.rs`'s `run_daemon`.
+/// Spawns the ten ongoing memory-maintenance sweeps shared by every `/sessions*` agent: eviction,
+/// tier-promotion, scene-consolidation, consolidation, forgetting (#5914), plus guidelines,
+/// tree-consolidation, hebbian-consolidation, episodic-consolidation, and optical-forgetting
+/// (#5979). Extracted from [`assemble_serve_deps`] to keep that function under clippy's
+/// `too_many_lines`; mirrors the equivalent block in `src/runner.rs`'s CLI/TUI path,
+/// `src/acp.rs`'s `build_acp_deps`, and `src/daemon.rs`'s `run_daemon`.
 #[allow(clippy::too_many_lines)]
 fn spawn_memory_maintenance_loops(
     app: &crate::bootstrap::AppBuilder,
@@ -604,6 +605,144 @@ fn spawn_memory_maintenance_loops(
             },
         });
     }
+    if config.memory.compression_guidelines.enabled {
+        let store = Arc::new(memory.sqlite().clone());
+        let guidelines_provider = app
+            .build_guidelines_provider()
+            .unwrap_or_else(|| provider.clone());
+        let token_counter = Arc::clone(&memory.token_counter);
+        let guidelines_cfg = config.memory.compression_guidelines.clone();
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
+            name: "mem-guidelines",
+            restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_guidelines_updater(
+                    store.clone(),
+                    guidelines_provider.clone(),
+                    token_counter.clone(),
+                    guidelines_cfg.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    if config.memory.tree.enabled {
+        let store = Arc::new(memory.sqlite().clone());
+        let tree_provider = app
+            .build_tree_consolidation_provider()
+            .unwrap_or_else(|| provider.clone());
+        let tree_cfg = zeph_memory::TreeConsolidationConfig {
+            enabled: config.memory.tree.enabled,
+            sweep_interval_secs: config.memory.tree.sweep_interval_secs,
+            batch_size: config.memory.tree.batch_size,
+            similarity_threshold: config.memory.tree.similarity_threshold,
+            max_level: config.memory.tree.max_level,
+            min_cluster_size: config.memory.tree.min_cluster_size,
+            embed_timeout_secs: config.memory.semantic.embed_timeout_secs,
+        };
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
+            name: "mem-tree-consolidation",
+            restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_tree_consolidation_loop(
+                    store.clone(),
+                    tree_provider.clone(),
+                    tree_cfg.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    if config.memory.hebbian.enabled && config.memory.hebbian.consolidation_interval_secs > 0 {
+        let store = Arc::new(memory.sqlite().clone());
+        let hebbian_consolidation_cfg = zeph_memory::HebbianConsolidationConfig {
+            consolidation_interval_secs: config.memory.hebbian.consolidation_interval_secs,
+            consolidation_threshold: config.memory.hebbian.consolidation_threshold,
+            max_candidates_per_sweep: config.memory.hebbian.max_candidates_per_sweep,
+            consolidation_cooldown_secs: config.memory.hebbian.consolidation_cooldown_secs,
+            consolidation_prompt_timeout_secs: config
+                .memory
+                .hebbian
+                .consolidation_prompt_timeout_secs,
+            consolidation_max_neighbors: config.memory.hebbian.consolidation_max_neighbors,
+        };
+        let hebbian_provider = app
+            .build_hebbian_consolidation_provider()
+            .unwrap_or_else(|| provider.clone());
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
+            name: "mem-hebbian-consolidation",
+            restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::spawn_hebbian_consolidation_loop(
+                    store.clone(),
+                    hebbian_consolidation_cfg.clone(),
+                    hebbian_provider.clone(),
+                    None,
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    if config.memory.episodic_consolidation.enabled {
+        let store = Arc::new(memory.sqlite().clone());
+        let ep_cfg = zeph_memory::EpisodicConsolidationConfig {
+            enabled: config.memory.episodic_consolidation.enabled,
+            consolidation_provider: config
+                .memory
+                .episodic_consolidation
+                .consolidation_provider
+                .clone(),
+            interval_secs: config.memory.episodic_consolidation.interval_secs,
+            batch_size: config.memory.episodic_consolidation.batch_size,
+            min_age_secs: config.memory.episodic_consolidation.min_age_secs,
+            dedup_jaccard_threshold: config.memory.episodic_consolidation.dedup_jaccard_threshold,
+        };
+        let ep_provider = app
+            .build_episodic_consolidation_provider()
+            .unwrap_or_else(|| provider.clone());
+        let ep_qdrant = memory.embedding_store().cloned();
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
+            name: "mem-episodic-consolidation",
+            restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_episodic_consolidation_loop(
+                    store.clone(),
+                    ep_provider.clone(),
+                    ep_cfg.clone(),
+                    ep_qdrant.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    if config.memory.optical_forgetting.enabled {
+        let store = Arc::new(memory.sqlite().clone());
+        let optical_provider = app
+            .build_optical_forgetting_provider()
+            .unwrap_or_else(|| provider.clone());
+        let optical_cfg = config.memory.optical_forgetting.clone();
+        let forgetting_floor = config.memory.forgetting.forgetting_floor;
+        let cancel = supervisor.cancellation_token();
+        tracing::info_span!("serve.memory.optical_forgetting.startup").in_scope(|| {
+            supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
+                name: "mem-optical-forgetting",
+                restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
+                factory: move || {
+                    zeph_memory::start_optical_forgetting_loop(
+                        store.clone(),
+                        optical_provider.clone(),
+                        optical_cfg.clone(),
+                        forgetting_floor,
+                        cancel.clone(),
+                    )
+                },
+            });
+        });
+    }
 }
 
 /// Resolves `[serve] auth_token_vault_key` from the vault. `None` when the key is empty
@@ -732,17 +871,26 @@ mod tests {
         )
     }
 
-    /// Regression test confirming the five #5914 memory-maintenance loops (eviction,
-    /// tier-promotion, scene-consolidation, consolidation, forgetting) are actually spawned by
-    /// `spawn_memory_maintenance_loops` (called from `assemble_serve_deps` at
-    /// `zeph serve-sessions` startup) on the supplied `TaskSupervisor`. Unlike the sibling
-    /// acp.rs/daemon.rs coverage — which must reconstruct the block inline since it isn't
-    /// extracted there — `spawn_memory_maintenance_loops` is already its own narrowly-scoped
-    /// function, and `AppBuilder::for_test` lets this test call the real, shipped production
-    /// code directly rather than a copy of it.
+    /// Regression test confirming all ten memory-maintenance loops (eviction, tier-promotion,
+    /// scene-consolidation, consolidation, forgetting — #5914; plus guidelines,
+    /// tree-consolidation, hebbian-consolidation, episodic-consolidation, optical-forgetting —
+    /// #5979) are actually spawned by `spawn_memory_maintenance_loops` (called from
+    /// `assemble_serve_deps` at `zeph serve-sessions` startup) on the supplied `TaskSupervisor`.
+    /// The five #5979 loops are config-gated (unlike the unconditional first five), so the test
+    /// config below explicitly enables each — mirrors production behavior with those settings
+    /// on. Unlike the sibling acp.rs/daemon.rs coverage — which must reconstruct the block
+    /// inline since it isn't extracted there — `spawn_memory_maintenance_loops` is already its
+    /// own narrowly-scoped function, and `AppBuilder::for_test` lets this test call the real,
+    /// shipped production code directly rather than a copy of it.
     #[tokio::test]
-    async fn spawn_memory_maintenance_loops_registers_all_five_tasks() {
-        let app = crate::bootstrap::AppBuilder::for_test(zeph_core::config::Config::default());
+    async fn spawn_memory_maintenance_loops_registers_all_ten_tasks() {
+        let mut config = zeph_core::config::Config::default();
+        config.memory.compression_guidelines.enabled = true;
+        config.memory.tree.enabled = true;
+        config.memory.hebbian.enabled = true;
+        config.memory.episodic_consolidation.enabled = true;
+        config.memory.optical_forgetting.enabled = true;
+        let app = crate::bootstrap::AppBuilder::for_test(config);
         let memory = make_memory().await;
         let provider = AnyProvider::Mock(zeph_llm::mock::MockProvider::default());
         let core = crate::acp::SharedCore {
@@ -770,10 +918,66 @@ mod tests {
             "mem-scene-consolidation",
             "mem-consolidation",
             "mem-forgetting",
+            "mem-guidelines",
+            "mem-tree-consolidation",
+            "mem-hebbian-consolidation",
+            "mem-episodic-consolidation",
+            "mem-optical-forgetting",
         ] {
             assert!(
                 names.contains(expected),
                 "expected {expected} registered by spawn_memory_maintenance_loops, got {names:?}"
+            );
+        }
+    }
+
+    /// #5979 regression: with `Config::default()` (the five new `[memory.*] enabled` flags all
+    /// default to `false`), `spawn_memory_maintenance_loops` must NOT register any of the five
+    /// newly-gated loops, while the five unconditional loops from #5914 must still fire. Sibling
+    /// of `spawn_memory_maintenance_loops_registers_all_ten_tasks` above, which only exercises
+    /// the enabled-flags path — this closes the gap where an inverted or missing `if` guard
+    /// would otherwise slip through undetected, since this is the one file among the three
+    /// #5979 call sites where the test exercises the real production gating logic directly
+    /// rather than a hand-reconstructed copy of it.
+    #[tokio::test]
+    async fn spawn_memory_maintenance_loops_gates_the_five_new_tasks_off_by_default() {
+        let app = crate::bootstrap::AppBuilder::for_test(zeph_core::config::Config::default());
+        let memory = make_memory().await;
+        let core = make_test_core(memory);
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let supervisor = zeph_common::task_supervisor::TaskSupervisor::new(cancel);
+
+        spawn_memory_maintenance_loops(&app, &core, &supervisor);
+
+        let names: std::collections::HashSet<String> = supervisor
+            .snapshot()
+            .into_iter()
+            .map(|s| s.name.to_string())
+            .collect();
+        for expected in [
+            "mem-eviction",
+            "mem-tier-promotion",
+            "mem-scene-consolidation",
+            "mem-consolidation",
+            "mem-forgetting",
+        ] {
+            assert!(
+                names.contains(expected),
+                "expected {expected} registered by spawn_memory_maintenance_loops even with \
+                 Config::default(), got {names:?}"
+            );
+        }
+        for absent in [
+            "mem-guidelines",
+            "mem-tree-consolidation",
+            "mem-hebbian-consolidation",
+            "mem-episodic-consolidation",
+            "mem-optical-forgetting",
+        ] {
+            assert!(
+                !names.contains(absent),
+                "expected {absent} NOT registered by spawn_memory_maintenance_loops under \
+                 Config::default() (all five new loops default to disabled), got {names:?}"
             );
         }
     }


### PR DESCRIPTION
## Summary

- Guidelines extraction (`mem-guidelines`), tree-consolidation (`mem-tree-consolidation`), hebbian-consolidation (`mem-hebbian-consolidation`), episodic-consolidation (`mem-episodic-consolidation`), and optical-forgetting (`mem-optical-forgetting`) were only spawned via `src/runner.rs`'s `TaskSupervisor` — the CLI/TUI entry point. ACP, daemon, and serve/gateway sessions never ran these sweeps regardless of config, a partial-parity gap left after #5914/#5978 wired the other 5 loops (eviction, tier-promotion, scene-consolidation, consolidation, forgetting).
- Wires all 5 remaining loops into `src/acp.rs`, `src/daemon.rs`, and `src/serve/deps.rs`, mirroring `runner.rs`'s config-gated construction field-for-field (each loop gated by its own `[memory.*] enabled` flag, provider fallback via `app.build_*_provider().unwrap_or_else(|| provider.clone())`).
- Extends the existing per-entry-point regression tests (`acp_memory_maintenance_loops_registered_on_connection_supervisor`, `daemon_memory_maintenance_loops_registered_on_mem_supervisor`, `spawn_memory_maintenance_loops_registers_all_ten_tasks` in `serve/deps.rs`) with the 5 new loop names, plus a new negative-case test (`spawn_memory_maintenance_loops_gates_the_five_new_tasks_off_by_default`) confirming the 5 new loops stay off under `Config::default()` while the original 5 unconditional loops still fire.

`src/runner.rs` (the reference implementation) is untouched.

Closes #5979

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph --features full -E 'test(memory_maintenance_loops) or test(spawn_memory_maintenance_loops_registers)'` — 4/4 pass
- [x] Config-gating conditions diffed against `runner.rs` for parity (including hebbian's compound `enabled && consolidation_interval_secs > 0` guard)
- [x] `CHANGELOG.md` updated under `[Unreleased]`