### PR TITLE
fix(vault): require --force to overwrite an existing secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `crates/zeph-vault/src/age.rs`: `AgeVaultProvider::set_secret_mut` silently overwrote an
+  existing secret with no confirmation, diff, or backup — the same defect class as the
+  `ZEPH_DURABLE_KEY` incident fixed for the `zeph init` wizard in #5880/#5874, but one layer
+  down in the vault crate itself, so every caller (CLI, wizards, OAuth credential store)
+  inherited the same silent-overwrite risk (#5955). `set_secret_mut` now takes an explicit
+  `overwrite: bool` and returns `AgeVaultError::AlreadyExists` when a key already exists and
+  `overwrite` is `false`, leaving the previous value untouched. `zeph vault set <key> <value>`
+  gained a `--force` flag: without it, attempting to overwrite an existing key fails with a
+  clear error telling the operator to re-run with `--force`; the previous secret value is never
+  printed, only its presence. Call sites that intentionally always overwrite (OAuth token
+  refresh in `src/bootstrap/oauth.rs`, and `zeph init`'s durable-key wizard step, which already
+  gates rotation behind its own explicit "rotate" confirmation phrase) pass `overwrite: true`
+  explicitly.
 - `src/commands/skill.rs`/`src/commands/plugin.rs`: `zeph skill search`/`get` and
   `zeph plugin search`/`get` printed the correct, actionable FR-004 message
   (`REGISTRY_NOT_CONFIGURED_MSG`) to stdout when the registry is disabled, then

--- a/crates/zeph-vault/README.md
+++ b/crates/zeph-vault/README.md
@@ -36,7 +36,7 @@ let mut vault = AgeVaultProvider::new(
 )?;
 
 // Store a secret, then persist the re-encrypted vault to disk.
-vault.set_secret_mut("ZEPH_CLAUDE_API_KEY".to_owned(), "sk-ant-...".to_owned());
+vault.set_secret_mut("ZEPH_CLAUDE_API_KEY".to_owned(), "sk-ant-...".to_owned(), false)?;
 vault.save()?;
 
 // Retrieve a secret synchronously via the direct getter.

--- a/crates/zeph-vault/src/age.rs
+++ b/crates/zeph-vault/src/age.rs
@@ -66,6 +66,10 @@ pub enum AgeVaultError {
     /// The key file could not be written to disk.
     #[error("failed to write key file: {0}")]
     KeyWrite(std::io::Error),
+    /// [`AgeVaultProvider::set_secret_mut`] was called with `overwrite: false` for a key that
+    /// already exists in the vault.
+    #[error("secret key already exists: {0} (pass overwrite=true to replace it)")]
+    AlreadyExists(String),
 }
 
 // ---------------------------------------------------------------------------
@@ -249,7 +253,7 @@ impl AgeVaultProvider {
     ///     Path::new("/etc/zeph/vault-key.txt"),
     ///     Path::new("/etc/zeph/secrets.age"),
     /// )?;
-    /// vault.set_secret_mut("MY_TOKEN".into(), "tok_abc123".into());
+    /// vault.set_secret_mut("MY_TOKEN".into(), "tok_abc123".into(), false)?;
     /// vault.save()?;
     /// # Ok::<_, zeph_vault::AgeVaultError>(())
     /// ```
@@ -282,7 +286,7 @@ impl AgeVaultProvider {
     ///     Path::new("/etc/zeph/vault-key.txt"),
     ///     Path::new("/etc/zeph/secrets.age"),
     /// )?;
-    /// vault.set_secret_mut("MY_TOKEN".into(), "tok_abc123".into());
+    /// vault.set_secret_mut("MY_TOKEN".into(), "tok_abc123".into(), false)?;
     /// vault.save_async().await?;
     /// # Ok(())
     /// # }
@@ -309,7 +313,18 @@ impl AgeVaultProvider {
 
     /// Insert or update a secret in the in-memory map.
     ///
+    /// Refuses to replace an existing key unless `overwrite` is `true`, so that callers cannot
+    /// silently destroy a previously-stored secret by accident — see #5955 (and the sibling
+    /// incident #5874, which hit the same gap in the `zeph init` durable-execution wizard before
+    /// this guard existed at the vault layer). Callers that intend an unconditional update (e.g.
+    /// OAuth token refresh) pass `overwrite: true` explicitly.
+    ///
     /// Call [`save`][Self::save] afterwards to persist the change to disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AgeVaultError::AlreadyExists`] if `key` is already present and `overwrite` is
+    /// `false`. The in-memory map is left untouched in that case.
     ///
     /// # Examples
     ///
@@ -321,12 +336,21 @@ impl AgeVaultProvider {
     ///     Path::new("/etc/zeph/vault-key.txt"),
     ///     Path::new("/etc/zeph/secrets.age"),
     /// )?;
-    /// vault.set_secret_mut("API_KEY".into(), "sk-...".into());
+    /// vault.set_secret_mut("API_KEY".into(), "sk-...".into(), false)?;
     /// vault.save()?;
     /// # Ok::<_, zeph_vault::AgeVaultError>(())
     /// ```
-    pub fn set_secret_mut(&mut self, key: String, value: String) {
+    pub fn set_secret_mut(
+        &mut self,
+        key: String,
+        value: String,
+        overwrite: bool,
+    ) -> Result<(), AgeVaultError> {
+        if !overwrite && self.secrets.contains_key(&key) {
+            return Err(AgeVaultError::AlreadyExists(key));
+        }
         self.secrets.insert(key, Zeroizing::new(value));
+        Ok(())
     }
 
     /// Remove a secret from the in-memory map.
@@ -563,7 +587,9 @@ mod tests {
         let (key_path, vault_path) = init_temp_vault(dir.path());
 
         let mut vault = AgeVaultProvider::new(&key_path, &vault_path).unwrap();
-        vault.set_secret_mut("KEY".into(), "val".into());
+        vault
+            .set_secret_mut("KEY".into(), "val".into(), false)
+            .unwrap();
         vault.save().unwrap();
 
         let loaded = AgeVaultProvider::load(&key_path, &vault_path).unwrap();
@@ -576,7 +602,9 @@ mod tests {
         let (key_path, vault_path) = init_temp_vault(dir.path());
 
         let mut vault = AgeVaultProvider::new(&key_path, &vault_path).unwrap();
-        vault.set_secret_mut("KEY".into(), "val".into());
+        vault
+            .set_secret_mut("KEY".into(), "val".into(), false)
+            .unwrap();
 
         assert!(vault.remove_secret_mut("KEY"));
         assert!(!vault.remove_secret_mut("KEY"));
@@ -656,11 +684,50 @@ mod tests {
         let (key_path, vault_path) = init_temp_vault(dir.path());
 
         let mut vault = AgeVaultProvider::new(&key_path, &vault_path).unwrap();
-        vault.set_secret_mut("TMP_TEST".into(), "value".into());
+        vault
+            .set_secret_mut("TMP_TEST".into(), "value".into(), false)
+            .unwrap();
         vault.save().unwrap();
 
         let tmp_path = vault_path.with_added_extension("tmp");
         assert!(!tmp_path.exists(), ".age.tmp must not exist after save()");
         assert!(vault_path.exists(), "secrets.age must exist after save()");
+    }
+
+    /// Regression for #5955: `set_secret_mut` must refuse to replace an existing key when
+    /// `overwrite` is `false`, and must leave the previous value untouched.
+    #[test]
+    fn set_secret_mut_rejects_overwrite_when_not_requested() {
+        let dir = tempdir().unwrap();
+        let (key_path, vault_path) = init_temp_vault(dir.path());
+
+        let mut vault = AgeVaultProvider::new(&key_path, &vault_path).unwrap();
+        vault
+            .set_secret_mut("KEY".into(), "original".into(), false)
+            .unwrap();
+
+        let result = vault.set_secret_mut("KEY".into(), "clobbered".into(), false);
+        assert!(
+            matches!(result, Err(AgeVaultError::AlreadyExists(ref k)) if k == "KEY"),
+            "expected AlreadyExists(\"KEY\"), got {result:?}",
+        );
+        assert_eq!(vault.get("KEY"), Some("original"));
+    }
+
+    /// Regression for #5955: `overwrite: true` must replace an existing value.
+    #[test]
+    fn set_secret_mut_replaces_when_overwrite_requested() {
+        let dir = tempdir().unwrap();
+        let (key_path, vault_path) = init_temp_vault(dir.path());
+
+        let mut vault = AgeVaultProvider::new(&key_path, &vault_path).unwrap();
+        vault
+            .set_secret_mut("KEY".into(), "original".into(), false)
+            .unwrap();
+        vault
+            .set_secret_mut("KEY".into(), "updated".into(), true)
+            .unwrap();
+
+        assert_eq!(vault.get("KEY"), Some("updated"));
     }
 }

--- a/crates/zeph-vault/src/arc.rs
+++ b/crates/zeph-vault/src/arc.rs
@@ -91,7 +91,8 @@ mod tests {
         )
         .unwrap();
         for (k, v) in keys {
-            age.set_secret_mut((*k).to_owned(), (*v).to_owned());
+            age.set_secret_mut((*k).to_owned(), (*v).to_owned(), false)
+                .unwrap();
         }
         // Keep tempdir alive by leaking — tests are short-lived, no I/O after this.
         std::mem::forget(dir);

--- a/crates/zeph-vault/src/lib.rs
+++ b/crates/zeph-vault/src/lib.rs
@@ -501,8 +501,12 @@ mod age_tests {
         let (_dir, key_path, vault_path) = write_temp_files(&identity, &encrypted);
 
         let mut vault = AgeVaultProvider::load(&key_path, &vault_path).unwrap();
-        vault.set_secret_mut("B".to_owned(), "2".to_owned());
-        vault.set_secret_mut("C".to_owned(), "3".to_owned());
+        vault
+            .set_secret_mut("B".to_owned(), "2".to_owned(), false)
+            .unwrap();
+        vault
+            .set_secret_mut("C".to_owned(), "3".to_owned(), false)
+            .unwrap();
 
         let keys = vault.list_keys();
         assert_eq!(keys, vec!["A", "B", "C"]);
@@ -529,7 +533,9 @@ mod age_tests {
         let (_dir, key_path, vault_path) = write_temp_files(&identity, &encrypted);
 
         let mut vault = AgeVaultProvider::load(&key_path, &vault_path).unwrap();
-        vault.set_secret_mut("NEW_KEY".to_owned(), "new_value".to_owned());
+        vault
+            .set_secret_mut("NEW_KEY".to_owned(), "new_value".to_owned(), false)
+            .unwrap();
         vault.save().unwrap();
 
         let reloaded = AgeVaultProvider::load(&key_path, &vault_path).unwrap();
@@ -598,7 +604,9 @@ mod age_tests {
         let (_dir, key_path, vault_path) = write_temp_files(&identity, &encrypted);
 
         let mut vault = AgeVaultProvider::load(&key_path, &vault_path).unwrap();
-        vault.set_secret_mut("B_KEY".to_owned(), "b".to_owned());
+        vault
+            .set_secret_mut("B_KEY".to_owned(), "b".to_owned(), false)
+            .unwrap();
         vault.save().unwrap();
 
         let reloaded = AgeVaultProvider::load(&key_path, &vault_path).unwrap();
@@ -654,7 +662,9 @@ mod age_tests {
         let mut vault = AgeVaultProvider::load_async(&key_path, &vault_path)
             .await
             .unwrap();
-        vault.set_secret_mut("ADDED".to_owned(), "added_val".to_owned());
+        vault
+            .set_secret_mut("ADDED".to_owned(), "added_val".to_owned(), false)
+            .unwrap();
         vault.save_async().await.unwrap();
 
         let reloaded = AgeVaultProvider::load_async(&key_path, &vault_path)

--- a/src/bootstrap/oauth.rs
+++ b/src/bootstrap/oauth.rs
@@ -69,7 +69,11 @@ impl CredentialStore for VaultCredentialStore {
             let mut guard = vault
                 .write()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            guard.set_secret_mut(key, json);
+            // OAuth credential refresh is an intentional update of the store's own managed
+            // entry, not a user-facing secret set — always overwrite.
+            guard
+                .set_secret_mut(key, json, true)
+                .map_err(|e| AuthError::InternalError(format!("vault save: {e}")))?;
             guard
                 .save()
                 .map_err(|e| AuthError::InternalError(format!("vault save: {e}")))

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1139,6 +1139,10 @@ pub(crate) enum VaultCommand {
         key: String,
         #[arg()]
         value: String,
+        /// Overwrite an existing key. Without this flag, `vault set` refuses to replace
+        /// a key that is already present in the vault.
+        #[arg(long)]
+        force: bool,
     },
     /// Decrypt and print a secret value
     Get {

--- a/src/commands/durable.rs
+++ b/src/commands/durable.rs
@@ -747,10 +747,13 @@ mod tests {
             &vault_root.join("secrets.age"),
         )
         .unwrap();
-        provider.set_secret_mut(
-            "ZEPH_DURABLE_KEY".to_owned(),
-            zeph_core::durable::generate_durable_key_b64(),
-        );
+        provider
+            .set_secret_mut(
+                "ZEPH_DURABLE_KEY".to_owned(),
+                zeph_core::durable::generate_durable_key_b64(),
+                false,
+            )
+            .unwrap();
         provider.save().unwrap();
 
         // Exercise the exact glue the write paths (runner.rs, scheduler_daemon.rs) call.
@@ -943,10 +946,13 @@ mod tests {
             &vault_root.join("secrets.age"),
         )
         .unwrap();
-        provider.set_secret_mut(
-            "ZEPH_DURABLE_KEY".to_owned(),
-            zeph_core::durable::generate_durable_key_b64(),
-        );
+        provider
+            .set_secret_mut(
+                "ZEPH_DURABLE_KEY".to_owned(),
+                zeph_core::durable::generate_durable_key_b64(),
+                false,
+            )
+            .unwrap();
         provider.save().unwrap();
 
         let result = load_write_hmac_key(&config);

--- a/src/commands/vault.rs
+++ b/src/commands/vault.rs
@@ -3,7 +3,7 @@
 
 use std::path::PathBuf;
 
-use zeph_core::vault::AgeVaultProvider;
+use zeph_core::vault::{AgeVaultError, AgeVaultProvider};
 
 use crate::cli::VaultCommand;
 
@@ -25,10 +25,18 @@ pub(crate) fn handle_vault_command(
             AgeVaultProvider::init_vault(&dir)
                 .map_err(|e| anyhow::anyhow!("vault init failed: {e}"))?;
         }
-        VaultCommand::Set { key, value } => {
+        VaultCommand::Set { key, value, force } => {
             let mut provider = AgeVaultProvider::load(&key_path_owned, &vault_path_owned)
                 .map_err(|e| anyhow::anyhow!("failed to load vault: {e}"))?;
-            provider.set_secret_mut(key, value);
+            provider
+                .set_secret_mut(key.clone(), value, force)
+                .map_err(|e| match e {
+                    AgeVaultError::AlreadyExists(_) => anyhow::anyhow!(
+                        "key '{key}' already exists in the vault. Re-run with --force to \
+                         overwrite it."
+                    ),
+                    other => anyhow::anyhow!("failed to set secret: {other}"),
+                })?;
             provider
                 .save()
                 .map_err(|e| anyhow::anyhow!("failed to save vault: {e}"))?;
@@ -128,6 +136,7 @@ mod tests {
             VaultCommand::Set {
                 key: "FOO".into(),
                 value: "bar".into(),
+                force: false,
             },
             Some(&key_path),
             Some(&vault_path),
@@ -168,6 +177,75 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.to_string().contains("key not found"));
+    }
+
+    // R-05: Set refuses to silently overwrite an existing key (#5955)
+    #[test]
+    fn handle_vault_command_set_existing_key_without_force_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("vault-key.txt");
+        let vault_path = dir.path().join("secrets.age");
+        zeph_core::vault::AgeVaultProvider::init_vault(dir.path()).unwrap();
+
+        handle_vault_command(
+            VaultCommand::Set {
+                key: "FOO".into(),
+                value: "original".into(),
+                force: false,
+            },
+            Some(&key_path),
+            Some(&vault_path),
+        )
+        .unwrap();
+
+        let err = handle_vault_command(
+            VaultCommand::Set {
+                key: "FOO".into(),
+                value: "clobbered".into(),
+                force: false,
+            },
+            Some(&key_path),
+            Some(&vault_path),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("--force"));
+
+        // The original value must survive the rejected overwrite attempt.
+        let provider = zeph_core::vault::AgeVaultProvider::load(&key_path, &vault_path).unwrap();
+        assert_eq!(provider.get("FOO"), Some("original"));
+    }
+
+    #[test]
+    fn handle_vault_command_set_existing_key_with_force_overwrites() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("vault-key.txt");
+        let vault_path = dir.path().join("secrets.age");
+        zeph_core::vault::AgeVaultProvider::init_vault(dir.path()).unwrap();
+
+        handle_vault_command(
+            VaultCommand::Set {
+                key: "FOO".into(),
+                value: "original".into(),
+                force: false,
+            },
+            Some(&key_path),
+            Some(&vault_path),
+        )
+        .unwrap();
+
+        handle_vault_command(
+            VaultCommand::Set {
+                key: "FOO".into(),
+                value: "updated".into(),
+                force: true,
+            },
+            Some(&key_path),
+            Some(&vault_path),
+        )
+        .unwrap();
+
+        let provider = zeph_core::vault::AgeVaultProvider::load(&key_path, &vault_path).unwrap();
+        assert_eq!(provider.get("FOO"), Some("updated"));
     }
 
     #[test]

--- a/src/init/durable.rs
+++ b/src/init/durable.rs
@@ -170,7 +170,11 @@ pub(super) fn store_durable_key(state: &WizardState) -> anyhow::Result<()> {
     }
     let mut provider = zeph_core::vault::AgeVaultProvider::load(&key_path, &vault_path)
         .map_err(|e| anyhow::anyhow!("failed to load age vault: {e}"))?;
-    provider.set_secret_mut("ZEPH_DURABLE_KEY".to_owned(), key.to_owned());
+    // Reaching this point already implies the caller's own rotation gate approved an
+    // overwrite (no pre-existing key, or the user typed the "rotate" confirmation above).
+    provider
+        .set_secret_mut("ZEPH_DURABLE_KEY".to_owned(), key.to_owned(), true)
+        .map_err(|e| anyhow::anyhow!("failed to set ZEPH_DURABLE_KEY: {e}"))?;
     provider
         .save()
         .map_err(|e| anyhow::anyhow!("failed to save age vault: {e}"))?;
@@ -249,7 +253,13 @@ mod tests {
         let vault_path = vault_root.join("secrets.age");
         let mut provider =
             zeph_core::vault::AgeVaultProvider::load(&key_path, &vault_path).expect("load vault");
-        provider.set_secret_mut("ZEPH_DURABLE_KEY".to_owned(), "existing-key".to_owned());
+        provider
+            .set_secret_mut(
+                "ZEPH_DURABLE_KEY".to_owned(),
+                "existing-key".to_owned(),
+                false,
+            )
+            .expect("set secret");
         provider.save().expect("save vault");
 
         let state = durable_state(None);
@@ -273,7 +283,13 @@ mod tests {
         let vault_path = vault_root.join("secrets.age");
         let mut provider =
             zeph_core::vault::AgeVaultProvider::load(&key_path, &vault_path).expect("load vault");
-        provider.set_secret_mut("ZEPH_DURABLE_KEY".to_owned(), "existing-key".to_owned());
+        provider
+            .set_secret_mut(
+                "ZEPH_DURABLE_KEY".to_owned(),
+                "existing-key".to_owned(),
+                false,
+            )
+            .expect("set secret");
         provider.save().expect("save vault");
 
         let new_key = zeph_core::durable::generate_durable_key_b64();
@@ -355,7 +371,13 @@ mod tests {
         let vault_path = dir.path().join("secrets.age");
         let mut provider =
             zeph_core::vault::AgeVaultProvider::load(&key_path, &vault_path).expect("load vault");
-        provider.set_secret_mut("ZEPH_DURABLE_KEY".to_owned(), "existing-key".to_owned());
+        provider
+            .set_secret_mut(
+                "ZEPH_DURABLE_KEY".to_owned(),
+                "existing-key".to_owned(),
+                false,
+            )
+            .expect("set secret");
         provider.save().expect("save vault");
 
         assert!(vault_has_durable_key(dir.path()).expect("should not error"));
@@ -369,7 +391,9 @@ mod tests {
         let vault_path = dir.path().join("secrets.age");
         let mut provider =
             zeph_core::vault::AgeVaultProvider::load(&key_path, &vault_path).expect("load vault");
-        provider.set_secret_mut("ZEPH_OTHER_KEY".to_owned(), "value".to_owned());
+        provider
+            .set_secret_mut("ZEPH_OTHER_KEY".to_owned(), "value".to_owned(), false)
+            .expect("set secret");
         provider.save().expect("save vault");
 
         assert!(!vault_has_durable_key(dir.path()).expect("should not error"));

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -641,11 +641,24 @@ fn cli_parse_vault_set() {
     let cli = Cli::try_parse_from(["zeph", "vault", "set", "MY_KEY", "MY_VAL"]).unwrap();
     match cli.command {
         Some(Command::Vault {
-            command: VaultCommand::Set { key, value },
+            command: VaultCommand::Set { key, value, force },
         }) => {
             assert_eq!(key, "MY_KEY");
             assert_eq!(value, "MY_VAL");
+            assert!(!force, "force must default to false");
         }
+        _ => panic!("expected VaultCommand::Set"),
+    }
+}
+
+// Regression for #5955: `--force` must parse and set `force = true`.
+#[test]
+fn cli_parse_vault_set_force() {
+    let cli = Cli::try_parse_from(["zeph", "vault", "set", "MY_KEY", "MY_VAL", "--force"]).unwrap();
+    match cli.command {
+        Some(Command::Vault {
+            command: VaultCommand::Set { force, .. },
+        }) => assert!(force, "--force must set force = true"),
         _ => panic!("expected VaultCommand::Set"),
     }
 }


### PR DESCRIPTION
## Summary
- `AgeVaultProvider::set_secret_mut` now takes an explicit `overwrite: bool` and returns `AgeVaultError::AlreadyExists` when a key already exists and overwrite wasn't requested, instead of silently replacing it — the guard lives in the shared `zeph-vault` crate, so every current and future caller (CLI, OAuth token refresh, durable-key wizard) must state its intent explicitly.
- CLI `zeph vault set <key> <value>` gained a `--force` flag; without it, an existing key is left untouched and the error names the key without ever printing its value.
- `src/bootstrap/oauth.rs` (managed OAuth token refresh) and `src/init/durable.rs::store_durable_key` (already gated by the pre-existing #5874/#5880 rotate-confirmation flow) pass `overwrite: true` explicitly, with an inline comment justifying why unconditional overwrite is correct there.

This closes the same defect class as the `ZEPH_DURABLE_KEY` incident (#5874/#5880), one layer down from that fix's wizard-specific gate — any current or future caller of the vault's set-style API now inherits the protection by default.

Closes #5955

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-vault -p zeph --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (828 passed)
- [x] `cargo test --doc -p zeph-vault` (17 passed)
- [x] Rustdoc gate (`RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links"`) clean for `zeph-vault`
- [x] New unit tests: `set_secret_mut` reject/replace paths (`crates/zeph-vault/src/age.rs`), CLI-level reject/overwrite (`src/commands/vault.rs`), CLI-parsing (`src/tests.rs`)
- [x] `.local/testing/playbooks/vault.md` and `.local/testing/coverage-status.md` updated (main repo root) with a live-testing scenario for the overwrite guard