### PR TITLE
test: guard workspace linker_messages=allow against silent removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `--force` reaching `WorktreeManager` with correct semantics). Previously only the
   disabled-subsystem `None` short-circuit had coverage, via `zeph-commands`'
   `NullAgent`-backed tests (#6142).
+- `tests/workspace_lints.rs`: added a guard test asserting
+  `workspace.lints.rust.linker_messages` stays `"allow"` in root `Cargo.toml`, closing a CI
+  blind spot where an accidental removal would only surface on a manual `ci-non-linux.yml`
+  macOS/arm64 run or the next tagged release build, not on any automated per-PR check (#5961).
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,6 +203,11 @@ unsafe_code = "deny"
 # scoped to it. Accepted tradeoff: linker *errors* still fail the build; only
 # non-fatal linker diagnostics are suppressed. All other rustc/clippy/rustdoc
 # warnings remain denied. See #5895.
+# `tests/workspace_lints.rs` guards this line's presence/value on every PR via
+# Linux CI (ci.yml) — it only verifies the config value, not actual linker
+# behavior. Verifying the real linker behavior on macOS/arm64 still requires
+# either a manual `ci-non-linux.yml` workflow_dispatch run or the next tagged
+# `release.yml` build. See #5961.
 linker_messages = "allow"
 
 [workspace.lints.clippy]

--- a/tests/workspace_lints.rs
+++ b/tests/workspace_lints.rs
@@ -1,0 +1,36 @@
+//! Guards workspace-level lint configuration in the root `Cargo.toml` that has
+//! no automated coverage from platform-specific CI runners (see #5961).
+
+/// `workspace.lints.rust.linker_messages` must stay `"allow"`.
+///
+/// `ci.yml` (the workflow gating every push/PR to `main`) is Linux-only, and
+/// `ci-non-linux.yml` — the workflow that builds on macOS/arm64 and would
+/// otherwise catch a regression here — only runs on manual `workflow_dispatch`.
+/// Without this test, an accidental removal of the `allow` would stay green on
+/// every PR and only surface as a build failure on the next manual macOS run
+/// or tagged release build. This test inspects the TOML content directly, so
+/// it runs on any OS, including Linux CI.
+#[test]
+fn workspace_lints_keep_linker_messages_allowed() {
+    let manifest_path = concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml");
+    let manifest = std::fs::read_to_string(manifest_path).expect("read root Cargo.toml");
+    let parsed: toml::Table = manifest.parse().expect("parse root Cargo.toml as TOML");
+
+    let linker_messages = parsed
+        .get("workspace")
+        .and_then(|w| w.get("lints"))
+        .and_then(|l| l.get("rust"))
+        .and_then(|r| r.get("linker_messages"))
+        .and_then(|v| v.as_str());
+
+    assert_eq!(
+        linker_messages,
+        Some("allow"),
+        "workspace.lints.rust.linker_messages must stay \"allow\" (see #5961, #5895): \
+         it suppresses Apple ld's arm64-only __eh_frame section warning that \
+         build.warnings = \"deny\" (.cargo/config.toml) would otherwise escalate to a hard \
+         build failure on macOS/arm64. ci.yml (the PR/push gate) is Linux-only and cannot \
+         detect this in the linker itself — this test is the only automated per-PR guard. \
+         Do not remove this assertion without re-reading #5961."
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `tests/workspace_lints.rs`, an integration test in the root `zeph` binary crate that parses root `Cargo.toml` (via the existing `toml` dependency) and asserts `workspace.lints.rust.linker_messages == "allow"`.
- Adds a doc-comment note above the lint line in `Cargo.toml` pointing to the new guard test and its limitations.
- Updates `CHANGELOG.md`.

## Why

PR #5960 added `linker_messages = "allow"` to unblock macOS/arm64 builds against Apple ld's `__eh_frame section too large` warning under `build.warnings = "deny"`. That line has no automated protection: `ci-non-linux.yml` (which builds on macOS and would catch a regression) only runs on manual `workflow_dispatch`, and `ci.yml` (which gates every PR) is deliberately Linux-only. An accidental removal would stay green on every PR and only surface the next time someone manually dispatches `ci-non-linux.yml` or cuts a tagged release.

The new test closes that blind spot by checking the config value directly, so it runs on every PR via `ci.yml`'s Linux runners without needing a macOS machine.

Closes #5961

## Test plan

- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph -E 'test(workspace_lints)'` — passes
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy -p zeph --profile ci --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] Verified the test fails when `linker_messages` is changed or removed (negative-control test, reverted)