### PR TITLE
fix(core): pass model identifier, not provider name, to is_reasoning_model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   instead of "plugin registry" (#5943). All four call sites now reuse
   `REGISTRY_NOT_CONFIGURED_MSG` for the bail as well, so stdout and the error both show
   the same, subsystem-neutral, actionable message.
+- `crates/zeph-core/src/agent/tool_execution/tool_result.rs`: the `reasoning_amplification`
+  anomaly (`AnomalyOutcome::ReasoningQualityFailure`, arXiv:2510.22977) fed `self.provider.name()`
+  — the provider *instance* name (e.g. `"openai"`, or a custom `[[llm.providers]]` name) — into
+  `is_reasoning_model()`, which pattern-matches *model identifiers* (`o3-mini`, `deepseek-r1`,
+  `claude-*-think`, ...). Instance names never match those patterns, so the branch was permanently
+  unreachable (#5909). Both the detection call and the stored `model:` field now use
+  `self.provider.model_identifier()`. Also added a missing `model_identifier()` override on
+  `GeminiProvider`, which fell back to the trait default (`""`) for the same reason.
 - `src/commands/db.rs`: `zeph db migrate` fell back to the raw, unredacted database URL
   in error messages and the migration-status line whenever `redact_url` returned `None`
   — which only means the URL didn't match a recognized credential-bearing shape, not that

--- a/crates/zeph-core/src/agent/tool_execution/tests/boundary_and_classifier_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/boundary_and_classifier_tests.rs
@@ -1482,3 +1482,171 @@ async fn utility_window_exempt_tool_does_not_trigger_break() {
         "exempt tool invoke_skill must not trigger utility-window exhaustion"
     );
 }
+
+// --- #5909: reasoning-amplification anomaly must key off model_identifier(), not name() ---
+//
+// `classify_tool_result` (tool_result.rs) feeds `is_reasoning_model()` with the provider's
+// *model identifier* (e.g. "o3-mini") to decide whether a quality-failure tool error should be
+// classified as `AnomalyOutcome::ReasoningQualityFailure`. Before the fix it passed the
+// provider's *instance name* (e.g. "openai") instead, which never matches a reasoning-model
+// pattern, so the branch was permanently unreachable. These tests exercise the real call site
+// via `process_one_tool_result` (not `is_reasoning_model()` in isolation, which already has
+// coverage in `zeph-tools/src/anomaly.rs`) and assert on the `reasoning_amplification` tracing
+// event that only `record_reasoning_quality_failure` (in `zeph-tools`, a *different* crate)
+// emits.
+//
+// `tracing_test::traced_test` / `logs_contain` is deliberately NOT used here: it installs an
+// env filter equivalent to `RUST_LOG=zeph_core=trace`, silently dropping events from other
+// crates such as `zeph-tools` — the very event this regression needs to observe. Instead these
+// tests install a minimal `tracing_subscriber::Layer` that captures every event regardless of
+// origin crate, scoped to the test via a `set_default` guard.
+mod reasoning_amplification_call_site {
+    use std::fmt::Write as _;
+    use std::sync::{Arc, Mutex};
+
+    use tracing::field::{Field, Visit};
+    use tracing_subscriber::Layer;
+    use tracing_subscriber::layer::{Context, SubscriberExt};
+    use tracing_subscriber::registry::{LookupSpan, Registry};
+
+    use crate::agent::agent_tests::{MockChannel, MockToolExecutor, create_test_registry};
+
+    use super::make_tool_use_request;
+
+    /// Captures every tracing event's fields (regardless of origin crate) into a shared buffer.
+    #[derive(Clone, Default)]
+    struct EventCapture(Arc<Mutex<String>>);
+
+    struct FieldWriter<'a>(&'a mut String);
+
+    impl Visit for FieldWriter<'_> {
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            let _ = write!(self.0, "{}={value:?} ", field.name());
+        }
+    }
+
+    impl<S> Layer<S> for EventCapture
+    where
+        S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+    {
+        fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+            let mut line = String::new();
+            event.record(&mut FieldWriter(&mut line));
+            let mut buf = self.0.lock().unwrap();
+            buf.push_str(&line);
+            buf.push('\n');
+        }
+    }
+
+    /// Runs `f` under a subscriber that records all tracing events, returning the captured text.
+    async fn capture_logs<F, Fut>(f: F) -> String
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = ()>,
+    {
+        let capture = EventCapture::default();
+        let subscriber = Registry::default().with(capture.clone());
+        let guard = tracing::subscriber::set_default(subscriber);
+        f().await;
+        drop(guard);
+        capture.0.lock().unwrap().clone()
+    }
+
+    #[tokio::test]
+    async fn quality_failure_from_reasoning_model_identifier_is_flagged() {
+        // Instance name deliberately does NOT match a reasoning-model pattern; only
+        // model_identifier() does. Before the fix (which read provider.name()), this case
+        // could never reach the ReasoningQualityFailure branch.
+        let provider = zeph_llm::any::AnyProvider::Mock(
+            zeph_llm::mock::MockProvider::with_responses(vec![])
+                .with_name("openai")
+                .with_model_identifier("o3-mini"),
+        );
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+        agent.runtime.debug.anomaly_detector = Some(zeph_tools::AnomalyDetector::new(10, 0.0, 1.0));
+        agent.runtime.debug.reasoning_model_warning = true;
+
+        let tc = make_tool_use_request("id-reasoning", "bash");
+        let err = zeph_tools::executor::ToolError::InvalidParams {
+            message: "missing required field 'command'".into(),
+        };
+
+        let logs = capture_logs(|| async {
+            agent
+                .process_one_tool_result(
+                    &tc,
+                    "id-reasoning",
+                    &std::time::Instant::now(),
+                    Err(err),
+                    &mut Vec::new(),
+                    &mut Vec::new(),
+                    &mut false,
+                    &mut None,
+                    &mut Vec::new(),
+                )
+                .await
+                .unwrap();
+        })
+        .await;
+
+        assert!(
+            logs.contains("reasoning_amplification"),
+            "quality failure from a provider whose model_identifier() is a reasoning-model \
+             pattern must emit the reasoning_amplification warning; captured logs:\n{logs}"
+        );
+        assert!(
+            logs.contains("o3-mini"),
+            "the emitted warning must carry the model identifier, not the provider instance \
+             name; captured logs:\n{logs}"
+        );
+    }
+
+    #[tokio::test]
+    async fn quality_failure_is_not_flagged_when_only_provider_name_matches() {
+        // Instance name looks like a reasoning model, but model_identifier() does not
+        // (defaults to ""). This is the negative control for the fix: it proves the call
+        // site now reads model_identifier() and no longer falls back to name() by accident.
+        let provider = zeph_llm::any::AnyProvider::Mock(
+            zeph_llm::mock::MockProvider::with_responses(vec![]).with_name("deepseek-r1"),
+        );
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+        agent.runtime.debug.anomaly_detector = Some(zeph_tools::AnomalyDetector::new(10, 0.0, 1.0));
+        agent.runtime.debug.reasoning_model_warning = true;
+
+        let tc = make_tool_use_request("id-name-only", "bash");
+        let err = zeph_tools::executor::ToolError::InvalidParams {
+            message: "missing required field 'command'".into(),
+        };
+
+        let logs = capture_logs(|| async {
+            agent
+                .process_one_tool_result(
+                    &tc,
+                    "id-name-only",
+                    &std::time::Instant::now(),
+                    Err(err),
+                    &mut Vec::new(),
+                    &mut Vec::new(),
+                    &mut false,
+                    &mut None,
+                    &mut Vec::new(),
+                )
+                .await
+                .unwrap();
+        })
+        .await;
+
+        assert!(
+            !logs.contains("reasoning_amplification"),
+            "a provider whose model_identifier() is empty must not be classified as a \
+             reasoning model just because its instance name matches a reasoning-model pattern; \
+             captured logs:\n{logs}"
+        );
+    }
+}

--- a/crates/zeph-core/src/agent/tool_execution/tool_result.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tool_result.rs
@@ -314,10 +314,11 @@ impl<C: Channel> Agent<C> {
                 let is_quality_failure = category.is_quality_failure();
                 let anomaly_outcome = if matches!(e, zeph_tools::ToolError::Blocked { .. }) {
                     AnomalyOutcome::Blocked
-                } else if is_quality_failure && zeph_tools::is_reasoning_model(self.provider.name())
+                } else if is_quality_failure
+                    && zeph_tools::is_reasoning_model(self.provider.model_identifier())
                 {
                     AnomalyOutcome::ReasoningQualityFailure {
-                        model: self.provider.name().to_owned(),
+                        model: self.provider.model_identifier().to_owned(),
                         tool: tc.name.to_string(),
                     }
                 } else {

--- a/crates/zeph-llm/src/gemini/mod.rs
+++ b/crates/zeph-llm/src/gemini/mod.rs
@@ -1254,6 +1254,10 @@ impl LlmProvider for GeminiProvider {
         &self.provider_name
     }
 
+    fn model_identifier(&self) -> &str {
+        &self.model
+    }
+
     fn context_window(&self) -> Option<usize> {
         // Gemini 1.5 Pro has 2M token context; all other Gemini models default to 1M.
         if self.model.contains("1.5-pro") || self.model.contains("gemini-1.5-pro") {

--- a/crates/zeph-llm/src/gemini/tests.rs
+++ b/crates/zeph-llm/src/gemini/tests.rs
@@ -27,6 +27,17 @@ fn gemini_with_provider_name_overrides_name() {
     assert_eq!(p.name(), "fast-gemini");
 }
 
+// Regression guard for #5909: `GeminiProvider` was missing a `model_identifier()` override,
+// so it fell back to the trait default (`""`), which broke any caller keying model-specific
+// heuristics (e.g. `is_reasoning_model()`) off the model string instead of the instance name.
+#[test]
+fn gemini_model_identifier_returns_model_not_name() {
+    let p = GeminiProvider::new("key".into(), "gemini-2.0-flash".into(), 1024)
+        .with_provider_name("fast-gemini");
+    assert_eq!(p.model_identifier(), "gemini-2.0-flash");
+    assert_ne!(p.model_identifier(), p.name());
+}
+
 #[test]
 fn gemini_supports_streaming_true() {
     let p = GeminiProvider::new("key".into(), "gemini-2.0-flash".into(), 1024);

--- a/crates/zeph-llm/src/mock.rs
+++ b/crates/zeph-llm/src/mock.rs
@@ -45,6 +45,9 @@ pub struct MockProvider {
     pub models: Vec<RemoteModelInfo>,
     /// Optional name override for tests that require distinct provider names.
     pub name_override: Option<String>,
+    /// Optional model identifier override for tests that require `model_identifier()`
+    /// to return a specific value (e.g. a reasoning-model pattern like `"o3-mini"`).
+    pub model_identifier_override: Option<String>,
     /// When true, `embed()` returns `LlmError::InvalidInput` regardless of `supports_embeddings`.
     pub embed_invalid_input: bool,
     /// When true, `chat_with_tools()` returns `LlmError::InvalidInput`.
@@ -98,6 +101,7 @@ impl Default for MockProvider {
             tool_call_count: Arc::new(Mutex::new(0)),
             models: vec![],
             name_override: None,
+            model_identifier_override: None,
             embed_invalid_input: false,
             tool_chat_invalid_input: false,
             embed_call_count: Arc::new(std::sync::atomic::AtomicU64::new(0)),
@@ -137,6 +141,15 @@ impl MockProvider {
     #[must_use]
     pub fn with_name(mut self, name: impl Into<String>) -> Self {
         self.name_override = Some(name.into());
+        self
+    }
+
+    /// Set a custom model identifier returned by `model_identifier()`. Useful for testing
+    /// model-identifier-driven heuristics (e.g. `is_reasoning_model()`) without spinning up
+    /// a real provider whose instance name differs from its model string.
+    #[must_use]
+    pub fn with_model_identifier(mut self, model: impl Into<String>) -> Self {
+        self.model_identifier_override = Some(model.into());
         self
     }
 
@@ -388,6 +401,10 @@ impl LlmProvider for MockProvider {
     #[allow(clippy::unnecessary_literal_bound)]
     fn name(&self) -> &str {
         self.name_override.as_deref().unwrap_or("mock")
+    }
+
+    fn model_identifier(&self) -> &str {
+        self.model_identifier_override.as_deref().unwrap_or("")
     }
 
     async fn chat(&self, messages: &[Message]) -> Result<String, crate::LlmError> {


### PR DESCRIPTION
## Summary

- `tool_result.rs` fed `self.provider.name()` (the provider *instance/config* name, e.g. `"openai"`) into `is_reasoning_model()`, which pattern-matches *model identifiers* (`o3-mini`, `deepseek-r1`, `claude-*-think`, ...). Instance names never match those patterns, so `AnomalyOutcome::ReasoningQualityFailure` (the `reasoning_amplification` anomaly, arXiv:2510.22977) was permanently unreachable.
- Both the detection call and the stored `model:` field now use `self.provider.model_identifier()`, which already existed on the `LlmProvider` trait (dyn-safe, no new trait method added).
- Also adds a missing `model_identifier()` override on `GeminiProvider`, which fell back to the trait default (`""`) for the same reason.

Closes #5909

## Test plan

- [x] Added 2 regression tests exercising the real production entry point (`process_one_tool_result`), including a negative control proving the fix reads the correct field
- [x] Added `MockProvider::with_model_identifier()` test helper
- [x] Added a unit test for the Gemini `model_identifier()` addition
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 2925 passed, 0 failed
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`) clean
- [x] CHANGELOG.md updated under `[Unreleased]` → `Fixed`