### PR TITLE
refactor(durable): dedup step-cap check and warn on unsafe shared_db migration topology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   (`zeph_llm::ClassifierMetrics`) is never imported unqualified in this module, breaking the
   `rustdoc::broken_intra_doc_links` gate (#6177). Changed the link to the fully-qualified path
   `[`ClassifierMetrics`](zeph_llm::ClassifierMetrics)`.
+- `crates/zeph-durable/src/handle.rs`: `DurableContext::checked_step_id` and `run_step_at`
+  repeated the identical per-execution step-cap condition verbatim. Extracted into a single
+  `enforce_step_cap` helper called from both sites (#6082). Pure refactor, no behavior change.
 
 ### Testing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `crates/zeph-durable/src/handle.rs`: `DurableContext::checked_step_id` and `run_step_at`
   repeated the identical per-execution step-cap condition verbatim. Extracted into a single
   `enforce_step_cap` helper called from both sites (#6082). Pure refactor, no behavior change.
+- `crates/zeph-config/src/migrate/infra.rs`: `--migrate-config`'s `migrate_durable_shared_db`
+  step silently left an unsafe combination undetected — `durable.encrypt_payload = false` with
+  `shared_db` unset passes the INV-8 `encryption_gate`'s local-only override even when the
+  durable journal database actually lives on a network-shared mount, since `shared_db` is
+  purely operator-declared and cannot be inferred from the filesystem (#6042). The migration
+  step now emits a `tracing::warn!`/stderr warning (matching the existing
+  `migrate_llm_to_providers` warning convention) asking the operator to confirm their
+  deployment topology whenever this combination is detected. Filesystem-type detection and
+  path-prefix heuristics remain explicitly out of scope, deferred to a future issue.
 
 ### Testing
 

--- a/crates/zeph-config/src/migrate/infra.rs
+++ b/crates/zeph-config/src/migrate/infra.rs
@@ -623,6 +623,44 @@ pub fn migrate_durable_config(toml_src: &str) -> Result<MigrationResult, Migrate
     })
 }
 
+/// Whether `durable.encrypt_payload = false` is active while `shared_db` is left unset (#6042).
+///
+/// `shared_db` is purely operator-declared (INV-8 `encryption_gate` cannot infer it from the
+/// filesystem), so this combination silently satisfies the gate's local-only override even when
+/// the durable journal database actually lives on a network-shared mount. A commented-out
+/// `# shared_db = ...` line does not set the value, so this stays `true` until the operator
+/// declares the field explicitly.
+pub(crate) fn is_unsafe_shared_topology(doc: &DocumentMut) -> bool {
+    let durable = doc.get("durable").and_then(toml_edit::Item::as_table);
+    let encrypt_payload_disabled = durable
+        .and_then(|t| t.get("encrypt_payload"))
+        .and_then(toml_edit::Item::as_bool)
+        == Some(false);
+    let shared_db_declared = durable.is_some_and(|t| t.contains_key("shared_db"));
+    encrypt_payload_disabled && !shared_db_declared
+}
+
+/// Warns the operator when [`is_unsafe_shared_topology`] detects the dangerous combination.
+///
+/// # Errors
+///
+/// Returns [`MigrateError`] if `toml_src` is not valid TOML.
+fn warn_if_unsafe_shared_topology(toml_src: &str) -> Result<(), MigrateError> {
+    let doc: DocumentMut = toml_src.parse()?;
+    if is_unsafe_shared_topology(&doc) {
+        let msg = "durable.encrypt_payload = false with shared_db unset: confirm your \
+            deployment topology before proceeding. If the durable journal database (see \
+            memory.sqlite_path / the durable db path) is reachable from more than one \
+            process or client (e.g. a network-shared mount), set shared_db = true explicitly — \
+            leaving it unset silently passes the INV-8 encryption_gate's local-only override \
+            even on unsafe shared storage (#6042).";
+        tracing::warn!("{msg}");
+        eprintln!("WARNING: {msg}");
+    }
+
+    Ok(())
+}
+
 /// Adds a commented `# shared_db = false` advisory line to an existing active `[durable]` table
 /// that lacks the field: the operator-declared flag the INV-8 `encryption_gate` uses to forbid
 /// `encrypt_payload = false` on a multi-process/client journal database (#5996).
@@ -648,6 +686,8 @@ pub fn migrate_durable_shared_db(toml_src: &str) -> Result<MigrationResult, Migr
             sections_changed: Vec::new(),
         });
     }
+
+    warn_if_unsafe_shared_topology(toml_src)?;
 
     let already_present = toml_src.lines().any(|l| {
         l.trim()

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -4002,6 +4002,64 @@ fn step_79_idempotent_on_own_output() {
     );
 }
 
+#[test]
+fn step_79_still_adds_advisory_when_unsafe_topology_detected() {
+    // encrypt_payload = false + shared_db unset (#6042) triggers a warning as a side effect but
+    // must not change the pre-existing advisory-comment behavior or fail the migration.
+    let src = "[durable]\nenabled = true\nencrypt_payload = false\n";
+    let result = migrate_durable_shared_db(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert!(result.output.contains("# shared_db = false"));
+    assert_eq!(
+        result.sections_changed,
+        vec!["durable.shared_db".to_owned()]
+    );
+}
+
+// ── is_unsafe_shared_topology tests (#6042) ───────────────────────────────
+
+#[test]
+fn unsafe_topology_true_when_encrypt_disabled_and_shared_db_absent() {
+    let doc: DocumentMut = "[durable]\nencrypt_payload = false\n".parse().unwrap();
+    assert!(is_unsafe_shared_topology(&doc));
+}
+
+#[test]
+fn unsafe_topology_true_when_shared_db_only_commented() {
+    // A commented-out line doesn't set the value — still effectively unset.
+    let doc: DocumentMut = "[durable]\nencrypt_payload = false\n# shared_db = false\n"
+        .parse()
+        .unwrap();
+    assert!(is_unsafe_shared_topology(&doc));
+}
+
+#[test]
+fn unsafe_topology_false_when_shared_db_declared() {
+    let doc: DocumentMut = "[durable]\nencrypt_payload = false\nshared_db = true\n"
+        .parse()
+        .unwrap();
+    assert!(!is_unsafe_shared_topology(&doc));
+}
+
+#[test]
+fn unsafe_topology_false_when_encrypt_payload_true() {
+    let doc: DocumentMut = "[durable]\nencrypt_payload = true\n".parse().unwrap();
+    assert!(!is_unsafe_shared_topology(&doc));
+}
+
+#[test]
+fn unsafe_topology_false_when_encrypt_payload_absent() {
+    // Absent encrypt_payload defaults to `true` at the config layer, not the dangerous `false`.
+    let doc: DocumentMut = "[durable]\nenabled = true\n".parse().unwrap();
+    assert!(!is_unsafe_shared_topology(&doc));
+}
+
+#[test]
+fn unsafe_topology_false_when_durable_section_absent() {
+    let doc: DocumentMut = "[agent]\nname = \"zeph\"\n".parse().unwrap();
+    assert!(!is_unsafe_shared_topology(&doc));
+}
+
 // ── migrate_skill_trust_require_check tests (step 80, #6087) ─────────────────
 
 #[test]

--- a/crates/zeph-durable/src/handle.rs
+++ b/crates/zeph-durable/src/handle.rs
@@ -453,12 +453,18 @@ impl DurableContext {
     /// Assign the next step id, rejecting it if it exceeds the per-execution step cap.
     fn checked_step_id(&self) -> Result<StepId, DurableError> {
         let step_id = self.assign_step_id();
+        self.enforce_step_cap(step_id)?;
+        Ok(step_id)
+    }
+
+    /// Reject `step_id` if it exceeds the per-execution step cap (`0` means uncapped).
+    fn enforce_step_cap(&self, step_id: StepId) -> Result<(), DurableError> {
         if self.max_steps_per_execution != 0 && step_id.value() >= self.max_steps_per_execution {
             return Err(DurableError::StepCapExceeded {
                 cap: self.max_steps_per_execution,
             });
         }
-        Ok(step_id)
+        Ok(())
     }
 
     /// Fold a checkpoint on a background task the first time a step crosses the soft cap.
@@ -514,11 +520,7 @@ impl DurableContext {
         F: FnOnce(StepHandle) -> Fut + Send,
         Fut: Future<Output = Result<T, StepError>> + Send,
     {
-        if self.max_steps_per_execution != 0 && step_id.value() >= self.max_steps_per_execution {
-            return Err(DurableError::StepCapExceeded {
-                cap: self.max_steps_per_execution,
-            });
-        }
+        self.enforce_step_cap(step_id)?;
         // Soft cap (90%): fold a checkpoint on a background task, once per execution.
         self.maybe_checkpoint(step_id);
         let effect = desc.effect();
@@ -1553,6 +1555,40 @@ mod tests {
             )
             .await
             .unwrap_err();
+        assert_matches!(err, DurableError::StepCapExceeded { cap: 1 });
+        drop(ctx);
+        drop(handle);
+        task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn step_cap_is_enforced_via_checked_step_id() {
+        // `promise`/`timer` route through `checked_step_id` rather than `run_step_at`; assert both
+        // call sites share the same enforcement after the dedup refactor (#6082).
+        let exec = ExecutionId::new();
+        let local = Arc::new(LocalBackend::open(":memory:", 1_048_576).await.unwrap());
+        local.init().await.unwrap();
+        local
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        let (writer, handle) = JournalWriter::new(local.clone(), &fast_config());
+        let task = tokio::spawn(writer.run());
+        let backend = Arc::new(DurableBackendEnum::Local(local.clone()));
+        let ctx = DurableContext::new(
+            exec,
+            ExecutionKind::AgentTurn,
+            false,
+            backend,
+            handle.clone(),
+            &DurableConfig {
+                max_steps_per_execution: 1,
+                ..fast_config()
+            },
+        );
+        // Step id 0 is allowed; step id 1 exceeds the cap of 1.
+        ctx.promise::<u32>().await.unwrap();
+        let err = ctx.promise::<u32>().await.unwrap_err();
         assert_matches!(err, DurableError::StepCapExceeded { cap: 1 });
         drop(ctx);
         drop(handle);


### PR DESCRIPTION
## Summary

Two small, independently-scoped fixes in the durable execution area, grouped into one PR per triage-and-solve (no critical/high/bug-labeled unassigned issues existed; both are `enhancement`-tier, same durable-execution subsystem, no dependency between them).

- `crates/zeph-durable/src/handle.rs`: `DurableContext::checked_step_id` and `run_step_at` repeated the identical per-execution step-cap comparison verbatim. Extracted a single `enforce_step_cap` helper called from both sites. Pure behavior-preserving refactor.
- `crates/zeph-config/src/migrate/infra.rs`: `--migrate-config`'s `migrate_durable_shared_db` step only left a commented `# shared_db = false` advisory line for pre-existing configs — no active signal. An operator with `encrypt_payload = false` and `shared_db` left unset gets no warning even though that combination silently passes the INV-8 `encryption_gate`'s local-only override, and `shared_db` cannot be inferred from the filesystem today. Now emits an active `tracing::warn!`/stderr warning (matching the existing `migrate_llm_to_providers` convention) asking the operator to confirm their deployment topology. Filesystem-type auto-detection and path-prefix heuristics are explicitly out of scope for this fix, deferred to a future issue per the issue's own fix-complexity assessment.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (13265 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] New regression test `step_cap_is_enforced_via_checked_step_id` covering the previously-uncovered `checked_step_id`/`promise()` path
- [x] 7 new tests for `is_unsafe_shared_topology`/`warn_if_unsafe_shared_topology` covering commented-vs-live `shared_db`, `encrypt_payload` true/absent, missing `[durable]` table
- [x] CHANGELOG.md updated under `[Unreleased]`
- [x] Testing playbook (`.local/testing/playbooks/durable.md`) and coverage-status.md rows added

Closes #6082
Closes #6042