### PR TITLE
docs(a2a): reconcile IBCT wire-format drift between specs and implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 ### Fixed
 
+- **Docs**: `specs/010-security/spec.md` and `specs/014-a2a/spec.md` described two different IBCT
+  (Invocation-Bound Capability Token) wire formats, and neither fully matched the actual
+  implementation in `crates/zeph-a2a/src/ibct.rs`. Reconciled both specs against `ibct.rs` and
+  `crates/zeph-config/src/channels.rs` ground truth: the token is a single base64-encoded JSON
+  blob (not a dot-separated triplet) signed over `{key_id}|{task_id}|{endpoint}|{issued_at}|
+  {expires_at}`, default TTL is 300s (not 60s), and `ibct_keys` is an array of `{key_id, key_hex}`
+  entries (not a `key_id → vault_ref` map) with `ibct_signing_key_vault_ref` as the separate
+  vault-resolved primary-key path. Also corrected both specs' claim that IBCT prevents replay
+  attacks — `Ibct::verify` performs no `invocation_id`/nonce dedup, so a captured, still-valid
+  token is replayable against the same `task_id` + `endpoint` until it expires; this is now
+  documented as a known implementation limitation. Documentation-only change, no source code
+  modified (#6197).
+
 - **LLM**: the Claude request funnel's no-prefill gate (`ClaudeProvider::structured_history`/
   `plain_history`) was convention-enforced only — `request::split_messages`/
   `split_messages_structured` stayed reachable from anywhere inside `crate::claude`, so a new

--- a/specs/010-security/spec.md
+++ b/specs/010-security/spec.md
@@ -18,6 +18,7 @@ related:
   - "[[025-classifiers/spec]]"
   - "[[008-mcp/spec]]"
   - "[[010-7-shadow-memory-guardrail]]"
+  - "[[014-a2a/spec]]"
 ---
 
 # Spec: Security (Parent Index)
@@ -361,25 +362,28 @@ When an MCP tool result triggers an ACP action (e.g., an MCP server result instr
 
 ### IBCT: Invocation-Bound Capability Tokens
 
-IBCT (Invocation-Bound Capability Tokens) are short-lived HMAC-SHA256 tokens bound to a specific tool invocation. They prevent capability reuse or replay across different invocations.
+IBCT (Invocation-Bound Capability Tokens, `crates/zeph-a2a/src/ibct.rs`, feature: `ibct`) are short-lived tokens that scope an A2A delegation request to a specific `task_id` + `endpoint`. See `014-a2a/spec.md` §"IBCT: Invocation-Bound Capability Tokens" for the authoritative wire-format description; this section covers the security posture only.
 
-Token format: `HMAC-SHA256(key_id + ":" + invocation_id + ":" + capability_name + ":" + timestamp)`. Tokens are sent via `X-Zeph-IBCT` header on A2A calls (feature: `ibct`).
+Signature: HMAC-SHA256 over `{key_id}|{task_id}|{endpoint}|{issued_at}|{expires_at}`, hex-encoded. The full token (`key_id`, `task_id`, `endpoint`, `issued_at`, `expires_at`, `signature`) is JSON-serialized, base64-encoded, and sent as a single opaque blob via the `X-Zeph-IBCT` header (feature: `ibct`).
 
-Key rotation: `key_id` field allows multiple active keys during rotation windows.
+Key rotation: `ibct_keys` is a `Vec<IbctKeyConfig>` of `{key_id, key_hex}` entries (inline hex-encoded keys, legacy path) allowing multiple active keys during rotation windows; `ibct_signing_key_vault_ref` resolves the vault-backed primary signing key and takes precedence over `ibct_keys[0]` when both are set.
 
 ### Config
 
 ```toml
 [a2a]
-ibct_enabled = false       # feature: ibct
-ibct_key_rotation_secs = 3600
+ibct_keys = [
+  { key_id = "k1", key_hex = "68656c6c6f2d7365637265742d6b6579" },  # legacy: inline hex key
+]
+ibct_signing_key_vault_ref = "ZEPH_A2A_IBCT_KEY"  # vault-resolved primary key; takes precedence over ibct_keys[0]
+ibct_ttl_secs = 300   # default; token time-to-live in seconds
 ```
 
 ### Key Invariants
 
-- IBCT tokens are single-use — replay detected by `invocation_id` deduplication
-- Token validity window is bounded — expired tokens are always rejected regardless of signature validity
-- `key_id` rotation must maintain a grace window for in-flight requests during rotation
+- IBCT tokens are **NOT single-use** — `Ibct::verify` has no `invocation_id`/nonce dedup. A captured, still-valid token can be replayed against the same `task_id` + `endpoint` until it expires. This is a known limitation of the current implementation, not a documentation gap — do not assume single-use replay protection exists until this is implemented and this invariant is updated
+- Token validity window is bounded — expired tokens are always rejected regardless of signature validity, with a `CLOCK_SKEW_GRACE_SECS` (30s) grace window applied on top of `ibct_ttl_secs`
+- `key_id` rotation must maintain a grace window for in-flight requests during rotation — retired keys stay in `ibct_keys` until all tokens signed with them expire
 - NEVER use IBCT for MCP calls — IBCT applies to A2A calls only (see `014-a2a/spec.md`)
 
 ---

--- a/specs/014-a2a/spec.md
+++ b/specs/014-a2a/spec.md
@@ -176,26 +176,29 @@ error type instead.
 ## IBCT: Invocation-Bound Capability Tokens
 
 
-IBCT binds each A2A tool invocation to a short-lived capability token carried in the `X-Zeph-IBCT` HTTP header. The token is an HMAC-SHA256 MAC over the invocation identity (task ID + method + timestamp), signed with a key from the vault. This prevents replay attacks and capability escalation across invocations.
+IBCT binds each A2A tool invocation to a short-lived capability token carried in the `X-Zeph-IBCT` HTTP header. The token is an HMAC-SHA256 MAC over its own fields — `key_id`, `task_id`, `endpoint`, `issued_at`, `expires_at` — signed with a key from the vault. This scopes the token to a specific task and endpoint and bounds its validity window. It does **not** provide single-use replay protection: there is no `invocation_id`/nonce dedup, so a captured, still-valid token can be replayed against the same `task_id` + `endpoint` until expiry (see Key Invariants).
 
 ### Token Structure
 
 - Algorithm: HMAC-SHA256
-- Inputs: task ID, method name, UTC timestamp (seconds), key ID
-- Header: `X-Zeph-IBCT: <base64-encoded-mac>.<key_id>.<timestamp>`
-- TTL: `ibct_ttl_secs` (default 60 seconds) — tokens older than TTL are rejected by the server
+- Signed fields: MAC computed over `{key_id}|{task_id}|{endpoint}|{issued_at}|{expires_at}`, hex-encoded into the token's `signature` field
+- Wire format: the full token (`key_id`, `task_id`, `endpoint`, `issued_at`, `expires_at`, `signature`) is JSON-serialized, then base64-encoded as a single opaque blob — not a dot-separated triplet
+- Header: `X-Zeph-IBCT: <base64-encoded-json>`
+- TTL: `ibct_ttl_secs` (default 300 seconds) — tokens older than TTL are rejected by the server, with an additional `CLOCK_SKEW_GRACE_SECS` (30s) grace window on verification
 
 ### Key Rotation
 
-`ibct_keys` holds a map of `key_id → vault_ref`. The signing key is selected by `ibct_signing_key_vault_ref`. Key rotation is performed by adding a new entry to `ibct_keys` and updating `ibct_signing_key_vault_ref` — old tokens signed with retired keys are rejected after their TTL expires.
+`ibct_keys` is a `Vec<IbctKeyConfig>` of `{key_id, key_hex}` entries — `key_hex` is an inline hex-encoded HMAC-SHA256 key (legacy path). `ibct_signing_key_vault_ref` resolves the primary signing key from the vault at startup, constructing an `IbctKey` with `key_id = "primary"`; it takes precedence over `ibct_keys[0]` when both are set. Key rotation is performed by adding a new entry to `ibct_keys` (or rotating the vault-referenced secret) — old tokens signed with retired keys are rejected once their TTL expires.
 
 ### Config
 
 ```toml
 [a2a]
-ibct_keys = { "k1" = "VAULT_A2A_IBCT_KEY_1" }   # key_id → vault secret ref
-ibct_signing_key_vault_ref = "VAULT_A2A_IBCT_KEY_1"  # active signing key vault ref
-ibct_ttl_secs = 60   # token time-to-live in seconds
+ibct_keys = [
+  { key_id = "k1", key_hex = "68656c6c6f2d7365637265742d6b6579" },  # legacy: inline hex key
+]
+ibct_signing_key_vault_ref = "ZEPH_A2A_IBCT_KEY"  # vault-resolved primary key; takes precedence over ibct_keys[0]
+ibct_ttl_secs = 300   # default; token time-to-live in seconds
 ```
 
 The `ibct` feature flag must be enabled for IBCT to be compiled in.
@@ -204,11 +207,12 @@ The `ibct` feature flag must be enabled for IBCT to be compiled in.
 
 - IBCT is opt-in via the `ibct` feature flag — NEVER enable it by default in builds without the flag
 - Token TTL must be enforced at the server side — expired tokens are always rejected, regardless of signature validity
+- IBCT tokens are **NOT single-use** — `Ibct::verify` performs no `invocation_id`/nonce dedup. A captured, still-valid token can be replayed against the same `task_id` + `endpoint` until it expires. This is a known limitation, not a documentation gap
 - `ibct_signing_key_vault_ref` must resolve to a vault key — startup fails if the ref is set but the vault key is absent
 - Key IDs are included in the token header — the verifier must select the correct key by ID, not by position
 - NEVER log or dump raw IBCT tokens — they are bearer credentials
 - `X-Zeph-IBCT` header must be stripped from any request before forwarding to MCP servers or external tools
-- HMAC-SHA256 comparison must use constant-time equality (`subtle::ConstantTimeEq`) — not `==`
+- HMAC-SHA256 comparison must use constant-time equality — not `==` (enforced via `Mac::verify_slice`, not `subtle::ConstantTimeEq`)
 
 ---
 


### PR DESCRIPTION
## Summary

- `specs/010-security/spec.md` and `specs/014-a2a/spec.md` described two different IBCT (Invocation-Bound Capability Token) wire formats. Investigation showed neither spec fully matched the actual implementation in `crates/zeph-a2a/src/ibct.rs` — the issue's premise that `014-a2a` was already accurate turned out to be only half right.
- Reconciled both specs against `ibct.rs` and `crates/zeph-config/src/channels.rs` ground truth:
  - Wire format is a single base64-encoded JSON blob (not a dot-separated `<mac>.<key_id>.<timestamp>` triplet), signed over `{key_id}|{task_id}|{endpoint}|{issued_at}|{expires_at}`.
  - Default TTL is 300s, not 60s.
  - `ibct_keys` is an array of `{key_id, key_hex}` entries (inline hex signing key), not a `key_id -> vault_ref` map; `ibct_signing_key_vault_ref` is the separate vault-resolved primary-key path that takes precedence over `ibct_keys[0]`.
  - Both specs previously claimed IBCT prevents replay attacks. `Ibct::verify` performs no `invocation_id`/nonce dedup, so a captured, still-valid token is replayable against the same `task_id` + `endpoint` until it expires — this is now documented as a known implementation limitation in both specs' Key Invariants sections instead of being silently misdescribed in opposite directions.
- Documentation-only change — no source code under `crates/` was modified.

## Test plan

- [x] `gitleaks protect --staged` — no leaks found
- [x] Every factual claim in the diff independently verified against `crates/zeph-a2a/src/ibct.rs` and `crates/zeph-config/src/channels.rs` (signed-field format, base64-JSON wire encoding, `default_ibct_ttl()` = 300, `CLOCK_SKEW_GRACE_SECS` = 30, `IbctKeyConfig { key_id, key_hex }` struct shape, `Mac::verify_slice`, absence of any `invocation_id` dedup)
- [x] `git diff --stat` scoped to `specs/010-security/spec.md`, `specs/014-a2a/spec.md`, `CHANGELOG.md` only
- [x] No changes required to `config/default.toml`, docker compose files, or `docs/src/` — no config keys or user-facing behavior changed, only spec text corrected to match existing behavior
- [x] N/A: testing playbook / coverage-status updates (docs-only spec correction, no new functionality)

Closes #6197