### PR TITLE
fix(sanitizer): qualify broken rustdoc intra-doc link to ClassifierMetrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `build_combined_deps(...).await` call sites with `Box::pin(...)` that #6169 added unboxed,
   reintroducing `clippy::large_futures` after #6168 had already closed the same lint class
   (#6175). Same fix pattern as #6168/#3521. No behavior change.
+- `crates/zeph-sanitizer/src/sanitizer.rs`: `with_classifier_metrics`'s doc comment linked
+  `[`ClassifierMetrics`]` unqualified, which rustdoc could not resolve since the type
+  (`zeph_llm::ClassifierMetrics`) is never imported unqualified in this module, breaking the
+  `rustdoc::broken_intra_doc_links` gate (#6177). Changed the link to the fully-qualified path
+  `[`ClassifierMetrics`](zeph_llm::ClassifierMetrics)`.
 
 ### Testing
 

--- a/crates/zeph-sanitizer/src/sanitizer.rs
+++ b/crates/zeph-sanitizer/src/sanitizer.rs
@@ -286,7 +286,7 @@ impl ContentSanitizer {
         self
     }
 
-    /// Attach a [`ClassifierMetrics`] instance to record injection and PII latencies.
+    /// Attach a [`ClassifierMetrics`](zeph_llm::ClassifierMetrics) instance to record injection and PII latencies.
     #[cfg(feature = "classifiers")]
     #[must_use]
     pub fn with_classifier_metrics(


### PR DESCRIPTION
## Summary
- Fixed the `rustdoc::broken_intra_doc_links` gate failure in `crates/zeph-sanitizer/src/sanitizer.rs`: the doc comment on `with_classifier_metrics` linked the unqualified `[`ClassifierMetrics`]`, which rustdoc could not resolve since the type (`zeph_llm::ClassifierMetrics`) is never imported unqualified in this module. Changed the link to the fully-qualified path `[`ClassifierMetrics`](zeph_llm::ClassifierMetrics)`.
- Checked the rest of `zeph-sanitizer` for similar unqualified cross-crate intra-doc links; none found broken.

Closes #6177

## Test plan
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-sanitizer --features classifiers` passes clean
- [x] `cargo nextest run -p zeph-sanitizer --features classifiers` — 374 passed, 0 failed
- [x] `cargo test --doc -p zeph-sanitizer --features classifiers` — 52 passed, 0 failed
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy --profile ci -p zeph-sanitizer --all-targets --features classifiers -- -D warnings` clean