### PR TITLE
fix(commands): close command-list drift between COMMANDS, registries, and TUI autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   in. No live leak existed before this fix (audited: `--migrate-config` is text-based, the
   `--init` wizard never populates these fields with raw secrets, and the runtime types have no
   serialize-to-output path today) — this closes the latent risk for any future caller.
+- `zeph-commands`/`zeph-core`/`zeph-tui`: `/help` and TUI slash autocomplete were both
+  hand-maintained lists that had drifted from the real command registrations (#5987, #5875).
+  `/conv`, `/cocoon`, `/quit`, and `/worktree` were dispatchable but missing from
+  `zeph_commands::COMMANDS`, hiding them from `/help`; added the four missing entries.
+  `Agent::run`'s two command-registry constructions (session/debug and agent-command) are now
+  extracted into `zeph_commands::build_session_debug_registry`/`build_agent_command_registry`
+  (`crates/zeph-core/src/agent/slash_commands.rs`) so a new regression test
+  (`commands_rs_drift_tests`) can assert every registered handler has a matching `COMMANDS`
+  entry, closing the door on this recurring drift class. Separately, `zeph-tui`'s `/`-triggered
+  autocomplete (`SlashAutocompleteState`/`filter_commands`) never sourced from
+  `zeph_commands::COMMANDS` at all, so every channel-agnostic `AgentAccess` command
+  (`/model`, `/provider`, `/skill`, `/policy`, `/think-tokens`, `/reasoning-effort`, etc.) was
+  dispatchable when typed in full but never suggested. Added `TuiCommand::SendVerbatim`/
+  `TuiCommand::PrefillVerbatim` and `zeph_tui::command::zeph_commands_entries()`, which
+  projects `zeph_commands::COMMANDS` into `CommandEntry`s and merges them into
+  `filter_commands`, so future `AgentAccess` commands get TUI autocomplete automatically
+  instead of requiring a parallel hand-authored registration. Commands whose bare (no-argument)
+  form is not a valid default (e.g. `/image <path>`, `/feedback <skill> <message>`) prefill the
+  input for the user to complete instead of submitting an incomplete command, mirroring the
+  existing `*Prompt` variants' behavior. Deduplicated against existing hand-authored entries
+  that already cover the identical bare command; entries gated behind a Cargo feature that is
+  actually unified with this crate's own feature of the same name (currently only `cocoon`)
+  are excluded when that feature is off, so a feature-off build cannot show a dead command in
+  autocomplete.
 - `zeph-orchestration`/`zeph-subagent`/`zeph-core`: `TaskNode::network_scope: Deny` was
   advisory-only — the field was never read at dispatch time, so a planner-emitted
   `network_scope: Deny` silently left a task's network egress unrestricted (spec

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11216,6 +11216,7 @@ dependencies = [
  "tree-sitter-typescript",
  "tree-sitter-yaml",
  "unicode-width",
+ "zeph-commands",
  "zeph-common",
  "zeph-config",
  "zeph-core",

--- a/crates/zeph-commands/src/commands.rs
+++ b/crates/zeph-commands/src/commands.rs
@@ -90,6 +90,13 @@ pub const COMMANDS: &[CommandInfo] = &[
         feature_gate: None,
     },
     CommandInfo {
+        name: "/quit",
+        args: "",
+        description: "Exit the agent (alias for /exit)",
+        category: SlashCategory::Session,
+        feature_gate: None,
+    },
+    CommandInfo {
         name: "/new",
         args: "[--no-digest] [--keep-plan]",
         description: "Start a new conversation (reset context, preserve memory and MCP)",
@@ -130,6 +137,13 @@ pub const COMMANDS: &[CommandInfo] = &[
         description: "Show a recap of the current or previous session",
         category: SlashCategory::Session,
         feature_gate: None,
+    },
+    CommandInfo {
+        name: "/conv",
+        args: "[list | show <id> | resume <id> | fork <id>]",
+        description: "List, inspect, resume, or fork durable conversation-sessions",
+        category: SlashCategory::Session,
+        feature_gate: Some("session"),
     },
     // --- Configuration (model/provider) ---
     CommandInfo {
@@ -234,6 +248,13 @@ pub const COMMANDS: &[CommandInfo] = &[
         feature_gate: None,
     },
     CommandInfo {
+        name: "/cocoon",
+        args: "[status | models]",
+        description: "Inspect Cocoon sidecar (status, models)",
+        category: SlashCategory::Integration,
+        feature_gate: Some("cocoon"),
+    },
+    CommandInfo {
         name: "/image",
         args: "<path>",
         description: "Attach an image to the next message",
@@ -296,6 +317,13 @@ pub const COMMANDS: &[CommandInfo] = &[
         name: "/scope",
         args: "[list [task_type]]",
         description: "List configured capability scopes (spec 050)",
+        category: SlashCategory::Advanced,
+        feature_gate: None,
+    },
+    CommandInfo {
+        name: "/worktree",
+        args: "list | clean [--force]",
+        description: "List or clean the live session's git worktrees",
         category: SlashCategory::Advanced,
         feature_gate: None,
     },

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -534,27 +534,7 @@ impl<C: Channel> Agent<C> {
             // null_agent must be declared before reg so it lives longer (LIFO drop order).
             let mut null_agent = zeph_commands::NullAgent;
             let registry_handled = {
-                use zeph_commands::CommandRegistry;
-                use zeph_commands::handlers::debug::{
-                    DebugDumpCommand, DumpFormatCommand, LogCommand,
-                };
-                use zeph_commands::handlers::help::HelpCommand;
-                use zeph_commands::handlers::session::{
-                    ClearCommand, ClearQueueCommand, ExitCommand, QuitCommand, ResetCommand,
-                };
-
-                let mut reg = CommandRegistry::new();
-                reg.register(ExitCommand);
-                reg.register(QuitCommand);
-                reg.register(ClearCommand);
-                reg.register(ResetCommand);
-                reg.register(ClearQueueCommand);
-                reg.register(LogCommand);
-                reg.register(DebugDumpCommand);
-                reg.register(DumpFormatCommand);
-                reg.register(HelpCommand);
-                #[cfg(test)]
-                reg.register(test_stubs::TestErrorCommand);
+                let reg = slash_commands::build_session_debug_registry();
 
                 let mut ctx = zeph_commands::CommandContext {
                     sink: &mut sink_adapter,
@@ -589,83 +569,7 @@ impl<C: Channel> Agent<C> {
             let agent_result: Option<
                 Result<zeph_commands::CommandOutput, zeph_commands::CommandError>,
             > = if session_reg_missed {
-                use zeph_commands::CommandRegistry;
-                use zeph_commands::handlers::{
-                    acp::AcpCommand,
-                    agent_cmd::AgentCommand,
-                    agents_fleet::AgentsFleetCommand,
-                    caveman::CavemanCommand,
-                    checkpoint::{RedoCommand, UndoCommand},
-                    compaction::{CompactCommand, NewConversationCommand, RecapCommand},
-                    conv::ConvCommand,
-                    experiment::ExperimentCommand,
-                    goal::GoalCommand,
-                    loop_cmd::LoopCommand,
-                    lsp::LspCommand,
-                    mcp::McpCommand,
-                    memory::{
-                        GraphCommand, GuidelinesCommand, KnowledgeSlashCommand, MemoryCommand,
-                    },
-                    misc::{CacheStatsCommand, ImageCommand, NotifyTestCommand},
-                    model::{ModelCommand, ProviderCommand},
-                    plan::PlanCommand,
-                    plugins::PluginsCommand,
-                    policy::PolicyCommand,
-                    reasoning_effort::ReasoningEffortCommand,
-                    scheduler::SchedulerCommand,
-                    skill::{FeedbackCommand, SkillCommand, SkillsCommand},
-                    status::{FocusCommand, GuardrailCommand, SideQuestCommand, StatusCommand},
-                    think_tokens::ThinkTokensCommand,
-                    trajectory::{ScopeCommand, TrajectoryCommand},
-                    worktree::WorktreeCommand,
-                };
-
-                let mut agent_reg = CommandRegistry::new();
-                agent_reg.register(CavemanCommand);
-                agent_reg.register(MemoryCommand);
-                agent_reg.register(GraphCommand);
-                agent_reg.register(KnowledgeSlashCommand);
-                agent_reg.register(GuidelinesCommand);
-                agent_reg.register(ModelCommand);
-                agent_reg.register(ProviderCommand);
-                agent_reg.register(ThinkTokensCommand);
-                agent_reg.register(ReasoningEffortCommand);
-                // Phase 6 migrations: /skill, /skills, /feedback use clone-before-await pattern.
-                agent_reg.register(SkillCommand);
-                agent_reg.register(SkillsCommand);
-                agent_reg.register(FeedbackCommand);
-                agent_reg.register(McpCommand);
-                agent_reg.register(PolicyCommand);
-                agent_reg.register(SchedulerCommand);
-                agent_reg.register(LspCommand);
-                // Phase 4 migrations (Send-safe commands):
-                agent_reg.register(CacheStatsCommand);
-                agent_reg.register(ImageCommand);
-                agent_reg.register(NotifyTestCommand);
-                agent_reg.register(StatusCommand);
-                agent_reg.register(GuardrailCommand);
-                agent_reg.register(FocusCommand);
-                agent_reg.register(SideQuestCommand);
-                agent_reg.register(AgentCommand);
-                agent_reg.register(AgentsFleetCommand);
-                // Phase 5 migrations (Send-compatible):
-                agent_reg.register(CompactCommand);
-                agent_reg.register(NewConversationCommand);
-                agent_reg.register(RecapCommand);
-                agent_reg.register(ExperimentCommand);
-                agent_reg.register(PlanCommand);
-                agent_reg.register(LoopCommand);
-                agent_reg.register(PluginsCommand);
-                agent_reg.register(AcpCommand);
-                #[cfg(feature = "cocoon")]
-                agent_reg.register(zeph_commands::handlers::cocoon::CocoonCommand);
-                agent_reg.register(TrajectoryCommand);
-                agent_reg.register(ScopeCommand);
-                agent_reg.register(GoalCommand);
-                agent_reg.register(UndoCommand);
-                agent_reg.register(RedoCommand);
-                agent_reg.register(ConvCommand);
-                agent_reg.register(WorktreeCommand);
+                let agent_reg = slash_commands::build_agent_command_registry();
 
                 let mut ctx = zeph_commands::CommandContext {
                     sink: &mut agent_null_sink,

--- a/crates/zeph-core/src/agent/slash_commands.rs
+++ b/crates/zeph-core/src/agent/slash_commands.rs
@@ -675,6 +675,122 @@ impl<C: crate::channel::Channel> Agent<C> {
     }
 }
 
+/// Builds the phase-1 (session/debug) command registry used by [`Agent::run`]: handlers
+/// that only need `ChannelSink`/`DebugAccess`/`MessageAccess`/`SessionAccess`, not
+/// `&mut Agent<C>` itself.
+///
+/// Extracted into its own function (rather than inlined in `run`) so the exact set of
+/// registered handlers can be inspected by tests without duplicating the `.register()`
+/// call list — see `commands_rs_drift_tests` for the regression guard this enables
+/// against `zeph_commands::COMMANDS` silently drifting from the real registrations (#5987).
+pub(crate) fn build_session_debug_registry<'ctx>()
+-> zeph_commands::CommandRegistry<zeph_commands::CommandContext<'ctx>> {
+    use zeph_commands::CommandRegistry;
+    use zeph_commands::handlers::debug::{DebugDumpCommand, DumpFormatCommand, LogCommand};
+    use zeph_commands::handlers::help::HelpCommand;
+    use zeph_commands::handlers::session::{
+        ClearCommand, ClearQueueCommand, ExitCommand, QuitCommand, ResetCommand,
+    };
+
+    let mut reg = CommandRegistry::new();
+    reg.register(ExitCommand);
+    reg.register(QuitCommand);
+    reg.register(ClearCommand);
+    reg.register(ResetCommand);
+    reg.register(ClearQueueCommand);
+    reg.register(LogCommand);
+    reg.register(DebugDumpCommand);
+    reg.register(DumpFormatCommand);
+    reg.register(HelpCommand);
+    #[cfg(test)]
+    reg.register(super::test_stubs::TestErrorCommand);
+    reg
+}
+
+/// Builds the phase-2 (agent-command) registry used by [`Agent::run`]: handlers that
+/// need `&mut Agent<C>` directly.
+///
+/// See [`build_session_debug_registry`] for why this is extracted.
+pub(crate) fn build_agent_command_registry<'ctx>()
+-> zeph_commands::CommandRegistry<zeph_commands::CommandContext<'ctx>> {
+    use zeph_commands::CommandRegistry;
+    use zeph_commands::handlers::{
+        acp::AcpCommand,
+        agent_cmd::AgentCommand,
+        agents_fleet::AgentsFleetCommand,
+        caveman::CavemanCommand,
+        checkpoint::{RedoCommand, UndoCommand},
+        compaction::{CompactCommand, NewConversationCommand, RecapCommand},
+        conv::ConvCommand,
+        experiment::ExperimentCommand,
+        goal::GoalCommand,
+        loop_cmd::LoopCommand,
+        lsp::LspCommand,
+        mcp::McpCommand,
+        memory::{GraphCommand, GuidelinesCommand, KnowledgeSlashCommand, MemoryCommand},
+        misc::{CacheStatsCommand, ImageCommand, NotifyTestCommand},
+        model::{ModelCommand, ProviderCommand},
+        plan::PlanCommand,
+        plugins::PluginsCommand,
+        policy::PolicyCommand,
+        reasoning_effort::ReasoningEffortCommand,
+        scheduler::SchedulerCommand,
+        skill::{FeedbackCommand, SkillCommand, SkillsCommand},
+        status::{FocusCommand, GuardrailCommand, SideQuestCommand, StatusCommand},
+        think_tokens::ThinkTokensCommand,
+        trajectory::{ScopeCommand, TrajectoryCommand},
+        worktree::WorktreeCommand,
+    };
+
+    let mut agent_reg = CommandRegistry::new();
+    agent_reg.register(CavemanCommand);
+    agent_reg.register(MemoryCommand);
+    agent_reg.register(GraphCommand);
+    agent_reg.register(KnowledgeSlashCommand);
+    agent_reg.register(GuidelinesCommand);
+    agent_reg.register(ModelCommand);
+    agent_reg.register(ProviderCommand);
+    agent_reg.register(ThinkTokensCommand);
+    agent_reg.register(ReasoningEffortCommand);
+    // Phase 6 migrations: /skill, /skills, /feedback use clone-before-await pattern.
+    agent_reg.register(SkillCommand);
+    agent_reg.register(SkillsCommand);
+    agent_reg.register(FeedbackCommand);
+    agent_reg.register(McpCommand);
+    agent_reg.register(PolicyCommand);
+    agent_reg.register(SchedulerCommand);
+    agent_reg.register(LspCommand);
+    // Phase 4 migrations (Send-safe commands):
+    agent_reg.register(CacheStatsCommand);
+    agent_reg.register(ImageCommand);
+    agent_reg.register(NotifyTestCommand);
+    agent_reg.register(StatusCommand);
+    agent_reg.register(GuardrailCommand);
+    agent_reg.register(FocusCommand);
+    agent_reg.register(SideQuestCommand);
+    agent_reg.register(AgentCommand);
+    agent_reg.register(AgentsFleetCommand);
+    // Phase 5 migrations (Send-compatible):
+    agent_reg.register(CompactCommand);
+    agent_reg.register(NewConversationCommand);
+    agent_reg.register(RecapCommand);
+    agent_reg.register(ExperimentCommand);
+    agent_reg.register(PlanCommand);
+    agent_reg.register(LoopCommand);
+    agent_reg.register(PluginsCommand);
+    agent_reg.register(AcpCommand);
+    #[cfg(feature = "cocoon")]
+    agent_reg.register(zeph_commands::handlers::cocoon::CocoonCommand);
+    agent_reg.register(TrajectoryCommand);
+    agent_reg.register(ScopeCommand);
+    agent_reg.register(GoalCommand);
+    agent_reg.register(UndoCommand);
+    agent_reg.register(RedoCommand);
+    agent_reg.register(ConvCommand);
+    agent_reg.register(WorktreeCommand);
+    agent_reg
+}
+
 struct StatusMetrics {
     api_calls: u64,
     prompt_tokens: u64,

--- a/crates/zeph-core/src/agent/tests/commands_rs_drift_tests.rs
+++ b/crates/zeph-core/src/agent/tests/commands_rs_drift_tests.rs
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Regression guard for #5987: `zeph_commands::COMMANDS` (the static list `/help` renders
+//! from) has drifted from the real `CommandRegistry` registrations in `Agent::run` at
+//! least 4 times. This asserts every handler registered in either of the two production
+//! registries (`build_session_debug_registry`, `build_agent_command_registry`) has a
+//! matching name in `zeph_commands::COMMANDS`, so a future handler addition without a
+//! matching `COMMANDS` entry fails CI instead of silently hiding the command from `/help`.
+
+use crate::agent::slash_commands::{build_agent_command_registry, build_session_debug_registry};
+
+/// Registered in `#[cfg(test)]` builds only (`build_session_debug_registry`) to exercise
+/// the non-fatal `CommandError` dispatch path — not a real user-facing command, so it is
+/// intentionally excluded from the drift check below.
+const TEST_ONLY_STUB_NAME: &str = "/test-error";
+
+#[test]
+fn every_registered_command_has_a_commands_rs_entry() {
+    let mut missing = Vec::new();
+
+    for info in build_session_debug_registry().list() {
+        if info.name == TEST_ONLY_STUB_NAME {
+            continue;
+        }
+        if !zeph_commands::COMMANDS.iter().any(|c| c.name == info.name) {
+            missing.push(info.name);
+        }
+    }
+    for info in build_agent_command_registry().list() {
+        if !zeph_commands::COMMANDS.iter().any(|c| c.name == info.name) {
+            missing.push(info.name);
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "handlers registered but missing from zeph_commands::COMMANDS (would be hidden \
+         from /help — see #5987): {missing:?}"
+    );
+}

--- a/crates/zeph-core/src/agent/tests/mod.rs
+++ b/crates/zeph-core/src/agent/tests/mod.rs
@@ -6,6 +6,8 @@ pub mod agent_tests; // path-preserving — DO NOT rename (used by 24+ modules v
 #[cfg(test)]
 mod bare_mode_shutdown_tests;
 #[cfg(test)]
+mod commands_rs_drift_tests;
+#[cfg(test)]
 mod compaction_e2e;
 #[cfg(test)]
 mod confirmation_propagation_tests;

--- a/crates/zeph-tui/Cargo.toml
+++ b/crates/zeph-tui/Cargo.toml
@@ -46,6 +46,7 @@ tree-sitter-toml-ng.workspace = true
 tree-sitter-typescript.workspace = true
 tree-sitter-yaml.workspace = true
 unicode-width.workspace = true
+zeph-commands.workspace = true
 zeph-common.workspace = true
 zeph-config.workspace = true
 zeph-core.workspace = true

--- a/crates/zeph-tui/src/app/reducer.rs
+++ b/crates/zeph-tui/src/app/reducer.rs
@@ -897,6 +897,15 @@ pub(crate) fn reduce(app: &mut App, action: Action) -> Vec<Effect> {
                 TuiCommand::SendClearQueue => {
                     return vec![Effect::SendUserInput("/clear-queue".to_owned())];
                 }
+                TuiCommand::SendVerbatim(text) => {
+                    return vec![Effect::SendUserInput(text.clone())];
+                }
+                TuiCommand::PrefillVerbatim(text) => {
+                    app.sessions.current_mut().input.clear();
+                    app.sessions.current_mut().input.push_str(text);
+                    app.sessions.current_mut().cursor_position = app.char_count();
+                    return vec![];
+                }
 
                 _ => {}
             }
@@ -1741,6 +1750,37 @@ mod tests {
         assert_eq!(
             effects,
             vec![Effect::SendUserInput("/clear-queue".to_owned())]
+        );
+    }
+
+    #[test]
+    fn dispatch_send_verbatim_sends_slash_command() {
+        let (mut app, _rx) = make_app();
+        let effects = reduce(
+            &mut app,
+            Action::Dispatch(TuiCommand::SendVerbatim("/model".to_owned())),
+        );
+        assert_eq!(effects, vec![Effect::SendUserInput("/model".to_owned())]);
+    }
+
+    #[test]
+    fn dispatch_prefill_verbatim_fills_input_without_submitting() {
+        // #5875 F1: mandatory-argument zeph_commands entries (e.g. /image) must prefill
+        // rather than submit an incomplete command.
+        let (mut app, _rx) = make_app();
+        let effects = reduce(
+            &mut app,
+            Action::Dispatch(TuiCommand::PrefillVerbatim("/image ".to_owned())),
+        );
+        assert!(effects.is_empty());
+        assert_eq!(app.sessions.current().input, "/image ");
+        assert!(
+            app.sessions
+                .current()
+                .messages
+                .iter()
+                .all(|m| m.role != MessageRole::User),
+            "prefilled command must not be sent as a chat message"
         );
     }
 

--- a/crates/zeph-tui/src/command.rs
+++ b/crates/zeph-tui/src/command.rs
@@ -162,6 +162,22 @@ pub enum TuiCommand {
     SubagentSidebarUp,
     /// Send `/clear-queue` to the agent input channel (Ctrl+K in Insert mode).
     SendClearQueue,
+    /// Send an arbitrary slash command's bare text verbatim to the agent input channel.
+    ///
+    /// Used for [`zeph_commands::COMMANDS`] entries that have no dedicated hand-authored
+    /// `TuiCommand` variant (#5875): every such command gets autocomplete for free instead
+    /// of requiring a matching enum variant and reducer arm to be added by hand. Only used
+    /// for commands whose bare (no-argument) form is a valid, useful default — see
+    /// [`crate::command::zeph_commands_entries`].
+    SendVerbatim(String),
+    /// Fill the input box with an arbitrary slash command's text without submitting it.
+    ///
+    /// Counterpart to [`TuiCommand::SendVerbatim`] for [`zeph_commands::COMMANDS`] entries
+    /// whose argument is required (e.g. `/image <path>`) — submitting the bare command would
+    /// just produce a usage error, so this instead prefills the input for the user to
+    /// complete, mirroring the existing `*Prompt` variants' `prefill_input` behavior (#5875
+    /// F1).
+    PrefillVerbatim(String),
 }
 
 /// Metadata for a single entry in the command palette.
@@ -859,6 +875,118 @@ fn build_knowledge_commands() -> Vec<CommandEntry> {
     ]
 }
 
+/// Top-level command names already covered — exactly, with no arguments — by an existing
+/// hand-authored [`TuiCommand`] entry in [`command_registry`], [`daemon_command_registry`],
+/// or [`extra_command_registry`].
+///
+/// Excluded from [`zeph_commands_entries`] so the merged autocomplete list never shows the
+/// same bare invocation twice (#5875). Each comment names the existing entry that already
+/// performs the identical bare command (either by sending the same text, or — for the
+/// locally-rendered view commands — by displaying the same information without a round
+/// trip through the agent).
+///
+/// Every name here must have a real matching `id` in [`command_registry`],
+/// [`daemon_command_registry`], or [`extra_command_registry`] — see the
+/// `zeph_commands_dedup_entries_have_a_real_hand_authored_replacement` test, which fails
+/// loudly if a covering entry is ever renamed or removed without updating this list (#5875
+/// F3). `/clear-queue` was deliberately **not** added here even though a `SendClearQueue`
+/// `TuiCommand` variant exists — that variant is reachable only via the Ctrl+K keybinding
+/// (`crates/zeph-tui/src/app/keys.rs`), not through any `CommandEntry` in the three
+/// registries above, so there is nothing to actually deduplicate against.
+const ZEPH_COMMANDS_DEDUP: &[&str] = &[
+    "/skills",     // skill:list
+    "/mcp",        // mcp:list
+    "/memory",     // memory:stats
+    "/guidelines", // guidelines:view
+    "/log",        // log:status
+    "/undo",       // session:undo
+    "/redo",       // session:redo
+    "/graph",      // graph:stats
+    "/lsp",        // lsp:status
+    "/scheduler",  // scheduler:list
+    "/subagent",   // acp:subagent-spawn (already prefills "/subagent spawn " when empty)
+];
+
+/// Returns `false` only for entries whose `feature_gate` names a Cargo feature that is
+/// unified, via the root binary crate, with this crate's own feature of the same name — and
+/// that feature is disabled in this build.
+///
+/// Every `feature_gate` value in [`zeph_commands::COMMANDS`] is otherwise purely descriptive
+/// (rendered as `[requires: X]` in `/help` text): the underlying `CommandHandler` is
+/// unconditionally registered in `Agent::run` regardless of any Cargo feature with a
+/// matching name (most such names — `"acp"`, `"guardrail"`, `"scheduler"`, `"session"`,
+/// etc. — do not even exist as Cargo features on the relevant crates). `"cocoon"` is the one
+/// exception: `CocoonCommand`'s registration in `crates/zeph-core/src/agent/slash_commands.rs`
+/// really is `#[cfg(feature = "cocoon")]`-gated, and the root `Cargo.toml`'s `cocoon` feature
+/// unifies `zeph-core/cocoon` with this crate's own `cocoon` feature (which already gates
+/// `build_cocoon_commands`), so checking it here faithfully predicts whether `CocoonCommand`
+/// exists in this exact build (#5875 F2) — without this check, a `cocoon`-feature-off build
+/// would still show `/cocoon` in autocomplete and fail when submitted.
+fn command_is_compiled_in_this_build(entry: &zeph_commands::CommandInfo) -> bool {
+    entry.feature_gate != Some("cocoon") || cfg!(feature = "cocoon")
+}
+
+/// Returns the [`CommandEntry`] projection of every [`zeph_commands::COMMANDS`] entry that
+/// has no dedicated hand-authored `TuiCommand` (see `ZEPH_COMMANDS_DEDUP`).
+///
+/// `zeph_commands::COMMANDS` is the canonical, always-up-to-date list of channel-agnostic
+/// `AgentAccess` slash commands (`/model`, `/provider`, `/skill`, `/policy`, etc.) — the
+/// same list `/help` renders from. Projecting it here means a new command registered there
+/// automatically gets TUI autocomplete, instead of requiring a second, hand-authored
+/// `TuiCommand` variant and registry entry that can silently drift out of sync (#5875).
+///
+/// Commands whose `args` hint signals a *required* argument (e.g. `/image <path>`,
+/// `/feedback <skill> <message>`) dispatch [`TuiCommand::PrefillVerbatim`] instead — this
+/// fills the input box with the bare command plus a trailing space for the user to complete,
+/// the same behavior every existing hand-authored `*Prompt` `TuiCommand` variant uses (see
+/// `execute_command` in `app/keys.rs`), rather than submitting an incomplete command that the
+/// handler would just reject. Every other entry dispatches [`TuiCommand::SendVerbatim`] with
+/// the command's bare name (no arguments) — verified against each handler's actual empty-args
+/// behavior (not just the `args` hint text, which is documentation-only and not always
+/// bracket-consistent — e.g. `/goal` and `/worktree` both default sensibly on empty args
+/// despite their hint text not being `[`-wrapped).
+///
+/// Entries whose `feature_gate` corresponds to a real, compile-time-relevant Cargo feature
+/// are excluded when that feature is off in this build (see `command_is_compiled_in_this_build`)
+/// — otherwise a feature-gated command that was never actually registered would still appear
+/// in autocomplete and fail when submitted (#5875 F2).
+///
+/// Lazily initialised and shared for the process lifetime, like [`command_registry`] and
+/// [`extra_command_registry`].
+///
+/// # Examples
+///
+/// ```rust
+/// use zeph_tui::command::zeph_commands_entries;
+///
+/// let entries = zeph_commands_entries();
+/// assert!(entries.iter().any(|e| e.id == "/model"));
+/// // Commands already covered by a hand-authored entry are not duplicated.
+/// assert!(!entries.iter().any(|e| e.id == "/graph"));
+/// ```
+#[must_use]
+pub fn zeph_commands_entries() -> &'static [CommandEntry] {
+    static ENTRIES: std::sync::OnceLock<Vec<CommandEntry>> = std::sync::OnceLock::new();
+    ENTRIES.get_or_init(|| {
+        zeph_commands::COMMANDS
+            .iter()
+            .filter(|c| !ZEPH_COMMANDS_DEDUP.contains(&c.name))
+            .filter(|c| command_is_compiled_in_this_build(c))
+            .map(|c| CommandEntry {
+                id: c.name,
+                label: c.description,
+                category: c.category.as_str(),
+                shortcut: None,
+                command: if c.args.starts_with('<') {
+                    TuiCommand::PrefillVerbatim(format!("{} ", c.name))
+                } else {
+                    TuiCommand::SendVerbatim(c.name.to_owned())
+                },
+            })
+            .collect()
+    })
+}
+
 fn build_extra_commands() -> Vec<CommandEntry> {
     let mut cmds = build_infra_commands();
     cmds.extend(build_agent_plan_commands());
@@ -985,6 +1113,7 @@ pub fn filter_commands(query: &str) -> Vec<&'static CommandEntry> {
     let mut all: Vec<&'static CommandEntry> = command_registry().iter().collect();
     all.extend(daemon_command_registry());
     all.extend(extra_command_registry());
+    all.extend(zeph_commands_entries());
 
     if query.is_empty() {
         return all;
@@ -1065,6 +1194,7 @@ mod tests {
             command_registry().len()
                 + daemon_command_registry().len()
                 + extra_command_registry().len()
+                + zeph_commands_entries().len()
         );
     }
 
@@ -1225,6 +1355,172 @@ mod tests {
         let help = registry.iter().find(|e| e.id == "app:help").unwrap();
         assert_eq!(quit.shortcut, Some("q"));
         assert_eq!(help.shortcut, Some("?"));
+    }
+
+    #[test]
+    fn zeph_commands_entries_includes_previously_invisible_commands() {
+        // #5875: these AgentAccess-routed commands were dispatchable when typed in full but
+        // never appeared in TUI autocomplete because zeph-tui's registry never sourced from
+        // zeph_commands::COMMANDS.
+        let entries = zeph_commands_entries();
+        for name in [
+            "/model",
+            "/provider",
+            "/skill",
+            "/policy",
+            "/think-tokens",
+            "/reasoning-effort",
+            "/status",
+            "/conv",
+        ] {
+            assert!(
+                entries.iter().any(|e| e.id == name),
+                "{name} must appear in zeph_commands_entries()"
+            );
+        }
+    }
+
+    #[test]
+    fn zeph_commands_entries_excludes_dedup_list() {
+        let entries = zeph_commands_entries();
+        for name in ZEPH_COMMANDS_DEDUP {
+            assert!(
+                !entries.iter().any(|e| &e.id == name),
+                "{name} is already covered by a hand-authored TuiCommand and must not be \
+                 duplicated in zeph_commands_entries()"
+            );
+        }
+    }
+
+    #[test]
+    fn zeph_commands_entries_includes_clear_queue_not_a_real_duplicate() {
+        // #5875 F3 fix: /clear-queue was incorrectly in ZEPH_COMMANDS_DEDUP — the only
+        // matching TuiCommand (SendClearQueue) is reachable exclusively via the Ctrl+K
+        // keybinding, with no CommandEntry in any of the three hand-authored registries, so
+        // there was nothing to actually deduplicate against. It must appear here.
+        let entries = zeph_commands_entries();
+        assert!(entries.iter().any(|e| e.id == "/clear-queue"));
+    }
+
+    #[test]
+    fn zeph_commands_dedup_entries_have_a_real_hand_authored_replacement() {
+        // #5875 F3: guards against a dedup'd name silently becoming an orphan (e.g. if the
+        // hand-authored entry it claims to duplicate is later renamed or removed).
+        let mut hand_authored: Vec<&'static CommandEntry> = command_registry().iter().collect();
+        hand_authored.extend(daemon_command_registry());
+        hand_authored.extend(extra_command_registry());
+
+        let expected: &[(&str, &str)] = &[
+            ("/skills", "skill:list"),
+            ("/mcp", "mcp:list"),
+            ("/memory", "memory:stats"),
+            ("/guidelines", "guidelines:view"),
+            ("/log", "log:status"),
+            ("/undo", "session:undo"),
+            ("/redo", "session:redo"),
+            ("/graph", "graph:stats"),
+            ("/lsp", "lsp:status"),
+            ("/scheduler", "scheduler:list"),
+            ("/subagent", "acp:subagent-spawn"),
+        ];
+        assert_eq!(
+            expected.len(),
+            ZEPH_COMMANDS_DEDUP.len(),
+            "this test's `expected` table has drifted out of sync with ZEPH_COMMANDS_DEDUP — \
+             update both together"
+        );
+        for (dedup_name, expected_hand_id) in expected {
+            assert!(
+                ZEPH_COMMANDS_DEDUP.contains(dedup_name),
+                "test out of sync: {dedup_name} is not in ZEPH_COMMANDS_DEDUP"
+            );
+            assert!(
+                hand_authored.iter().any(|e| &e.id == expected_hand_id),
+                "{dedup_name} is in ZEPH_COMMANDS_DEDUP claiming to be covered by \
+                 {expected_hand_id}, but no such hand-authored CommandEntry exists — either \
+                 restore equivalent coverage or remove {dedup_name} from ZEPH_COMMANDS_DEDUP \
+                 so it reappears in autocomplete"
+            );
+        }
+    }
+
+    #[test]
+    fn zeph_commands_entries_prefills_mandatory_arg_commands() {
+        // #5875 F1: commands whose bare form would just produce a usage error must prefill
+        // the input for the user to complete, not submit immediately.
+        let entries = zeph_commands_entries();
+        for name in [
+            "/image",
+            "/feedback",
+            "/skill",
+            "/skill create",
+            "/dump-format",
+            "/loop",
+        ] {
+            let entry = entries
+                .iter()
+                .find(|e| e.id == name)
+                .unwrap_or_else(|| panic!("{name} must appear in zeph_commands_entries()"));
+            assert!(
+                matches!(entry.command, TuiCommand::PrefillVerbatim(_)),
+                "{name} requires an argument and must prefill rather than submit bare"
+            );
+        }
+    }
+
+    #[test]
+    fn zeph_commands_entries_sends_safe_bare_commands_immediately() {
+        // #5875 F1: commands whose bare (no-arg) form is a valid, useful default (verified
+        // against each handler's real empty-args behavior, not just the `args` hint text —
+        // `/goal` and `/worktree` both default sensibly despite non-bracket-wrapped hints)
+        // must still submit immediately.
+        let entries = zeph_commands_entries();
+        for name in ["/model", "/status", "/goal", "/worktree", "/conv"] {
+            let entry = entries
+                .iter()
+                .find(|e| e.id == name)
+                .unwrap_or_else(|| panic!("{name} must appear in zeph_commands_entries()"));
+            assert!(
+                matches!(entry.command, TuiCommand::SendVerbatim(_)),
+                "{name} has a safe bare default and should submit immediately"
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "cocoon")]
+    fn zeph_commands_entries_includes_cocoon_when_feature_enabled() {
+        // #5875 F2.
+        let entries = zeph_commands_entries();
+        assert!(entries.iter().any(|e| e.id == "/cocoon"));
+    }
+
+    #[test]
+    #[cfg(not(feature = "cocoon"))]
+    fn zeph_commands_entries_excludes_cocoon_when_feature_disabled() {
+        // #5875 F2: without this, a cocoon-feature-off build would still show /cocoon in
+        // autocomplete and fail when submitted, since CocoonCommand is never registered.
+        let entries = zeph_commands_entries();
+        assert!(!entries.iter().any(|e| e.id == "/cocoon"));
+    }
+
+    #[test]
+    fn filter_commands_merges_zeph_commands_entries() {
+        let results = filter_commands("model");
+        assert!(results.iter().any(|e| e.id == "/model"));
+    }
+
+    #[test]
+    fn no_duplicate_ids_across_merged_registries() {
+        let all = filter_commands("");
+        let mut seen = std::collections::HashSet::new();
+        for entry in &all {
+            assert!(
+                seen.insert(entry.id),
+                "duplicate command id in merged autocomplete list: {}",
+                entry.id
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `zeph_commands::COMMANDS` was hand-maintained separately from the real `CommandHandler` registrations, hiding `/conv` and `/cocoon` (plus `/quit` and `/worktree`, found by the new regression test) from `/help`. `Agent::run`'s two inline registry constructions are now extracted into `zeph_commands::build_session_debug_registry`/`build_agent_command_registry` so a new drift test can assert every registered handler has a matching `COMMANDS` entry.
- `zeph-tui`'s `/`-triggered slash autocomplete never sourced from `zeph_commands::COMMANDS` at all, so every channel-agnostic `AgentAccess` command (`/model`, `/provider`, `/skill`, `/policy`, `/think-tokens`, `/reasoning-effort`, etc.) was dispatchable in full but never suggested. Added `zeph_tui::command::zeph_commands_entries()`, merged into `filter_commands`, with `TuiCommand::SendVerbatim`/`PrefillVerbatim` dispatch depending on whether the command requires a mandatory argument, deduplicated against existing hand-authored entries, and excluding commands gated behind a Cargo feature that isn't compiled into this build (currently only `cocoon`).

Closes #5987
Closes #5875

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (13252 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked`
- [x] New regression tests: `commands_rs_drift_tests::every_registered_command_has_a_commands_rs_entry`, `zeph_commands_entries_*`, `dispatch_prefill_verbatim_fills_input_without_submitting`, `zeph_commands_dedup_entries_have_a_real_hand_authored_replacement`
- [x] Verified `cocoon`-feature-off build correctly excludes `/cocoon` from autocomplete