### PR TITLE
fix: unify skill/plugin registry disabled-state messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `src/commands/skill.rs`/`src/commands/plugin.rs`: `zeph skill search`/`get` and
+  `zeph plugin search`/`get` printed the correct, actionable FR-004 message
+  (`REGISTRY_NOT_CONFIGURED_MSG`) to stdout when the registry is disabled, then
+  immediately failed with a second, differently-worded `anyhow::bail!` on stderr — and
+  for the plugin subcommands that second message incorrectly said "skill registry"
+  instead of "plugin registry" (#5943). All four call sites now reuse
+  `REGISTRY_NOT_CONFIGURED_MSG` for the bail as well, so stdout and the error both show
+  the same, subsystem-neutral, actionable message.
 - `src/commands/db.rs`: `zeph db migrate` fell back to the raw, unredacted database URL
   in error messages and the migration-status line whenever `redact_url` returned `None`
   — which only means the URL didn't match a recognized credential-bearing shape, not that

--- a/src/commands/plugin.rs
+++ b/src/commands/plugin.rs
@@ -178,7 +178,7 @@ async fn registry_search(config: &zeph_core::config::Config, query: &str) -> any
 
     if !config.skills.registry.enabled {
         println!("{REGISTRY_NOT_CONFIGURED_MSG}");
-        anyhow::bail!("skill registry is not configured");
+        anyhow::bail!("{REGISTRY_NOT_CONFIGURED_MSG}");
     }
 
     let token = resolve_registry_token(config).await?;
@@ -225,7 +225,7 @@ async fn registry_get(
 
     if !config.skills.registry.enabled {
         println!("{REGISTRY_NOT_CONFIGURED_MSG}");
-        anyhow::bail!("skill registry is not configured");
+        anyhow::bail!("{REGISTRY_NOT_CONFIGURED_MSG}");
     }
 
     let token = resolve_registry_token(config).await?;
@@ -374,5 +374,39 @@ mod registry_tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("registry fetch failed"));
+    }
+
+    // ── #5943: disabled-registry bail must match the printed FR-004 message ──
+    //
+    // Regression coverage for the outer `registry_search`/`registry_get` gate (not exercised by
+    // the `_with` tests above, which only drive post-gate logic): before the fix, the bail! used
+    // a hardcoded `"skill registry is not configured"` string — wrong wording for a plugin
+    // subcommand too — that diverged from the `REGISTRY_NOT_CONFIGURED_MSG` printed to stdout
+    // just above it. Asserting exact equality (not just `contains`) pins both wording and future
+    // re-divergence.
+
+    #[tokio::test]
+    async fn registry_search_bails_with_registry_not_configured_msg_when_disabled() {
+        use crate::commands::registry_client::REGISTRY_NOT_CONFIGURED_MSG;
+
+        let config = zeph_core::config::Config::default();
+        assert!(!config.skills.registry.enabled);
+
+        let err = registry_search(&config, "query").await.unwrap_err();
+        assert_eq!(err.to_string(), REGISTRY_NOT_CONFIGURED_MSG);
+    }
+
+    #[tokio::test]
+    async fn registry_get_bails_with_registry_not_configured_msg_when_disabled() {
+        use crate::commands::registry_client::REGISTRY_NOT_CONFIGURED_MSG;
+
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = test_manager(dir.path());
+
+        let config = zeph_core::config::Config::default();
+        assert!(!config.skills.registry.enabled);
+
+        let err = registry_get(&config, &mgr, "acme/x").await.unwrap_err();
+        assert_eq!(err.to_string(), REGISTRY_NOT_CONFIGURED_MSG);
     }
 }

--- a/src/commands/skill.rs
+++ b/src/commands/skill.rs
@@ -496,7 +496,7 @@ async fn registry_search(config: &zeph_core::config::Config, query: &str) -> any
 
     if !config.skills.registry.enabled {
         println!("{REGISTRY_NOT_CONFIGURED_MSG}");
-        anyhow::bail!("skill registry is not configured");
+        anyhow::bail!("{REGISTRY_NOT_CONFIGURED_MSG}");
     }
 
     let token = resolve_registry_token(config).await?;
@@ -544,7 +544,7 @@ async fn registry_get(
 
     if !config.skills.registry.enabled {
         println!("{REGISTRY_NOT_CONFIGURED_MSG}");
-        anyhow::bail!("skill registry is not configured");
+        anyhow::bail!("{REGISTRY_NOT_CONFIGURED_MSG}");
     }
 
     let token = resolve_registry_token(config).await?;
@@ -724,6 +724,49 @@ mod registry_tests {
         .await
         .unwrap_err();
         assert!(err.to_string().contains("registry fetch failed"));
+    }
+
+    // ── #5943: disabled-registry bail must match the printed FR-004 message ──
+    //
+    // Regression coverage for the outer `registry_search`/`registry_get` gate (not exercised by
+    // the `_with` tests above, which only drive post-gate logic): before the fix, the bail! used
+    // a hardcoded `"skill registry is not configured"` string that diverged from the
+    // `REGISTRY_NOT_CONFIGURED_MSG` printed to stdout just above it. Asserting exact equality
+    // (not just `contains`) pins both wording and future re-divergence.
+
+    #[tokio::test]
+    async fn registry_search_bails_with_registry_not_configured_msg_when_disabled() {
+        use crate::commands::registry_client::REGISTRY_NOT_CONFIGURED_MSG;
+
+        let config = zeph_core::config::Config::default();
+        assert!(!config.skills.registry.enabled);
+
+        let err = registry_search(&config, "query").await.unwrap_err();
+        assert_eq!(err.to_string(), REGISTRY_NOT_CONFIGURED_MSG);
+    }
+
+    #[tokio::test]
+    async fn registry_get_bails_with_registry_not_configured_msg_when_disabled() {
+        use crate::commands::registry_client::REGISTRY_NOT_CONFIGURED_MSG;
+
+        let dir = tempfile::tempdir().unwrap();
+        let managed_dir = dir.path().join("managed");
+        let sqlite_path = dir.path().join("test.db");
+        let mgr = zeph_skills::manager::SkillManager::new(managed_dir.clone());
+
+        let config = zeph_core::config::Config::default();
+        assert!(!config.skills.registry.enabled);
+
+        let err = registry_get(
+            &config,
+            &mgr,
+            &managed_dir,
+            sqlite_path.to_str().unwrap(),
+            "acme/x",
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.to_string(), REGISTRY_NOT_CONFIGURED_MSG);
     }
 }
 


### PR DESCRIPTION
## Summary
- `zeph skill search`/`get` and `zeph plugin search`/`get` printed the correct, actionable FR-004 message (`REGISTRY_NOT_CONFIGURED_MSG`) to stdout when the registry is disabled, then immediately failed with a second, mismatched `anyhow::bail!` on stderr — and for the plugin subcommands that second message incorrectly said "skill registry" instead of "plugin registry".
- All four call sites (`src/commands/skill.rs:499,547`, `src/commands/plugin.rs:181,228`) now reuse `REGISTRY_NOT_CONFIGURED_MSG` for the bail as well, so stdout and the propagated error show the same, subsystem-neutral, actionable message. Exit code and zero-network-call gating behavior are unchanged.
- Added regression tests asserting the bail error text equals `REGISTRY_NOT_CONFIGURED_MSG` for both `registry_search`/`registry_get` in each file.

Closes #5943

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins`
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace ...`)
- [x] New regression tests pass under `--features full`