### PR TITLE
refactor(agent-persistence): remove dead redaction_applied field and stale TODO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   token is replayable against the same `task_id` + `endpoint` until it expires; this is now
   documented as a known implementation limitation. Documentation-only change, no source code
   modified (#6197).
+- **Persistence**: `PersistMessageRequest`'s doc comment carried a stale TODO describing an
+  unimplemented R3 batching design and a pending-request-loss risk that does not exist —
+  persistence is inline and synchronous today (`Agent::persist_message` builds the request and
+  immediately awaits `PersistenceService::persist_message`, with no queue/buffer layer). Replaced
+  the TODO with a doc comment describing the actual inline/synchronous behavior (#5962).
+- **Persistence**: removed the dead `PersistMessageOutcome::redaction_applied` field — it was
+  hardcoded to `false` at all four construction sites in `PersistenceService::persist_message` and
+  read by nothing, since no redaction logic exists in the service. Breaking change to a `pub`
+  struct, acceptable pre-v1.0.0 (#5995).
 
 - **LLM**: the Claude request funnel's no-prefill gate (`ClaudeProvider::structured_history`/
   `plain_history`) was convention-enforced only — `request::split_messages`/

--- a/crates/zeph-agent-persistence/src/request.rs
+++ b/crates/zeph-agent-persistence/src/request.rs
@@ -14,9 +14,10 @@ use zeph_llm::provider::{MessagePart, Role};
 /// Clone cost is small: typical message content is less than 10 KB; allocation count
 /// is two (one for `content`, one for `parts`) per persist request.
 ///
-/// # TODO(critic): R3 batches persist requests until end of `process_response`.
-/// On panic/cancel mid-response, pending requests are LOST, unlike today's inline
-/// persist. See critic-3515-3516.md F2. File follow-up issue if observed in live testing.
+/// Persistence is inline and synchronous today: the sole caller
+/// (`Agent::persist_message`) builds this request and immediately awaits
+/// [`crate::service::PersistenceService::persist_message`]. There is no
+/// batching/queue layer, so no pending-request-loss window exists.
 #[derive(Debug, Clone)]
 pub struct PersistMessageRequest {
     /// Message role: `User`, `Assistant`, or `System`.
@@ -74,8 +75,6 @@ pub struct PersistMessageOutcome {
     pub message_id: Option<i64>,
     /// Whether the message was embedded into Qdrant (as opposed to saved to `SQLite` only).
     pub embedded: bool,
-    /// Whether a redaction was applied to the content before persistence.
-    pub redaction_applied: bool,
     /// Number of bytes written to the persistence layer.
     pub bytes_written: usize,
 }

--- a/crates/zeph-agent-persistence/src/service.rs
+++ b/crates/zeph-agent-persistence/src/service.rs
@@ -188,7 +188,6 @@ impl PersistenceService {
             return PersistMessageOutcome {
                 message_id: None,
                 embedded: false,
-                redaction_applied: false,
                 bytes_written: 0,
             };
         };
@@ -197,7 +196,6 @@ impl PersistenceService {
             return PersistMessageOutcome {
                 message_id: None,
                 embedded: false,
-                redaction_applied: false,
                 bytes_written: 0,
             };
         };
@@ -237,7 +235,6 @@ impl PersistenceService {
             return PersistMessageOutcome {
                 message_id: None,
                 embedded: false,
-                redaction_applied: false,
                 bytes_written: 0,
             };
         };
@@ -256,7 +253,6 @@ impl PersistenceService {
         PersistMessageOutcome {
             message_id: Some(message_id),
             embedded: embedding_stored,
-            redaction_applied: false,
             bytes_written: request.content.len() + parts_json.len(),
         }
     }


### PR DESCRIPTION
## Summary

- `PersistMessageRequest`'s doc comment carried a stale TODO describing an unimplemented R3 batching design and a pending-request-loss risk that does not exist — persistence is inline and synchronous today (`Agent::persist_message` builds the request and immediately awaits `PersistenceService::persist_message`, no queue/buffer layer). Rewrote the comment to describe actual behavior.
- Removed the dead `PersistMessageOutcome::redaction_applied` field — hardcoded to `false` at all four construction sites in `PersistenceService::persist_message` and read by nothing, since no redaction logic exists in the service. Breaking change to a `pub` struct, acceptable pre-v1.0.0.

Closes #5962
Closes #5995

## Test plan

- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-agent-persistence -p zeph-core` — 1881 passed
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13297 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean, intra-doc link resolves
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — all passed
- [x] `cargo +nightly fmt --check` — clean
- [x] `gitleaks protect --staged --no-banner --redact` — no leaks
- [x] Rebased onto `origin/main` (conflict only in CHANGELOG.md, resolved by keeping both entries — no source touched, so no re-run of the full suite per project policy)