### PR TITLE
fix(llm): make Claude no-prefill gate compile-time enforced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 ### Fixed
 
+- **LLM**: the Claude request funnel's no-prefill gate (`ClaudeProvider::structured_history`/
+  `plain_history`) was convention-enforced only — `request::split_messages`/
+  `split_messages_structured` stayed reachable from anywhere inside `crate::claude`, so a new
+  request-construction path added directly in `mod.rs` (or any sibling file) could call the raw
+  split functions and skip the no-prefill strip, silently reintroducing the bug class fixed by
+  #5903/#6145/#6146/#6154. Introduced `GatedStructuredHistory`/`GatedPlainHistory` newtypes with
+  a private inner `Vec`, constructible only via `structured_history`/`plain_history`.
+  `RequestBody`, `ToolRequestBody`, `VisionRequestBody`, and `TypedToolRequestBody`'s `messages`
+  field now require the gated type instead of a bare `Vec`/slice, so bypassing the funnel is a
+  compile error (wrong type) instead of a code-review catch. Pure refactor — wire format is
+  byte-identical (verified via existing insta snapshots) (#6158).
+
 - **CI**: the `registry` feature (`zeph-plugins/registry`, spec-045) was declared in root
   `Cargo.toml` and bundled into `full`, but excluded from every PR-gating CI job's feature
   string — `lint-clippy`, `msrv`, `build-tests` (and by extension the sharded `test` job that

--- a/crates/zeph-llm/src/claude/mod.rs
+++ b/crates/zeph-llm/src/claude/mod.rs
@@ -249,6 +249,42 @@ fn stale_model_suggestion(model: &str) -> Option<&'static str> {
     ((major, minor) < (floor_major, floor_minor)).then_some(suggestion)
 }
 
+/// A structured chat history with the no-prefill gate already applied.
+///
+/// The tuple field is private to this module, so this type is constructible only via the
+/// module-private [`Self::new`], called by [`ClaudeProvider::structured_history`] on the
+/// production path, after it has stripped trailing assistant turns. `ToolRequestBody`,
+/// `VisionRequestBody`, and `TypedToolRequestBody` require `&GatedStructuredHistory` for their
+/// `messages` field instead of `&[StructuredApiMessage]` — a request-construction path that
+/// calls `request::split_messages_structured` directly and tries to hand its raw `Vec` to a
+/// request body now fails to compile with a type mismatch, closing the loophole left open by
+/// #6155/#6156 (#6158).
+#[derive(serde::Serialize)]
+#[serde(transparent)]
+pub(in crate::claude) struct GatedStructuredHistory(Vec<StructuredApiMessage>);
+
+impl GatedStructuredHistory {
+    fn new(chat: Vec<StructuredApiMessage>) -> Self {
+        Self(chat)
+    }
+}
+
+/// A plain (non-structured) chat history with the no-prefill gate already applied.
+///
+/// Same construction guarantee as [`GatedStructuredHistory`]: constructible only via the
+/// module-private [`Self::new`], called by [`ClaudeProvider::plain_history`] on the production
+/// path. `RequestBody`'s `messages` field requires `&GatedPlainHistory` instead of
+/// `&[ApiMessage]`.
+#[derive(serde::Serialize)]
+#[serde(transparent)]
+pub(in crate::claude) struct GatedPlainHistory<'m>(Vec<ApiMessage<'m>>);
+
+impl<'m> GatedPlainHistory<'m> {
+    fn new(chat: Vec<ApiMessage<'m>>) -> Self {
+        Self(chat)
+    }
+}
+
 impl ClaudeProvider {
     const MAX_CACHE_CONTROL_BLOCKS: usize = 4;
 
@@ -963,22 +999,20 @@ impl ClaudeProvider {
     /// cache-control blocks are capped at Anthropic's budget and the no-prefill gate has
     /// already been applied.
     ///
-    /// This is the *sanctioned* way to obtain a `Vec<StructuredApiMessage>` for a request body,
-    /// not a compiler-enforced one. `split_messages_structured` itself is intentionally NOT
-    /// imported at this module's top level (see the local `use` inside this function) so it
-    /// isn't one autocomplete away from every call site, which raises the friction of pulling
-    /// the split and the no-prefill strip apart again the way they were before #6146 (this is
-    /// the second filing of this bug class; #5903 fixed the gate for `build_request` only). A
-    /// true compile-time barrier is not achievable while this funnel lives in `claude` (this
-    /// module) and `split_messages_structured` must remain visible to it — see the doc comment
-    /// on `split_messages_structured` in `request.rs` and follow-up #6158 for a design that
-    /// would make bypassing this funnel a compile error instead of a code-review catch.
+    /// This is the production path that builds a [`GatedStructuredHistory`] for a request body
+    /// — the wrapper's tuple field is private to this module, so `ToolRequestBody`,
+    /// `VisionRequestBody`, and `TypedToolRequestBody` (which all take `&GatedStructuredHistory`
+    /// for their `messages` field) cannot be built from a raw `Vec<StructuredApiMessage>`
+    /// returned by calling `split_messages_structured` directly. `split_messages_structured`
+    /// itself is intentionally NOT imported at this module's top level (see the local `use`
+    /// inside this function) to additionally keep it off autocomplete at call sites — belt and
+    /// braces on top of the type-level guarantee (#5903, #6146, #6155/#6156, #6158).
     fn structured_history(
         &self,
         messages: &[Message],
         thinking_param: Option<&types::ThinkingParam>,
         cache_tool_blocks: usize,
-    ) -> (Option<Vec<SystemContentBlock>>, Vec<StructuredApiMessage>) {
+    ) -> (Option<Vec<SystemContentBlock>>, GatedStructuredHistory) {
         use self::request::split_messages_structured;
 
         let (system, mut chat_messages) =
@@ -994,24 +1028,23 @@ impl ClaudeProvider {
             self.no_prefill(thinking_param),
             &mut chat_messages,
         );
-        (system_blocks, chat_messages)
+        (system_blocks, GatedStructuredHistory::new(chat_messages))
     }
 
     /// Split `messages` into a system prompt and a plain chat history, with the no-prefill gate
-    /// already applied. Same friction-raising rationale (not a compile-time guarantee) as
-    /// [`Self::structured_history`].
+    /// already applied. Same construction guarantee as [`Self::structured_history`].
     fn plain_history<'m>(
         &self,
         messages: &'m [Message],
         thinking_param: Option<&types::ThinkingParam>,
-    ) -> (Option<Vec<SystemContentBlock>>, Vec<ApiMessage<'m>>) {
+    ) -> (Option<Vec<SystemContentBlock>>, GatedPlainHistory<'m>) {
         use self::request::split_messages;
 
         let (system, mut chat_messages) = split_messages(messages);
         Self::strip_trailing_assistant_plain(self.no_prefill(thinking_param), &mut chat_messages);
         let system_blocks =
             system.map(|s| split_system_into_blocks(&s, &self.model, self.prompt_cache_ttl));
-        (system_blocks, chat_messages)
+        (system_blocks, GatedPlainHistory::new(chat_messages))
     }
 
     fn build_request(&self, messages: &[Message], stream: bool) -> reqwest::RequestBuilder {

--- a/crates/zeph-llm/src/claude/request.rs
+++ b/crates/zeph-llm/src/claude/request.rs
@@ -20,22 +20,14 @@ use crate::CacheTtl;
 /// request-construction path — `ClaudeProvider::plain_history` is the funnel that applies the
 /// no-prefill strip after this split (see its doc comment for why).
 ///
-/// Visibility is `pub(in crate::claude)` rather than plain `pub(super)`, but in the current
-/// module nesting (`request` is a direct child of `claude`, and `mod.rs` *is* the `claude`
-/// module) the two are functionally identical — this is a self-documenting anchor to the
-/// intended boundary, NOT a new compile-time bypass barrier. Rust has no way to grant a child
-/// module's item to its parent while excluding the parent's other children, so `claude::tests`
-/// remains exactly as reachable as before in raw visibility terms. A true compile-error barrier
-/// is architecturally impossible while `structured_history`/`plain_history` live in the parent
-/// module (`claude`/`mod.rs`) and therefore need at least this visibility to call these
-/// functions — a new request-construction path added directly in `mod.rs` that calls
-/// `split_messages`/`split_messages_structured` instead of the funnel would still compile fine;
-/// it remains a code-review catch, not a compiler error. The actual hardening this change
-/// delivers is moving the tests that used to call this directly out of `claude::tests` and into
-/// this file's own `mod tests` below — reduced discoverability/habit, not a compiler-enforced
-/// guarantee. A genuine compile-time guarantee (e.g. a newtype only constructible by
-/// `structured_history`/`plain_history`, so a request body cannot accept an ungated history) is
-/// tracked as a follow-up: #6158.
+/// Visibility is `pub(in crate::claude)` rather than plain `pub(super)` as a self-documenting
+/// anchor to the intended boundary. The actual compile-time guarantee against skipping the
+/// no-prefill strip lives one level up: `RequestBody`'s `messages` field requires
+/// `&GatedPlainHistory` (a newtype constructible only via its module-private `Self::new`,
+/// called by `ClaudeProvider::plain_history` on the production path), not `&[ApiMessage]`, so a
+/// request-construction path that calls this function directly and tries to feed its raw `Vec`
+/// to a request body fails to compile with a type mismatch (#6158, resolving the gap left open
+/// by #6155/#6156).
 pub(in crate::claude) fn split_messages(
     messages: &[Message],
 ) -> (Option<String>, Vec<ApiMessage<'_>>) {
@@ -76,8 +68,8 @@ pub(in crate::claude) fn split_messages(
 /// Not re-exported at `claude` module top level and not meant to be called directly from a
 /// request-construction path — `ClaudeProvider::structured_history` is the funnel that applies
 /// the no-prefill strip after this split (see its doc comment for why). See [`split_messages`]
-/// for why the `pub(in crate::claude)` visibility here is a documentation anchor rather than a
-/// new compile-time barrier, and for the compile-time-enforcement follow-up (#6158).
+/// for why the `pub(in crate::claude)` visibility here is a documentation anchor, and for where
+/// the real compile-time guarantee (`GatedStructuredHistory`) lives (#6158).
 pub(in crate::claude) fn split_messages_structured(
     messages: &[Message],
     cache_user_messages: bool,

--- a/crates/zeph-llm/src/claude/tests.rs
+++ b/crates/zeph-llm/src/claude/tests.rs
@@ -172,14 +172,15 @@ fn debug_includes_model_and_max_tokens() {
 
 #[test]
 fn request_body_serializes_without_system() {
+    let history = GatedPlainHistory::new(vec![ApiMessage {
+        role: "user",
+        content: "hello",
+    }]);
     let body = RequestBody {
         model: "claude-sonnet-4-5-20250929",
         max_tokens: 1024,
         system: None,
-        messages: &[ApiMessage {
-            role: "user",
-            content: "hello",
-        }],
+        messages: &history,
         stream: false,
         thinking: None,
         output_config: None,
@@ -195,6 +196,7 @@ fn request_body_serializes_without_system() {
 
 #[test]
 fn request_body_serializes_with_system_blocks() {
+    let history = GatedPlainHistory::new(vec![]);
     let body = RequestBody {
         model: "claude-sonnet-4-5-20250929",
         max_tokens: 1024,
@@ -206,7 +208,7 @@ fn request_body_serializes_with_system_blocks() {
                 ttl: None,
             }),
         }]),
-        messages: &[],
+        messages: &history,
         stream: false,
         thinking: None,
         output_config: None,
@@ -221,11 +223,12 @@ fn request_body_serializes_with_system_blocks() {
 
 #[test]
 fn request_body_serializes_stream_true() {
+    let history = GatedPlainHistory::new(vec![]);
     let body = RequestBody {
         model: "test",
         max_tokens: 100,
         system: None,
-        messages: &[],
+        messages: &history,
         stream: true,
         thinking: None,
         output_config: None,
@@ -291,11 +294,12 @@ async fn chat_stream_with_unreachable_endpoint_errors() {
 
 #[test]
 fn request_body_serializes_with_stream_false_omits_stream() {
+    let history = GatedPlainHistory::new(vec![]);
     let body = RequestBody {
         model: "test",
         max_tokens: 100,
         system: None,
-        messages: &[],
+        messages: &history,
         stream: false,
         thinking: None,
         output_config: None,

--- a/crates/zeph-llm/src/claude/types.rs
+++ b/crates/zeph-llm/src/claude/types.rs
@@ -519,7 +519,7 @@ pub(super) struct RequestBody<'a> {
     pub max_tokens: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system: Option<Vec<SystemContentBlock>>,
-    pub messages: &'a [ApiMessage<'a>],
+    pub messages: &'a super::GatedPlainHistory<'a>,
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub stream: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -538,7 +538,7 @@ pub(super) struct VisionRequestBody<'a> {
     pub max_tokens: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system: Option<Vec<SystemContentBlock>>,
-    pub messages: &'a [StructuredApiMessage],
+    pub messages: &'a super::GatedStructuredHistory,
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub stream: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -557,7 +557,7 @@ pub(super) struct ToolRequestBody<'a> {
     pub max_tokens: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system: Option<Vec<SystemContentBlock>>,
-    pub messages: &'a [StructuredApiMessage],
+    pub messages: &'a super::GatedStructuredHistory,
     pub tools: &'a [serde_json::Value],
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub stream: bool,
@@ -584,7 +584,7 @@ pub(super) struct TypedToolRequestBody<'a> {
     pub max_tokens: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system: Option<Vec<SystemContentBlock>>,
-    pub messages: &'a [StructuredApiMessage],
+    pub messages: &'a super::GatedStructuredHistory,
     pub tools: &'a [AnthropicTool<'a>],
     pub tool_choice: ToolChoice<'a>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary

- `request::split_messages`/`split_messages_structured` were `pub(in crate::claude)`, reachable from anywhere inside `crate::claude` — a new request-construction path added in `mod.rs` or any sibling file could call them directly and skip the no-prefill gate applied by `ClaudeProvider::structured_history`/`plain_history`, reintroducing the bug class fixed by #5903/#6145/#6146/#6154. The protection added in #6155/#6156 was convention + reduced discoverability, not a compiler-enforced barrier.
- Introduces `GatedStructuredHistory`/`GatedPlainHistory<'m>` newtypes (private inner `Vec`) constructible only via `structured_history`/`plain_history`. `RequestBody`, `ToolRequestBody`, `VisionRequestBody`, and `TypedToolRequestBody`'s `messages` field now require the gated type instead of a bare `Vec`/slice, so bypassing the gate is a compile error (`E0308`) instead of a code-review catch.
- Pure type-level refactor — request-construction logic and wire format are unchanged (`#[serde(transparent)]`, verified byte-identical via existing insta snapshots).

Closes #6158

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13290 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] `cargo insta test -p zeph-llm --features testing --check` — zero snapshot diffs (confirms byte-identical wire format)
- [x] `gitleaks protect --staged` — no leaks
- [x] Compile-fail bypass verified directly: feeding a raw `Vec<StructuredApiMessage>`/`Vec<ApiMessage>` from the split functions into a request body fails with `error[E0308]: mismatched types` (reproduced independently by developer, tester, and reviewer)
- [ ] Live Claude API round-trip: attempted, blocked by non-interactive age-vault unlock in this session (tooling limitation, not a code concern). Change is a byte-identical wire-format type-level refactor with the request-construction logic itself untouched; substitute evidence (insta snapshot + compile-fail proof + full unit suite) judged acceptable per prior precedent (coverage-status.md). `.local/testing/coverage-status.md` row left `Untested` for a future live-tester session to close out.

## Notes

- A residual: the gated types' private field/constructor are technically reachable from descendant modules of `claude` (`request`, `types`, `tests`) per Rust's privacy model, so a *deliberate* raw tuple-literal construction remains theoretically possible. This matches the issue's own proposed-fix snippet and threat model (the issue is about *accidental* bypass via the split functions, now fully closed). Reviewed and judged out of scope for this issue.
- Optional low-priority follow-up suggested (not filed): a permanent compile-fail regression test for this guarantee, since the manual probe used to verify it was not committed. Evaluated `pub`-bumping for a doctest and `trybuild`; both judged not worth the added surface/dependency for this PR.