### PR TITLE
fix(llm): resolve reasoning_amplification model identifier for Router/TriageRouter/CandleProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   unreachable (#5909). Both the detection call and the stored `model:` field now use
   `self.provider.model_identifier()`. Also added a missing `model_identifier()` override on
   `GeminiProvider`, which fell back to the trait default (`""`) for the same reason.
+- `crates/zeph-llm/src/provider.rs`: `RouterProvider`, `TriageRouter`, and `CandleProvider`
+  still fed a value that could never match `is_reasoning_model()`'s patterns into the
+  `reasoning_amplification` anomaly check fixed by #5909 above — `Router`/`TriageRouter`
+  hardcode the stable routing-policy label `"router"`/`""` from `model_identifier()`, and
+  `CandleProvider` had no override at all, so detection stayed permanently unreachable for
+  these three providers, the same defect class one call site removed (#6182, follow-up
+  #6183). Added `LlmProvider::effective_model_identifier()` (defaults to
+  `model_identifier()`) and switched the `tool_result.rs` call site to it: `RouterProvider`
+  and `TriageRouter` override it to resolve the sub-provider that actually served the most
+  recent dispatch (reusing the existing `last_active_provider`/`last_provider_idx` state
+  already read by reputation attribution), and `CandleProvider` gets a genuine static
+  `model_id` field derived from its `ModelSource` (`repo_id` for `HuggingFace` sources, file
+  stem for `Local` sources). `MaskedProvider` (the outbound-secret-masking wrapper applied to
+  every provider by default) also needed an explicit override forwarding to its inner
+  provider's `effective_model_identifier()` — without it, a masked Router/TriageRouter
+  (the structural default configuration) silently fell back to the trait default and the fix
+  never took effect.
 - `src/commands/db.rs`: `zeph db migrate` fell back to the raw, unredacted database URL
   in error messages and the migration-status line whenever `redact_url` returned `None`
   — which only means the URL didn't match a recognized credential-bearing shape, not that

--- a/crates/zeph-core/src/agent/tool_execution/tests/boundary_and_classifier_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/boundary_and_classifier_tests.rs
@@ -1649,4 +1649,202 @@ mod reasoning_amplification_call_site {
              captured logs:\n{logs}"
         );
     }
+
+    // --- #6183: same call site through Router/TriageRouter (model_identifier() == "router" / "") ---
+    //
+    // `Router::model_identifier()` returns the stable label `"router"` and `TriageRouter`
+    // inherits the trait default `""` — neither ever matches an `is_reasoning_model` pattern,
+    // so before this fix the branch was permanently unreachable whenever `self.provider` was a
+    // Router/TriageRouter (same defect class #5909/#6182 fixed for 7 concrete providers).
+    // `effective_model_identifier()` resolves the sub-provider that actually served the last
+    // dispatch instead. These tests drive a *real* dispatch (not a direct state poke) so the
+    // coverage matches production: construct the router, call `chat_with_tools` once to let it
+    // naturally record the dispatched sub-provider, then trigger the failure path.
+
+    #[tokio::test]
+    async fn quality_failure_reachable_through_router_last_active_provider() {
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+        use zeph_llm::router::RouterProvider;
+
+        let reasoner = AnyProvider::Mock(
+            MockProvider::default()
+                .with_name("reasoner")
+                .with_model_identifier("o3-mini"),
+        );
+        let router = RouterProvider::new(vec![reasoner]);
+        // Drive a real dispatch so the router records the sub-provider that served it —
+        // mirrors what the agent's normal `chat_with_tools` call does before a tool result
+        // is classified.
+        zeph_llm::provider::LlmProvider::chat_with_tools(&router, &[], &[])
+            .await
+            .unwrap();
+        let provider = AnyProvider::Router(Box::new(router));
+
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+        agent.runtime.debug.anomaly_detector = Some(zeph_tools::AnomalyDetector::new(10, 0.0, 1.0));
+        agent.runtime.debug.reasoning_model_warning = true;
+
+        let tc = make_tool_use_request("id-router-reasoning", "bash");
+        let err = zeph_tools::executor::ToolError::InvalidParams {
+            message: "missing required field 'command'".into(),
+        };
+
+        let logs = capture_logs(|| async {
+            agent
+                .process_one_tool_result(
+                    &tc,
+                    "id-router-reasoning",
+                    &std::time::Instant::now(),
+                    Err(err),
+                    &mut Vec::new(),
+                    &mut Vec::new(),
+                    &mut false,
+                    &mut None,
+                    &mut Vec::new(),
+                )
+                .await
+                .unwrap();
+        })
+        .await;
+
+        assert!(
+            logs.contains("reasoning_amplification"),
+            "a Router whose last-active sub-provider's model_identifier() is a reasoning-model \
+             pattern must emit the reasoning_amplification warning; captured logs:\n{logs}"
+        );
+        assert!(
+            logs.contains("o3-mini"),
+            "the emitted warning must carry the resolved sub-provider's model identifier, not \
+             the router's own \"router\" label; captured logs:\n{logs}"
+        );
+    }
+
+    #[tokio::test]
+    async fn quality_failure_not_flagged_for_router_with_non_reasoning_sub_provider() {
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+        use zeph_llm::router::RouterProvider;
+
+        let openai = AnyProvider::Mock(
+            MockProvider::default()
+                .with_name("openai")
+                .with_model_identifier("gpt-4o"),
+        );
+        let router = RouterProvider::new(vec![openai]);
+        zeph_llm::provider::LlmProvider::chat_with_tools(&router, &[], &[])
+            .await
+            .unwrap();
+        let provider = AnyProvider::Router(Box::new(router));
+
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+        agent.runtime.debug.anomaly_detector = Some(zeph_tools::AnomalyDetector::new(10, 0.0, 1.0));
+        agent.runtime.debug.reasoning_model_warning = true;
+
+        let tc = make_tool_use_request("id-router-non-reasoning", "bash");
+        let err = zeph_tools::executor::ToolError::InvalidParams {
+            message: "missing required field 'command'".into(),
+        };
+
+        let logs = capture_logs(|| async {
+            agent
+                .process_one_tool_result(
+                    &tc,
+                    "id-router-non-reasoning",
+                    &std::time::Instant::now(),
+                    Err(err),
+                    &mut Vec::new(),
+                    &mut Vec::new(),
+                    &mut false,
+                    &mut None,
+                    &mut Vec::new(),
+                )
+                .await
+                .unwrap();
+        })
+        .await;
+
+        assert!(
+            !logs.contains("reasoning_amplification"),
+            "a Router whose last-active sub-provider is not a reasoning model must not \
+             misclassify; captured logs:\n{logs}"
+        );
+    }
+
+    #[tokio::test]
+    async fn quality_failure_reachable_through_triage_router_last_provider_idx() {
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+        use zeph_llm::provider::{Message, MessageMetadata, Role};
+        use zeph_llm::router::triage::{ComplexityTier, TriageRouter};
+
+        let triage_model = AnyProvider::Mock(MockProvider::with_responses(vec![
+            r#"{"tier":"expert","reason":"complex task"}"#.to_owned(),
+        ]));
+        let expert = AnyProvider::Mock(
+            MockProvider::default()
+                .with_name("expert")
+                .with_model_identifier("deepseek-r1"),
+        );
+        let triage_router =
+            TriageRouter::new(triage_model, vec![(ComplexityTier::Expert, expert)], 5, 100);
+        let classify_msgs = vec![Message {
+            role: Role::User,
+            content: "design a distributed consensus protocol".to_owned(),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        }];
+        zeph_llm::provider::LlmProvider::chat_with_tools(&triage_router, &classify_msgs, &[])
+            .await
+            .unwrap();
+        let provider = AnyProvider::Triage(Box::new(triage_router));
+
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+        agent.runtime.debug.anomaly_detector = Some(zeph_tools::AnomalyDetector::new(10, 0.0, 1.0));
+        agent.runtime.debug.reasoning_model_warning = true;
+
+        let tc = make_tool_use_request("id-triage-reasoning", "bash");
+        let err = zeph_tools::executor::ToolError::InvalidParams {
+            message: "missing required field 'command'".into(),
+        };
+
+        let logs = capture_logs(|| async {
+            agent
+                .process_one_tool_result(
+                    &tc,
+                    "id-triage-reasoning",
+                    &std::time::Instant::now(),
+                    Err(err),
+                    &mut Vec::new(),
+                    &mut Vec::new(),
+                    &mut false,
+                    &mut None,
+                    &mut Vec::new(),
+                )
+                .await
+                .unwrap();
+        })
+        .await;
+
+        assert!(
+            logs.contains("reasoning_amplification"),
+            "a TriageRouter whose last-dispatched tier provider's model_identifier() is a \
+             reasoning-model pattern must emit the reasoning_amplification warning; captured \
+             logs:\n{logs}"
+        );
+        assert!(
+            logs.contains("deepseek-r1"),
+            "the emitted warning must carry the resolved tier provider's model identifier; \
+             captured logs:\n{logs}"
+        );
+    }
 }

--- a/crates/zeph-core/src/agent/tool_execution/tool_result.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tool_result.rs
@@ -315,10 +315,10 @@ impl<C: Channel> Agent<C> {
                 let anomaly_outcome = if matches!(e, zeph_tools::ToolError::Blocked { .. }) {
                     AnomalyOutcome::Blocked
                 } else if is_quality_failure
-                    && zeph_tools::is_reasoning_model(self.provider.model_identifier())
+                    && zeph_tools::is_reasoning_model(self.provider.effective_model_identifier())
                 {
                     AnomalyOutcome::ReasoningQualityFailure {
-                        model: self.provider.model_identifier().to_owned(),
+                        model: self.provider.effective_model_identifier().to_owned(),
                         tool: tc.name.to_string(),
                     }
                 } else {

--- a/crates/zeph-llm/src/any.rs
+++ b/crates/zeph-llm/src/any.rs
@@ -786,6 +786,10 @@ impl LlmProvider for AnyProvider {
         delegate_provider!(self, |p| p.model_identifier())
     }
 
+    fn effective_model_identifier(&self) -> &str {
+        delegate_provider!(self, |p| p.effective_model_identifier())
+    }
+
     fn supports_structured_output(&self) -> bool {
         delegate_provider!(self, |p| p.supports_structured_output())
     }

--- a/crates/zeph-llm/src/candle_provider/loader.rs
+++ b/crates/zeph-llm/src/candle_provider/loader.rs
@@ -27,6 +27,26 @@ pub enum ModelSource {
     },
 }
 
+impl ModelSource {
+    /// Returns a model identifier suitable for `is_reasoning_model` classification.
+    ///
+    /// `HuggingFace` sources use `repo_id` (e.g. `deepseek-ai/DeepSeek-R1-Distill-Qwen-7B`),
+    /// the canonical identity that reasoning-model heuristics match against. `Local` sources
+    /// have no such canonical id, so this falls back to the file stem of `path` — a known
+    /// limitation: a generically-named local GGUF (e.g. `model-q4.gguf`) yields a false
+    /// negative for reasoning-model detection, since the filename carries no model identity.
+    #[must_use]
+    pub fn model_id(&self) -> String {
+        match self {
+            ModelSource::Local { path } => path
+                .file_stem()
+                .and_then(std::ffi::OsStr::to_str)
+                .map_or_else(|| path.display().to_string(), ToOwned::to_owned),
+            ModelSource::HuggingFace { repo_id, .. } => repo_id.clone(),
+        }
+    }
+}
+
 pub struct LoadedModel {
     pub weights: ModelWeights,
     pub tokenizer: Tokenizer,
@@ -161,5 +181,46 @@ mod tests {
         let debug = format!("{source:?}");
         assert!(debug.contains("HuggingFace"));
         assert!(debug.contains("TheBloke/Mistral-7B"));
+    }
+
+    // ── #6183: model_id() must return an identifier `is_reasoning_model` can match ──
+
+    #[test]
+    fn model_source_model_id_local_uses_file_stem() {
+        let source = ModelSource::Local {
+            path: PathBuf::from("/models/deepseek-r1-distill-qwen-7b.gguf"),
+        };
+        assert_eq!(source.model_id(), "deepseek-r1-distill-qwen-7b");
+    }
+
+    #[test]
+    fn model_source_model_id_local_falls_back_to_full_path_when_no_stem() {
+        // `Path::file_stem()` returns `None` when there is no file name component
+        // (e.g. the root path) — verify the documented fallback to `path.display()`.
+        let source = ModelSource::Local {
+            path: PathBuf::from("/"),
+        };
+        assert_eq!(source.model_id(), "/");
+    }
+
+    #[test]
+    fn model_source_model_id_huggingface_uses_repo_id() {
+        let source = ModelSource::HuggingFace {
+            repo_id: "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B".into(),
+            filename: Some("model.Q4_K_M.gguf".into()),
+            sha256: None,
+        };
+        assert_eq!(source.model_id(), "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B");
+    }
+
+    #[test]
+    fn model_source_model_id_huggingface_ignores_filename() {
+        // repo_id is the canonical identity even when filename carries no signal.
+        let source = ModelSource::HuggingFace {
+            repo_id: "microsoft/Phi-3-mini-4k-instruct".into(),
+            filename: None,
+            sha256: None,
+        };
+        assert_eq!(source.model_id(), "microsoft/Phi-3-mini-4k-instruct");
     }
 }

--- a/crates/zeph-llm/src/candle_provider/mod.rs
+++ b/crates/zeph-llm/src/candle_provider/mod.rs
@@ -112,6 +112,9 @@ pub struct CandleProvider {
     /// tracking and provider selection can distinguish between multiple configured Candle
     /// instances (#5892).
     provider_name: String,
+    /// Model identifier reported by [`LlmProvider::model_identifier`], derived once from
+    /// the [`ModelSource`](crate::candle_provider::loader::ModelSource) at construction time.
+    model_id: String,
 }
 
 impl std::fmt::Debug for CandleProvider {
@@ -122,6 +125,7 @@ impl std::fmt::Debug for CandleProvider {
             .field("device", &format!("{:?}", self.device))
             .field("embed_model", &self.embed_model)
             .field("provider_name", &self.provider_name)
+            .field("model_id", &self.model_id)
             .finish_non_exhaustive()
     }
 }
@@ -143,6 +147,7 @@ impl Clone for CandleProvider {
             embed_model: self.embed_model.clone(),
             device: self.device.clone(),
             provider_name: self.provider_name.clone(),
+            model_id: self.model_id.clone(),
         }
     }
 }
@@ -190,6 +195,7 @@ impl CandleProvider {
         device: Device,
         inference_timeout: Duration,
     ) -> Result<Self, LlmError> {
+        let model_id = source.model_id();
         let LoadedModel {
             weights,
             tokenizer,
@@ -230,6 +236,7 @@ impl CandleProvider {
             embed_model,
             device,
             provider_name: "candle".to_owned(),
+            model_id,
         })
     }
 
@@ -362,5 +369,9 @@ impl LlmProvider for CandleProvider {
 
     fn name(&self) -> &str {
         &self.provider_name
+    }
+
+    fn model_identifier(&self) -> &str {
+        &self.model_id
     }
 }

--- a/crates/zeph-llm/src/masking.rs
+++ b/crates/zeph-llm/src/masking.rs
@@ -287,6 +287,10 @@ impl LlmProvider for MaskedProvider {
         LlmProvider::model_identifier(self.inner.as_ref())
     }
 
+    fn effective_model_identifier(&self) -> &str {
+        LlmProvider::effective_model_identifier(self.inner.as_ref())
+    }
+
     fn supports_structured_output(&self) -> bool {
         LlmProvider::supports_structured_output(self.inner.as_ref())
     }
@@ -540,5 +544,29 @@ mod tests {
         let mp = masked(mock_any(vec![]));
         let s = format!("{mp:?}");
         assert!(s.contains("MaskedProvider"));
+    }
+
+    /// #6183: a masked Router must still resolve the real dispatched sub-provider's model id,
+    /// not fall through to the trait default (`model_identifier()` -> inner `"router"` label).
+    #[test]
+    fn effective_model_identifier_resolves_through_masked_router() {
+        use crate::claude::ClaudeProvider;
+        use crate::router::RouterProvider;
+
+        let claude = AnyProvider::Claude(ClaudeProvider::new(
+            "k".into(),
+            "claude-3-opus-think".into(),
+            1024,
+        ));
+        let router = RouterProvider::new(vec![claude]);
+        *router.state.last_active_provider.lock() = Some("claude".to_owned());
+
+        let mp = masked(AnyProvider::Router(Box::new(router)));
+
+        assert_eq!(
+            LlmProvider::effective_model_identifier(&mp),
+            "claude-3-opus-think"
+        );
+        assert_ne!(LlmProvider::effective_model_identifier(&mp), "router");
     }
 }

--- a/crates/zeph-llm/src/provider.rs
+++ b/crates/zeph-llm/src/provider.rs
@@ -825,6 +825,21 @@ pub trait LlmProvider: Send + Sync {
         ""
     }
 
+    /// Model identifier that actually served the most recent dispatch.
+    ///
+    /// For a concrete single-model provider (Claude, `OpenAI`, Candle, ...) this is
+    /// identical to [`model_identifier`](Self::model_identifier) — the default
+    /// implementation simply forwards to it. Routing providers (`Router`,
+    /// `TriageRouter`) override it to resolve the sub-provider that served the last
+    /// call, since their own `model_identifier()` returns a stable routing-policy
+    /// label (e.g. `"router"`) rather than a real model id. Callers that need to
+    /// reason about the model that produced a specific response (for example,
+    /// `is_reasoning_model` detection) should call this method instead of
+    /// `model_identifier()`.
+    fn effective_model_identifier(&self) -> &str {
+        self.model_identifier()
+    }
+
     /// Whether this provider supports image input (vision).
     fn supports_vision(&self) -> bool {
         false

--- a/crates/zeph-llm/src/provider_dyn.rs
+++ b/crates/zeph-llm/src/provider_dyn.rs
@@ -120,6 +120,10 @@ pub trait LlmProviderDyn: private::Sealed + std::fmt::Debug + Send + Sync {
     /// Model identifier string (e.g. `gpt-4o-mini`, `claude-sonnet-5`).
     fn model_identifier(&self) -> &str;
 
+    /// Model identifier that actually served the most recent dispatch. See
+    /// [`LlmProvider::effective_model_identifier`] for the full contract.
+    fn effective_model_identifier(&self) -> &str;
+
     /// Whether this provider supports image input (vision).
     fn supports_vision(&self) -> bool;
 
@@ -223,6 +227,10 @@ impl<T: LlmProvider + std::fmt::Debug + Send + Sync + 'static> LlmProviderDyn fo
 
     fn model_identifier(&self) -> &str {
         LlmProvider::model_identifier(self)
+    }
+
+    fn effective_model_identifier(&self) -> &str {
+        LlmProvider::effective_model_identifier(self)
     }
 
     fn supports_vision(&self) -> bool {

--- a/crates/zeph-llm/src/router/provider_impl.rs
+++ b/crates/zeph-llm/src/router/provider_impl.rs
@@ -568,6 +568,24 @@ impl LlmProvider for RouterProvider {
         "router"
     }
 
+    // Mirrors the `last_active_provider` read pattern already used by reputation
+    // attribution (`last_selected_provider_kind`, `record_quality_outcome`): correct
+    // as long as the tool loop stays sequential per turn (no interleaving dispatch
+    // between the call that sets `last_active_provider` and this read). Concurrent
+    // dispatch on a shared Router `Arc` across subagents can race (last-writer-wins);
+    // pre-existing and inherited from the same attribution state, not a new class.
+    fn effective_model_identifier(&self) -> &str {
+        let name = self.state.last_active_provider.lock().clone();
+        let Some(name) = name else {
+            return "router";
+        };
+        self.state
+            .providers
+            .iter()
+            .find(|p| p.name() == name)
+            .map_or("router", |p| p.model_identifier())
+    }
+
     fn supports_tool_use(&self) -> bool {
         self.state
             .providers

--- a/crates/zeph-llm/src/router/tests.rs
+++ b/crates/zeph-llm/src/router/tests.rs
@@ -2173,3 +2173,110 @@ fn masked_triage_set_thinking_budget_delegates_through_inner() {
     masked.set_thinking_budget(Some(4096)).unwrap();
     assert_eq!(masked.current_thinking_budget(), Some(4096));
 }
+
+// ── #6183: effective_model_identifier resolves the real dispatched sub-provider ──
+//
+// `model_identifier()` returns the stable `"router"` label (never a reasoning-model
+// pattern), so `is_reasoning_model(self.provider.model_identifier())` at the
+// `tool_result.rs` call site was permanently unreachable for Router-wrapped
+// providers. `effective_model_identifier()` resolves the actually-dispatched
+// sub-provider instead, reusing the same `last_active_provider` state already
+// read by reputation attribution (`last_selected_provider_kind`).
+
+#[test]
+fn router_effective_model_identifier_before_dispatch_is_router_label() {
+    use crate::mock::MockProvider;
+
+    let p1 = AnyProvider::Mock(
+        MockProvider::default()
+            .with_name("p1")
+            .with_model_identifier("o3"),
+    );
+    let r = RouterProvider::new(vec![p1]);
+    assert_eq!(r.effective_model_identifier(), "router");
+}
+
+#[test]
+fn router_effective_model_identifier_resolves_last_active_reasoning_model() {
+    use crate::mock::MockProvider;
+
+    let openai = AnyProvider::Mock(
+        MockProvider::default()
+            .with_name("openai")
+            .with_model_identifier("gpt-4o"),
+    );
+    let reasoner = AnyProvider::Mock(
+        MockProvider::default()
+            .with_name("reasoner")
+            .with_model_identifier("o3-mini"),
+    );
+    let r = RouterProvider::new(vec![openai, reasoner]);
+    *r.state.last_active_provider.lock() = Some("reasoner".to_owned());
+
+    assert_eq!(r.effective_model_identifier(), "o3-mini");
+}
+
+#[test]
+fn router_effective_model_identifier_resolves_last_active_non_reasoning_model() {
+    use crate::mock::MockProvider;
+
+    let openai = AnyProvider::Mock(
+        MockProvider::default()
+            .with_name("openai")
+            .with_model_identifier("gpt-4o"),
+    );
+    let r = RouterProvider::new(vec![openai]);
+    *r.state.last_active_provider.lock() = Some("openai".to_owned());
+
+    assert_eq!(r.effective_model_identifier(), "gpt-4o");
+}
+
+#[test]
+fn router_effective_model_identifier_falls_back_to_router_on_stale_name() {
+    use crate::mock::MockProvider;
+
+    let p1 = AnyProvider::Mock(
+        MockProvider::default()
+            .with_name("p1")
+            .with_model_identifier("gpt-4o"),
+    );
+    let r = RouterProvider::new(vec![p1]);
+    *r.state.last_active_provider.lock() = Some("gone".to_owned());
+
+    assert_eq!(r.effective_model_identifier(), "router");
+}
+
+/// End-to-end: drive a real `chat_with_tools` dispatch (not a direct state poke) and
+/// verify `effective_model_identifier()` resolves the sub-provider that actually served
+/// it, exercising the same `last_active_provider` write the production dispatch loop
+/// performs (`provider_impl.rs` `chat_with_tools`).
+#[tokio::test]
+async fn router_effective_model_identifier_resolves_via_real_dispatch() {
+    use crate::mock::MockProvider;
+
+    let reasoner = AnyProvider::Mock(
+        MockProvider::default()
+            .with_name("reasoner")
+            .with_model_identifier("deepseek-r1"),
+    );
+    let r = RouterProvider::new(vec![reasoner]);
+
+    r.chat_with_tools(&[], &[]).await.unwrap();
+
+    assert_eq!(r.effective_model_identifier(), "deepseek-r1");
+}
+
+/// Regression guard: the default `effective_model_identifier()` impl must forward
+/// unchanged to `model_identifier()` for a concrete (non-router) provider — the new
+/// trait method must not alter behavior for the 7 providers PR #6182 already fixed.
+#[test]
+fn mock_provider_effective_model_identifier_defaults_to_model_identifier() {
+    use crate::mock::MockProvider;
+
+    let p = MockProvider::default()
+        .with_name("openai")
+        .with_model_identifier("o3-mini");
+
+    assert_eq!(p.effective_model_identifier(), p.model_identifier());
+    assert_eq!(p.effective_model_identifier(), "o3-mini");
+}

--- a/crates/zeph-llm/src/router/triage.rs
+++ b/crates/zeph-llm/src/router/triage.rs
@@ -603,6 +603,16 @@ impl LlmProvider for TriageRouter {
         &self.name
     }
 
+    // Mirrors the `capability_target_index` read pattern already used by
+    // `/think-tokens` / `/reasoning-effort` command targeting: correct as long as
+    // the tool loop stays sequential per turn (no interleaving dispatch between the
+    // call that sets `last_provider_idx` and this read) — same invariant
+    // `record_quality_outcome`-style attribution already relies on for Router.
+    fn effective_model_identifier(&self) -> &str {
+        self.capability_target_index()
+            .map_or("", |idx| self.tier_providers[idx].1.model_identifier())
+    }
+
     fn context_window(&self) -> Option<usize> {
         // Return the largest context window across all tier providers.
         self.tier_providers
@@ -906,6 +916,138 @@ mod tests {
             100,
         );
         assert_eq!(router.capability_delegation_advisory(), None);
+    }
+
+    // ── #6183: effective_model_identifier resolves the real dispatched tier provider ──
+    //
+    // `model_identifier()` returns `""` (trait default, never overridden by `TriageRouter`),
+    // which never matches an `is_reasoning_model` pattern — reasoning-quality detection was
+    // permanently unreachable for triage-routed calls. `effective_model_identifier()` reuses
+    // `capability_target_index()` (the same seam already used by `/think-tokens` delegation)
+    // to resolve the tier provider that actually served the last dispatch.
+
+    #[test]
+    fn triage_effective_model_identifier_falls_back_to_default_index_before_first_call() {
+        let router = TriageRouter::new(
+            mock_provider("triage-model"),
+            vec![
+                (
+                    ComplexityTier::Simple,
+                    AnyProvider::Mock(
+                        MockProvider::default()
+                            .with_name("simple")
+                            .with_model_identifier("gpt-4o-mini"),
+                    ),
+                ),
+                (
+                    ComplexityTier::Expert,
+                    AnyProvider::Mock(
+                        MockProvider::default()
+                            .with_name("expert")
+                            .with_model_identifier("o3"),
+                    ),
+                ),
+            ],
+            5,
+            100,
+        );
+        // default_index == 0 (Simple) — no dispatch has happened yet.
+        assert_eq!(router.effective_model_identifier(), "gpt-4o-mini");
+    }
+
+    #[test]
+    fn triage_effective_model_identifier_resolves_last_provider_idx() {
+        let router = TriageRouter::new(
+            mock_provider("triage-model"),
+            vec![
+                (
+                    ComplexityTier::Simple,
+                    AnyProvider::Mock(
+                        MockProvider::default()
+                            .with_name("simple")
+                            .with_model_identifier("gpt-4o-mini"),
+                    ),
+                ),
+                (
+                    ComplexityTier::Expert,
+                    AnyProvider::Mock(
+                        MockProvider::default()
+                            .with_name("expert")
+                            .with_model_identifier("deepseek-r1"),
+                    ),
+                ),
+            ],
+            5,
+            100,
+        );
+        router.last_provider_idx.store(1, Ordering::Relaxed);
+
+        assert_eq!(router.effective_model_identifier(), "deepseek-r1");
+    }
+
+    #[test]
+    fn triage_effective_model_identifier_resolves_last_provider_idx_non_reasoning() {
+        let router = TriageRouter::new(
+            mock_provider("triage-model"),
+            vec![
+                (
+                    ComplexityTier::Simple,
+                    AnyProvider::Mock(
+                        MockProvider::default()
+                            .with_name("simple")
+                            .with_model_identifier("gpt-4o-mini"),
+                    ),
+                ),
+                (
+                    ComplexityTier::Expert,
+                    AnyProvider::Mock(
+                        MockProvider::default()
+                            .with_name("expert")
+                            .with_model_identifier("gpt-4o"),
+                    ),
+                ),
+            ],
+            5,
+            100,
+        );
+        router.last_provider_idx.store(1, Ordering::Relaxed);
+
+        assert_eq!(router.effective_model_identifier(), "gpt-4o");
+    }
+
+    /// End-to-end: drive a real `chat_with_tools` dispatch through triage classification
+    /// (not a direct `last_provider_idx` poke) and verify `effective_model_identifier()`
+    /// resolves the tier provider that actually served it.
+    #[tokio::test]
+    async fn triage_effective_model_identifier_resolves_via_real_dispatch() {
+        let router = TriageRouter::new(
+            triage_mock(r#"{"tier":"expert","reason":"architecture decision"}"#),
+            vec![
+                (
+                    ComplexityTier::Simple,
+                    AnyProvider::Mock(
+                        MockProvider::default()
+                            .with_name("simple")
+                            .with_model_identifier("gpt-4o-mini"),
+                    ),
+                ),
+                (
+                    ComplexityTier::Expert,
+                    AnyProvider::Mock(
+                        MockProvider::default()
+                            .with_name("expert")
+                            .with_model_identifier("o3"),
+                    ),
+                ),
+            ],
+            5,
+            100,
+        );
+        let msgs = vec![make_user_msg("design a distributed consensus protocol")];
+
+        router.chat_with_tools(&msgs, &[]).await.unwrap();
+
+        assert_eq!(router.effective_model_identifier(), "o3");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `LlmProvider::effective_model_identifier()` (defaults to `model_identifier()`), and switches the `reasoning_amplification` anomaly detection call site in `tool_result.rs` to use it instead of the static `model_identifier()`.
- `Router` and `TriageRouter` override it to resolve the sub-provider that actually served the most recent dispatch, reusing the existing `last_active_provider`/`last_provider_idx` state already read by reputation attribution — no new shared state introduced.
- `CandleProvider` gets a genuine `model_id` field derived from its `ModelSource` (`repo_id` for HuggingFace sources, file stem for Local sources), threaded through the constructor and hand-rolled `Clone`.
- `MaskedProvider` (the outbound secret-masking wrapper applied to every provider by default) needed an explicit forwarding override — without it, a masked Router/TriageRouter, which is the structural default configuration, silently fell back to the trait default and the fix never took effect. Found by adversarial critique during implementation review.

This closes the remaining gap left by #6182, which fixed the same defect class (provider-instance-name vs. model-identifier confusion feeding `is_reasoning_model()`) for Claude, OpenAI, Ollama, Compatible, Gonka, Cocoon, and Gemini, but intentionally left Router/TriageRouter/CandleProvider out of scope pending a design for how the actually-dispatched model gets threaded back to the detection call site.

Closes #6183

## Test plan

- [x] 17 new tests added: 13 unit + 4 real-dispatch end-to-end (Router/TriageRouter unit tests for `effective_model_identifier` resolution and fallback; `ModelSource::model_id()` unit tests for HuggingFace/Local variants; `zeph-core` end-to-end tests extending the existing `reasoning_amplification_call_site` module from #6182, driving an actual `chat_with_tools` dispatch through `AnyProvider::Router`/`AnyProvider::Triage` and `process_one_tool_result`, proving the anomaly now fires with the correct resolved model id)
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (13271 passed, 0 failed)
- [x] `cargo doc --no-deps --workspace` with `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links"`
- [x] `gitleaks protect --staged --redact`
- [x] CHANGELOG.md updated
- [x] `.local/testing/playbooks/reasoning-amplification-model-check.md` updated with new Router/TriageRouter live-test scenarios
- [x] `.local/testing/coverage-status.md` row updated in place (status: Partial — live end-to-end verification through a real routed config is still outstanding, tracked in the playbook)