### PR TITLE
fix(commands,durable): flip requires_auth default to fail-closed, fix durable replay dedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+### Changed
+
+- **BREAKING**: `CommandHandler::requires_auth()` now defaults to `true` (fail-closed),
+  reversing the previous fail-open default. This is the 4th recurrence of a slash-command
+  handler silently exposing privileged behavior to remote channels (Telegram/Discord/Slack)
+  by omitting the override (#5967/#5988, #5997/#6002, #6003/PR#6033); a new handler that
+  forgets to override now becomes unreachable from remote channels (annoyance) rather than
+  silently exposed there (vulnerability). Read-only or self-gated handlers safe to expose on
+  remote channels must now explicitly override `requires_auth()` to return `false` — all
+  in-tree handlers relying on the old implicit default (`ExitCommand`, `QuitCommand`,
+  `GuidelinesCommand`, `SkillsCommand`, `RecapCommand`, `HelpCommand`) were updated with an
+  explicit `false` override, so their behavior is unchanged. Out-of-tree `CommandHandler`
+  implementors relying on the previous `false` default will have their commands rejected on
+  untrusted channels until they add the explicit override (#6034).
+
+### Docs
+
+- **Core**: documented at the `resolve_durable_spawn_gate` call site why falling back to a
+  plain spawn is safe when a resumed sub-agent's durable promise is still pending after a
+  parent restart — the current architecture is LocalBackend-only, in-process tokio tasks, so
+  a parent crash necessarily kills its in-process children too, meaning a still-pending
+  promise on resume cannot be a live duplicate child (spec-064 INV-9). No functional change
+  (#6010).
+
 ### Fixed
 
 - **Docs**: `specs/010-security/spec.md` and `specs/014-a2a/spec.md` described two different IBCT
@@ -40,6 +64,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   field now require the gated type instead of a bare `Vec`/slice, so bypassing the funnel is a
   compile error (wrong type) instead of a code-review catch. Pure refactor — wire format is
   byte-identical (verified via existing insta snapshots) (#6158).
+- **Core**: durable sub-agent replay (`handle_agent_spawn_foreground`) fired its channel side
+  effects — the "replayed from durable journal" user notice and the TUI completion event — as
+  plain awaits outside any dedup guard. A parent that restarted more than once after taking the
+  replay branch would re-fire both side effects on every subsequent restart. An initial fix
+  gated them behind a `ctx.step()` created only on the replay path, but that step consumed a
+  durable step id on replay runs only, shifting every subsequent step id relative to the fresh
+  run's journal and causing a hard `ReplayDivergence` abort whenever another durable step
+  (e.g. an LLM turn) followed the spawn in the same execution — a regression, not a fix.
+  Replaced it with an out-of-band `notified_at` claim column on `durable_promises` (migration
+  109, sqlite+postgres): the first caller to win a conditional
+  `UPDATE ... WHERE notified_at IS NULL` fires the side effects, every later replay is
+  suppressed. The claim consumes zero durable step ids, so it cannot perturb step-id
+  determinism (INV-2) or cause `ReplayDivergence` under any restart count (#6027).
 
 - **CI**: the `registry` feature (`zeph-plugins/registry`, spec-045) was declared in root
   `Cargo.toml` and bundled into `full`, but excluded from every PR-gating CI job's feature

--- a/crates/zeph-commands/src/handlers/compaction.rs
+++ b/crates/zeph-commands/src/handlers/compaction.rs
@@ -123,6 +123,10 @@ impl CommandHandler<CommandContext<'_>> for RecapCommand {
         SlashCategory::Session
     }
 
+    fn requires_auth(&self) -> bool {
+        false
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,
@@ -182,6 +186,11 @@ mod tests {
         assert_eq!(parse_new_flags("--keep"), (false, false));
         assert_eq!(parse_new_flags("--no"), (false, false));
         assert_eq!(parse_new_flags("keep-plan"), (false, false));
+    }
+
+    #[test]
+    fn recap_requires_auth_false() {
+        assert!(!RecapCommand.requires_auth());
     }
 
     #[tokio::test]

--- a/crates/zeph-commands/src/handlers/help.rs
+++ b/crates/zeph-commands/src/handlers/help.rs
@@ -75,6 +75,10 @@ impl CommandHandler<CommandContext<'_>> for HelpCommand {
         SlashCategory::Debugging
     }
 
+    fn requires_auth(&self) -> bool {
+        false
+    }
+
     fn handle<'a>(
         &'a self,
         _ctx: &'a mut CommandContext<'_>,
@@ -96,6 +100,11 @@ mod tests {
     fn help_name_and_description() {
         assert_eq!(HelpCommand.name(), "/help");
         assert!(!HelpCommand.description().is_empty());
+    }
+
+    #[test]
+    fn help_requires_auth_false() {
+        assert!(!HelpCommand.requires_auth());
     }
 
     #[tokio::test]

--- a/crates/zeph-commands/src/handlers/memory.rs
+++ b/crates/zeph-commands/src/handlers/memory.rs
@@ -149,6 +149,10 @@ impl CommandHandler<CommandContext<'_>> for GuidelinesCommand {
         Some("compression-guidelines")
     }
 
+    fn requires_auth(&self) -> bool {
+        false
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,
@@ -239,6 +243,11 @@ mod tests {
         assert_eq!(parse_backfill_limit("backfill"), None);
         assert_eq!(parse_backfill_limit("backfill --limit"), None);
         assert_eq!(parse_backfill_limit("backfill --limit 0"), Some(0));
+    }
+
+    #[test]
+    fn guidelines_requires_auth_false() {
+        assert!(!GuidelinesCommand.requires_auth());
     }
 
     #[tokio::test]

--- a/crates/zeph-commands/src/handlers/session.rs
+++ b/crates/zeph-commands/src/handlers/session.rs
@@ -41,6 +41,10 @@ impl CommandHandler<CommandContext<'_>> for ExitCommand {
         SlashCategory::Session
     }
 
+    fn requires_auth(&self) -> bool {
+        false
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,
@@ -66,6 +70,10 @@ impl CommandHandler<CommandContext<'_>> for QuitCommand {
 
     fn category(&self) -> SlashCategory {
         SlashCategory::Session
+    }
+
+    fn requires_auth(&self) -> bool {
+        false
     }
 
     fn handle<'a>(
@@ -403,6 +411,16 @@ mod tests {
         };
         assert!(msg.contains('3'));
         assert_eq!(messages.queue, 0);
+    }
+
+    #[test]
+    fn exit_requires_auth_false() {
+        assert!(!ExitCommand.requires_auth());
+    }
+
+    #[test]
+    fn quit_requires_auth_false() {
+        assert!(!QuitCommand.requires_auth());
     }
 
     #[test]

--- a/crates/zeph-commands/src/handlers/skill.rs
+++ b/crates/zeph-commands/src/handlers/skill.rs
@@ -75,6 +75,10 @@ impl CommandHandler<CommandContext<'_>> for SkillsCommand {
         SlashCategory::Skills
     }
 
+    fn requires_auth(&self) -> bool {
+        false
+    }
+
     fn handle<'a>(
         &'a self,
         ctx: &'a mut CommandContext<'_>,
@@ -151,6 +155,11 @@ mod tests {
     fn skills_name_and_description() {
         assert_eq!(SkillsCommand.name(), "/skills");
         assert!(!SkillsCommand.description().is_empty());
+    }
+
+    #[test]
+    fn skills_requires_auth_false() {
+        assert!(!SkillsCommand.requires_auth());
     }
 
     #[test]

--- a/crates/zeph-commands/src/lib.rs
+++ b/crates/zeph-commands/src/lib.rs
@@ -225,13 +225,14 @@ pub trait CommandHandler<Ctx: ?Sized>: Send + Sync {
     /// Returns `true` if this command requires a trusted (local) caller.
     ///
     /// When `true`, [`CommandRegistry::dispatch`] rejects the command with an authorization
-    /// error if the dispatch site passes `trusted = false`. Commands in the `Debugging`,
-    /// `Configuration`, and `Advanced` categories that should not be accessible from
-    /// remote channels (Telegram, Discord, Slack) must override this to return `true`.
+    /// error if the dispatch site passes `trusted = false`.
     ///
-    /// The default returns `false` (accessible from all channels).
+    /// The default returns `true` (fail-closed): a handler that does not override this
+    /// method requires a trusted session. Read-only or self-gated commands that are safe
+    /// to expose on remote channels (Telegram, Discord, Slack) must explicitly opt out by
+    /// overriding this to return `false`.
     fn requires_auth(&self) -> bool {
-        false
+        true
     }
 
     /// Execute the command.
@@ -537,6 +538,22 @@ mod tests {
 
         // Untrusted: command is rejected.
         let result = reg.dispatch(&mut ctx, "/secret", false).await;
+        let err = result.unwrap().unwrap_err();
+        assert!(err.0.contains("trusted"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_rejects_handler_without_requires_auth_override_when_untrusted() {
+        // A handler that does not override `requires_auth` inherits the fail-closed default
+        // (`true`) and must be rejected on an untrusted channel — locks in #6034.
+        let mut reg: CommandRegistry<MockCtx> = CommandRegistry::new();
+        reg.register(make_handler("/default-gated"));
+        let mut ctx = MockCtx;
+
+        let result = reg.dispatch(&mut ctx, "/default-gated", true).await;
+        assert!(result.unwrap().is_ok());
+
+        let result = reg.dispatch(&mut ctx, "/default-gated", false).await;
         let err = result.unwrap().unwrap_err();
         assert!(err.0.contains("trusted"));
     }

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -2031,6 +2031,10 @@ mod test_stubs {
             SlashCategory::Session
         }
 
+        fn requires_auth(&self) -> bool {
+            true
+        }
+
         fn handle<'a>(
             &'a self,
             _ctx: &'a mut CommandContext<'_>,

--- a/crates/zeph-core/src/agent/subagent_commands.rs
+++ b/crates/zeph-core/src/agent/subagent_commands.rs
@@ -452,7 +452,7 @@ impl<C: Channel> Agent<C> {
         .await
         {
             DurableSpawnGate::Fresh(seat) => spawn_ctx.durable_resolver = Some(seat),
-            DurableSpawnGate::Replayed(result) => {
+            DurableSpawnGate::Replayed { result, .. } => {
                 let short = &result.task_id[..8.min(result.task_id.len())];
                 return Some(if result.output.is_empty() {
                     format!(
@@ -487,6 +487,65 @@ impl<C: Channel> Agent<C> {
             Err(e) => Some(format!("Failed to spawn sub-agent: {e}")),
         }
     }
+    /// Handle a [`DurableSpawnGate::Replayed`] result for a foreground spawn.
+    ///
+    /// Gates the channel side effects (user notice + TUI completion event) behind an
+    /// out-of-band `notified_at` claim on the sub-agent's durable promise, so a parent that
+    /// restarts *again* after already taking the replay branch once does not re-fire them
+    /// (#6027). The claim consumes no durable step id, so unlike a `ctx.step()`-based guard it
+    /// cannot perturb INV-2 step-id determinism or cause `ReplayDivergence`. Returns the
+    /// journaled output/error text either way.
+    async fn notify_replayed_foreground_subagent(
+        &mut self,
+        name: &str,
+        result: zeph_subagent::SubagentResult,
+        promise_id: zeph_durable::PromiseId,
+    ) -> String {
+        let success = result.state == zeph_subagent::SubAgentState::Completed;
+        let task_id = result.task_id.clone();
+
+        // Out-of-band, step-counter-independent claim: the FIRST caller to set `notified_at` fires
+        // the channel side effects; every later replay is suppressed. Unlike a ctx.step this consumes
+        // no StepId, so it cannot cause ReplayDivergence under any restart count (#6027). Degrade to
+        // firing directly when durable is off (no replay can happen) or the claim errors.
+        let should_notify = if let Some(ctx) = self.services.session.durable_ctx.clone() {
+            match ctx.claim_promise_notification(promise_id).await {
+                Ok(claimed) => claimed,
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "durable: promise-notification claim failed; \
+                         firing the replayed sub-agent notice directly"
+                    );
+                    true
+                }
+            }
+        } else {
+            true
+        };
+
+        let text = if success {
+            result.output
+        } else {
+            result.error.unwrap_or_else(|| "unknown error".to_owned())
+        };
+
+        if should_notify {
+            let _ = self
+                .channel
+                .send(&format!(
+                    "Sub-agent '{name}' replayed from durable journal (already finished \
+                     before the parent restarted)."
+                ))
+                .await;
+            let _ = self
+                .channel
+                .notify_foreground_subagent_completed(&task_id, name, success)
+                .await;
+        }
+        text
+    }
+
     async fn handle_agent_spawn_foreground(&mut self, name: &str, prompt: &str) -> Option<String> {
         let provider = self.provider.clone();
         let tool_executor = Arc::clone(&self.tool_executor);
@@ -505,25 +564,11 @@ impl<C: Channel> Agent<C> {
         .await
         {
             DurableSpawnGate::Fresh(seat) => spawn_ctx.durable_resolver = Some(seat),
-            DurableSpawnGate::Replayed(result) => {
-                let success = result.state == zeph_subagent::SubAgentState::Completed;
-                let text = if success {
-                    result.output
-                } else {
-                    result.error.unwrap_or_else(|| "unknown error".to_owned())
-                };
-                let _ = self
-                    .channel
-                    .send(&format!(
-                        "Sub-agent '{name}' replayed from durable journal (already finished \
-                         before the parent restarted)."
-                    ))
-                    .await;
-                let _ = self
-                    .channel
-                    .notify_foreground_subagent_completed(&result.task_id, name, success)
-                    .await;
-                return Some(text);
+            DurableSpawnGate::Replayed { result, promise_id } => {
+                return Some(
+                    self.notify_replayed_foreground_subagent(name, result, promise_id)
+                        .await,
+                );
             }
             DurableSpawnGate::None => {}
         }
@@ -792,11 +837,21 @@ enum DurableSpawnGate {
     /// Resumed run whose child already resolved its promise before the parent crashed. The
     /// caller must skip `spawn` entirely and replay this result instead — spawning here would
     /// duplicate the LLM calls and any side-effecting tool calls the finished child already
-    /// performed (#5944).
-    Replayed(zeph_subagent::SubagentResult),
+    /// performed (#5944). `promise_id` lets the foreground caller claim a one-time replay
+    /// notification (#6027) via [`zeph_durable::DurableContext::claim_promise_notification`].
+    Replayed {
+        result: zeph_subagent::SubagentResult,
+        promise_id: zeph_durable::PromiseId,
+    },
     /// Gate closed: durable subagent support disabled, a resumed run whose child promise is
     /// still pending (out of v1 scope — see `durable.rs` module docs "Scope boundary"), or an
     /// error (logged at `warn`). The caller degrades to a plain spawn with no durable wiring.
+    ///
+    /// The still-pending case is safe only because the current architecture is
+    /// LocalBackend-only, in-process tokio tasks (spec-064 INV-9): a parent-process crash
+    /// necessarily kills its in-process children too, so a still-pending promise on resume
+    /// means the original child is genuinely gone, and re-spawning cannot duplicate a live
+    /// child. See `durable.rs` "Scope boundary".
     None,
 }
 
@@ -823,8 +878,19 @@ async fn resolve_durable_spawn_gate(
     // Resumed: token unrecoverable (INV-9). Check without blocking whether the child already
     // resolved the promise before the crash — replay it instead of re-spawning a duplicate.
     match zeph_subagent::try_replay_durable_subagent(ctx, &promise).await {
-        Ok(Some(result)) => DurableSpawnGate::Replayed(result),
+        Ok(Some(result)) => DurableSpawnGate::Replayed {
+            result,
+            promise_id: promise.id(),
+        },
         Ok(None) => {
+            // Safe to fall back to a plain spawn here only because the current architecture
+            // is LocalBackend-only, in-process tokio tasks: the parent process crashing kills
+            // its in-process children too, so a still-pending promise on resume means the
+            // original child is genuinely gone, not merely unreachable. Re-attaching to a
+            // live child would require cross-process liveness detection, which is out of v1
+            // scope — see `durable.rs` module docs "Scope boundary" and spec-064 INV-9 (the
+            // resolver token is unrecoverable by design, so it cannot be re-minted to attempt
+            // reattachment).
             tracing::warn!(
                 "durable: resumed sub-agent promise still pending after restart — original \
                  child did not resolve before the crash; re-spawning may duplicate side effects \
@@ -1342,6 +1408,22 @@ mod tests {
         let loop_result: Result<String, zeph_subagent::SubAgentError> =
             Ok("foreground child output".to_owned());
         zeph_subagent::resolve_durable_promise(seat, "task-e2e-02", &loop_result).await;
+        // C1 regression guard (#6027): journal a durable step AFTER the promise, exactly the
+        // foreground-spawn-followed-by-another-turn topology that triggered the original
+        // ReplayDivergence bug (a replay-only `ctx.step()` used to land at this same ordinal
+        // position and collide with whatever the fresh run had already recorded there). The
+        // `notified_at` claim consumes no step id, so it can never collide with this marker —
+        // if it regressed to a step-based mechanism, the assertions below would fail with a
+        // `ReplayDivergence` error instead of the expected replayed output.
+        ctx1.step(
+            zeph_durable::StepDescriptor::idempotent(
+                "post_spawn_marker",
+                b"post_spawn_marker".to_vec(),
+            ),
+            |_handle| async move { Ok::<i64, zeph_durable::StepError>(42) },
+        )
+        .await
+        .unwrap();
         agent1
             .services
             .session
@@ -1372,6 +1454,11 @@ mod tests {
                 .any(|m| m.contains("replayed from durable journal")),
             "expected the replay notice to be sent to the channel"
         );
+        assert_eq!(
+            agent2.channel.notify_completed_calls().len(),
+            1,
+            "expected exactly one TUI completion notification on the first replay"
+        );
         assert!(
             agent2
                 .services
@@ -1382,6 +1469,31 @@ mod tests {
                 .statuses()
                 .is_empty(),
             "mgr.spawn must not be called when the child result is replayed"
+        );
+        drop(agent2);
+
+        // "Run 3": the parent restarts *again* after already taking the replay branch once.
+        // Per #6027, the channel side effects (notice + completion event) must not re-fire on
+        // this second replay — only the first winner of the out-of-band `notified_at` claim
+        // fires them; the journaled output is still returned.
+        let mut agent3 = Box::pin(agent_with_durable_and_manager(&db_url, 200)).await;
+
+        let resp = agent3
+            .handle_agent_spawn_foreground("helper", "do work")
+            .await
+            .unwrap();
+        assert_eq!(resp, "foreground child output");
+        assert!(
+            !agent3
+                .channel
+                .sent_messages()
+                .iter()
+                .any(|m| m.contains("replayed from durable journal")),
+            "replay notice must not re-fire on a second replay after a parent restart"
+        );
+        assert!(
+            agent3.channel.notify_completed_calls().is_empty(),
+            "TUI completion event must not re-fire on a second replay after a parent restart"
         );
     }
 

--- a/crates/zeph-core/src/agent/tests/agent_tests/common.rs
+++ b/crates/zeph-core/src/agent/tests/agent_tests/common.rs
@@ -96,6 +96,10 @@ pub(crate) struct MockChannel {
     pub(crate) confirmed_prompts: Arc<Mutex<Vec<String>>>,
     pub(crate) statuses: Arc<Mutex<Vec<String>>>,
     pub(crate) tool_starts: Arc<Mutex<Vec<ToolStartEvent>>>,
+    /// Records every `Channel::notify_foreground_subagent_completed` call as
+    /// `(task_id, name, success)`, in order — lets tests assert on TUI-completion-event count
+    /// and content (e.g. that a durable replay does not re-fire it, #6027).
+    pub(crate) notify_completed_calls: Arc<Mutex<Vec<(String, String, bool)>>>,
     pub(crate) exit_supported: bool,
     pub(crate) input_sanitization_required: bool,
     /// When `true`, `send()` fails with `ChannelError::ChannelClosed` instead of recording the
@@ -115,6 +119,7 @@ impl MockChannel {
             confirmed_prompts: Arc::new(Mutex::new(Vec::new())),
             statuses: Arc::new(Mutex::new(Vec::new())),
             tool_starts: Arc::new(Mutex::new(Vec::new())),
+            notify_completed_calls: Arc::new(Mutex::new(Vec::new())),
             exit_supported: true,
             input_sanitization_required: false,
             fail_send: false,
@@ -150,6 +155,10 @@ impl MockChannel {
 
     pub(crate) fn confirmed_prompts(&self) -> Vec<String> {
         self.confirmed_prompts.lock().unwrap().clone()
+    }
+
+    pub(crate) fn notify_completed_calls(&self) -> Vec<(String, String, bool)> {
+        self.notify_completed_calls.lock().unwrap().clone()
     }
 }
 
@@ -231,6 +240,19 @@ impl Channel for MockChannel {
 
     fn requires_input_sanitization(&self) -> bool {
         self.input_sanitization_required
+    }
+
+    async fn notify_foreground_subagent_completed(
+        &mut self,
+        id: &str,
+        name: &str,
+        success: bool,
+    ) -> Result<(), crate::channel::ChannelError> {
+        self.notify_completed_calls
+            .lock()
+            .unwrap()
+            .push((id.to_owned(), name.to_owned(), success));
+        Ok(())
     }
 }
 

--- a/crates/zeph-db/migrations/postgres/109_durable_promise_notified.sql
+++ b/crates/zeph-db/migrations/postgres/109_durable_promise_notified.sql
@@ -1,0 +1,10 @@
+-- Out-of-band, step-counter-independent notification claim for durable subagent replay (#6027).
+-- A resumed foreground @mention/spawn whose child already resolved replays the journaled result
+-- and fires a one-time channel notice + TUI completion event. Those side effects must fire at
+-- most once even if the parent restarts AGAIN after the first replay. `notified_at` (Unix epoch
+-- millis, NULL until claimed) records the single winning claim: the first
+-- `UPDATE ... SET notified_at = ? WHERE promise_id = ? AND notified_at IS NULL` transitions the
+-- row (rows_affected = 1) and fires the effects; every later replay sees a non-NULL value and
+-- suppresses them. This is deliberately NOT a durable journal step: it consumes no StepId, so it
+-- cannot perturb INV-2 step-id determinism the way a replay-only ctx.step would (#6027 C1).
+ALTER TABLE durable_promises ADD COLUMN IF NOT EXISTS notified_at BIGINT;

--- a/crates/zeph-db/migrations/sqlite/109_durable_promise_notified.sql
+++ b/crates/zeph-db/migrations/sqlite/109_durable_promise_notified.sql
@@ -1,0 +1,10 @@
+-- Out-of-band, step-counter-independent notification claim for durable subagent replay (#6027).
+-- A resumed foreground @mention/spawn whose child already resolved replays the journaled result
+-- and fires a one-time channel notice + TUI completion event. Those side effects must fire at
+-- most once even if the parent restarts AGAIN after the first replay. `notified_at` (Unix epoch
+-- millis, NULL until claimed) records the single winning claim: the first
+-- `UPDATE ... SET notified_at = ? WHERE promise_id = ? AND notified_at IS NULL` transitions the
+-- row (rows_affected = 1) and fires the effects; every later replay sees a non-NULL value and
+-- suppresses them. This is deliberately NOT a durable journal step: it consumes no StepId, so it
+-- cannot perturb INV-2 step-id determinism the way a replay-only ctx.step would (#6027 C1).
+ALTER TABLE durable_promises ADD COLUMN notified_at INTEGER;

--- a/crates/zeph-durable/src/backend.rs
+++ b/crates/zeph-durable/src/backend.rs
@@ -304,6 +304,17 @@ impl DurableBackendEnum {
         }
     }
 
+    /// Claim a promise's one-time replay notification. See [`LocalBackend::claim_promise_notification`].
+    pub(crate) async fn claim_promise_notification(
+        &self,
+        id: PromiseId,
+        notified_at_ms: i64,
+    ) -> Result<bool, DurableError> {
+        match self {
+            Self::Local(backend) => backend.claim_promise_notification(id, notified_at_ms).await,
+        }
+    }
+
     /// Open a promise's sealed resolved payload. See [`LocalBackend::open_promise_payload`].
     pub(crate) fn open_promise_payload(
         &self,

--- a/crates/zeph-durable/src/backend/local.rs
+++ b/crates/zeph-durable/src/backend/local.rs
@@ -669,6 +669,41 @@ impl LocalBackend {
         .await
     }
 
+    /// Claim the one-time replay notification for a promise, returning whether this call won.
+    ///
+    /// The conditional `WHERE notified_at IS NULL` makes the claim single-winner: the first caller
+    /// transitions the row (returns `true`); every later caller is a no-op (returns `false`). This
+    /// backs #6027 — a resumed foreground sub-agent's replay notice / TUI completion event must fire
+    /// at most once across repeated parent restarts. Unlike [`resolve_promise`](Self::resolve_promise)
+    /// it touches only the `notified_at` bookkeeping column and carries no payload, so no sealing /
+    /// waiter wakeup is involved. Span: `durable.promise.claim_notify`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DurableError::Storage`] on a database error.
+    pub(crate) async fn claim_promise_notification(
+        &self,
+        id: PromiseId,
+        notified_at_ms: i64,
+    ) -> Result<bool, DurableError> {
+        let span = tracing::info_span!("durable.promise.claim_notify", promise_id = %id.as_uuid());
+        async move {
+            let affected = zeph_db::query(sql!(
+                "UPDATE durable_promises SET notified_at = ?
+                 WHERE promise_id = ? AND notified_at IS NULL"
+            ))
+            .bind(notified_at_ms)
+            .bind(id.as_uuid().to_string())
+            .execute(&self.pool)
+            .await
+            .map_err(|e| DurableError::storage("claim_promise_notification", e))?
+            .rows_affected();
+            Ok(affected > 0)
+        }
+        .instrument(span)
+        .await
+    }
+
     /// Open a promise's sealed resolved payload back to plaintext.
     ///
     /// # Errors
@@ -2284,6 +2319,36 @@ mod tests {
             .open_promise_payload(promise, exec, &sealed)
             .unwrap();
         assert_eq!(opened.as_ref(), b"answer");
+    }
+
+    #[tokio::test]
+    async fn claim_promise_notification_is_single_winner() {
+        let backend = mem_backend(1_048_576).await;
+        let exec = ExecutionId::new();
+        backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        let promise = PromiseId::derive(exec, StepId::new(0));
+        backend
+            .insert_promise(promise, exec, [9u8; 32], 100)
+            .await
+            .unwrap();
+
+        // First claim wins (transitions notified_at from NULL).
+        assert!(
+            backend
+                .claim_promise_notification(promise, 200)
+                .await
+                .unwrap()
+        );
+        // Every later claim on the same promise is a no-op.
+        assert!(
+            !backend
+                .claim_promise_notification(promise, 300)
+                .await
+                .unwrap()
+        );
     }
 
     #[tokio::test]

--- a/crates/zeph-durable/src/handle.rs
+++ b/crates/zeph-durable/src/handle.rs
@@ -270,6 +270,28 @@ impl DurableContext {
         Ok(DurablePromise::fresh(promise_id, token))
     }
 
+    /// Claim the one-time out-of-band notification for a replayed promise result.
+    ///
+    /// Returns `true` for the first caller (fire the side effects) and `false` on every later call
+    /// (suppress — already claimed). The claim is a single conditional `UPDATE` on the promise's
+    /// `notified_at` column keyed by its [`PromiseId`]; it does **not** allocate a durable step id, so
+    /// — unlike wrapping the notice in [`step`](Self::step) — it has zero interaction with the INV-2
+    /// step-id counter and can never cause a [`DurableError::ReplayDivergence`], regardless of how many
+    /// times the parent restarts (#6027).
+    ///
+    /// Because [`PromiseId::derive`] is deterministic across runs (a resumed execution re-derives the
+    /// same id at the same program position), the claim converges on one row for the fresh run and
+    /// every replay.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DurableError::Storage`] on a database error.
+    pub async fn claim_promise_notification(&self, id: PromiseId) -> Result<bool, DurableError> {
+        self.backend
+            .claim_promise_notification(id, now_unix_millis())
+            .await
+    }
+
     /// Await a durable promise's resolved value, parking until it is resolved.
     ///
     /// Returns immediately if the promise is already resolved (the common replay case). Otherwise it


### PR DESCRIPTION
## Summary

- **#6034**: `CommandHandler::requires_auth()` defaulted to `false` (accessible from all channels) — the 4th confirmed recurrence of a slash-command handler silently staying reachable from untrusted remote channels (Telegram/Discord/Slack/gateway) until an audit caught it (#5967/#5988, #5997/#6002, #6003/PR#6033). Flips the default to `true` (fail-closed); the 6 previously-implicit read-only handlers (`ExitCommand`, `QuitCommand`, `GuidelinesCommand`, `SkillsCommand`, `RecapCommand`, `HelpCommand`) now explicitly override it to preserve current behavior. Breaking change for out-of-tree `CommandHandler` implementors (documented in CHANGELOG).
- **#6027**: durable subagent replay's channel-notify side effects bypassed the `ctx.step()` dedup discipline (spec-064 INV-10) — a resumed parent could refire the "replayed from durable journal" notice on every restart. An initial `ctx.step()`-based fix was caught by adversarial review as breaking step-id determinism between fresh and replay runs (risk of `ReplayDivergence`); the shipped fix instead dedups via an out-of-band `notified_at` claim column on `durable_promises` (migration 109, sqlite+postgres), which consumes no step id and cannot interact with INV-2.
- **#6010**: tightened the doc comment on `resolve_durable_spawn_gate`'s still-pending resume branch to make the LocalBackend-only safety rationale explicit at the call site. Doc-only, no functional change.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — full suite green
- [x] `cargo check --workspace --no-default-features --features full,postgres` — postgres backend parity
- [x] rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace ...`)
- [x] `gitleaks protect --staged`
- [x] New regression test locking in the fail-closed default (`dispatch_rejects_handler_without_requires_auth_override_when_untrusted`)
- [x] New backend single-winner test for `claim_promise_notification`, and an extended e2e replay test proving no `ReplayDivergence` across repeated restarts
- [x] `.local/testing/coverage-status.md` and `.local/testing/playbooks/durable.md` updated to reflect the shipped mechanism

Closes #6034
Closes #6027
Closes #6010