### PR TITLE
refactor(mcp): extract shared connect-scaffolding helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   test, which already called the real function); both now call the shared production function
   directly via `AppBuilder::for_test`, closing a test-realism gap left by #6170. No behavior
   change for any entry point.
+- **DRY**: `zeph-mcp` — extracted `McpManager::commit_pending` to replace the near-identical
+  `commit_connect_outputs`/`commit_oauth_outputs` pair in `manager/connect.rs`, and
+  `finish_connect` to replace the handler-build + timeout-wrapped-handshake + error-classify
+  scaffolding duplicated across all five `McpClient` connect paths (`connect`, `connect_url`,
+  `connect_url_with_headers`, `connect_url_oauth`'s cached-token branch, `complete_oauth`) in
+  `client.rs` (#6070, #6065). Pure internal refactor, no observable behavior change: the
+  never-hold-a-lock-across-an-`.await` invariant is preserved on every path, and
+  `finish_connect` now routes every site through `classify_connect_error` uniformly (verified
+  byte-for-byte equivalent to the prior inline mapping used by the stdio `connect` path). One
+  intrinsic side effect of unifying two helpers that committed `server_tools` and
+  `server_fingerprints` in opposite relative orders: `commit_pending` adopts the OAuth path's
+  order (`fingerprints` then `tools`) on `connect_all` too, where it was previously reversed.
+  Both are independent `RwLock`s never held simultaneously by any code in the module, so this
+  ordering swap has no observable effect.
 
 - **DRY**: extracted the `zeph worktree clean` reconcile → remove → prune pipeline and its
   removed/skipped/errored counting into a single `WorktreeManager::clean` method plus a

--- a/crates/zeph-mcp/src/client.rs
+++ b/crates/zeph-mcp/src/client.rs
@@ -14,6 +14,7 @@ use http::{HeaderName, HeaderValue};
 use rmcp::ServiceExt;
 use rmcp::model::{CallToolRequestParams, CallToolResult};
 use rmcp::service::{ClientInitializeError, NotificationContext, RoleClient, RunningService};
+use rmcp::transport::IntoTransport;
 use rmcp::transport::TokioChildProcess;
 use rmcp::transport::auth::{
     AuthClient, AuthError, CredentialStore, InMemoryStateStore, OAuthState, StoredCredentials,
@@ -452,26 +453,8 @@ impl McpClient {
             })?
         };
 
-        let handler = ToolListChangedHandler::new(
-            server_id,
-            tx,
-            last_refresh,
-            handler_cfg.roots,
-            handler_cfg.max_description_bytes,
-            handler_cfg.elicitation_tx,
-            handler_cfg.elicitation_timeout,
-        );
-        let service = tokio::time::timeout(timeout, handler.serve(transport))
-            .await
-            .map_err(|_| McpError::Timeout {
-                server_id: server_id.into(),
-                tool_name: "initialize".into(),
-                timeout_secs: timeout.as_secs(),
-            })?
-            .map_err(|e| McpError::Connection {
-                server_id: server_id.into(),
-                message: e.to_string(),
-            })?;
+        let service =
+            finish_connect(server_id, timeout, transport, tx, last_refresh, handler_cfg).await?;
 
         Ok(Self {
             server_id: server_id.into(),
@@ -511,23 +494,8 @@ impl McpClient {
         let config = StreamableHttpClientTransportConfig::with_uri(url.to_owned());
         let transport = StreamableHttpClientTransport::with_client(client, config);
 
-        let handler = ToolListChangedHandler::new(
-            server_id,
-            tx,
-            last_refresh,
-            handler_cfg.roots,
-            handler_cfg.max_description_bytes,
-            handler_cfg.elicitation_tx,
-            handler_cfg.elicitation_timeout,
-        );
-        let service = tokio::time::timeout(timeout, handler.serve(transport))
-            .await
-            .map_err(|_| McpError::Timeout {
-                server_id: server_id.into(),
-                tool_name: "initialize".into(),
-                timeout_secs: timeout.as_secs(),
-            })?
-            .map_err(|e| classify_connect_error(server_id, &e))?;
+        let service =
+            finish_connect(server_id, timeout, transport, tx, last_refresh, handler_cfg).await?;
 
         Ok(Self {
             server_id: server_id.into(),
@@ -593,23 +561,8 @@ impl McpClient {
         let client = build_hardened_client(server_id, pinned.as_ref())?;
         let transport = StreamableHttpClientTransport::with_client(client, config);
 
-        let handler = ToolListChangedHandler::new(
-            server_id,
-            tx,
-            last_refresh,
-            handler_cfg.roots,
-            handler_cfg.max_description_bytes,
-            handler_cfg.elicitation_tx,
-            handler_cfg.elicitation_timeout,
-        );
-        let service = tokio::time::timeout(timeout, handler.serve(transport))
-            .await
-            .map_err(|_| McpError::Timeout {
-                server_id: server_id.into(),
-                tool_name: "initialize".into(),
-                timeout_secs: timeout.as_secs(),
-            })?
-            .map_err(|e| classify_connect_error(server_id, &e))?;
+        let service =
+            finish_connect(server_id, timeout, transport, tx, last_refresh, handler_cfg).await?;
 
         Ok(Self {
             server_id: server_id.into(),
@@ -698,23 +651,9 @@ impl McpClient {
             let config = StreamableHttpClientTransportConfig::with_uri(url);
             let transport = StreamableHttpClientTransport::with_client(auth_client, config);
 
-            let handler = ToolListChangedHandler::new(
-                server_id,
-                tx,
-                last_refresh,
-                handler_cfg.roots,
-                handler_cfg.max_description_bytes,
-                handler_cfg.elicitation_tx,
-                handler_cfg.elicitation_timeout,
-            );
-            let service = tokio::time::timeout(timeout, handler.serve(transport))
-                .await
-                .map_err(|_| McpError::Timeout {
-                    server_id: server_id.into(),
-                    tool_name: "initialize".into(),
-                    timeout_secs: timeout.as_secs(),
-                })?
-                .map_err(|e| classify_connect_error(server_id, &e))?;
+            let service =
+                finish_connect(server_id, timeout, transport, tx, last_refresh, handler_cfg)
+                    .await?;
 
             return Ok(OAuthConnectResult::Connected(McpClient {
                 server_id: server_id.into(),
@@ -827,23 +766,21 @@ impl McpClient {
         let config = StreamableHttpClientTransportConfig::with_uri(pending.url.as_str());
         let transport = StreamableHttpClientTransport::with_client(auth_client, config);
 
-        let handler = ToolListChangedHandler::new(
+        let handler_cfg = HandlerConfig {
+            roots: pending.roots,
+            max_description_bytes: pending.max_description_bytes,
+            elicitation_tx: pending.elicitation_tx,
+            elicitation_timeout: pending.elicitation_timeout,
+        };
+        let service = finish_connect(
             &pending.server_id,
+            pending.timeout,
+            transport,
             pending.tx,
             pending.last_refresh,
-            pending.roots,
-            pending.max_description_bytes,
-            pending.elicitation_tx,
-            pending.elicitation_timeout,
-        );
-        let service = tokio::time::timeout(pending.timeout, handler.serve(transport))
-            .await
-            .map_err(|_| McpError::Timeout {
-                server_id: pending.server_id.clone(),
-                tool_name: "initialize".into(),
-                timeout_secs: pending.timeout.as_secs(),
-            })?
-            .map_err(|e| classify_connect_error(&pending.server_id, &e))?;
+            handler_cfg,
+        )
+        .await?;
 
         Ok(McpClient {
             server_id: pending.server_id,
@@ -1073,6 +1010,39 @@ impl McpClient {
             }
         }
     }
+}
+
+/// Build the tool-refresh handler, run the timeout-bounded MCP handshake, and classify
+/// any resulting error uniformly — shared by every `McpClient` connect path.
+async fn finish_connect<T, E, A>(
+    server_id: &str,
+    timeout: Duration,
+    transport: T,
+    tx: Sender<ToolRefreshEvent>,
+    last_refresh: Arc<DashMap<String, Instant>>,
+    handler_cfg: HandlerConfig,
+) -> Result<ClientService, McpError>
+where
+    T: IntoTransport<RoleClient, E, A>,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    let handler = ToolListChangedHandler::new(
+        server_id,
+        tx,
+        last_refresh,
+        handler_cfg.roots,
+        handler_cfg.max_description_bytes,
+        handler_cfg.elicitation_tx,
+        handler_cfg.elicitation_timeout,
+    );
+    tokio::time::timeout(timeout, handler.serve(transport))
+        .await
+        .map_err(|_| McpError::Timeout {
+            server_id: server_id.into(),
+            tool_name: "initialize".into(),
+            timeout_secs: timeout.as_secs(),
+        })?
+        .map_err(|e| classify_connect_error(server_id, &e))
 }
 
 /// Classify a [`ClientInitializeError`] into the appropriate [`McpError`] variant.

--- a/crates/zeph-mcp/src/manager/connect.rs
+++ b/crates/zeph-mcp/src/manager/connect.rs
@@ -216,7 +216,7 @@ impl McpManager {
             instructions_bytes: self.max_instructions_bytes,
         };
         let outputs = self.process_connect_results(raw, limits).await;
-        let (all_tools, outcomes) = self.commit_connect_outputs(outputs).await;
+        let (all_tools, outcomes, _snapshot) = self.commit_pending(outputs).await;
         self.log_tool_collisions(&all_tools).await;
         (all_tools, outcomes)
     }
@@ -291,11 +291,15 @@ impl McpManager {
         outputs
     }
 
-    #[tracing::instrument(name = "mcp.manager.commit_connect_outputs", skip_all)]
-    async fn commit_connect_outputs(
+    /// Drain connect outputs into the shared maps and return everything callers need to
+    /// finish up: the output-order tool list (for collision logging), one outcome per
+    /// server, and a snapshot of all currently known tools (for publishing to
+    /// `tools_watch_tx`, when the caller wants that).
+    #[tracing::instrument(name = "mcp.manager.commit_pending", skip_all)]
+    async fn commit_pending(
         &self,
         outputs: Vec<ConnectOutput>,
-    ) -> (Vec<McpTool>, Vec<ServerConnectOutcome>) {
+    ) -> (Vec<McpTool>, Vec<ServerConnectOutcome>, Vec<McpTool>) {
         // All async work is done. Collect into vecs first, then commit each lock
         // in its own guarded block — never hold one lock across another .await.
         let mut pending_instructions: Vec<(String, String)> = Vec::new();
@@ -333,18 +337,19 @@ impl McpManager {
             }
         }
         {
-            let mut g = self.server_tools.write().await;
-            for (sid, tools) in pending_tools {
-                g.insert(sid, tools);
-            }
-        }
-        {
             let mut g = self.server_fingerprints.write().await;
             for (sid, fp) in pending_fingerprints {
                 g.insert(sid, fp);
             }
         }
-        (all_tools, outcomes)
+        let server_tools_snapshot = {
+            let mut g = self.server_tools.write().await;
+            for (sid, tools) in pending_tools {
+                g.insert(sid, tools);
+            }
+            g.values().flatten().cloned().collect::<Vec<McpTool>>()
+        };
+        (all_tools, outcomes, server_tools_snapshot)
     }
 
     /// Returns `true` if any configured server uses OAuth transport.
@@ -377,11 +382,10 @@ impl McpManager {
         let join_set = self.spawn_oauth_connections(&self.last_refresh).await;
         let raw = drain_oauth_results(join_set).await;
         let outputs = self.process_oauth_results(raw, limits).await;
-        let all_tools: Vec<McpTool> = outputs
-            .iter()
-            .flat_map(|o| o.tools.iter().cloned())
-            .collect();
-        self.commit_oauth_outputs(outputs).await;
+        let (all_tools, _outcomes, snapshot) = self.commit_pending(outputs).await;
+        if !snapshot.is_empty() {
+            let _ = self.tools_watch_tx.send(snapshot);
+        }
         self.log_tool_collisions(&all_tools).await;
     }
 
@@ -503,61 +507,6 @@ impl McpManager {
             }
         }
         outputs
-    }
-
-    #[tracing::instrument(name = "mcp.manager.commit_oauth_outputs", skip_all)]
-    async fn commit_oauth_outputs(&self, outputs: Vec<ConnectOutput>) {
-        // Batch-commit to shared maps in separate guarded blocks — never hold one
-        // lock across another .await (same pattern as connect_all).
-        let mut pending_instructions: Vec<(String, String)> = Vec::new();
-        let mut pending_clients: Vec<(String, McpClient)> = Vec::new();
-        let mut pending_tools: Vec<(String, Vec<McpTool>)> = Vec::new();
-        let mut pending_fingerprints: Vec<(
-            String,
-            HashMap<String, crate::attestation::ToolFingerprint>,
-        )> = Vec::new();
-        for output in outputs {
-            if let Some((sid, instr)) = output.instructions {
-                pending_instructions.push((sid, instr));
-            }
-            if let Some((sid, client)) = output.client_entry {
-                pending_clients.push((sid, client));
-            }
-            if let Some((sid, tools)) = output.tools_entry {
-                pending_tools.push((sid, tools));
-            }
-            if let Some((sid, fp)) = output.fingerprints {
-                pending_fingerprints.push((sid, fp));
-            }
-        }
-        {
-            let mut g = self.server_instructions.write().await;
-            for (sid, instr) in pending_instructions {
-                g.insert(sid, instr);
-            }
-        }
-        {
-            let mut g = self.clients.write().await;
-            for (sid, client) in pending_clients {
-                g.insert(sid, client);
-            }
-        }
-        {
-            let mut g = self.server_fingerprints.write().await;
-            for (sid, fp) in pending_fingerprints {
-                g.insert(sid, fp);
-            }
-        }
-        let updated = {
-            let mut g = self.server_tools.write().await;
-            for (sid, tools) in pending_tools {
-                g.insert(sid, tools);
-            }
-            g.values().flatten().cloned().collect::<Vec<McpTool>>()
-        };
-        if !updated.is_empty() {
-            let _ = self.tools_watch_tx.send(updated);
-        }
     }
 
     /// Log warnings for all `sanitized_id` collisions in `tools`.


### PR DESCRIPTION
## Summary

- `manager/connect.rs`: `commit_connect_outputs` and `commit_oauth_outputs` implemented nearly identical three-lock batch-commit patterns; merged into a single `commit_pending` helper. Each caller decides whether to publish the tools snapshot to `tools_watch_tx` (only the OAuth-deferred path does, unchanged from before).
- `client.rs`: the five connect call sites (`connect_stdio`, `connect_url`, `connect_url_with_headers`, `connect_url_oauth` cached-token branch, `complete_oauth`) each hand-rolled the same handler-construction + timeout-wrapped-serve + error-classification sequence; extracted into a shared `finish_connect` helper, making the timeout bound structural across all sites instead of a per-site opt-in.
- Pure internal dedup, no observable behavior change. One intrinsic side effect noted in CHANGELOG.md: merging the two `manager/connect.rs` helpers necessarily picks one lock-commit order for the shared maps, swapping it on the `connect_all` path relative to before — inert, since both are independent `RwLock`s never held simultaneously anywhere in the module.

Closes #6070
Closes #6065

## Test plan

- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-mcp` — 536/536 pass, suite unmodified
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13257/13257 pass
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] `gitleaks protect --staged --no-banner --redact` — no leaks
- [x] `.local/testing/coverage-status.md` and `.local/testing/playbooks/mcp.md` updated with refactor verification notes