### PR TITLE
fix: box remaining large_futures call sites reintroduced by #6169

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   over the 16384-byte threshold) that only triggered on macOS/aarch64 due to platform-specific
   stack layout differences (#6163). Same fix pattern as #3521: move the large future onto the
   heap rather than tuning its size. No behavior change.
+- `src/acp.rs`, `src/serve/agent_factory.rs`, `src/serve/test_support.rs`: boxed 3 new
+  `build_combined_deps(...).await` call sites with `Box::pin(...)` that #6169 added unboxed,
+  reintroducing `clippy::large_futures` after #6168 had already closed the same lint class
+  (#6175). Same fix pattern as #6168/#3521. No behavior change.
 
 ### Testing
 

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -4725,7 +4725,7 @@ mod tests {
         let cancel = tokio_util::sync::CancellationToken::new();
         let supervisor = std::sync::Arc::new(zeph_common::TaskSupervisor::new(cancel));
 
-        let (serve_deps, acp_deps, _keepalive) = build_combined_deps(&app, &supervisor)
+        let (serve_deps, acp_deps, _keepalive) = Box::pin(build_combined_deps(&app, &supervisor))
             .await
             .expect("build_combined_deps must succeed against a mock-provider AppBuilder");
 

--- a/src/serve/agent_factory.rs
+++ b/src/serve/agent_factory.rs
@@ -1959,7 +1959,7 @@ mod tests {
         let supervisor = std::sync::Arc::new(zeph_common::TaskSupervisor::new(cancel));
 
         let (serve_deps, _acp_deps, _keepalive) =
-            crate::acp::build_combined_deps(&app, &supervisor)
+            Box::pin(crate::acp::build_combined_deps(&app, &supervisor))
                 .await
                 .expect("build_combined_deps must succeed against a mock-provider AppBuilder");
 

--- a/src/serve/test_support.rs
+++ b/src/serve/test_support.rs
@@ -239,9 +239,10 @@ pub(crate) async fn build_shared_pair() -> (super::deps::ServeAgentDeps, crate::
     let cancel = tokio_util::sync::CancellationToken::new();
     let supervisor = Arc::new(zeph_common::task_supervisor::TaskSupervisor::new(cancel));
 
-    let (serve_deps, acp_deps, _keepalive) = crate::acp::build_combined_deps(&app, &supervisor)
-        .await
-        .expect("build_combined_deps must succeed against a mock-provider AppBuilder");
+    let (serve_deps, acp_deps, _keepalive) =
+        Box::pin(crate::acp::build_combined_deps(&app, &supervisor))
+            .await
+            .expect("build_combined_deps must succeed against a mock-provider AppBuilder");
     (serve_deps, acp_deps)
 }
 


### PR DESCRIPTION
## Summary
- PR #6169 added new unboxed test-only `build_combined_deps(...)` call sites in `src/acp.rs`, `src/serve/agent_factory.rs`, and `src/serve/test_support.rs`, reintroducing `clippy::large_futures` after PR #6168 had already closed the same lint class.
- Boxed all 3 sites with `Box::pin(...)`, matching the exact pattern #6168 uses at every other `build_combined_deps`/`build_agent_factory` call site (confirmed via team critique: no helper-wrapper divergence, all 4 workspace call sites now boxed identically).
- No behavior change — purely a compile-time future-size fix.

Closes #6175

## Test plan
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — zero `large_futures` warnings (only unrelated pre-existing `proc-macro-error2` RUSTSEC-2026-0173 future-incompat note)
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins -E 'test(build_combined_deps)'` — 3/3 pass
- [x] Full workspace test suite — 13253/13253 passed, 0 failed (via team tester validation)
- [x] Verified via grep that all 4 `build_combined_deps(...).await` sites in the workspace (3 fixed here + 1 pre-existing production site from #6168) are now boxed, and the sibling `build_agent_factory` class remains fully boxed (14/14, no second regression)