### PR TITLE
security: add gitleaks allowlist for known test-fixture dummy secrets

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,37 @@
+title = "zeph gitleaks config"
+
+# Extend gitleaks' built-in ruleset instead of replacing it, so all default
+# detectors (generic-api-key, jwt, curl-auth-user, curl-auth-header,
+# stripe-access-token, etc.) keep running; only the allowlist below is added.
+[extend]
+useDefault = true
+
+# Known-benign dummy secrets used in test fixtures, doctests, and
+# documentation examples across the codebase (issues #6056, #6081).
+# Every entry here was verified via a real `gitleaks detect` run to
+# resolve to a fake/example value, never a live credential. Matching on
+# the literal dummy string (not just file path) also suppresses future
+# test fixtures that reuse the same established dummy pattern — see the
+# convention note in SECURITY.md.
+[[allowlists]]
+description = "Test-fixture and documentation dummy secrets"
+regexTarget = "match"
+regexes = [
+  '''sk-abc123secret''',
+  '''sk-abc123def456''',
+  '''sk-abc123def''',
+  '''sk-abc123xyz''',
+  '''AKIA1234567890ABCDEF''',
+  '''AIzaSyA1234567890abcdefghijklmnop''',
+  '''sk_live_abcdef123456''',
+  '''sk-REDACTMEAKIA1234567890abcdef''',
+  '''tg-injected-789''',
+  '''mysecret12345678''',
+  '''supersecretvalue1''',
+  '''admin:secret''',
+  '''eyJhbGciOiJub25lIn0\.eyJzdWIiOiJ1c2VyIn0\.''',
+  '''eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9\.eyJzdWIiOiJ1c2VyMTIzIn0\.SflKxwRJSMeKKF2''',
+  '''eyJhbGciOi\.\.\.''',
+  '''ZEPH_A2A_IBCT_KEY''',
+  '''VAULT_A2A_IBCT_KEY_1''',
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 ### Added
 
+- **Security**: added `.gitleaks.toml` allowlisting the 31 known-benign gitleaks
+  findings from a full git-history scan — all fake/example secrets in test
+  fixtures, doctests, and documentation (`secret_mask.rs`, `redact.rs`,
+  `tool_execution.rs`/tests, `notifications.rs`, `secrets.rs`, `doctor.rs`,
+  `compression_guidelines.rs`, the `api-request` skill doc, and A2A
+  `ZEPH_A2A_IBCT_KEY`/`VAULT_A2A_IBCT_KEY_1` env-var names), none a real
+  credential. Extends (not replaces) gitleaks' default ruleset via
+  `[extend] useDefault = true`; allowlist entries match the literal dummy
+  string so future test fixtures reusing the same established pattern are
+  also covered, not just the already-known commits. `gitleaks detect` now
+  exits clean (0 findings) instead of re-surfacing the same 31 hits on every
+  scan. `SECURITY.md` documents the convention: reuse an existing dummy
+  pattern in new test fixtures where possible, or add a new allowlist entry
+  (#6056, #6081).
 - **Memory**: wired the five remaining memory-maintenance loops — guidelines
   (`mem-guidelines`), tree-consolidation (`mem-tree-consolidation`), hebbian-consolidation
   (`mem-hebbian-consolidation`), episodic-consolidation (`mem-episodic-consolidation`), and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,3 +29,4 @@ You can expect an initial response within 72 hours.
 - Dependabot monitors for known vulnerabilities in dependencies
 - Shell execution is sandboxed with a 30-second timeout
 - Telegram bot supports user whitelisting to restrict access
+- Full git history is scanned for leaked secrets with [gitleaks](https://github.com/gitleaks/gitleaks); `.gitleaks.toml` allowlists known-benign dummy secrets used in test fixtures, doctests, and documentation examples. When adding a new test fixture that needs a fake secret, reuse an already-allowlisted dummy pattern where possible, or add a new entry to `.gitleaks.toml` and re-run `gitleaks detect --no-banner --source .` to confirm it stays clean


### PR DESCRIPTION
## Summary

- A full-history `gitleaks detect` scan (2879 commits) reports 31 findings — up from the 25 both issues originally cited, expected drift they explicitly flagged as possible. Every finding was individually inspected and confirmed to be a fake/example secret in a test fixture, doctest, or documentation snippet (redaction-subsystem test data, doctor.rs example keys, A2A env-var *names*, etc.), never a real credential.
- Adds `.gitleaks.toml` at the repo root: `[extend] useDefault = true` keeps all built-in detectors active, plus one `[[allowlists]]` block with 17 literal-string/regex entries matching the known dummy secrets. Verified locally with `gitleaks` v8.30.1: 31 findings → 0 findings, exit code 0.
- Adds one line to `SECURITY.md` documenting the scan and the convention: reuse an already-allowlisted dummy pattern in new test fixtures where possible, otherwise add a new `.gitleaks.toml` entry.

## Issue closure note

Both issues describe the same 31 (nee 25) findings, but propose different mechanisms: #6056's title and Expected Behavior section explicitly name `.gitleaksignore` (commit+fingerprint-keyed suppression); #6081 explicitly asks for `.gitleaks.toml` (regex/path/stopwords allowlist). This PR implements `.gitleaks.toml` for both, not `.gitleaksignore`, because:
- No existing gitleaks CI job exists in this repo to reconcile with (only `cargo-deny` runs in `security.yml`), so there was no external constraint favoring one mechanism.
- Literal-string allowlisting survives history rewrites/rebases better than fingerprint-keyed `.gitleaksignore` entries, which are pinned to specific commit SHAs.
- It automatically covers future test fixtures that reuse the same established dummy pattern, not just the 31 already-known commits.

No `.gitleaksignore` was added. If a future CI job specifically expects that mechanism, it can be layered on top — the two are not mutually exclusive.

## Follow-up (not in scope here)

No gitleaks step currently runs in any GitHub Actions workflow — `gitleaks detect` was only run manually/locally for this PR. Recommend a follow-up to add a PR-gating `gitleaks detect` step to `.github/workflows/security.yml` so this stays enforced automatically rather than relying on manual runs. Tracked as a "Known Gap" in the new playbook (see below).

## Test plan

- [x] `gitleaks detect --no-banner --source . --report-format json` — before: 31 findings; after: 0 findings, exit code 0 (run independently by both the implementer and the reviewer, same result both times)
- [x] `git status --short -- src/ crates/ Cargo.toml Cargo.lock` — empty; no production/build-manifest files touched, config-only change
- [x] Not applicable: fmt/clippy/nextest/rustdoc gates — no Rust source changed
- [x] Not applicable: LLM serialization gate — no LLM request/response paths touched
- [x] `.local/testing/coverage-status.md` (main repo) — new row added under Security / Cross-cutting, status `Tested` (config-verified via gitleaks exit code, not a live-agent session — noted explicitly, since this change has no agent-session testing surface)
- [x] `.local/testing/playbooks/security-gitleaks-allowlist.md` (main repo, new) — 3 scenarios: clean-scan (verified), negative-control new-secret-still-caught (documented, not yet executed — flagged as a known gap), new-dummy-fixture guidance (documented)

Closes #6056
Closes #6081