### PR TITLE
test: exercise real production wiring in acp/daemon memory-loop tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing
 
+- `src/acp.rs`/`src/daemon.rs`: the memory-maintenance-loop regression tests
+  (`acp_memory_maintenance_loops_registered_on_connection_supervisor`,
+  `daemon_memory_maintenance_loops_registered_on_mem_supervisor`) reconstructed the
+  spawn blocks inline with a mock `TaskSupervisor` instead of calling the real
+  production wiring path, so a broken or inverted `config.memory.*.enabled` guard in
+  `build_acp_deps`/`run_daemon` would go undetected by either test (#6170). Extracted
+  the wiring into standalone `spawn_acp_memory_maintenance_loops`/
+  `spawn_daemon_memory_maintenance_loops` functions, mirroring the existing
+  `spawn_memory_maintenance_loops` pattern in `src/serve/deps.rs` (#5979); both tests
+  now call the extracted functions directly. No behavior change — all ten loops still
+  spawn identically, gated the same way, via `TaskSupervisor::spawn`.
 - `zeph-llm`: reduced the discoverability of bypassing the Claude no-prefill funnel introduced
   by #6154, and closed a real HTTP-level coverage gap (#6155, #6156). `split_messages`/
   `split_messages_structured` in `crates/zeph-llm/src/claude/request.rs` are now

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -1199,6 +1199,7 @@ async fn build_acp_deps(
 /// a hand-reconstructed copy could never catch a broken or inverted `if config.memory.*.enabled`
 /// guard in production, since it would only prove the test's own copy of the condition was
 /// correct.
+#[cfg(feature = "acp")]
 #[allow(clippy::too_many_lines)]
 fn spawn_acp_memory_maintenance_loops(
     app: &AppBuilder,

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -648,269 +648,10 @@ async fn build_acp_deps(
     // tree-consolidation/hebbian-consolidation/episodic-consolidation/optical-forgetting sweeps
     // instead of an ever-growing, never-maintained memory store. Spawned once per connection
     // (shared across all sessions on `acp_mem_supervisor`), matching runner.rs's
-    // once-per-process cadence.
-    {
-        let store = std::sync::Arc::new(memory.sqlite().clone());
-        let embedding = memory.embedding_store().cloned();
-        let eviction_cfg = config.memory.eviction.clone();
-        let policy = std::sync::Arc::new(zeph_memory::EbbinghausPolicy::default());
-        let cancel = acp_mem_supervisor.cancellation_token();
-        acp_mem_supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
-            name: "mem-eviction",
-            restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
-            factory: move || {
-                zeph_memory::start_eviction_loop(
-                    store.clone(),
-                    embedding.clone(),
-                    eviction_cfg.clone(),
-                    policy.clone(),
-                    cancel.clone(),
-                )
-            },
-        });
-    }
-    {
-        let store = std::sync::Arc::new(memory.sqlite().clone());
-        let tier_cfg = zeph_memory::TierPromotionConfig {
-            enabled: config.memory.tiers.enabled,
-            promotion_min_sessions: config.memory.tiers.promotion_min_sessions,
-            similarity_threshold: config.memory.tiers.similarity_threshold,
-            sweep_interval_secs: config.memory.tiers.sweep_interval_secs,
-            sweep_batch_size: config.memory.tiers.sweep_batch_size,
-            embed_timeout_secs: config.memory.semantic.embed_timeout_secs,
-        };
-        let tier_provider = provider.clone();
-        let cancel = acp_mem_supervisor.cancellation_token();
-        acp_mem_supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
-            name: "mem-tier-promotion",
-            restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
-            factory: move || {
-                zeph_memory::start_tier_promotion_loop(
-                    store.clone(),
-                    tier_provider.clone(),
-                    tier_cfg.clone(),
-                    cancel.clone(),
-                )
-            },
-        });
-    }
-    {
-        let store = std::sync::Arc::new(memory.sqlite().clone());
-        let scene_provider = app
-            .build_scene_provider()
-            .unwrap_or_else(|| provider.clone());
-        let scene_cfg = zeph_memory::SceneConfig {
-            enabled: config.memory.tiers.scene_enabled,
-            similarity_threshold: config.memory.tiers.scene_similarity_threshold,
-            batch_size: config.memory.tiers.scene_batch_size,
-            sweep_interval_secs: config.memory.tiers.scene_sweep_interval_secs,
-        };
-        let cancel = acp_mem_supervisor.cancellation_token();
-        acp_mem_supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
-            name: "mem-scene-consolidation",
-            restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
-            factory: move || {
-                zeph_memory::start_scene_consolidation_loop(
-                    store.clone(),
-                    scene_provider.clone(),
-                    scene_cfg.clone(),
-                    cancel.clone(),
-                )
-            },
-        });
-    }
-    {
-        let store = std::sync::Arc::new(memory.sqlite().clone());
-        let consolidation_cfg = zeph_memory::ConsolidationConfig {
-            enabled: config.memory.consolidation.enabled,
-            confidence_threshold: config.memory.consolidation.confidence_threshold,
-            sweep_interval_secs: config.memory.consolidation.sweep_interval_secs,
-            sweep_batch_size: config.memory.consolidation.sweep_batch_size,
-            similarity_threshold: config.memory.consolidation.similarity_threshold,
-            llm_timeout_secs: config.memory.consolidation.llm_timeout_secs,
-            embed_timeout_secs: config.memory.semantic.embed_timeout_secs,
-        };
-        let consolidation_provider = app
-            .build_consolidation_provider()
-            .unwrap_or_else(|| provider.clone());
-        let cancel = acp_mem_supervisor.cancellation_token();
-        acp_mem_supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
-            name: "mem-consolidation",
-            restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
-            factory: move || {
-                zeph_memory::start_consolidation_loop(
-                    store.clone(),
-                    consolidation_provider.clone(),
-                    consolidation_cfg.clone(),
-                    cancel.clone(),
-                )
-            },
-        });
-    }
-    {
-        let store = std::sync::Arc::new(memory.sqlite().clone());
-        let forgetting_cfg = zeph_memory::ForgettingConfig {
-            enabled: config.memory.forgetting.enabled,
-            decay_rate: config.memory.forgetting.decay_rate,
-            forgetting_floor: config.memory.forgetting.forgetting_floor,
-            sweep_interval_secs: config.memory.forgetting.sweep_interval_secs,
-            sweep_batch_size: config.memory.forgetting.sweep_batch_size,
-            replay_window_hours: config.memory.forgetting.replay_window_hours,
-            replay_min_access_count: config.memory.forgetting.replay_min_access_count,
-            protect_recent_hours: config.memory.forgetting.protect_recent_hours,
-            protect_min_access_count: config.memory.forgetting.protect_min_access_count,
-        };
-        let cancel = acp_mem_supervisor.cancellation_token();
-        acp_mem_supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
-            name: "mem-forgetting",
-            restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
-            factory: move || {
-                zeph_memory::start_forgetting_loop(
-                    store.clone(),
-                    forgetting_cfg.clone(),
-                    cancel.clone(),
-                )
-            },
-        });
-    }
-    if config.memory.compression_guidelines.enabled {
-        let store = std::sync::Arc::new(memory.sqlite().clone());
-        let guidelines_provider = app
-            .build_guidelines_provider()
-            .unwrap_or_else(|| provider.clone());
-        let token_counter = std::sync::Arc::clone(&memory.token_counter);
-        let guidelines_cfg = config.memory.compression_guidelines.clone();
-        let cancel = acp_mem_supervisor.cancellation_token();
-        acp_mem_supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
-            name: "mem-guidelines",
-            restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
-            factory: move || {
-                zeph_memory::start_guidelines_updater(
-                    store.clone(),
-                    guidelines_provider.clone(),
-                    token_counter.clone(),
-                    guidelines_cfg.clone(),
-                    cancel.clone(),
-                )
-            },
-        });
-    }
-    if config.memory.tree.enabled {
-        let store = std::sync::Arc::new(memory.sqlite().clone());
-        let tree_provider = app
-            .build_tree_consolidation_provider()
-            .unwrap_or_else(|| provider.clone());
-        let tree_cfg = zeph_memory::TreeConsolidationConfig {
-            enabled: config.memory.tree.enabled,
-            sweep_interval_secs: config.memory.tree.sweep_interval_secs,
-            batch_size: config.memory.tree.batch_size,
-            similarity_threshold: config.memory.tree.similarity_threshold,
-            max_level: config.memory.tree.max_level,
-            min_cluster_size: config.memory.tree.min_cluster_size,
-            embed_timeout_secs: config.memory.semantic.embed_timeout_secs,
-        };
-        let cancel = acp_mem_supervisor.cancellation_token();
-        acp_mem_supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
-            name: "mem-tree-consolidation",
-            restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
-            factory: move || {
-                zeph_memory::start_tree_consolidation_loop(
-                    store.clone(),
-                    tree_provider.clone(),
-                    tree_cfg.clone(),
-                    cancel.clone(),
-                )
-            },
-        });
-    }
-    if config.memory.hebbian.enabled && config.memory.hebbian.consolidation_interval_secs > 0 {
-        let store = std::sync::Arc::new(memory.sqlite().clone());
-        let hebbian_consolidation_cfg = zeph_memory::HebbianConsolidationConfig {
-            consolidation_interval_secs: config.memory.hebbian.consolidation_interval_secs,
-            consolidation_threshold: config.memory.hebbian.consolidation_threshold,
-            max_candidates_per_sweep: config.memory.hebbian.max_candidates_per_sweep,
-            consolidation_cooldown_secs: config.memory.hebbian.consolidation_cooldown_secs,
-            consolidation_prompt_timeout_secs: config
-                .memory
-                .hebbian
-                .consolidation_prompt_timeout_secs,
-            consolidation_max_neighbors: config.memory.hebbian.consolidation_max_neighbors,
-        };
-        let hebbian_provider = app
-            .build_hebbian_consolidation_provider()
-            .unwrap_or_else(|| provider.clone());
-        let cancel = acp_mem_supervisor.cancellation_token();
-        acp_mem_supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
-            name: "mem-hebbian-consolidation",
-            restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
-            factory: move || {
-                zeph_memory::spawn_hebbian_consolidation_loop(
-                    store.clone(),
-                    hebbian_consolidation_cfg.clone(),
-                    hebbian_provider.clone(),
-                    None,
-                    cancel.clone(),
-                )
-            },
-        });
-    }
-    if config.memory.episodic_consolidation.enabled {
-        let store = std::sync::Arc::new(memory.sqlite().clone());
-        let ep_cfg = zeph_memory::EpisodicConsolidationConfig {
-            enabled: config.memory.episodic_consolidation.enabled,
-            consolidation_provider: config
-                .memory
-                .episodic_consolidation
-                .consolidation_provider
-                .clone(),
-            interval_secs: config.memory.episodic_consolidation.interval_secs,
-            batch_size: config.memory.episodic_consolidation.batch_size,
-            min_age_secs: config.memory.episodic_consolidation.min_age_secs,
-            dedup_jaccard_threshold: config.memory.episodic_consolidation.dedup_jaccard_threshold,
-        };
-        let ep_provider = app
-            .build_episodic_consolidation_provider()
-            .unwrap_or_else(|| provider.clone());
-        let ep_qdrant = memory.embedding_store().cloned();
-        let cancel = acp_mem_supervisor.cancellation_token();
-        acp_mem_supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
-            name: "mem-episodic-consolidation",
-            restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
-            factory: move || {
-                zeph_memory::start_episodic_consolidation_loop(
-                    store.clone(),
-                    ep_provider.clone(),
-                    ep_cfg.clone(),
-                    ep_qdrant.clone(),
-                    cancel.clone(),
-                )
-            },
-        });
-    }
-    if config.memory.optical_forgetting.enabled {
-        let store = std::sync::Arc::new(memory.sqlite().clone());
-        let optical_provider = app
-            .build_optical_forgetting_provider()
-            .unwrap_or_else(|| provider.clone());
-        let optical_cfg = config.memory.optical_forgetting.clone();
-        let forgetting_floor = config.memory.forgetting.forgetting_floor;
-        let cancel = acp_mem_supervisor.cancellation_token();
-        tracing::info_span!("acp.memory.optical_forgetting.startup").in_scope(|| {
-            acp_mem_supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
-                name: "mem-optical-forgetting",
-                restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
-                factory: move || {
-                    zeph_memory::start_optical_forgetting_loop(
-                        store.clone(),
-                        optical_provider.clone(),
-                        optical_cfg.clone(),
-                        forgetting_floor,
-                        cancel.clone(),
-                    )
-                },
-            });
-        });
-    }
+    // once-per-process cadence. Extracted into `spawn_acp_memory_maintenance_loops` (#6170) so
+    // the regression test below can call the real, shipped production wiring instead of
+    // reconstructing a copy of it.
+    spawn_acp_memory_maintenance_loops(app, &memory, &provider, &acp_mem_supervisor);
 
     let filter_registry = if config.tools.filters.enabled {
         zeph_tools::OutputFilterRegistry::default_filters(&config.tools.filters)
@@ -1444,6 +1185,290 @@ async fn build_acp_deps(
 
     let keepalive: Box<dyn std::any::Any> = Box::new((skill_watcher, config_watcher));
     Ok((deps, keepalive))
+}
+
+/// Spawns the ten ongoing memory-maintenance sweeps (eviction, tier-promotion,
+/// scene-consolidation, consolidation, forgetting — #5914; plus guidelines, tree-consolidation,
+/// hebbian-consolidation, episodic-consolidation, optical-forgetting — #5979) on `supervisor`,
+/// shared by every session built from this ACP connection's `SharedCore` — mirrors
+/// `src/runner.rs`'s CLI/TUI wiring and `src/serve/deps.rs`'s `spawn_memory_maintenance_loops`.
+///
+/// Extracted from [`build_acp_deps`] (#6170) so the regression test
+/// `acp_memory_maintenance_loops_registered_on_connection_supervisor` can call this real,
+/// shipped production function directly rather than reconstructing a copy of its spawn blocks —
+/// a hand-reconstructed copy could never catch a broken or inverted `if config.memory.*.enabled`
+/// guard in production, since it would only prove the test's own copy of the condition was
+/// correct.
+#[allow(clippy::too_many_lines)]
+fn spawn_acp_memory_maintenance_loops(
+    app: &AppBuilder,
+    memory: &std::sync::Arc<zeph_memory::semantic::SemanticMemory>,
+    provider: &zeph_llm::any::AnyProvider,
+    supervisor: &zeph_common::TaskSupervisor,
+) {
+    let config = app.config();
+    {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let embedding = memory.embedding_store().cloned();
+        let eviction_cfg = config.memory.eviction.clone();
+        let policy = std::sync::Arc::new(zeph_memory::EbbinghausPolicy::default());
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
+            name: "mem-eviction",
+            restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_eviction_loop(
+                    store.clone(),
+                    embedding.clone(),
+                    eviction_cfg.clone(),
+                    policy.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let tier_cfg = zeph_memory::TierPromotionConfig {
+            enabled: config.memory.tiers.enabled,
+            promotion_min_sessions: config.memory.tiers.promotion_min_sessions,
+            similarity_threshold: config.memory.tiers.similarity_threshold,
+            sweep_interval_secs: config.memory.tiers.sweep_interval_secs,
+            sweep_batch_size: config.memory.tiers.sweep_batch_size,
+            embed_timeout_secs: config.memory.semantic.embed_timeout_secs,
+        };
+        let tier_provider = provider.clone();
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
+            name: "mem-tier-promotion",
+            restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_tier_promotion_loop(
+                    store.clone(),
+                    tier_provider.clone(),
+                    tier_cfg.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let scene_provider = app
+            .build_scene_provider()
+            .unwrap_or_else(|| provider.clone());
+        let scene_cfg = zeph_memory::SceneConfig {
+            enabled: config.memory.tiers.scene_enabled,
+            similarity_threshold: config.memory.tiers.scene_similarity_threshold,
+            batch_size: config.memory.tiers.scene_batch_size,
+            sweep_interval_secs: config.memory.tiers.scene_sweep_interval_secs,
+        };
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
+            name: "mem-scene-consolidation",
+            restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_scene_consolidation_loop(
+                    store.clone(),
+                    scene_provider.clone(),
+                    scene_cfg.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let consolidation_cfg = zeph_memory::ConsolidationConfig {
+            enabled: config.memory.consolidation.enabled,
+            confidence_threshold: config.memory.consolidation.confidence_threshold,
+            sweep_interval_secs: config.memory.consolidation.sweep_interval_secs,
+            sweep_batch_size: config.memory.consolidation.sweep_batch_size,
+            similarity_threshold: config.memory.consolidation.similarity_threshold,
+            llm_timeout_secs: config.memory.consolidation.llm_timeout_secs,
+            embed_timeout_secs: config.memory.semantic.embed_timeout_secs,
+        };
+        let consolidation_provider = app
+            .build_consolidation_provider()
+            .unwrap_or_else(|| provider.clone());
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
+            name: "mem-consolidation",
+            restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_consolidation_loop(
+                    store.clone(),
+                    consolidation_provider.clone(),
+                    consolidation_cfg.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let forgetting_cfg = zeph_memory::ForgettingConfig {
+            enabled: config.memory.forgetting.enabled,
+            decay_rate: config.memory.forgetting.decay_rate,
+            forgetting_floor: config.memory.forgetting.forgetting_floor,
+            sweep_interval_secs: config.memory.forgetting.sweep_interval_secs,
+            sweep_batch_size: config.memory.forgetting.sweep_batch_size,
+            replay_window_hours: config.memory.forgetting.replay_window_hours,
+            replay_min_access_count: config.memory.forgetting.replay_min_access_count,
+            protect_recent_hours: config.memory.forgetting.protect_recent_hours,
+            protect_min_access_count: config.memory.forgetting.protect_min_access_count,
+        };
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
+            name: "mem-forgetting",
+            restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_forgetting_loop(
+                    store.clone(),
+                    forgetting_cfg.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    if config.memory.compression_guidelines.enabled {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let guidelines_provider = app
+            .build_guidelines_provider()
+            .unwrap_or_else(|| provider.clone());
+        let token_counter = std::sync::Arc::clone(&memory.token_counter);
+        let guidelines_cfg = config.memory.compression_guidelines.clone();
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
+            name: "mem-guidelines",
+            restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_guidelines_updater(
+                    store.clone(),
+                    guidelines_provider.clone(),
+                    token_counter.clone(),
+                    guidelines_cfg.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    if config.memory.tree.enabled {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let tree_provider = app
+            .build_tree_consolidation_provider()
+            .unwrap_or_else(|| provider.clone());
+        let tree_cfg = zeph_memory::TreeConsolidationConfig {
+            enabled: config.memory.tree.enabled,
+            sweep_interval_secs: config.memory.tree.sweep_interval_secs,
+            batch_size: config.memory.tree.batch_size,
+            similarity_threshold: config.memory.tree.similarity_threshold,
+            max_level: config.memory.tree.max_level,
+            min_cluster_size: config.memory.tree.min_cluster_size,
+            embed_timeout_secs: config.memory.semantic.embed_timeout_secs,
+        };
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
+            name: "mem-tree-consolidation",
+            restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_tree_consolidation_loop(
+                    store.clone(),
+                    tree_provider.clone(),
+                    tree_cfg.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    if config.memory.hebbian.enabled && config.memory.hebbian.consolidation_interval_secs > 0 {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let hebbian_consolidation_cfg = zeph_memory::HebbianConsolidationConfig {
+            consolidation_interval_secs: config.memory.hebbian.consolidation_interval_secs,
+            consolidation_threshold: config.memory.hebbian.consolidation_threshold,
+            max_candidates_per_sweep: config.memory.hebbian.max_candidates_per_sweep,
+            consolidation_cooldown_secs: config.memory.hebbian.consolidation_cooldown_secs,
+            consolidation_prompt_timeout_secs: config
+                .memory
+                .hebbian
+                .consolidation_prompt_timeout_secs,
+            consolidation_max_neighbors: config.memory.hebbian.consolidation_max_neighbors,
+        };
+        let hebbian_provider = app
+            .build_hebbian_consolidation_provider()
+            .unwrap_or_else(|| provider.clone());
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
+            name: "mem-hebbian-consolidation",
+            restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::spawn_hebbian_consolidation_loop(
+                    store.clone(),
+                    hebbian_consolidation_cfg.clone(),
+                    hebbian_provider.clone(),
+                    None,
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    if config.memory.episodic_consolidation.enabled {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let ep_cfg = zeph_memory::EpisodicConsolidationConfig {
+            enabled: config.memory.episodic_consolidation.enabled,
+            consolidation_provider: config
+                .memory
+                .episodic_consolidation
+                .consolidation_provider
+                .clone(),
+            interval_secs: config.memory.episodic_consolidation.interval_secs,
+            batch_size: config.memory.episodic_consolidation.batch_size,
+            min_age_secs: config.memory.episodic_consolidation.min_age_secs,
+            dedup_jaccard_threshold: config.memory.episodic_consolidation.dedup_jaccard_threshold,
+        };
+        let ep_provider = app
+            .build_episodic_consolidation_provider()
+            .unwrap_or_else(|| provider.clone());
+        let ep_qdrant = memory.embedding_store().cloned();
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
+            name: "mem-episodic-consolidation",
+            restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_episodic_consolidation_loop(
+                    store.clone(),
+                    ep_provider.clone(),
+                    ep_cfg.clone(),
+                    ep_qdrant.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    if config.memory.optical_forgetting.enabled {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let optical_provider = app
+            .build_optical_forgetting_provider()
+            .unwrap_or_else(|| provider.clone());
+        let optical_cfg = config.memory.optical_forgetting.clone();
+        let forgetting_floor = config.memory.forgetting.forgetting_floor;
+        let cancel = supervisor.cancellation_token();
+        tracing::info_span!("acp.memory.optical_forgetting.startup").in_scope(|| {
+            supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
+                name: "mem-optical-forgetting",
+                restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
+                factory: move || {
+                    zeph_memory::start_optical_forgetting_loop(
+                        store.clone(),
+                        optical_provider.clone(),
+                        optical_cfg.clone(),
+                        forgetting_floor,
+                        cancel.clone(),
+                    )
+                },
+            });
+        });
+    }
 }
 
 /// Text shown to the client when session persistence is disabled due to a held write lock.
@@ -3948,17 +3973,13 @@ mod tests {
     /// Regression test confirming all ten memory-maintenance loops (eviction, tier-promotion,
     /// scene-consolidation, consolidation, forgetting — #5914; plus guidelines,
     /// tree-consolidation, hebbian-consolidation, episodic-consolidation, optical-forgetting —
-    /// #5979) are actually registered on the ACP connection's own `TaskSupervisor`:
-    /// `build_acp_deps` previously spawned none of them, unlike the CLI path (`src/runner.rs`).
-    /// Reconstructs the same `TaskDescriptor`/`supervisor.spawn` block `build_acp_deps` now runs
-    /// (falling back directly to the primary provider where production uses
-    /// `app.build_scene_provider()`/`app.build_consolidation_provider()`/etc., since this test
-    /// has no `AppBuilder` to resolve a named override from, and passing `None` for the hebbian
-    /// status sender since `build_acp_deps` has no status-sender handle in scope either) and
-    /// asserts every expected task name is present in the connection supervisor's snapshot. The
-    /// five #5979 loops are config-gated, so the config below explicitly enables each.
+    /// #5979) are actually registered on the ACP connection's own `TaskSupervisor`. Calls the
+    /// real, shipped `spawn_acp_memory_maintenance_loops` (extracted from `build_acp_deps` in
+    /// #6170) directly rather than reconstructing a copy of its spawn blocks, so a broken or
+    /// inverted `if config.memory.*.enabled` guard in production is actually caught here instead
+    /// of only proving the test's own copy of the condition was correct. The five #5979 loops
+    /// are config-gated, so the config below explicitly enables each.
     #[tokio::test]
-    #[allow(clippy::too_many_lines)]
     async fn acp_memory_maintenance_loops_registered_on_connection_supervisor() {
         let mock_provider =
             zeph_llm::any::AnyProvider::Mock(zeph_llm::mock::MockProvider::default());
@@ -3979,260 +4000,11 @@ mod tests {
         config.memory.hebbian.enabled = true;
         config.memory.episodic_consolidation.enabled = true;
         config.memory.optical_forgetting.enabled = true;
+        let app = crate::bootstrap::AppBuilder::for_test(config);
         let cancel = tokio_util::sync::CancellationToken::new();
         let supervisor = zeph_common::TaskSupervisor::new(cancel);
 
-        {
-            let store = std::sync::Arc::new(memory.sqlite().clone());
-            let embedding = memory.embedding_store().cloned();
-            let eviction_cfg = config.memory.eviction.clone();
-            let policy = std::sync::Arc::new(zeph_memory::EbbinghausPolicy::default());
-            let cancel = supervisor.cancellation_token();
-            supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
-                name: "mem-eviction",
-                restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
-                factory: move || {
-                    zeph_memory::start_eviction_loop(
-                        store.clone(),
-                        embedding.clone(),
-                        eviction_cfg.clone(),
-                        policy.clone(),
-                        cancel.clone(),
-                    )
-                },
-            });
-        }
-        {
-            let store = std::sync::Arc::new(memory.sqlite().clone());
-            let tier_cfg = zeph_memory::TierPromotionConfig {
-                enabled: config.memory.tiers.enabled,
-                promotion_min_sessions: config.memory.tiers.promotion_min_sessions,
-                similarity_threshold: config.memory.tiers.similarity_threshold,
-                sweep_interval_secs: config.memory.tiers.sweep_interval_secs,
-                sweep_batch_size: config.memory.tiers.sweep_batch_size,
-                embed_timeout_secs: config.memory.semantic.embed_timeout_secs,
-            };
-            let tier_provider = mock_provider.clone();
-            let cancel = supervisor.cancellation_token();
-            supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
-                name: "mem-tier-promotion",
-                restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
-                factory: move || {
-                    zeph_memory::start_tier_promotion_loop(
-                        store.clone(),
-                        tier_provider.clone(),
-                        tier_cfg.clone(),
-                        cancel.clone(),
-                    )
-                },
-            });
-        }
-        {
-            let store = std::sync::Arc::new(memory.sqlite().clone());
-            let scene_provider = mock_provider.clone();
-            let scene_cfg = zeph_memory::SceneConfig {
-                enabled: config.memory.tiers.scene_enabled,
-                similarity_threshold: config.memory.tiers.scene_similarity_threshold,
-                batch_size: config.memory.tiers.scene_batch_size,
-                sweep_interval_secs: config.memory.tiers.scene_sweep_interval_secs,
-            };
-            let cancel = supervisor.cancellation_token();
-            supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
-                name: "mem-scene-consolidation",
-                restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
-                factory: move || {
-                    zeph_memory::start_scene_consolidation_loop(
-                        store.clone(),
-                        scene_provider.clone(),
-                        scene_cfg.clone(),
-                        cancel.clone(),
-                    )
-                },
-            });
-        }
-        {
-            let store = std::sync::Arc::new(memory.sqlite().clone());
-            let consolidation_cfg = zeph_memory::ConsolidationConfig {
-                enabled: config.memory.consolidation.enabled,
-                confidence_threshold: config.memory.consolidation.confidence_threshold,
-                sweep_interval_secs: config.memory.consolidation.sweep_interval_secs,
-                sweep_batch_size: config.memory.consolidation.sweep_batch_size,
-                similarity_threshold: config.memory.consolidation.similarity_threshold,
-                llm_timeout_secs: config.memory.consolidation.llm_timeout_secs,
-                embed_timeout_secs: config.memory.semantic.embed_timeout_secs,
-            };
-            let consolidation_provider = mock_provider.clone();
-            let cancel = supervisor.cancellation_token();
-            supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
-                name: "mem-consolidation",
-                restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
-                factory: move || {
-                    zeph_memory::start_consolidation_loop(
-                        store.clone(),
-                        consolidation_provider.clone(),
-                        consolidation_cfg.clone(),
-                        cancel.clone(),
-                    )
-                },
-            });
-        }
-        {
-            let store = std::sync::Arc::new(memory.sqlite().clone());
-            let forgetting_cfg = zeph_memory::ForgettingConfig {
-                enabled: config.memory.forgetting.enabled,
-                decay_rate: config.memory.forgetting.decay_rate,
-                forgetting_floor: config.memory.forgetting.forgetting_floor,
-                sweep_interval_secs: config.memory.forgetting.sweep_interval_secs,
-                sweep_batch_size: config.memory.forgetting.sweep_batch_size,
-                replay_window_hours: config.memory.forgetting.replay_window_hours,
-                replay_min_access_count: config.memory.forgetting.replay_min_access_count,
-                protect_recent_hours: config.memory.forgetting.protect_recent_hours,
-                protect_min_access_count: config.memory.forgetting.protect_min_access_count,
-            };
-            let cancel = supervisor.cancellation_token();
-            supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
-                name: "mem-forgetting",
-                restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
-                factory: move || {
-                    zeph_memory::start_forgetting_loop(
-                        store.clone(),
-                        forgetting_cfg.clone(),
-                        cancel.clone(),
-                    )
-                },
-            });
-        }
-        {
-            let store = std::sync::Arc::new(memory.sqlite().clone());
-            let guidelines_provider = mock_provider.clone();
-            let token_counter = std::sync::Arc::clone(&memory.token_counter);
-            let guidelines_cfg = config.memory.compression_guidelines.clone();
-            let cancel = supervisor.cancellation_token();
-            supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
-                name: "mem-guidelines",
-                restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
-                factory: move || {
-                    zeph_memory::start_guidelines_updater(
-                        store.clone(),
-                        guidelines_provider.clone(),
-                        token_counter.clone(),
-                        guidelines_cfg.clone(),
-                        cancel.clone(),
-                    )
-                },
-            });
-        }
-        {
-            let store = std::sync::Arc::new(memory.sqlite().clone());
-            let tree_provider = mock_provider.clone();
-            let tree_cfg = zeph_memory::TreeConsolidationConfig {
-                enabled: config.memory.tree.enabled,
-                sweep_interval_secs: config.memory.tree.sweep_interval_secs,
-                batch_size: config.memory.tree.batch_size,
-                similarity_threshold: config.memory.tree.similarity_threshold,
-                max_level: config.memory.tree.max_level,
-                min_cluster_size: config.memory.tree.min_cluster_size,
-                embed_timeout_secs: config.memory.semantic.embed_timeout_secs,
-            };
-            let cancel = supervisor.cancellation_token();
-            supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
-                name: "mem-tree-consolidation",
-                restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
-                factory: move || {
-                    zeph_memory::start_tree_consolidation_loop(
-                        store.clone(),
-                        tree_provider.clone(),
-                        tree_cfg.clone(),
-                        cancel.clone(),
-                    )
-                },
-            });
-        }
-        {
-            let store = std::sync::Arc::new(memory.sqlite().clone());
-            let hebbian_consolidation_cfg = zeph_memory::HebbianConsolidationConfig {
-                consolidation_interval_secs: config.memory.hebbian.consolidation_interval_secs,
-                consolidation_threshold: config.memory.hebbian.consolidation_threshold,
-                max_candidates_per_sweep: config.memory.hebbian.max_candidates_per_sweep,
-                consolidation_cooldown_secs: config.memory.hebbian.consolidation_cooldown_secs,
-                consolidation_prompt_timeout_secs: config
-                    .memory
-                    .hebbian
-                    .consolidation_prompt_timeout_secs,
-                consolidation_max_neighbors: config.memory.hebbian.consolidation_max_neighbors,
-            };
-            let hebbian_provider = mock_provider.clone();
-            let cancel = supervisor.cancellation_token();
-            supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
-                name: "mem-hebbian-consolidation",
-                restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
-                factory: move || {
-                    zeph_memory::spawn_hebbian_consolidation_loop(
-                        store.clone(),
-                        hebbian_consolidation_cfg.clone(),
-                        hebbian_provider.clone(),
-                        None,
-                        cancel.clone(),
-                    )
-                },
-            });
-        }
-        {
-            let store = std::sync::Arc::new(memory.sqlite().clone());
-            let ep_cfg = zeph_memory::EpisodicConsolidationConfig {
-                enabled: config.memory.episodic_consolidation.enabled,
-                consolidation_provider: config
-                    .memory
-                    .episodic_consolidation
-                    .consolidation_provider
-                    .clone(),
-                interval_secs: config.memory.episodic_consolidation.interval_secs,
-                batch_size: config.memory.episodic_consolidation.batch_size,
-                min_age_secs: config.memory.episodic_consolidation.min_age_secs,
-                dedup_jaccard_threshold: config
-                    .memory
-                    .episodic_consolidation
-                    .dedup_jaccard_threshold,
-            };
-            let ep_provider = mock_provider.clone();
-            let ep_qdrant = memory.embedding_store().cloned();
-            let cancel = supervisor.cancellation_token();
-            supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
-                name: "mem-episodic-consolidation",
-                restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
-                factory: move || {
-                    zeph_memory::start_episodic_consolidation_loop(
-                        store.clone(),
-                        ep_provider.clone(),
-                        ep_cfg.clone(),
-                        ep_qdrant.clone(),
-                        cancel.clone(),
-                    )
-                },
-            });
-        }
-        {
-            let store = std::sync::Arc::new(memory.sqlite().clone());
-            let optical_provider = mock_provider.clone();
-            let optical_cfg = config.memory.optical_forgetting.clone();
-            let forgetting_floor = config.memory.forgetting.forgetting_floor;
-            let cancel = supervisor.cancellation_token();
-            tracing::info_span!("acp.memory.optical_forgetting.startup").in_scope(|| {
-                supervisor.spawn(zeph_common::task_supervisor::TaskDescriptor {
-                    name: "mem-optical-forgetting",
-                    restart: zeph_common::task_supervisor::RestartPolicy::RunOnce,
-                    factory: move || {
-                        zeph_memory::start_optical_forgetting_loop(
-                            store.clone(),
-                            optical_provider.clone(),
-                            optical_cfg.clone(),
-                            forgetting_floor,
-                            cancel.clone(),
-                        )
-                    },
-                });
-            });
-        }
+        spawn_acp_memory_maintenance_loops(&app, &memory, &mock_provider, &supervisor);
 
         let names: std::collections::HashSet<String> = supervisor
             .snapshot()

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -470,270 +470,10 @@ pub(crate) async fn run_daemon(
     // daemon (A2A) entry point gets the same ongoing eviction/tier-promotion/
     // scene-consolidation/consolidation/forgetting/guidelines/tree-consolidation/
     // hebbian-consolidation/episodic-consolidation/optical-forgetting sweeps instead of an
-    // ever-growing, never-maintained memory store.
-    {
-        let store = std::sync::Arc::new(memory.sqlite().clone());
-        let embedding = memory.embedding_store().cloned();
-        let eviction_cfg = config.memory.eviction.clone();
-        let policy = std::sync::Arc::new(zeph_memory::EbbinghausPolicy::default());
-        let cancel = mem_supervisor.cancellation_token();
-        mem_supervisor.spawn(zeph_common::TaskDescriptor {
-            name: "mem-eviction",
-            restart: zeph_common::RestartPolicy::RunOnce,
-            factory: move || {
-                zeph_memory::start_eviction_loop(
-                    store.clone(),
-                    embedding.clone(),
-                    eviction_cfg.clone(),
-                    policy.clone(),
-                    cancel.clone(),
-                )
-            },
-        });
-    }
-    {
-        let store = std::sync::Arc::new(memory.sqlite().clone());
-        let tier_cfg = zeph_memory::TierPromotionConfig {
-            enabled: config.memory.tiers.enabled,
-            promotion_min_sessions: config.memory.tiers.promotion_min_sessions,
-            similarity_threshold: config.memory.tiers.similarity_threshold,
-            sweep_interval_secs: config.memory.tiers.sweep_interval_secs,
-            sweep_batch_size: config.memory.tiers.sweep_batch_size,
-            embed_timeout_secs: config.memory.semantic.embed_timeout_secs,
-        };
-        let tier_provider = provider.clone();
-        let cancel = mem_supervisor.cancellation_token();
-        mem_supervisor.spawn(zeph_common::TaskDescriptor {
-            name: "mem-tier-promotion",
-            restart: zeph_common::RestartPolicy::RunOnce,
-            factory: move || {
-                zeph_memory::start_tier_promotion_loop(
-                    store.clone(),
-                    tier_provider.clone(),
-                    tier_cfg.clone(),
-                    cancel.clone(),
-                )
-            },
-        });
-    }
-    {
-        let store = std::sync::Arc::new(memory.sqlite().clone());
-        let scene_provider = app
-            .build_scene_provider()
-            .unwrap_or_else(|| provider.clone());
-        let scene_cfg = zeph_memory::SceneConfig {
-            enabled: config.memory.tiers.scene_enabled,
-            similarity_threshold: config.memory.tiers.scene_similarity_threshold,
-            batch_size: config.memory.tiers.scene_batch_size,
-            sweep_interval_secs: config.memory.tiers.scene_sweep_interval_secs,
-        };
-        let cancel = mem_supervisor.cancellation_token();
-        mem_supervisor.spawn(zeph_common::TaskDescriptor {
-            name: "mem-scene-consolidation",
-            restart: zeph_common::RestartPolicy::RunOnce,
-            factory: move || {
-                zeph_memory::start_scene_consolidation_loop(
-                    store.clone(),
-                    scene_provider.clone(),
-                    scene_cfg.clone(),
-                    cancel.clone(),
-                )
-            },
-        });
-    }
-    {
-        let store = std::sync::Arc::new(memory.sqlite().clone());
-        let consolidation_cfg = zeph_memory::ConsolidationConfig {
-            enabled: config.memory.consolidation.enabled,
-            confidence_threshold: config.memory.consolidation.confidence_threshold,
-            sweep_interval_secs: config.memory.consolidation.sweep_interval_secs,
-            sweep_batch_size: config.memory.consolidation.sweep_batch_size,
-            similarity_threshold: config.memory.consolidation.similarity_threshold,
-            llm_timeout_secs: config.memory.consolidation.llm_timeout_secs,
-            embed_timeout_secs: config.memory.semantic.embed_timeout_secs,
-        };
-        let consolidation_provider = app
-            .build_consolidation_provider()
-            .unwrap_or_else(|| provider.clone());
-        let cancel = mem_supervisor.cancellation_token();
-        mem_supervisor.spawn(zeph_common::TaskDescriptor {
-            name: "mem-consolidation",
-            restart: zeph_common::RestartPolicy::RunOnce,
-            factory: move || {
-                zeph_memory::start_consolidation_loop(
-                    store.clone(),
-                    consolidation_provider.clone(),
-                    consolidation_cfg.clone(),
-                    cancel.clone(),
-                )
-            },
-        });
-    }
-    {
-        let store = std::sync::Arc::new(memory.sqlite().clone());
-        let forgetting_cfg = zeph_memory::ForgettingConfig {
-            enabled: config.memory.forgetting.enabled,
-            decay_rate: config.memory.forgetting.decay_rate,
-            forgetting_floor: config.memory.forgetting.forgetting_floor,
-            sweep_interval_secs: config.memory.forgetting.sweep_interval_secs,
-            sweep_batch_size: config.memory.forgetting.sweep_batch_size,
-            replay_window_hours: config.memory.forgetting.replay_window_hours,
-            replay_min_access_count: config.memory.forgetting.replay_min_access_count,
-            protect_recent_hours: config.memory.forgetting.protect_recent_hours,
-            protect_min_access_count: config.memory.forgetting.protect_min_access_count,
-        };
-        let cancel = mem_supervisor.cancellation_token();
-        mem_supervisor.spawn(zeph_common::TaskDescriptor {
-            name: "mem-forgetting",
-            restart: zeph_common::RestartPolicy::RunOnce,
-            factory: move || {
-                zeph_memory::start_forgetting_loop(
-                    store.clone(),
-                    forgetting_cfg.clone(),
-                    cancel.clone(),
-                )
-            },
-        });
-    }
-    if config.memory.compression_guidelines.enabled {
-        let store = std::sync::Arc::new(memory.sqlite().clone());
-        let guidelines_provider = app
-            .build_guidelines_provider()
-            .unwrap_or_else(|| provider.clone());
-        let token_counter = std::sync::Arc::clone(&memory.token_counter);
-        let guidelines_cfg = config.memory.compression_guidelines.clone();
-        let cancel = mem_supervisor.cancellation_token();
-        mem_supervisor.spawn(zeph_common::TaskDescriptor {
-            name: "mem-guidelines",
-            restart: zeph_common::RestartPolicy::RunOnce,
-            factory: move || {
-                zeph_memory::start_guidelines_updater(
-                    store.clone(),
-                    guidelines_provider.clone(),
-                    token_counter.clone(),
-                    guidelines_cfg.clone(),
-                    cancel.clone(),
-                )
-            },
-        });
-    }
-    if config.memory.tree.enabled {
-        let store = std::sync::Arc::new(memory.sqlite().clone());
-        let tree_provider = app
-            .build_tree_consolidation_provider()
-            .unwrap_or_else(|| provider.clone());
-        let tree_cfg = zeph_memory::TreeConsolidationConfig {
-            enabled: config.memory.tree.enabled,
-            sweep_interval_secs: config.memory.tree.sweep_interval_secs,
-            batch_size: config.memory.tree.batch_size,
-            similarity_threshold: config.memory.tree.similarity_threshold,
-            max_level: config.memory.tree.max_level,
-            min_cluster_size: config.memory.tree.min_cluster_size,
-            embed_timeout_secs: config.memory.semantic.embed_timeout_secs,
-        };
-        let cancel = mem_supervisor.cancellation_token();
-        mem_supervisor.spawn(zeph_common::TaskDescriptor {
-            name: "mem-tree-consolidation",
-            restart: zeph_common::RestartPolicy::RunOnce,
-            factory: move || {
-                zeph_memory::start_tree_consolidation_loop(
-                    store.clone(),
-                    tree_provider.clone(),
-                    tree_cfg.clone(),
-                    cancel.clone(),
-                )
-            },
-        });
-    }
-    if config.memory.hebbian.enabled && config.memory.hebbian.consolidation_interval_secs > 0 {
-        let store = std::sync::Arc::new(memory.sqlite().clone());
-        let hebbian_consolidation_cfg = zeph_memory::HebbianConsolidationConfig {
-            consolidation_interval_secs: config.memory.hebbian.consolidation_interval_secs,
-            consolidation_threshold: config.memory.hebbian.consolidation_threshold,
-            max_candidates_per_sweep: config.memory.hebbian.max_candidates_per_sweep,
-            consolidation_cooldown_secs: config.memory.hebbian.consolidation_cooldown_secs,
-            consolidation_prompt_timeout_secs: config
-                .memory
-                .hebbian
-                .consolidation_prompt_timeout_secs,
-            consolidation_max_neighbors: config.memory.hebbian.consolidation_max_neighbors,
-        };
-        let hebbian_provider = app
-            .build_hebbian_consolidation_provider()
-            .unwrap_or_else(|| provider.clone());
-        let status_tx_clone = status_tx.clone();
-        let cancel = mem_supervisor.cancellation_token();
-        mem_supervisor.spawn(zeph_common::TaskDescriptor {
-            name: "mem-hebbian-consolidation",
-            restart: zeph_common::RestartPolicy::RunOnce,
-            factory: move || {
-                zeph_memory::spawn_hebbian_consolidation_loop(
-                    store.clone(),
-                    hebbian_consolidation_cfg.clone(),
-                    hebbian_provider.clone(),
-                    Some(status_tx_clone.clone()),
-                    cancel.clone(),
-                )
-            },
-        });
-    }
-    if config.memory.episodic_consolidation.enabled {
-        let store = std::sync::Arc::new(memory.sqlite().clone());
-        let ep_cfg = zeph_memory::EpisodicConsolidationConfig {
-            enabled: config.memory.episodic_consolidation.enabled,
-            consolidation_provider: config
-                .memory
-                .episodic_consolidation
-                .consolidation_provider
-                .clone(),
-            interval_secs: config.memory.episodic_consolidation.interval_secs,
-            batch_size: config.memory.episodic_consolidation.batch_size,
-            min_age_secs: config.memory.episodic_consolidation.min_age_secs,
-            dedup_jaccard_threshold: config.memory.episodic_consolidation.dedup_jaccard_threshold,
-        };
-        let ep_provider = app
-            .build_episodic_consolidation_provider()
-            .unwrap_or_else(|| provider.clone());
-        let ep_qdrant = memory.embedding_store().cloned();
-        let cancel = mem_supervisor.cancellation_token();
-        mem_supervisor.spawn(zeph_common::TaskDescriptor {
-            name: "mem-episodic-consolidation",
-            restart: zeph_common::RestartPolicy::RunOnce,
-            factory: move || {
-                zeph_memory::start_episodic_consolidation_loop(
-                    store.clone(),
-                    ep_provider.clone(),
-                    ep_cfg.clone(),
-                    ep_qdrant.clone(),
-                    cancel.clone(),
-                )
-            },
-        });
-    }
-    if config.memory.optical_forgetting.enabled {
-        let store = std::sync::Arc::new(memory.sqlite().clone());
-        let optical_provider = app
-            .build_optical_forgetting_provider()
-            .unwrap_or_else(|| provider.clone());
-        let optical_cfg = config.memory.optical_forgetting.clone();
-        let forgetting_floor = config.memory.forgetting.forgetting_floor;
-        let cancel = mem_supervisor.cancellation_token();
-        tracing::info_span!("daemon.memory.optical_forgetting.startup").in_scope(|| {
-            mem_supervisor.spawn(zeph_common::TaskDescriptor {
-                name: "mem-optical-forgetting",
-                restart: zeph_common::RestartPolicy::RunOnce,
-                factory: move || {
-                    zeph_memory::start_optical_forgetting_loop(
-                        store.clone(),
-                        optical_provider.clone(),
-                        optical_cfg.clone(),
-                        forgetting_floor,
-                        cancel.clone(),
-                    )
-                },
-            });
-        });
-    }
+    // ever-growing, never-maintained memory store. Extracted into
+    // `spawn_daemon_memory_maintenance_loops` (#6170) so the regression test below can call the
+    // real, shipped production wiring instead of reconstructing a copy of it.
+    spawn_daemon_memory_maintenance_loops(&app, &memory, &provider, &status_tx, &mem_supervisor);
 
     let (shutdown_tx, shutdown_rx) = AppBuilder::build_shutdown();
 
@@ -1458,6 +1198,292 @@ pub(crate) async fn run_daemon(
     drop(pid_guard);
 
     Ok(())
+}
+
+/// Spawns the ten ongoing memory-maintenance sweeps (eviction, tier-promotion,
+/// scene-consolidation, consolidation, forgetting — #5914; plus guidelines, tree-consolidation,
+/// hebbian-consolidation, episodic-consolidation, optical-forgetting — #5979) on `supervisor` —
+/// mirrors `src/runner.rs`'s CLI/TUI wiring and `src/serve/deps.rs`'s
+/// `spawn_memory_maintenance_loops`.
+///
+/// Extracted from [`run_daemon`] (#6170) so the regression test
+/// `daemon_memory_maintenance_loops_registered_on_mem_supervisor` can call this real, shipped
+/// production function directly rather than reconstructing a copy of its spawn blocks — a
+/// hand-reconstructed copy could never catch a broken or inverted `if config.memory.*.enabled`
+/// guard in production, since it would only prove the test's own copy of the condition was
+/// correct.
+#[allow(clippy::too_many_lines)]
+fn spawn_daemon_memory_maintenance_loops(
+    app: &AppBuilder,
+    memory: &std::sync::Arc<zeph_memory::semantic::SemanticMemory>,
+    provider: &zeph_llm::any::AnyProvider,
+    status_tx: &tokio::sync::mpsc::UnboundedSender<String>,
+    supervisor: &zeph_common::TaskSupervisor,
+) {
+    let config = app.config();
+    {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let embedding = memory.embedding_store().cloned();
+        let eviction_cfg = config.memory.eviction.clone();
+        let policy = std::sync::Arc::new(zeph_memory::EbbinghausPolicy::default());
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(zeph_common::TaskDescriptor {
+            name: "mem-eviction",
+            restart: zeph_common::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_eviction_loop(
+                    store.clone(),
+                    embedding.clone(),
+                    eviction_cfg.clone(),
+                    policy.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let tier_cfg = zeph_memory::TierPromotionConfig {
+            enabled: config.memory.tiers.enabled,
+            promotion_min_sessions: config.memory.tiers.promotion_min_sessions,
+            similarity_threshold: config.memory.tiers.similarity_threshold,
+            sweep_interval_secs: config.memory.tiers.sweep_interval_secs,
+            sweep_batch_size: config.memory.tiers.sweep_batch_size,
+            embed_timeout_secs: config.memory.semantic.embed_timeout_secs,
+        };
+        let tier_provider = provider.clone();
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(zeph_common::TaskDescriptor {
+            name: "mem-tier-promotion",
+            restart: zeph_common::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_tier_promotion_loop(
+                    store.clone(),
+                    tier_provider.clone(),
+                    tier_cfg.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let scene_provider = app
+            .build_scene_provider()
+            .unwrap_or_else(|| provider.clone());
+        let scene_cfg = zeph_memory::SceneConfig {
+            enabled: config.memory.tiers.scene_enabled,
+            similarity_threshold: config.memory.tiers.scene_similarity_threshold,
+            batch_size: config.memory.tiers.scene_batch_size,
+            sweep_interval_secs: config.memory.tiers.scene_sweep_interval_secs,
+        };
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(zeph_common::TaskDescriptor {
+            name: "mem-scene-consolidation",
+            restart: zeph_common::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_scene_consolidation_loop(
+                    store.clone(),
+                    scene_provider.clone(),
+                    scene_cfg.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let consolidation_cfg = zeph_memory::ConsolidationConfig {
+            enabled: config.memory.consolidation.enabled,
+            confidence_threshold: config.memory.consolidation.confidence_threshold,
+            sweep_interval_secs: config.memory.consolidation.sweep_interval_secs,
+            sweep_batch_size: config.memory.consolidation.sweep_batch_size,
+            similarity_threshold: config.memory.consolidation.similarity_threshold,
+            llm_timeout_secs: config.memory.consolidation.llm_timeout_secs,
+            embed_timeout_secs: config.memory.semantic.embed_timeout_secs,
+        };
+        let consolidation_provider = app
+            .build_consolidation_provider()
+            .unwrap_or_else(|| provider.clone());
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(zeph_common::TaskDescriptor {
+            name: "mem-consolidation",
+            restart: zeph_common::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_consolidation_loop(
+                    store.clone(),
+                    consolidation_provider.clone(),
+                    consolidation_cfg.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let forgetting_cfg = zeph_memory::ForgettingConfig {
+            enabled: config.memory.forgetting.enabled,
+            decay_rate: config.memory.forgetting.decay_rate,
+            forgetting_floor: config.memory.forgetting.forgetting_floor,
+            sweep_interval_secs: config.memory.forgetting.sweep_interval_secs,
+            sweep_batch_size: config.memory.forgetting.sweep_batch_size,
+            replay_window_hours: config.memory.forgetting.replay_window_hours,
+            replay_min_access_count: config.memory.forgetting.replay_min_access_count,
+            protect_recent_hours: config.memory.forgetting.protect_recent_hours,
+            protect_min_access_count: config.memory.forgetting.protect_min_access_count,
+        };
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(zeph_common::TaskDescriptor {
+            name: "mem-forgetting",
+            restart: zeph_common::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_forgetting_loop(
+                    store.clone(),
+                    forgetting_cfg.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    if config.memory.compression_guidelines.enabled {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let guidelines_provider = app
+            .build_guidelines_provider()
+            .unwrap_or_else(|| provider.clone());
+        let token_counter = std::sync::Arc::clone(&memory.token_counter);
+        let guidelines_cfg = config.memory.compression_guidelines.clone();
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(zeph_common::TaskDescriptor {
+            name: "mem-guidelines",
+            restart: zeph_common::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_guidelines_updater(
+                    store.clone(),
+                    guidelines_provider.clone(),
+                    token_counter.clone(),
+                    guidelines_cfg.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    if config.memory.tree.enabled {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let tree_provider = app
+            .build_tree_consolidation_provider()
+            .unwrap_or_else(|| provider.clone());
+        let tree_cfg = zeph_memory::TreeConsolidationConfig {
+            enabled: config.memory.tree.enabled,
+            sweep_interval_secs: config.memory.tree.sweep_interval_secs,
+            batch_size: config.memory.tree.batch_size,
+            similarity_threshold: config.memory.tree.similarity_threshold,
+            max_level: config.memory.tree.max_level,
+            min_cluster_size: config.memory.tree.min_cluster_size,
+            embed_timeout_secs: config.memory.semantic.embed_timeout_secs,
+        };
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(zeph_common::TaskDescriptor {
+            name: "mem-tree-consolidation",
+            restart: zeph_common::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_tree_consolidation_loop(
+                    store.clone(),
+                    tree_provider.clone(),
+                    tree_cfg.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    if config.memory.hebbian.enabled && config.memory.hebbian.consolidation_interval_secs > 0 {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let hebbian_consolidation_cfg = zeph_memory::HebbianConsolidationConfig {
+            consolidation_interval_secs: config.memory.hebbian.consolidation_interval_secs,
+            consolidation_threshold: config.memory.hebbian.consolidation_threshold,
+            max_candidates_per_sweep: config.memory.hebbian.max_candidates_per_sweep,
+            consolidation_cooldown_secs: config.memory.hebbian.consolidation_cooldown_secs,
+            consolidation_prompt_timeout_secs: config
+                .memory
+                .hebbian
+                .consolidation_prompt_timeout_secs,
+            consolidation_max_neighbors: config.memory.hebbian.consolidation_max_neighbors,
+        };
+        let hebbian_provider = app
+            .build_hebbian_consolidation_provider()
+            .unwrap_or_else(|| provider.clone());
+        let status_tx_clone = status_tx.clone();
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(zeph_common::TaskDescriptor {
+            name: "mem-hebbian-consolidation",
+            restart: zeph_common::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::spawn_hebbian_consolidation_loop(
+                    store.clone(),
+                    hebbian_consolidation_cfg.clone(),
+                    hebbian_provider.clone(),
+                    Some(status_tx_clone.clone()),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    if config.memory.episodic_consolidation.enabled {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let ep_cfg = zeph_memory::EpisodicConsolidationConfig {
+            enabled: config.memory.episodic_consolidation.enabled,
+            consolidation_provider: config
+                .memory
+                .episodic_consolidation
+                .consolidation_provider
+                .clone(),
+            interval_secs: config.memory.episodic_consolidation.interval_secs,
+            batch_size: config.memory.episodic_consolidation.batch_size,
+            min_age_secs: config.memory.episodic_consolidation.min_age_secs,
+            dedup_jaccard_threshold: config.memory.episodic_consolidation.dedup_jaccard_threshold,
+        };
+        let ep_provider = app
+            .build_episodic_consolidation_provider()
+            .unwrap_or_else(|| provider.clone());
+        let ep_qdrant = memory.embedding_store().cloned();
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(zeph_common::TaskDescriptor {
+            name: "mem-episodic-consolidation",
+            restart: zeph_common::RestartPolicy::RunOnce,
+            factory: move || {
+                zeph_memory::start_episodic_consolidation_loop(
+                    store.clone(),
+                    ep_provider.clone(),
+                    ep_cfg.clone(),
+                    ep_qdrant.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+    if config.memory.optical_forgetting.enabled {
+        let store = std::sync::Arc::new(memory.sqlite().clone());
+        let optical_provider = app
+            .build_optical_forgetting_provider()
+            .unwrap_or_else(|| provider.clone());
+        let optical_cfg = config.memory.optical_forgetting.clone();
+        let forgetting_floor = config.memory.forgetting.forgetting_floor;
+        let cancel = supervisor.cancellation_token();
+        tracing::info_span!("daemon.memory.optical_forgetting.startup").in_scope(|| {
+            supervisor.spawn(zeph_common::TaskDescriptor {
+                name: "mem-optical-forgetting",
+                restart: zeph_common::RestartPolicy::RunOnce,
+                factory: move || {
+                    zeph_memory::start_optical_forgetting_loop(
+                        store.clone(),
+                        optical_provider.clone(),
+                        optical_cfg.clone(),
+                        forgetting_floor,
+                        cancel.clone(),
+                    )
+                },
+            });
+        });
+    }
 }
 
 #[cfg(test)]
@@ -2636,17 +2662,13 @@ mod tests {
     /// Regression test confirming all ten memory-maintenance loops (eviction, tier-promotion,
     /// scene-consolidation, consolidation, forgetting — #5914; plus guidelines,
     /// tree-consolidation, hebbian-consolidation, episodic-consolidation, optical-forgetting —
-    /// #5979) are actually registered on the daemon's own `TaskSupervisor`: `run_daemon`
-    /// previously spawned none of them, unlike the CLI path (`src/runner.rs`). Reconstructs the
-    /// same `TaskDescriptor`/`supervisor.spawn` block `run_daemon` now runs (falling back
-    /// directly to the primary provider where production uses `app.build_scene_provider()`/
-    /// `app.build_consolidation_provider()`/etc., since this test has no `AppBuilder` to resolve
-    /// a named override from, and passing `None` for the hebbian status sender since this test
-    /// has no `status_tx` from `app.build_provider()`) and asserts every expected task name is
-    /// present in the daemon's memory supervisor snapshot. The five #5979 loops are
+    /// #5979) are actually registered on the daemon's own `TaskSupervisor`. Calls the real,
+    /// shipped `spawn_daemon_memory_maintenance_loops` (extracted from `run_daemon` in #6170)
+    /// directly rather than reconstructing a copy of its spawn blocks, so a broken or inverted
+    /// `if config.memory.*.enabled` guard in production is actually caught here instead of only
+    /// proving the test's own copy of the condition was correct. The five #5979 loops are
     /// config-gated, so the config below explicitly enables each.
     #[tokio::test]
-    #[allow(clippy::too_many_lines)]
     async fn daemon_memory_maintenance_loops_registered_on_mem_supervisor() {
         let mock_provider = mock_provider();
         let memory = make_daemon_test_memory().await;
@@ -2656,260 +2678,18 @@ mod tests {
         config.memory.hebbian.enabled = true;
         config.memory.episodic_consolidation.enabled = true;
         config.memory.optical_forgetting.enabled = true;
+        let app = AppBuilder::for_test(config);
+        let (status_tx, _status_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
         let cancel = tokio_util::sync::CancellationToken::new();
         let supervisor = zeph_common::TaskSupervisor::new(cancel);
 
-        {
-            let store = std::sync::Arc::new(memory.sqlite().clone());
-            let embedding = memory.embedding_store().cloned();
-            let eviction_cfg = config.memory.eviction.clone();
-            let policy = std::sync::Arc::new(zeph_memory::EbbinghausPolicy::default());
-            let cancel = supervisor.cancellation_token();
-            supervisor.spawn(zeph_common::TaskDescriptor {
-                name: "mem-eviction",
-                restart: zeph_common::RestartPolicy::RunOnce,
-                factory: move || {
-                    zeph_memory::start_eviction_loop(
-                        store.clone(),
-                        embedding.clone(),
-                        eviction_cfg.clone(),
-                        policy.clone(),
-                        cancel.clone(),
-                    )
-                },
-            });
-        }
-        {
-            let store = std::sync::Arc::new(memory.sqlite().clone());
-            let tier_cfg = zeph_memory::TierPromotionConfig {
-                enabled: config.memory.tiers.enabled,
-                promotion_min_sessions: config.memory.tiers.promotion_min_sessions,
-                similarity_threshold: config.memory.tiers.similarity_threshold,
-                sweep_interval_secs: config.memory.tiers.sweep_interval_secs,
-                sweep_batch_size: config.memory.tiers.sweep_batch_size,
-                embed_timeout_secs: config.memory.semantic.embed_timeout_secs,
-            };
-            let tier_provider = mock_provider.clone();
-            let cancel = supervisor.cancellation_token();
-            supervisor.spawn(zeph_common::TaskDescriptor {
-                name: "mem-tier-promotion",
-                restart: zeph_common::RestartPolicy::RunOnce,
-                factory: move || {
-                    zeph_memory::start_tier_promotion_loop(
-                        store.clone(),
-                        tier_provider.clone(),
-                        tier_cfg.clone(),
-                        cancel.clone(),
-                    )
-                },
-            });
-        }
-        {
-            let store = std::sync::Arc::new(memory.sqlite().clone());
-            let scene_provider = mock_provider.clone();
-            let scene_cfg = zeph_memory::SceneConfig {
-                enabled: config.memory.tiers.scene_enabled,
-                similarity_threshold: config.memory.tiers.scene_similarity_threshold,
-                batch_size: config.memory.tiers.scene_batch_size,
-                sweep_interval_secs: config.memory.tiers.scene_sweep_interval_secs,
-            };
-            let cancel = supervisor.cancellation_token();
-            supervisor.spawn(zeph_common::TaskDescriptor {
-                name: "mem-scene-consolidation",
-                restart: zeph_common::RestartPolicy::RunOnce,
-                factory: move || {
-                    zeph_memory::start_scene_consolidation_loop(
-                        store.clone(),
-                        scene_provider.clone(),
-                        scene_cfg.clone(),
-                        cancel.clone(),
-                    )
-                },
-            });
-        }
-        {
-            let store = std::sync::Arc::new(memory.sqlite().clone());
-            let consolidation_cfg = zeph_memory::ConsolidationConfig {
-                enabled: config.memory.consolidation.enabled,
-                confidence_threshold: config.memory.consolidation.confidence_threshold,
-                sweep_interval_secs: config.memory.consolidation.sweep_interval_secs,
-                sweep_batch_size: config.memory.consolidation.sweep_batch_size,
-                similarity_threshold: config.memory.consolidation.similarity_threshold,
-                llm_timeout_secs: config.memory.consolidation.llm_timeout_secs,
-                embed_timeout_secs: config.memory.semantic.embed_timeout_secs,
-            };
-            let consolidation_provider = mock_provider.clone();
-            let cancel = supervisor.cancellation_token();
-            supervisor.spawn(zeph_common::TaskDescriptor {
-                name: "mem-consolidation",
-                restart: zeph_common::RestartPolicy::RunOnce,
-                factory: move || {
-                    zeph_memory::start_consolidation_loop(
-                        store.clone(),
-                        consolidation_provider.clone(),
-                        consolidation_cfg.clone(),
-                        cancel.clone(),
-                    )
-                },
-            });
-        }
-        {
-            let store = std::sync::Arc::new(memory.sqlite().clone());
-            let forgetting_cfg = zeph_memory::ForgettingConfig {
-                enabled: config.memory.forgetting.enabled,
-                decay_rate: config.memory.forgetting.decay_rate,
-                forgetting_floor: config.memory.forgetting.forgetting_floor,
-                sweep_interval_secs: config.memory.forgetting.sweep_interval_secs,
-                sweep_batch_size: config.memory.forgetting.sweep_batch_size,
-                replay_window_hours: config.memory.forgetting.replay_window_hours,
-                replay_min_access_count: config.memory.forgetting.replay_min_access_count,
-                protect_recent_hours: config.memory.forgetting.protect_recent_hours,
-                protect_min_access_count: config.memory.forgetting.protect_min_access_count,
-            };
-            let cancel = supervisor.cancellation_token();
-            supervisor.spawn(zeph_common::TaskDescriptor {
-                name: "mem-forgetting",
-                restart: zeph_common::RestartPolicy::RunOnce,
-                factory: move || {
-                    zeph_memory::start_forgetting_loop(
-                        store.clone(),
-                        forgetting_cfg.clone(),
-                        cancel.clone(),
-                    )
-                },
-            });
-        }
-        {
-            let store = std::sync::Arc::new(memory.sqlite().clone());
-            let guidelines_provider = mock_provider.clone();
-            let token_counter = std::sync::Arc::clone(&memory.token_counter);
-            let guidelines_cfg = config.memory.compression_guidelines.clone();
-            let cancel = supervisor.cancellation_token();
-            supervisor.spawn(zeph_common::TaskDescriptor {
-                name: "mem-guidelines",
-                restart: zeph_common::RestartPolicy::RunOnce,
-                factory: move || {
-                    zeph_memory::start_guidelines_updater(
-                        store.clone(),
-                        guidelines_provider.clone(),
-                        token_counter.clone(),
-                        guidelines_cfg.clone(),
-                        cancel.clone(),
-                    )
-                },
-            });
-        }
-        {
-            let store = std::sync::Arc::new(memory.sqlite().clone());
-            let tree_provider = mock_provider.clone();
-            let tree_cfg = zeph_memory::TreeConsolidationConfig {
-                enabled: config.memory.tree.enabled,
-                sweep_interval_secs: config.memory.tree.sweep_interval_secs,
-                batch_size: config.memory.tree.batch_size,
-                similarity_threshold: config.memory.tree.similarity_threshold,
-                max_level: config.memory.tree.max_level,
-                min_cluster_size: config.memory.tree.min_cluster_size,
-                embed_timeout_secs: config.memory.semantic.embed_timeout_secs,
-            };
-            let cancel = supervisor.cancellation_token();
-            supervisor.spawn(zeph_common::TaskDescriptor {
-                name: "mem-tree-consolidation",
-                restart: zeph_common::RestartPolicy::RunOnce,
-                factory: move || {
-                    zeph_memory::start_tree_consolidation_loop(
-                        store.clone(),
-                        tree_provider.clone(),
-                        tree_cfg.clone(),
-                        cancel.clone(),
-                    )
-                },
-            });
-        }
-        {
-            let store = std::sync::Arc::new(memory.sqlite().clone());
-            let hebbian_consolidation_cfg = zeph_memory::HebbianConsolidationConfig {
-                consolidation_interval_secs: config.memory.hebbian.consolidation_interval_secs,
-                consolidation_threshold: config.memory.hebbian.consolidation_threshold,
-                max_candidates_per_sweep: config.memory.hebbian.max_candidates_per_sweep,
-                consolidation_cooldown_secs: config.memory.hebbian.consolidation_cooldown_secs,
-                consolidation_prompt_timeout_secs: config
-                    .memory
-                    .hebbian
-                    .consolidation_prompt_timeout_secs,
-                consolidation_max_neighbors: config.memory.hebbian.consolidation_max_neighbors,
-            };
-            let hebbian_provider = mock_provider.clone();
-            let cancel = supervisor.cancellation_token();
-            supervisor.spawn(zeph_common::TaskDescriptor {
-                name: "mem-hebbian-consolidation",
-                restart: zeph_common::RestartPolicy::RunOnce,
-                factory: move || {
-                    zeph_memory::spawn_hebbian_consolidation_loop(
-                        store.clone(),
-                        hebbian_consolidation_cfg.clone(),
-                        hebbian_provider.clone(),
-                        None,
-                        cancel.clone(),
-                    )
-                },
-            });
-        }
-        {
-            let store = std::sync::Arc::new(memory.sqlite().clone());
-            let ep_cfg = zeph_memory::EpisodicConsolidationConfig {
-                enabled: config.memory.episodic_consolidation.enabled,
-                consolidation_provider: config
-                    .memory
-                    .episodic_consolidation
-                    .consolidation_provider
-                    .clone(),
-                interval_secs: config.memory.episodic_consolidation.interval_secs,
-                batch_size: config.memory.episodic_consolidation.batch_size,
-                min_age_secs: config.memory.episodic_consolidation.min_age_secs,
-                dedup_jaccard_threshold: config
-                    .memory
-                    .episodic_consolidation
-                    .dedup_jaccard_threshold,
-            };
-            let ep_provider = mock_provider.clone();
-            let ep_qdrant = memory.embedding_store().cloned();
-            let cancel = supervisor.cancellation_token();
-            supervisor.spawn(zeph_common::TaskDescriptor {
-                name: "mem-episodic-consolidation",
-                restart: zeph_common::RestartPolicy::RunOnce,
-                factory: move || {
-                    zeph_memory::start_episodic_consolidation_loop(
-                        store.clone(),
-                        ep_provider.clone(),
-                        ep_cfg.clone(),
-                        ep_qdrant.clone(),
-                        cancel.clone(),
-                    )
-                },
-            });
-        }
-        {
-            let store = std::sync::Arc::new(memory.sqlite().clone());
-            let optical_provider = mock_provider.clone();
-            let optical_cfg = config.memory.optical_forgetting.clone();
-            let forgetting_floor = config.memory.forgetting.forgetting_floor;
-            let cancel = supervisor.cancellation_token();
-            tracing::info_span!("daemon.memory.optical_forgetting.startup").in_scope(|| {
-                supervisor.spawn(zeph_common::TaskDescriptor {
-                    name: "mem-optical-forgetting",
-                    restart: zeph_common::RestartPolicy::RunOnce,
-                    factory: move || {
-                        zeph_memory::start_optical_forgetting_loop(
-                            store.clone(),
-                            optical_provider.clone(),
-                            optical_cfg.clone(),
-                            forgetting_floor,
-                            cancel.clone(),
-                        )
-                    },
-                });
-            });
-        }
+        spawn_daemon_memory_maintenance_loops(
+            &app,
+            &memory,
+            &mock_provider,
+            &status_tx,
+            &supervisor,
+        );
 
         let names: std::collections::HashSet<String> = supervisor
             .snapshot()


### PR DESCRIPTION
## Summary

- `src/acp.rs`'s `acp_memory_maintenance_loops_registered_on_connection_supervisor` and `src/daemon.rs`'s `daemon_memory_maintenance_loops_registered_on_mem_supervisor` regression tests reconstructed the memory-maintenance-loop spawn blocks inline with a mock `TaskSupervisor`, rather than invoking the real production wiring path (`build_acp_deps`/`run_daemon`). A broken or inverted `config.memory.*.enabled` guard in production would go undetected by either test.
- Extracted the wiring into standalone `spawn_acp_memory_maintenance_loops` (src/acp.rs) and `spawn_daemon_memory_maintenance_loops` (src/daemon.rs) functions, mirroring the existing `spawn_memory_maintenance_loops` pattern already used in `src/serve/deps.rs`. Both `build_acp_deps`/`run_daemon` now call the extracted functions, and both regression tests now call them directly instead of reconstructing the spawn logic.
- Pure test/production-coupling fix — no behavior change. All ten memory-maintenance loops still spawn identically, gated the same way, via `TaskSupervisor::spawn`.

Closes #6170

## Test plan

- [x] Independently confirmed (by two separate agents, on two different config gates than the implementer's own check) that inverting a `config.memory.*.enabled` guard inside the extracted functions now causes the corresponding regression test to fail, and that reverting restores a clean pass
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13253 passed, 35 skipped
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] Rebased onto latest `origin/main` (picked up #6171/#6172/#6174) and re-ran the full check suite clean