### PR TITLE
feat(worktree): add disk-quota config and automatic reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     is not yet discoverable. `A2A_PROTOCOL_VERSION` stays `"0.2.1"` — this change is one additive
     1.0.0 feature, not full 1.0.0 conformance. `jku`/JWKS auto-fetch, EdDSA/RS256, and signing
     our own served card are all deferred.
+- **Worktree**: added disk-quota and automatic reconciliation to the `zeph-worktree` subsystem
+  (#5924). Four new `[worktree]` config fields: `max_worktrees` (creation-time admission cap,
+  enforced as `WorktreeError::QuotaExceeded`), `disk_quota_mb` (soft total-disk-usage threshold),
+  `auto_reconcile_secs` (periodic reconcile+quota sweep interval via `TaskSupervisor`, `0` =
+  disabled), and `reconcile_on_startup` (default `true` — one reconcile+quota sweep at bootstrap).
+  Automatic reclamation only ever removes worktrees git itself reports as `prunable` — an intact
+  worktree is never force-removed to satisfy either threshold (spec-063 INV-6, extends INV-5).
+  `WorktreeManager` gains `disk_usage()`/`cached_disk_usage()` (filesystem walk, offloaded to
+  `spawn_blocking`, never called on the `create()` hot path) and `sweep()` (reconcile +
+  prunable-only reclaim + quota evaluation). `zeph worktree list` and the agent-side
+  `/worktree list` slash command both always print a fresh usage/quota summary footer (no
+  cross-mode divergence). `Config::validate` rejects `Some(0)` for `max_worktrees`/
+  `disk_quota_mb`, rejects `disk_quota_mb` being set with no automatic evaluation path enabled
+  (neither `reconcile_on_startup` nor `auto_reconcile_secs`), and rejects a sub-60-second
+  `auto_reconcile_secs` (too short an interval would run a filesystem walk in a tight loop).
+  `--migrate-config` step 83 surfaces the four new fields as commented advisories on existing
+  `[worktree]` tables; the `--init` wizard gained matching prompts with the same validation.
 - **Config**: documented `[security.shadow_sentinel]` (`ShadowSentinelConfig`) as a commented
   advisory block in `config/default.toml`, and added migration step 81
   (`migrate_shadow_sentinel_config`) so existing configs gain the same discoverable block via

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11489,11 +11489,13 @@ dependencies = [
 name = "zeph-worktree"
 version = "0.22.0"
 dependencies = [
+ "parking_lot",
  "serde",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "walkdir",
  "zeph-config",
 ]
 

--- a/crates/zeph-config/src/loader.rs
+++ b/crates/zeph-config/src/loader.rs
@@ -163,6 +163,38 @@ impl Config {
                 "tool_call_cutoff must be >= 1".into(),
             ));
         }
+        if self.worktree.max_worktrees == Some(0) {
+            return Err(ConfigError::Validation(
+                "worktree.max_worktrees must be > 0 or unset (unlimited); 0 would block all \
+                 worktree creation"
+                    .into(),
+            ));
+        }
+        if self.worktree.disk_quota_mb == Some(0) {
+            return Err(ConfigError::Validation(
+                "worktree.disk_quota_mb must be > 0 or unset (no accounting); 0 would leave \
+                 every non-empty worktree permanently over quota"
+                    .into(),
+            ));
+        }
+        if self.worktree.disk_quota_mb.is_some()
+            && self.worktree.auto_reconcile_secs == 0
+            && !self.worktree.reconcile_on_startup
+        {
+            return Err(ConfigError::Validation(
+                "worktree.disk_quota_mb is set but neither reconcile_on_startup nor \
+                 auto_reconcile_secs is enabled — the quota will only be checked when you run \
+                 `zeph worktree list` manually, never automatically"
+                    .into(),
+            ));
+        }
+        if (1..60).contains(&self.worktree.auto_reconcile_secs) {
+            return Err(ConfigError::Validation(format!(
+                "worktree.auto_reconcile_secs must be 0 (disabled) or >= 60, got {}; a short \
+                 interval runs a full filesystem walk in a tight loop",
+                self.worktree.auto_reconcile_secs
+            )));
+        }
         Ok(())
     }
 
@@ -1357,6 +1389,104 @@ weight = 0.3
             cfg.validate().is_ok(),
             "inverted thresholds on a disabled shadow_memory config must not fail validation"
         );
+    }
+
+    #[test]
+    fn validate_rejects_worktree_max_worktrees_zero() {
+        let mut cfg = Config::default();
+        cfg.worktree.max_worktrees = Some(0);
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("max_worktrees"),
+            "expected max_worktrees in error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_worktree_max_worktrees_positive_or_unset() {
+        let mut cfg = Config::default();
+        cfg.worktree.max_worktrees = Some(1);
+        assert!(cfg.validate().is_ok());
+        cfg.worktree.max_worktrees = None;
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_worktree_disk_quota_mb_zero() {
+        let mut cfg = Config::default();
+        cfg.worktree.disk_quota_mb = Some(0);
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("disk_quota_mb"),
+            "expected disk_quota_mb in error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_worktree_disk_quota_mb_positive_or_unset() {
+        let mut cfg = Config::default();
+        cfg.worktree.disk_quota_mb = Some(1);
+        assert!(cfg.validate().is_ok());
+        cfg.worktree.disk_quota_mb = None;
+        assert!(cfg.validate().is_ok());
+    }
+
+    /// Review N1 / critic M1(b): `disk_quota_mb` set with neither the startup sweep nor the
+    /// periodic sweep enabled means the quota is evaluated nowhere automatically — must be a
+    /// hard config error, not a silent no-op.
+    #[test]
+    fn validate_rejects_worktree_disk_quota_mb_with_no_evaluation_path_enabled() {
+        let mut cfg = Config::default();
+        cfg.worktree.disk_quota_mb = Some(100);
+        cfg.worktree.auto_reconcile_secs = 0;
+        cfg.worktree.reconcile_on_startup = false;
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("disk_quota_mb") && err.contains("never automatically"),
+            "expected inert-path error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_worktree_disk_quota_mb_when_startup_sweep_enabled() {
+        let mut cfg = Config::default();
+        cfg.worktree.disk_quota_mb = Some(100);
+        cfg.worktree.auto_reconcile_secs = 0;
+        cfg.worktree.reconcile_on_startup = true;
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_worktree_disk_quota_mb_when_periodic_sweep_enabled() {
+        let mut cfg = Config::default();
+        cfg.worktree.disk_quota_mb = Some(100);
+        cfg.worktree.auto_reconcile_secs = 3600;
+        cfg.worktree.reconcile_on_startup = false;
+        assert!(cfg.validate().is_ok());
+    }
+
+    /// Review perf#3: a short `auto_reconcile_secs` runs a full filesystem walk in a tight
+    /// loop — must be rejected, matching the `Some(0)` rejection style for the sibling fields.
+    #[test]
+    fn validate_rejects_worktree_auto_reconcile_secs_short_interval() {
+        let mut cfg = Config::default();
+        cfg.worktree.auto_reconcile_secs = 1;
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("auto_reconcile_secs"),
+            "expected auto_reconcile_secs in error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_worktree_auto_reconcile_secs_zero_or_at_least_60() {
+        let mut cfg = Config::default();
+        cfg.worktree.auto_reconcile_secs = 0;
+        assert!(cfg.validate().is_ok());
+        cfg.worktree.auto_reconcile_secs = 60;
+        assert!(cfg.validate().is_ok());
+        cfg.worktree.auto_reconcile_secs = 3600;
+        assert!(cfg.validate().is_ok());
     }
 
     /// Regression test (critic S1): `Config::default()` must itself satisfy `validate_pool`

--- a/crates/zeph-config/src/migrate/infra.rs
+++ b/crates/zeph-config/src/migrate/infra.rs
@@ -571,6 +571,58 @@ pub fn migrate_worktree_git_timeout(toml_src: &str) -> Result<MigrationResult, M
     })
 }
 
+/// Add commented-out `max_worktrees`, `disk_quota_mb`, `auto_reconcile_secs`, and
+/// `reconcile_on_startup` fields to `[worktree]` when the section is present but the
+/// keys are absent (#5924).
+///
+/// Mirrors [`migrate_worktree_git_timeout`]'s idempotency guard and header-anchored
+/// insertion. `reconcile_on_startup` defaults to `true` in code even though the
+/// migration surfaces it as a comment — the comment documents the value so upgrading
+/// operators can discover and override it, without the migration itself silently
+/// changing already-loaded behavior (all four fields are `#[serde(default)]`, so an
+/// existing config without them already resolves to the code defaults before and
+/// after this migration runs). Only runs when `[worktree]` is present — configs
+/// without the section are unchanged.
+///
+/// # Errors
+///
+/// This function is infallible in practice; the `Result` return type matches the
+/// migration function convention for use in chained pipelines.
+pub fn migrate_worktree_quota_fields(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    static WORKTREE_HEADER_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+        Regex::new(r"(?m)^[ \t]*\[worktree\][ \t]*(?:#[^\r\n]*)?\r?\n").expect("static pattern")
+    });
+
+    if toml_src.contains("auto_reconcile_secs") || !WORKTREE_HEADER_RE.is_match(toml_src) {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "# max_worktrees = 10  # cap on concurrent worktrees under root; unset = unlimited\n\
+        # disk_quota_mb = 5120  # soft total-disk-usage threshold (MB) across all worktrees; unset = no accounting\n\
+        # auto_reconcile_secs = 3600  # periodic reconcile+quota sweep interval; 0 = disabled\n\
+        # reconcile_on_startup = true  # run one reconcile+quota sweep at bootstrap (default: true)\n";
+    let output = WORKTREE_HEADER_RE
+        .replacen(toml_src, 1, |caps: &regex::Captures| {
+            format!("{}{comment}", &caps[0])
+        })
+        .into_owned();
+
+    let changed = output != toml_src;
+    Ok(MigrationResult {
+        output,
+        changed_count: usize::from(changed),
+        sections_changed: if changed {
+            vec!["worktree".to_owned()]
+        } else {
+            Vec::new()
+        },
+    })
+}
+
 /// Add the `[durable]` execution-layer section with all defaults, commented out and default-off.
 ///
 /// Purely additive and idempotent: skips if either an active or a previously-injected commented

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -623,7 +623,7 @@ use steps::{
     MigrateSupervisorConfig, MigrateTelemetryConfig, MigrateToolsCompressionConfig,
     MigrateTraceMetadata, MigrateTuiDelights, MigrateTuiMouse, MigrateTuiThemeConfig,
     MigrateTuiThemeDefaults, MigrateUtilityHighGainTools, MigrateVigilConfig,
-    MigrateWorktreeConfig, MigrateWorktreeGitTimeout,
+    MigrateWorktreeConfig, MigrateWorktreeGitTimeout, MigrateWorktreeQuotaFields,
 };
 
 /// Ordered registry of all sequential migration steps (steps 1–82).
@@ -775,6 +775,10 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             Box::new(MigrateShadowSentinelConfig),
             // Step 82 — add [a2a_client] card_trust_policy/trusted_agent_keys advisory block (#5928)
             Box::new(MigrateA2aCardTrustConfig),
+            // Step 83 — add max_worktrees/disk_quota_mb/auto_reconcile_secs/
+            // reconcile_on_startup advisory comments to an existing active [worktree]
+            // table (#5924)
+            Box::new(MigrateWorktreeQuotaFields),
         ]
     });
 

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -626,7 +626,7 @@ use steps::{
     MigrateWorktreeConfig, MigrateWorktreeGitTimeout, MigrateWorktreeQuotaFields,
 };
 
-/// Ordered registry of all sequential migration steps (steps 1–82).
+/// Ordered registry of all sequential migration steps (steps 1–83).
 ///
 /// Each entry wraps the corresponding free function and is evaluated lazily at first access.
 /// The ordering is chronological; the dispatch loop in `src/commands/migrate.rs` iterates

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -45,7 +45,9 @@
 //! existing active `[skills.trust]` table (#6087);
 //! step 81 adds a commented `[security.shadow_sentinel]` advisory block (spec 050, #5934);
 //! step 82 adds a commented `[a2a_client]` `card_trust_policy`/`trusted_agent_keys` advisory
-//! block (#5928).
+//! block (#5928);
+//! step 83 adds commented `max_worktrees`/`disk_quota_mb`/`auto_reconcile_secs`/
+//! `reconcile_on_startup` fields to an existing active `[worktree]` table (#5924).
 //!
 //! Each struct is a zero-size type that delegates to the corresponding free function in
 //! `super`. They exist solely to satisfy the object-safe [`super::Migration`] trait so the
@@ -83,7 +85,7 @@ use super::{
     migrate_supervisor_config, migrate_telemetry_config, migrate_tools_compression_config,
     migrate_trace_metadata, migrate_tui_delights, migrate_tui_mouse, migrate_tui_theme_config,
     migrate_tui_theme_defaults, migrate_utility_high_gain_tools, migrate_vigil_config,
-    migrate_worktree_config, migrate_worktree_git_timeout,
+    migrate_worktree_config, migrate_worktree_git_timeout, migrate_worktree_quota_fields,
 };
 
 // ── Wrapper structs for all 73 sequential migration steps ───────────────────────────────────────
@@ -1010,5 +1012,18 @@ impl Migration for MigrateA2aCardTrustConfig {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_a2a_card_trust_config(toml_src)
+    }
+}
+
+/// Step 83 — adds commented `max_worktrees`/`disk_quota_mb`/`auto_reconcile_secs`/
+/// `reconcile_on_startup` fields to an existing active `[worktree]` table (#5924).
+pub(super) struct MigrateWorktreeQuotaFields;
+impl Migration for MigrateWorktreeQuotaFields {
+    fn name(&self) -> &'static str {
+        "migrate_worktree_quota_fields"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_worktree_quota_fields(toml_src)
     }
 }

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -1791,7 +1791,7 @@ fn registry_is_idempotent_on_empty_input() {
 
 #[test]
 fn registry_preserves_order_matches_dispatch() {
-    // Names must follow the documented step order (steps 1–81).
+    // Names must follow the documented step order (steps 1–82).
     let expected = [
         "migrate_stt_to_provider",
         "migrate_planner_model_to_provider",
@@ -1875,6 +1875,7 @@ fn registry_preserves_order_matches_dispatch() {
         "migrate_skill_trust_require_check",
         "migrate_shadow_sentinel_config",
         "migrate_a2a_card_trust_config",
+        "migrate_worktree_quota_fields",
     ];
     let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
     assert_eq!(actual, expected);
@@ -2829,6 +2830,62 @@ fn step_55_value_substring_is_noop() {
         "value substring must not trigger replacement"
     );
     assert_eq!(result.output, input);
+}
+
+// ── migrate_worktree_quota_fields tests (#5924) ──────────────────────────
+
+#[test]
+fn step_82_inserts_quota_comments_when_worktree_present() {
+    let input = "[worktree]\nenabled = true\n";
+    let result = migrate_worktree_quota_fields(input).unwrap();
+    assert_eq!(result.changed_count, 1);
+    assert!(result.output.contains("max_worktrees"));
+    assert!(result.output.contains("disk_quota_mb"));
+    assert!(result.output.contains("auto_reconcile_secs"));
+    assert!(result.output.contains("reconcile_on_startup"));
+    assert_eq!(result.sections_changed, vec!["worktree"]);
+}
+
+#[test]
+fn step_82_is_noop_when_no_worktree_section() {
+    let input = "[agent]\nmax_turns = 10\n";
+    let result = migrate_worktree_quota_fields(input).unwrap();
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, input);
+}
+
+#[test]
+fn step_82_is_idempotent_when_auto_reconcile_secs_already_present() {
+    let input = "[worktree]\nauto_reconcile_secs = 3600\n";
+    let result = migrate_worktree_quota_fields(input).unwrap();
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, input);
+}
+
+#[test]
+fn step_82_is_idempotent_when_quota_fields_commented() {
+    let input = "[worktree]\n# auto_reconcile_secs = 3600\n";
+    let result = migrate_worktree_quota_fields(input).unwrap();
+    assert_eq!(result.changed_count, 0);
+}
+
+#[test]
+fn step_82_subtable_only_is_noop() {
+    let input = "[worktree.git]\ntimeout = 30\n";
+    let result = migrate_worktree_quota_fields(input).unwrap();
+    assert_eq!(
+        result.changed_count, 0,
+        "subtable-only header must be a no-op"
+    );
+    assert_eq!(result.output, input);
+}
+
+#[test]
+fn step_82_handles_crlf_line_endings() {
+    let input = "[worktree]\r\nenabled = true\r\n";
+    let result = migrate_worktree_quota_fields(input).unwrap();
+    assert_eq!(result.changed_count, 1);
+    assert!(result.output.contains("auto_reconcile_secs"));
 }
 
 // ── Step 59 — migrate_caveman_config (#5027) ─────────────────────────────────────────────────

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -9,8 +9,8 @@ use super::*;
 fn migrations_registry_has_all_steps() {
     assert_eq!(
         MIGRATIONS.len(),
-        82,
-        "MIGRATIONS registry must contain all 82 sequential steps"
+        83,
+        "MIGRATIONS registry must contain all 83 sequential steps"
     );
     for m in MIGRATIONS.iter() {
         assert!(
@@ -1753,7 +1753,7 @@ fn migrate_focus_auto_consolidate_noop_when_only_commented_section() {
 
 #[test]
 fn registry_has_fifty_entries() {
-    assert_eq!(MIGRATIONS.len(), 82);
+    assert_eq!(MIGRATIONS.len(), 83);
 }
 
 #[test]
@@ -1791,7 +1791,7 @@ fn registry_is_idempotent_on_empty_input() {
 
 #[test]
 fn registry_preserves_order_matches_dispatch() {
-    // Names must follow the documented step order (steps 1–82).
+    // Names must follow the documented step order (steps 1–83).
     let expected = [
         "migrate_stt_to_provider",
         "migrate_planner_model_to_provider",
@@ -2835,7 +2835,7 @@ fn step_55_value_substring_is_noop() {
 // ── migrate_worktree_quota_fields tests (#5924) ──────────────────────────
 
 #[test]
-fn step_82_inserts_quota_comments_when_worktree_present() {
+fn step_83_inserts_quota_comments_when_worktree_present() {
     let input = "[worktree]\nenabled = true\n";
     let result = migrate_worktree_quota_fields(input).unwrap();
     assert_eq!(result.changed_count, 1);
@@ -2847,7 +2847,7 @@ fn step_82_inserts_quota_comments_when_worktree_present() {
 }
 
 #[test]
-fn step_82_is_noop_when_no_worktree_section() {
+fn step_83_is_noop_when_no_worktree_section() {
     let input = "[agent]\nmax_turns = 10\n";
     let result = migrate_worktree_quota_fields(input).unwrap();
     assert_eq!(result.changed_count, 0);
@@ -2855,7 +2855,7 @@ fn step_82_is_noop_when_no_worktree_section() {
 }
 
 #[test]
-fn step_82_is_idempotent_when_auto_reconcile_secs_already_present() {
+fn step_83_is_idempotent_when_auto_reconcile_secs_already_present() {
     let input = "[worktree]\nauto_reconcile_secs = 3600\n";
     let result = migrate_worktree_quota_fields(input).unwrap();
     assert_eq!(result.changed_count, 0);
@@ -2863,14 +2863,14 @@ fn step_82_is_idempotent_when_auto_reconcile_secs_already_present() {
 }
 
 #[test]
-fn step_82_is_idempotent_when_quota_fields_commented() {
+fn step_83_is_idempotent_when_quota_fields_commented() {
     let input = "[worktree]\n# auto_reconcile_secs = 3600\n";
     let result = migrate_worktree_quota_fields(input).unwrap();
     assert_eq!(result.changed_count, 0);
 }
 
 #[test]
-fn step_82_subtable_only_is_noop() {
+fn step_83_subtable_only_is_noop() {
     let input = "[worktree.git]\ntimeout = 30\n";
     let result = migrate_worktree_quota_fields(input).unwrap();
     assert_eq!(
@@ -2881,7 +2881,7 @@ fn step_82_subtable_only_is_noop() {
 }
 
 #[test]
-fn step_82_handles_crlf_line_endings() {
+fn step_83_handles_crlf_line_endings() {
     let input = "[worktree]\r\nenabled = true\r\n";
     let result = migrate_worktree_quota_fields(input).unwrap();
     assert_eq!(result.changed_count, 1);

--- a/crates/zeph-config/src/worktree.rs
+++ b/crates/zeph-config/src/worktree.rs
@@ -44,6 +44,7 @@ use serde::{Deserialize, Serialize};
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
+#[allow(clippy::struct_excessive_bools)] // config struct — boolean flags are idiomatic for TOML-deserialized configuration
 pub struct WorktreeConfig {
     /// Enable per-subagent git worktrees. When `false`, no worktrees are created
     /// regardless of other settings.
@@ -83,6 +84,62 @@ pub struct WorktreeConfig {
     /// [`DefaultGitRunner`](https://docs.rs/zeph-worktree/latest/zeph_worktree/git_runner/struct.DefaultGitRunner.html),
     /// not by any call site.
     pub git_timeout_secs: u64,
+    /// Maximum number of concurrent worktrees under `root`. `None` (default) means
+    /// unlimited.
+    ///
+    /// Enforced as a creation-time admission cap: a `create()` call that would push
+    /// the count of git-registered secondary worktrees to `max_worktrees` or beyond
+    /// fails with `WorktreeError::QuotaExceeded` instead of silently growing disk
+    /// usage. The count includes worktrees created by *other*, concurrently running
+    /// zeph sessions over the same `root` — `max_worktrees` bounds total disk-safe
+    /// usage under the repository, not just this session's own worktrees. The check
+    /// is a best-effort soft cap: it is not atomic across processes, so two
+    /// concurrent `create()` calls can both pass and briefly exceed the configured
+    /// maximum by a small margin. Lowering this value below the current worktree
+    /// count does not evict existing worktrees; it only blocks new admissions until
+    /// an operator runs `zeph worktree clean` or raises the limit. A value of
+    /// `Some(0)` is rejected at config-validation time (it would block all worktree
+    /// creation).
+    pub max_worktrees: Option<usize>,
+    /// Soft total-disk-usage threshold, in megabytes, across all worktrees under
+    /// `root`. `None` (default) disables disk accounting.
+    ///
+    /// When exceeded, the reconcile sweep (startup and/or periodic, see
+    /// `auto_reconcile_secs` / `reconcile_on_startup`) emits a warning status
+    /// indicator and auto-reclaims only git-`prunable` entries — an intact worktree
+    /// is never force-removed to satisfy this threshold. The reported total is a sum
+    /// of logical file sizes (`metadata().len()`), not on-disk block usage; content
+    /// shared via hardlinks across worktrees (e.g. zeph-session blobs) can be
+    /// double-counted, so treat the total as an approximation, not exact `du`
+    /// output. A value of `Some(0)` is rejected at config-validation time (it would
+    /// leave every non-empty worktree permanently over quota).
+    pub disk_quota_mb: Option<u64>,
+    /// Interval, in seconds, for the supervised background reconcile-and-quota
+    /// sweep. `0` (default) disables the periodic sweep.
+    ///
+    /// When greater than zero, one task is registered with the session
+    /// `TaskSupervisor` that, on this cadence, reconciles the git worktree
+    /// registry, auto-reclaims `prunable` entries via the same path as
+    /// `zeph worktree clean` (non-force), and evaluates `max_worktrees` /
+    /// `disk_quota_mb`. Each tick may perform a filesystem walk of every worktree
+    /// (potentially multi-gigabyte `target/` directories), so a short interval is
+    /// wasteful; an hourly cadence (`3600`) is a reasonable default when enabling
+    /// this. `Config::validate` rejects any value in `1..60` — a sub-minute interval
+    /// would run a full filesystem walk in a tight loop.
+    pub auto_reconcile_secs: u64,
+    /// Run one reconcile-and-quota sweep at bootstrap, immediately after the
+    /// worktree manager is constructed. Default `true`.
+    ///
+    /// Recovers from a crash that left `prunable` worktrees behind without waiting
+    /// for the first periodic tick, and evaluates `disk_quota_mb` / `max_worktrees`
+    /// once per launch even when `auto_reconcile_secs = 0` — without this, a
+    /// `disk_quota_mb` set by itself would never be evaluated at all. `Config::validate`
+    /// rejects `disk_quota_mb.is_some()` combined with both this field `false` and
+    /// `auto_reconcile_secs == 0`, so that exact inert combination cannot reach a running
+    /// session. Safe by construction: the startup sweep only ever removes entries git itself
+    /// reports as `prunable` (directory or gitdir-link already gone), identical to
+    /// `zeph worktree clean` without `--force`.
+    pub reconcile_on_startup: bool,
 }
 
 fn default_git_timeout_secs() -> u64 {
@@ -101,6 +158,10 @@ impl Default for WorktreeConfig {
             cleanup_on_completion: true,
             bg_isolation: BgIsolation::default(),
             git_timeout_secs: default_git_timeout_secs(),
+            max_worktrees: None,
+            disk_quota_mb: None,
+            auto_reconcile_secs: 0,
+            reconcile_on_startup: true,
         }
     }
 }
@@ -180,6 +241,10 @@ mod tests {
         assert!(cfg.cleanup_on_completion);
         assert_eq!(cfg.bg_isolation, BgIsolation::Worktree);
         assert_eq!(cfg.git_timeout_secs, 30);
+        assert_eq!(cfg.max_worktrees, None);
+        assert_eq!(cfg.disk_quota_mb, None);
+        assert_eq!(cfg.auto_reconcile_secs, 0);
+        assert!(cfg.reconcile_on_startup);
     }
 
     #[test]
@@ -192,6 +257,10 @@ mod tests {
         assert_eq!(deserialized.branch_prefix, cfg.branch_prefix);
         assert_eq!(deserialized.bg_isolation, cfg.bg_isolation);
         assert_eq!(deserialized.git_timeout_secs, 30);
+        assert_eq!(deserialized.max_worktrees, cfg.max_worktrees);
+        assert_eq!(deserialized.disk_quota_mb, cfg.disk_quota_mb);
+        assert_eq!(deserialized.auto_reconcile_secs, cfg.auto_reconcile_secs);
+        assert_eq!(deserialized.reconcile_on_startup, cfg.reconcile_on_startup);
     }
 
     #[test]
@@ -279,5 +348,33 @@ bg_isolation = "none"
         let toml_src = "enabled = false\n";
         let cfg: WorktreeConfig = toml::from_str(toml_src).expect("deserialize");
         assert_eq!(cfg.git_timeout_secs, 30);
+    }
+
+    #[test]
+    fn worktree_config_quota_fields_default_when_absent() {
+        // Configs written before max_worktrees/disk_quota_mb/auto_reconcile_secs/
+        // reconcile_on_startup were added must parse without error and resolve to
+        // their defaults (unlimited, no accounting, no periodic sweep, startup
+        // sweep on).
+        let toml_src = "enabled = true\n";
+        let cfg: WorktreeConfig = toml::from_str(toml_src).expect("deserialize");
+        assert_eq!(cfg.max_worktrees, None);
+        assert_eq!(cfg.disk_quota_mb, None);
+        assert_eq!(cfg.auto_reconcile_secs, 0);
+        assert!(cfg.reconcile_on_startup);
+    }
+
+    #[test]
+    fn worktree_config_quota_fields_custom_values_roundtrip() {
+        let toml_src = "enabled = true\n\
+             max_worktrees = 5\n\
+             disk_quota_mb = 2048\n\
+             auto_reconcile_secs = 3600\n\
+             reconcile_on_startup = false\n";
+        let cfg: WorktreeConfig = toml::from_str(toml_src).expect("deserialize");
+        assert_eq!(cfg.max_worktrees, Some(5));
+        assert_eq!(cfg.disk_quota_mb, Some(2048));
+        assert_eq!(cfg.auto_reconcile_secs, 3600);
+        assert!(!cfg.reconcile_on_startup);
     }
 }

--- a/crates/zeph-core/src/agent/worktree_commands.rs
+++ b/crates/zeph-core/src/agent/worktree_commands.rs
@@ -73,6 +73,19 @@ impl<C: Channel> Agent<C> {
                 }
             }
         }
+        // Always forces a fresh walk (never reads `cached_disk_usage()`), matching the CLI's
+        // `zeph worktree list` (`src/commands/worktree.rs`) exactly — this is a deliberate,
+        // infrequent, user-triggered command, not the `create()` hot path, so the walk cost is
+        // acceptable here (see `WorktreeManager::disk_usage`'s doc comment). Reading the cache
+        // instead previously made this command silently omit the usage footer under the default
+        // config (review N2 / cross-mode divergence).
+        let usage = wm.disk_usage().await?;
+        let count = active.len() + stale.len();
+        let _ = write!(
+            out,
+            "\n{}",
+            zeph_worktree::format_usage_summary(&usage, count, wm.config())
+        );
         Ok(Some(out.trim_end().to_owned()))
     }
 

--- a/crates/zeph-worktree/Cargo.toml
+++ b/crates/zeph-worktree/Cargo.toml
@@ -16,10 +16,12 @@ readme = "README.md"
 default = []
 
 [dependencies]
+parking_lot.workspace = true
 serde = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["fs", "process", "sync"] }
 tracing.workspace = true
+walkdir.workspace = true
 zeph-config.workspace = true
 
 [dev-dependencies]

--- a/crates/zeph-worktree/src/error.rs
+++ b/crates/zeph-worktree/src/error.rs
@@ -53,4 +53,24 @@ pub enum WorktreeError {
     /// An I/O error propagated from the OS or `std::fs`.
     #[error(transparent)]
     Io(#[from] std::io::Error),
+
+    /// A `create()` call was refused because `worktree.max_worktrees` would be
+    /// reached or exceeded.
+    ///
+    /// `current` is the number of git-registered secondary worktrees under `root`
+    /// at the time of the check (including worktrees owned by other, concurrently
+    /// running zeph sessions); `max` is the configured `max_worktrees` limit. This
+    /// is a soft, best-effort cap — see
+    /// [`WorktreeManager::create`](crate::WorktreeManager::create)'s doc comment
+    /// for the TOCTOU caveat under concurrent sessions.
+    #[error(
+        "worktree limit reached ({current}/{max}); run `zeph worktree clean` or raise \
+         `worktree.max_worktrees`"
+    )]
+    QuotaExceeded {
+        /// Number of git-registered secondary worktrees under `root` at check time.
+        current: usize,
+        /// The configured `worktree.max_worktrees` limit.
+        max: usize,
+    },
 }

--- a/crates/zeph-worktree/src/lib.rs
+++ b/crates/zeph-worktree/src/lib.rs
@@ -49,11 +49,13 @@ pub mod git_runner;
 pub mod handle;
 pub mod manager;
 pub mod sanitize;
+pub mod usage;
 
 pub use error::WorktreeError;
 pub use git_runner::{DefaultGitRunner, GitRunner};
 pub use handle::{BARE_WORKTREE_SENTINEL, DETACHED_BRANCH_SENTINEL, StaleWorktree, WorktreeHandle};
 pub use manager::{CleanOutcome, WorktreeManager, format_clean_summary, probe_capabilities};
+pub use usage::{QuotaStatus, WorktreeDiskUsage, format_usage_summary};
 
 /// A [`WorktreeManager`] using the production [`DefaultGitRunner`].
 ///

--- a/crates/zeph-worktree/src/manager.rs
+++ b/crates/zeph-worktree/src/manager.rs
@@ -4,7 +4,7 @@
 use std::{
     path::{Path, PathBuf},
     process::Output,
-    time::SystemTime,
+    time::{Instant, SystemTime},
 };
 
 use tracing::instrument;
@@ -15,6 +15,7 @@ use crate::{
     git_runner::GitRunner,
     handle::{BARE_WORKTREE_SENTINEL, DETACHED_BRANCH_SENTINEL, StaleWorktree, WorktreeHandle},
     sanitize::{canonicalize_root, validate_branch_component},
+    usage::{QuotaStatus, WorktreeDiskUsage},
 };
 
 /// Manages the full lifecycle of per-subagent git worktrees.
@@ -48,6 +49,10 @@ pub struct WorktreeManager<R: GitRunner> {
     runner: R,
     /// In-memory list of live worktree handles for the current session.
     handles: std::sync::Mutex<Vec<WorktreeHandle>>,
+    /// Last computed disk usage, populated by [`Self::disk_usage`]. Read cheaply
+    /// (without a filesystem walk) via [`Self::cached_disk_usage`]. `None` until
+    /// the first `disk_usage()` call.
+    usage_cache: parking_lot::Mutex<Option<(Instant, WorktreeDiskUsage)>>,
 }
 
 impl<R: GitRunner> WorktreeManager<R> {
@@ -101,6 +106,7 @@ impl<R: GitRunner> WorktreeManager<R> {
             config,
             runner,
             handles: std::sync::Mutex::new(Vec::new()),
+            usage_cache: parking_lot::Mutex::new(None),
         })
     }
 
@@ -108,6 +114,16 @@ impl<R: GitRunner> WorktreeManager<R> {
     #[must_use]
     pub fn repo_root(&self) -> &Path {
         &self.repo_root
+    }
+
+    /// Returns the [`WorktreeConfig`] this manager was constructed with.
+    ///
+    /// Exposed so callers that only hold the manager (not the original config, e.g.
+    /// `/worktree list` in `zeph-core`) can read `max_worktrees`/`disk_quota_mb` for
+    /// quota-status formatting without threading the config separately.
+    #[must_use]
+    pub fn config(&self) -> &WorktreeConfig {
+        &self.config
     }
 
     /// Whether [`remove`][Self::remove] should also delete the branch, per the
@@ -126,6 +142,22 @@ impl<R: GitRunner> WorktreeManager<R> {
     /// The branch name is `"{branch_prefix}{subagent_id}"`.  The path on disk is
     /// `"{root}/{subagent_id}"`.
     ///
+    /// ## Admission cap
+    ///
+    /// When `config.max_worktrees` is `Some(max)`, this call first counts all
+    /// git-registered secondary worktrees under `root` — via
+    /// [`reconcile`][Self::reconcile] (stale/foreign entries) plus
+    /// [`list`][Self::list] (this session's own) — and fails with
+    /// [`WorktreeError::QuotaExceeded`] if that count is already `>= max`. The
+    /// count includes worktrees created by *other*, concurrently running zeph
+    /// sessions over the same `root`, since they consume the same disk budget
+    /// `max_worktrees` is meant to bound. This is a best-effort **soft** cap, not
+    /// a hard guarantee: the count-then-`git worktree add` sequence is not atomic
+    /// across processes, so two concurrent `create()` calls on different sessions
+    /// can both pass the check and briefly push the total above `max`. No
+    /// cross-process locking is used to close this gap — it is out of scope for
+    /// the size of this feature.
+    ///
     /// ## TODO
     ///
     /// TODO(critic D2): head worktree does not include parent uncommitted changes
@@ -134,6 +166,8 @@ impl<R: GitRunner> WorktreeManager<R> {
     /// # Errors
     ///
     /// - [`WorktreeError::InvalidBranchName`] when `subagent_id` fails validation.
+    /// - [`WorktreeError::QuotaExceeded`] when `config.max_worktrees` would be
+    ///   reached or exceeded (see "Admission cap" above).
     /// - [`WorktreeError::PathExists`] when the worktree path already exists.
     /// - [`WorktreeError::BaseRefUnresolved`] when `base_ref = Fresh` and the
     ///   default branch cannot be resolved.
@@ -151,6 +185,13 @@ impl<R: GitRunner> WorktreeManager<R> {
     #[instrument(name = "worktree.create", skip(self), fields(subagent_id = %subagent_id))]
     pub async fn create(&self, subagent_id: &str) -> Result<WorktreeHandle, WorktreeError> {
         validate_branch_component(subagent_id)?;
+
+        if let Some(max) = self.config.max_worktrees {
+            let current = self.reconcile().await?.len() + self.list().len();
+            if current >= max {
+                return Err(WorktreeError::QuotaExceeded { current, max });
+            }
+        }
 
         let branch_name = format!("{}{}", self.config.branch_prefix, subagent_id);
         let path = self.worktree_root.join(subagent_id);
@@ -467,6 +508,183 @@ impl<R: GitRunner> WorktreeManager<R> {
                 .push(format!("warning: failed to prune worktree registry: {e}"));
         }
         Ok(outcome)
+    }
+
+    /// Computes total and per-worktree disk usage across every worktree under
+    /// `root` — both this session's own ([`list`][Self::list]) and any discovered
+    /// via [`reconcile`][Self::reconcile] (stale/foreign entries).
+    ///
+    /// The recursive filesystem walk runs on [`tokio::task::spawn_blocking`], so
+    /// it never stalls the async executor — but it is still an O(files-under-root)
+    /// operation that can be slow against multi-gigabyte `target/` directories.
+    /// Callers on a hot or interactive path should prefer
+    /// [`cached_disk_usage`][Self::cached_disk_usage] and only call this method
+    /// from a deliberate, infrequent trigger (a [`sweep`][Self::sweep] tick or an
+    /// explicit CLI invocation) — **never** from [`create`][Self::create].
+    ///
+    /// The reported total is a sum of logical file sizes
+    /// (`std::fs::Metadata::len`), not on-disk block usage — content shared via
+    /// hardlinks across worktrees (e.g. zeph-session blobs) can be double-counted.
+    /// Treat the result as an approximation suitable for a soft warn threshold.
+    ///
+    /// On success, the result is stored so a subsequent
+    /// [`cached_disk_usage`][Self::cached_disk_usage] call can read it without
+    /// re-walking the filesystem.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WorktreeError::GitCommand`] if the underlying
+    /// [`reconcile`][Self::reconcile] call fails, or [`WorktreeError::Io`] if the
+    /// blocking walk task itself panics or is cancelled.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # async fn example(mgr: &zeph_worktree::DefaultWorktreeManager) -> Result<(), zeph_worktree::WorktreeError> {
+    /// let usage = mgr.disk_usage().await?;
+    /// println!("total: {} bytes across {} worktree(s)", usage.total_bytes, usage.per_worktree.len());
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[instrument(name = "worktree.disk_usage", skip(self))]
+    pub async fn disk_usage(&self) -> Result<WorktreeDiskUsage, WorktreeError> {
+        let mut paths: Vec<PathBuf> = self
+            .reconcile()
+            .await?
+            .into_iter()
+            .map(|stale| stale.handle.path)
+            .collect();
+        paths.extend(self.list().into_iter().map(|h| h.path));
+
+        let usage = tokio::task::spawn_blocking(move || walk_worktree_sizes(&paths))
+            .await
+            .map_err(|e| WorktreeError::Io(std::io::Error::other(e)))?;
+
+        *self.usage_cache.lock() = Some((Instant::now(), usage.clone()));
+        Ok(usage)
+    }
+
+    /// Returns the disk usage computed by the most recent
+    /// [`disk_usage`][Self::disk_usage] call, without performing a filesystem
+    /// walk. Returns `None` if `disk_usage()` has never been called on this
+    /// manager instance.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # fn example(mgr: &zeph_worktree::DefaultWorktreeManager) {
+    /// if let Some(usage) = mgr.cached_disk_usage() {
+    ///     println!("last known total: {} bytes", usage.total_bytes);
+    /// }
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn cached_disk_usage(&self) -> Option<WorktreeDiskUsage> {
+        self.usage_cache
+            .lock()
+            .as_ref()
+            .map(|(_, usage)| usage.clone())
+    }
+
+    /// Runs one reconcile-and-quota sweep: [`reconcile`][Self::reconcile] +
+    /// prunable-only auto-reclaim (the same `clean(force=false, ..)` pipeline as
+    /// `zeph worktree clean`), then evaluates `config.max_worktrees` and, when
+    /// `config.disk_quota_mb` is set, [`disk_usage`][Self::disk_usage].
+    ///
+    /// Never force-removes an intact worktree — reclamation is delegated entirely
+    /// to [`clean`][Self::clean] with `force = false`, which only removes entries
+    /// git itself reports as `prunable` (spec-063 INV-5/INV-6). An over-quota
+    /// state with only intact worktrees is reported via
+    /// [`QuotaStatus::is_over_quota`], never resolved by deleting anything.
+    ///
+    /// The disk-usage walk is skipped entirely (and [`QuotaStatus::total_bytes`]
+    /// is left at `0` with [`QuotaStatus::disk_quota_bytes`] as `None`) when
+    /// `config.disk_quota_mb` is unset, avoiding the filesystem walk's cost when
+    /// there is no threshold to evaluate it against.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WorktreeError::GitCommand`] if the initial
+    /// [`reconcile`][Self::reconcile]/[`clean`][Self::clean] call fails, or an
+    /// error from [`disk_usage`][Self::disk_usage] when disk accounting is
+    /// enabled.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # async fn example(mgr: &zeph_worktree::DefaultWorktreeManager) -> Result<(), zeph_worktree::WorktreeError> {
+    /// let status = mgr.sweep().await?;
+    /// if status.is_over_quota() {
+    ///     eprintln!("worktrees over quota: {}/{:?}", status.count, status.max_worktrees);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[instrument(name = "worktree.sweep", skip(self))]
+    pub async fn sweep(&self) -> Result<QuotaStatus, WorktreeError> {
+        let outcome = self
+            .clean(
+                false,
+                self.config.prune_branch_on_remove,
+                "`zeph worktree clean --force`",
+            )
+            .await?;
+
+        let count = self.reconcile().await?.len() + self.list().len();
+        let max_worktrees = self.config.max_worktrees;
+        let over_count = max_worktrees.is_some_and(|max| count >= max);
+
+        let (total_bytes, disk_quota_bytes, over_disk) =
+            if let Some(quota_mb) = self.config.disk_quota_mb {
+                let usage = self.disk_usage().await?;
+                let quota_bytes = quota_mb.saturating_mul(1_048_576);
+                let over_disk = usage.total_bytes >= quota_bytes;
+                (usage.total_bytes, Some(quota_bytes), over_disk)
+            } else {
+                (0, None, false)
+            };
+
+        Ok(QuotaStatus {
+            count,
+            max_worktrees,
+            total_bytes,
+            disk_quota_bytes,
+            reclaimed: outcome.removed,
+            over_count,
+            over_disk,
+        })
+    }
+}
+
+/// Recursively sums regular-file sizes under each path in `paths`.
+///
+/// Runs on a blocking thread (see [`WorktreeManager::disk_usage`]). Entries that
+/// cannot be read (permission errors, races with concurrent removal) are silently
+/// skipped rather than failing the whole walk — a best-effort accounting is more
+/// useful than an aborted one for a soft warn threshold.
+fn walk_worktree_sizes(paths: &[PathBuf]) -> WorktreeDiskUsage {
+    let mut per_worktree = Vec::with_capacity(paths.len());
+    let mut total_bytes: u64 = 0;
+
+    for path in paths {
+        let mut size: u64 = 0;
+        for entry in walkdir::WalkDir::new(path)
+            .into_iter()
+            .filter_map(Result::ok)
+        {
+            if entry.file_type().is_file()
+                && let Ok(metadata) = entry.metadata()
+            {
+                size = size.saturating_add(metadata.len());
+            }
+        }
+        total_bytes = total_bytes.saturating_add(size);
+        per_worktree.push((path.clone(), size));
+    }
+
+    WorktreeDiskUsage {
+        total_bytes,
+        per_worktree,
     }
 }
 
@@ -1591,5 +1809,314 @@ mod tests {
             matches!(result, Err(WorktreeError::GitCommand { .. })),
             "expected GitCommand error from fake runner, not an early abort: {result:?}"
         );
+    }
+
+    // --- max_worktrees admission cap ---
+
+    #[tokio::test]
+    async fn create_succeeds_when_under_max_worktrees_cap() {
+        let dir = make_repo();
+        let runner = FakeGitRunner::new();
+        let porcelain = format!(
+            "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\n",
+            dir.path().display()
+        );
+        runner.push_ok(porcelain.into_bytes()); // reconcile for quota check
+        runner.push_ok(b"" as &[u8]); // status --porcelain (dirty check)
+        runner.push_ok(b"" as &[u8]); // worktree add
+
+        let config = WorktreeConfig {
+            max_worktrees: Some(5),
+            ..test_config()
+        };
+        let mgr = WorktreeManager::new(dir.path().to_path_buf(), config, runner)
+            .await
+            .unwrap();
+        assert!(mgr.create("agent-a").await.is_ok());
+    }
+
+    /// Regression test for #5924: `create()` must refuse admission once the
+    /// git-registered secondary worktree count reaches `max_worktrees`, without
+    /// issuing any further git calls (only `FakeGitRunner`'s queued reconcile
+    /// response is consumed for the rejected call).
+    #[tokio::test]
+    async fn create_fails_with_quota_exceeded_when_max_worktrees_reached() {
+        let dir = make_repo();
+        let runner = FakeGitRunner::new();
+        let porcelain = format!(
+            "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\n",
+            dir.path().display()
+        );
+        // First create(): reconcile (quota check), status --porcelain, worktree add.
+        runner.push_ok(porcelain.clone().into_bytes());
+        runner.push_ok(b"" as &[u8]);
+        runner.push_ok(b"" as &[u8]);
+        // Second create(): reconcile (quota check) only — QuotaExceeded short-circuits
+        // before any further git call.
+        runner.push_ok(porcelain.into_bytes());
+
+        let config = WorktreeConfig {
+            max_worktrees: Some(1),
+            ..test_config()
+        };
+        let mgr = WorktreeManager::new(dir.path().to_path_buf(), config, runner)
+            .await
+            .unwrap();
+
+        mgr.create("agent-a").await.unwrap();
+
+        let err = mgr.create("agent-b").await.unwrap_err();
+        assert_matches!(err, WorktreeError::QuotaExceeded { current: 1, max: 1 });
+    }
+
+    // --- disk_usage / cached_disk_usage ---
+
+    #[tokio::test]
+    async fn disk_usage_returns_zero_for_no_worktrees() {
+        let dir = make_repo();
+        let runner = FakeGitRunner::new();
+        let porcelain = format!(
+            "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\n",
+            dir.path().display()
+        );
+        runner.push_ok(porcelain.into_bytes());
+
+        let mgr = make_manager(&dir, runner).await;
+        let usage = mgr.disk_usage().await.unwrap();
+        assert_eq!(usage.total_bytes, 0);
+        assert!(usage.per_worktree.is_empty());
+    }
+
+    #[tokio::test]
+    async fn disk_usage_sums_file_sizes_under_registered_worktree() {
+        let dir = make_repo();
+        let runner = FakeGitRunner::new();
+        let porcelain = format!(
+            "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\n",
+            dir.path().display()
+        );
+        runner.push_ok(porcelain.into_bytes());
+
+        let mgr = make_manager(&dir, runner).await;
+
+        let wt_path = dir.path().join("worktrees/agent-1");
+        std::fs::create_dir_all(&wt_path).unwrap();
+        std::fs::write(wt_path.join("file.txt"), b"hello world").unwrap();
+
+        mgr.handles.lock().unwrap().push(WorktreeHandle {
+            path: wt_path.clone(),
+            branch_name: "agent/agent-1".to_string(),
+            base_ref_resolved: "HEAD".to_string(),
+            subagent_id: "agent-1".to_string(),
+            created_at: SystemTime::now(),
+        });
+
+        let usage = mgr.disk_usage().await.unwrap();
+        assert_eq!(usage.total_bytes, 11);
+        assert_eq!(usage.per_worktree.len(), 1);
+        assert_eq!(usage.per_worktree[0].0, wt_path);
+        assert_eq!(usage.per_worktree[0].1, 11);
+    }
+
+    #[tokio::test]
+    async fn cached_disk_usage_none_before_first_call() {
+        let dir = make_repo();
+        let runner = FakeGitRunner::new();
+        let mgr = make_manager(&dir, runner).await;
+        assert!(mgr.cached_disk_usage().is_none());
+    }
+
+    #[tokio::test]
+    async fn cached_disk_usage_populated_after_disk_usage_call() {
+        let dir = make_repo();
+        let runner = FakeGitRunner::new();
+        let porcelain = format!(
+            "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\n",
+            dir.path().display()
+        );
+        runner.push_ok(porcelain.into_bytes());
+        let mgr = make_manager(&dir, runner).await;
+
+        assert!(mgr.cached_disk_usage().is_none());
+        mgr.disk_usage().await.unwrap();
+        assert!(mgr.cached_disk_usage().is_some());
+    }
+
+    // --- sweep ---
+
+    /// Regression test for #5924: `sweep()` reclaims only `prunable` entries (via the
+    /// same `clean(force=false, ..)` pipeline as `zeph worktree clean`) and, with no
+    /// `disk_quota_mb` configured, never performs the filesystem walk.
+    #[tokio::test]
+    async fn sweep_reclaims_prunable_and_reports_count_without_disk_check() {
+        let dir = make_repo();
+        let runner = FakeGitRunner::new();
+        let porcelain_with_prunable = format!(
+            "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\n\
+             worktree {0}/worktrees/prunable-1\nHEAD def456\nbranch refs/heads/agent/prunable-1\n\
+             prunable gitdir file points to non-existent location\n\n",
+            dir.path().display()
+        );
+        // clean(): reconcile
+        runner.push_ok(porcelain_with_prunable.into_bytes());
+        // clean(): remove prunable-1
+        runner.push_ok(b"" as &[u8]);
+        // clean(): prune
+        runner.push_ok(b"" as &[u8]);
+        // sweep(): reconcile() for post-clean count
+        let porcelain_after = format!(
+            "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\n",
+            dir.path().display()
+        );
+        runner.push_ok(porcelain_after.into_bytes());
+
+        let mgr = make_manager(&dir, runner).await;
+        let status = mgr.sweep().await.unwrap();
+
+        assert_eq!(status.reclaimed, 1);
+        assert_eq!(status.count, 0);
+        assert_eq!(status.max_worktrees, None);
+        assert!(!status.over_count);
+        assert_eq!(status.total_bytes, 0);
+        assert_eq!(status.disk_quota_bytes, None);
+        assert!(!status.over_disk);
+        assert!(!status.is_over_quota());
+    }
+
+    /// Regression test for #5924 (critic M1): `sweep()` must evaluate `disk_quota_mb`
+    /// when configured — this is what makes the quota knob non-inert even when
+    /// `auto_reconcile_secs = 0` (periodic sweep disabled) and only the startup sweep
+    /// runs `sweep()` once.
+    #[tokio::test]
+    async fn sweep_evaluates_disk_quota_when_configured() {
+        let dir = make_repo();
+        let runner = FakeGitRunner::new();
+        let porcelain = format!(
+            "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\n",
+            dir.path().display()
+        );
+        // clean(): reconcile (no prunable entries)
+        runner.push_ok(porcelain.clone().into_bytes());
+        // clean(): prune
+        runner.push_ok(b"" as &[u8]);
+        // sweep(): reconcile() for count
+        runner.push_ok(porcelain.clone().into_bytes());
+        // sweep(): disk_usage() -> reconcile()
+        runner.push_ok(porcelain.into_bytes());
+
+        let config = WorktreeConfig {
+            disk_quota_mb: Some(1),
+            ..test_config()
+        };
+        let mgr = WorktreeManager::new(dir.path().to_path_buf(), config, runner)
+            .await
+            .unwrap();
+
+        let wt_path = dir.path().join("worktrees/agent-1");
+        std::fs::create_dir_all(&wt_path).unwrap();
+        std::fs::write(wt_path.join("big.bin"), vec![0u8; 2 * 1024 * 1024]).unwrap();
+
+        mgr.handles.lock().unwrap().push(WorktreeHandle {
+            path: wt_path.clone(),
+            branch_name: "agent/agent-1".to_string(),
+            base_ref_resolved: "HEAD".to_string(),
+            subagent_id: "agent-1".to_string(),
+            created_at: SystemTime::now(),
+        });
+
+        let status = mgr.sweep().await.unwrap();
+        assert_eq!(status.disk_quota_bytes, Some(1_048_576));
+        assert!(status.total_bytes >= 2 * 1024 * 1024);
+        assert!(status.over_disk);
+        assert!(status.is_over_quota());
+    }
+
+    /// Regression test (tester gap G1): `sweep()`'s `over_count = true` branch — the only
+    /// user-visible signal when an operator lowers `max_worktrees` below the existing worktree
+    /// count (which does not evict anything, only blocks new admissions).
+    #[tokio::test]
+    async fn sweep_reports_over_count_when_max_worktrees_exceeded() {
+        let dir = make_repo();
+        let runner = FakeGitRunner::new();
+        let porcelain = format!(
+            "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\n\
+             worktree {0}/worktrees/agent-1\nHEAD def456\nbranch refs/heads/agent/agent-1\n\n\
+             worktree {0}/worktrees/agent-2\nHEAD ghi789\nbranch refs/heads/agent/agent-2\n\n",
+            dir.path().display()
+        );
+        // clean(): reconcile (no prunable entries — nothing removed)
+        runner.push_ok(porcelain.clone().into_bytes());
+        // clean(): prune
+        runner.push_ok(b"" as &[u8]);
+        // sweep(): reconcile() for post-clean count
+        runner.push_ok(porcelain.into_bytes());
+
+        let config = WorktreeConfig {
+            max_worktrees: Some(1),
+            ..test_config()
+        };
+        let mgr = WorktreeManager::new(dir.path().to_path_buf(), config, runner)
+            .await
+            .unwrap();
+
+        let status = mgr.sweep().await.unwrap();
+        assert_eq!(status.count, 2);
+        assert_eq!(status.max_worktrees, Some(1));
+        assert!(status.over_count);
+        assert!(status.is_over_quota());
+        assert_eq!(
+            status.reclaimed, 0,
+            "over_count must never trigger removal of intact worktrees"
+        );
+    }
+
+    /// Regression test (tester gap G2): `max_worktrees` and `disk_quota_mb` set together must
+    /// report `over_count`/`over_disk` independently — one breached, the other not.
+    #[tokio::test]
+    async fn sweep_reports_independent_over_count_and_over_disk_flags() {
+        let dir = make_repo();
+        let runner = FakeGitRunner::new();
+        let porcelain = format!(
+            "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\n",
+            dir.path().display()
+        );
+        // clean(): reconcile (no prunable entries)
+        runner.push_ok(porcelain.clone().into_bytes());
+        // clean(): prune
+        runner.push_ok(b"" as &[u8]);
+        // sweep(): reconcile() for count
+        runner.push_ok(porcelain.clone().into_bytes());
+        // sweep(): disk_usage() -> reconcile()
+        runner.push_ok(porcelain.into_bytes());
+
+        let config = WorktreeConfig {
+            max_worktrees: Some(5),
+            disk_quota_mb: Some(1),
+            ..test_config()
+        };
+        let mgr = WorktreeManager::new(dir.path().to_path_buf(), config, runner)
+            .await
+            .unwrap();
+
+        let wt_path = dir.path().join("worktrees/agent-1");
+        std::fs::create_dir_all(&wt_path).unwrap();
+        std::fs::write(wt_path.join("big.bin"), vec![0u8; 2 * 1024 * 1024]).unwrap();
+
+        mgr.handles.lock().unwrap().push(WorktreeHandle {
+            path: wt_path.clone(),
+            branch_name: "agent/agent-1".to_string(),
+            base_ref_resolved: "HEAD".to_string(),
+            subagent_id: "agent-1".to_string(),
+            created_at: SystemTime::now(),
+        });
+
+        let status = mgr.sweep().await.unwrap();
+        assert_eq!(status.count, 1, "only the registered handle counts");
+        assert!(
+            !status.over_count,
+            "count (1) is under max_worktrees (5) — must not be flagged over"
+        );
+        assert!(status.over_disk, "disk usage over quota must be flagged");
+        assert!(status.is_over_quota());
     }
 }

--- a/crates/zeph-worktree/src/usage.rs
+++ b/crates/zeph-worktree/src/usage.rs
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: MIT
+//! Disk-usage accounting and quota-status types for [`crate::WorktreeManager`].
+
+use std::fmt::Write as _;
+use std::path::PathBuf;
+
+use zeph_config::WorktreeConfig;
+
+/// Total and per-worktree disk usage, as computed by
+/// [`WorktreeManager::disk_usage`][crate::WorktreeManager::disk_usage].
+///
+/// `total_bytes` is a sum of logical file sizes (`std::fs::Metadata::len`) across
+/// every regular file under each worktree's directory tree — not on-disk block
+/// usage. Content shared via hardlinks across worktrees (e.g. zeph-session blobs)
+/// can be double-counted, so treat this as an approximation suitable for a soft
+/// warn threshold, not exact `du` output.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_worktree::WorktreeDiskUsage;
+///
+/// let usage = WorktreeDiskUsage {
+///     total_bytes: 1024,
+///     per_worktree: vec![(std::path::PathBuf::from("/repo/worktrees/agent-1"), 1024)],
+/// };
+/// assert_eq!(usage.total_bytes, 1024);
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct WorktreeDiskUsage {
+    /// Sum of logical file sizes across every worktree under `root`.
+    pub total_bytes: u64,
+    /// Per-worktree logical size, in the same order `reconcile()` + `list()`
+    /// returned them.
+    pub per_worktree: Vec<(PathBuf, u64)>,
+}
+
+/// Result of one reconcile-and-quota sweep, as returned by
+/// [`WorktreeManager::sweep`][crate::WorktreeManager::sweep].
+///
+/// Carries enough information for a caller to decide whether to surface a status
+/// indicator: [`QuotaStatus::is_over_quota`] is `true` when either the count or
+/// disk-usage threshold configured in `WorktreeConfig` was exceeded at sweep time.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_worktree::QuotaStatus;
+///
+/// let status = QuotaStatus {
+///     count: 3,
+///     max_worktrees: Some(5),
+///     total_bytes: 1_000_000,
+///     disk_quota_bytes: None,
+///     reclaimed: 0,
+///     over_count: false,
+///     over_disk: false,
+/// };
+/// assert!(!status.is_over_quota());
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct QuotaStatus {
+    /// Number of git-registered secondary worktrees under `root` after reclamation.
+    pub count: usize,
+    /// The configured `worktree.max_worktrees` limit, if set.
+    pub max_worktrees: Option<usize>,
+    /// Total logical disk usage across all worktrees, in bytes, after reclamation.
+    ///
+    /// `0` when disk accounting was not performed for this sweep (see
+    /// [`WorktreeManager::sweep`][crate::WorktreeManager::sweep]'s use of
+    /// `config.disk_quota_mb` to decide whether to walk) — callers must check
+    /// `disk_quota_bytes.is_some()` before treating `0` as a meaningful "no usage" result.
+    pub total_bytes: u64,
+    /// The configured `worktree.disk_quota_mb` limit converted to bytes, if set.
+    pub disk_quota_bytes: Option<u64>,
+    /// Number of `prunable` entries automatically removed during this sweep.
+    pub reclaimed: usize,
+    /// `true` when `count >= max_worktrees` (only meaningful if `max_worktrees` is `Some`).
+    pub over_count: bool,
+    /// `true` when `total_bytes >= disk_quota_bytes` (only meaningful if
+    /// `disk_quota_bytes` is `Some`).
+    pub over_disk: bool,
+}
+
+impl QuotaStatus {
+    /// `true` if either the worktree-count or disk-usage threshold was exceeded.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_worktree::QuotaStatus;
+    ///
+    /// let status = QuotaStatus {
+    ///     over_count: true,
+    ///     ..Default::default()
+    /// };
+    /// assert!(status.is_over_quota());
+    /// ```
+    #[must_use]
+    pub fn is_over_quota(&self) -> bool {
+        self.over_count || self.over_disk
+    }
+}
+
+/// Formats a one-line disk-usage-and-quota summary, shared by the CLI's
+/// `zeph worktree list` (`src/commands/worktree.rs`) and the agent-side `/worktree list`
+/// slash command (`crates/zeph-core/src/agent/worktree_commands.rs`) so the two surfaces
+/// cannot silently diverge in how they report quota status.
+///
+/// `count` is the total number of git-registered secondary worktrees under `root`
+/// (active + stale), matching the same count [`WorktreeManager::create`][crate::WorktreeManager::create]
+/// and [`WorktreeManager::sweep`][crate::WorktreeManager::sweep] use for admission and
+/// quota evaluation.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_config::WorktreeConfig;
+/// use zeph_worktree::{WorktreeDiskUsage, format_usage_summary};
+///
+/// let usage = WorktreeDiskUsage { total_bytes: 2 * 1_048_576, per_worktree: Vec::new() };
+/// let config = WorktreeConfig { max_worktrees: Some(5), disk_quota_mb: Some(1), ..Default::default() };
+/// let summary = format_usage_summary(&usage, 2, &config);
+/// assert!(summary.contains("OVER"), "got: {summary}");
+/// ```
+#[must_use]
+pub fn format_usage_summary(
+    usage: &WorktreeDiskUsage,
+    count: usize,
+    config: &WorktreeConfig,
+) -> String {
+    let used_mb = usage.total_bytes / 1_048_576;
+    let mut line = format!("{count} worktree(s), {used_mb} MB");
+
+    if let Some(max) = config.max_worktrees {
+        let status = if count >= max { "OVER" } else { "ok" };
+        let _ = write!(line, ", max_worktrees: {count}/{max} [{status}]");
+    }
+    if let Some(quota_mb) = config.disk_quota_mb {
+        let status = if used_mb >= quota_mb { "OVER" } else { "ok" };
+        let _ = write!(line, ", disk_quota_mb: {used_mb}/{quota_mb} [{status}]");
+    }
+
+    line
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_over_quota_true_when_over_count() {
+        let status = QuotaStatus {
+            over_count: true,
+            ..Default::default()
+        };
+        assert!(status.is_over_quota());
+    }
+
+    #[test]
+    fn is_over_quota_true_when_over_disk() {
+        let status = QuotaStatus {
+            over_disk: true,
+            ..Default::default()
+        };
+        assert!(status.is_over_quota());
+    }
+
+    #[test]
+    fn is_over_quota_false_when_neither() {
+        assert!(!QuotaStatus::default().is_over_quota());
+    }
+
+    #[test]
+    fn format_usage_summary_no_quota_configured() {
+        let usage = WorktreeDiskUsage {
+            total_bytes: 5 * 1_048_576,
+            per_worktree: Vec::new(),
+        };
+        let summary = format_usage_summary(&usage, 3, &WorktreeConfig::default());
+        assert_eq!(summary, "3 worktree(s), 5 MB");
+    }
+
+    #[test]
+    fn format_usage_summary_reports_ok_under_thresholds() {
+        let usage = WorktreeDiskUsage {
+            total_bytes: 1_048_576,
+            per_worktree: Vec::new(),
+        };
+        let config = WorktreeConfig {
+            max_worktrees: Some(5),
+            disk_quota_mb: Some(10),
+            ..Default::default()
+        };
+        let summary = format_usage_summary(&usage, 1, &config);
+        assert!(
+            summary.contains("max_worktrees: 1/5 [ok]"),
+            "got: {summary}"
+        );
+        assert!(
+            summary.contains("disk_quota_mb: 1/10 [ok]"),
+            "got: {summary}"
+        );
+        assert!(!summary.contains("OVER"), "got: {summary}");
+    }
+
+    #[test]
+    fn format_usage_summary_reports_over_at_thresholds() {
+        let usage = WorktreeDiskUsage {
+            total_bytes: 10 * 1_048_576,
+            per_worktree: Vec::new(),
+        };
+        let config = WorktreeConfig {
+            max_worktrees: Some(2),
+            disk_quota_mb: Some(10),
+            ..Default::default()
+        };
+        let summary = format_usage_summary(&usage, 2, &config);
+        assert!(
+            summary.contains("max_worktrees: 2/2 [OVER]"),
+            "got: {summary}"
+        );
+        assert!(
+            summary.contains("disk_quota_mb: 10/10 [OVER]"),
+            "got: {summary}"
+        );
+    }
+}

--- a/specs/063-worktree-subsystem/spec.md
+++ b/specs/063-worktree-subsystem/spec.md
@@ -90,6 +90,19 @@ verdict (the worktree's directory or `.git` gitdir-link is gone/broken) and is t
 to force-remove on by default. `zeph worktree clean` MUST skip and warn on any stale entry that is
 not `prunable`, unless the operator explicitly passes `--force` (#6055).
 
+**INV-6 — Automatic reclamation (startup sweep + periodic task) MUST remove only worktrees
+where `StaleWorktree::is_safe_to_force_remove()` is true.**  
+`WorktreeManager::sweep()` — invoked at bootstrap when `reconcile_on_startup = true` (default)
+and, when `auto_reconcile_secs > 0`, on that interval via a supervised `TaskSupervisor` task —
+MUST NOT force-remove an intact worktree even when the sweep finds the count or disk-usage
+threshold (`max_worktrees` / `disk_quota_mb`) exceeded. `sweep()` reuses the exact
+`clean(force=false, ..)` pipeline INV-5 governs, so this invariant is a direct consequence of
+INV-5 applied to the automatic path, not a separate removal mechanism (#5924). An over-quota
+state with only intact (non-`prunable`) worktrees present MUST surface a warning status
+indicator — never a deletion. `max_worktrees` is instead enforced as a creation-time admission
+cap (`WorktreeError::QuotaExceeded`) that blocks new spawns rather than evicting existing
+worktrees.
+
 ---
 
 ## NEVER
@@ -104,6 +117,9 @@ not `prunable`, unless the operator explicitly passes `--force` (#6055).
 - **NEVER** skip the capability probe when `worktree.enabled = true`; a missing `git` must be caught at bootstrap, not at first spawn.
 - **NEVER** allow `git_timeout_secs = 0`; the value is clamped to `max(1, configured_value)` in `DefaultGitRunner`.
 - **NEVER** force-remove a `reconcile()`-discovered worktree whose directory is intact and not reported `prunable` by git without an explicit operator `--force` (INV-5, #6055).
+- **NEVER** let the automatic startup or periodic reconcile sweep force-remove an intact (non-`prunable`) worktree to satisfy `max_worktrees`/`disk_quota_mb` — over-quota-with-only-intact-worktrees is a warning, never a deletion (INV-6, #5924).
+- **NEVER** perform the `disk_usage()` filesystem walk synchronously on the `create()` hot path; it MUST run off the async executor (`spawn_blocking`) and only from a deliberate trigger (sweep tick, explicit CLI call) (#5924).
+- **NEVER** spawn the periodic reconcile task via raw `tokio::spawn`; it MUST go through `TaskSupervisor::spawn` (spec-039 binding, #5924).
 
 ---
 
@@ -119,7 +135,21 @@ branch_prefix = "agent/"           # branch = "{prefix}{subagent_id}"
 prune_branch_on_remove = false     # delete the branch after removing the worktree
 cleanup_on_completion = true       # remove worktree when agent completes or is cancelled
 git_timeout_secs = 30              # per-git-invocation timeout; clamped to ≥ 1 (#4784)
+# max_worktrees = 10               # cap on concurrent worktrees under root; unset = unlimited (#5924)
+# disk_quota_mb = 5120             # soft total-disk-usage threshold (MB); unset = no accounting (#5924)
+auto_reconcile_secs = 0            # periodic reconcile+quota sweep interval; 0 = disabled (#5924)
+reconcile_on_startup = true        # run one reconcile+quota sweep at bootstrap (#5924)
 ```
+
+`Config::validate` rejects three additional self-contradictory combinations at config-validation
+time (not runtime), so the misconfiguration is caught at load rather than silently doing nothing:
+- `max_worktrees = Some(0)` — would block all worktree creation.
+- `disk_quota_mb = Some(0)` — would leave every non-empty worktree permanently over quota.
+- `disk_quota_mb.is_some() && auto_reconcile_secs == 0 && !reconcile_on_startup` — the quota would
+  be evaluated nowhere automatically (no startup sweep, no periodic sweep); a manual
+  `zeph worktree list` still shows it, but the headline knob has no automatic effect.
+- `1 <= auto_reconcile_secs < 60` — a short interval runs a full filesystem walk in a tight loop;
+  must be `0` (disabled) or `>= 60`. The `--init` wizard applies the same floor to its prompt.
 
 Per-agent opt-in in subagent definition frontmatter:
 ```yaml
@@ -155,8 +185,17 @@ impl WorktreeManager {
     pub async fn remove(&self, handle: &WorktreeHandle, prune_branch: bool) -> Result<(), WorktreeError>;
     pub fn list(&self) -> &[WorktreeHandle];           // live-session in-RAM only
     pub async fn reconcile(&self) -> Result<Vec<StaleWorktree>, WorktreeError>; // reads git registry
+    // #5924 — disk-quota + auto-reconcile:
+    pub async fn disk_usage(&self) -> Result<WorktreeDiskUsage, WorktreeError>; // spawn_blocking FS walk
+    pub fn cached_disk_usage(&self) -> Option<WorktreeDiskUsage>;               // no FS walk
+    pub async fn sweep(&self) -> Result<QuotaStatus, WorktreeError>;            // reconcile + prunable-only reclaim + quota check
 }
 ```
+
+`create()` additionally enforces the `max_worktrees` admission cap (see INV-6) before issuing any
+`git` call: when the git-registered secondary worktree count (`reconcile().len() + list().len()`)
+is already `>= max_worktrees`, `create()` fails with `WorktreeError::QuotaExceeded` instead of
+proceeding. This is a best-effort soft cap — not atomic across concurrently running zeph sessions.
 
 ### `WorktreeError` Variants
 
@@ -169,6 +208,7 @@ pub enum WorktreeError {
     InvalidBranchName(String),
     RootOutsideRepo(PathBuf),
     Io(#[from] std::io::Error),
+    QuotaExceeded { current: usize, max: usize },  // #5924 — max_worktrees admission cap reached
 }
 ```
 
@@ -303,6 +343,10 @@ New file `crates/zeph-config/src/worktree.rs`:
 - `WorktreeConfig` struct with `#[serde(default)]` on all fields
 - `WorktreeBaseRef` enum: `#[non_exhaustive]`, `#[default] Head`, serde `rename_all = "snake_case"`
 - Add `pub worktree: WorktreeConfig` to root config struct (alongside `agents: SubAgentConfig`)
+- `max_worktrees: Option<usize>`, `disk_quota_mb: Option<u64>`, `auto_reconcile_secs: u64`,
+  `reconcile_on_startup: bool` (#5924) — `Config::validate` rejects `Some(0)` for the first two
+- `crates/zeph-config/src/migrate/infra.rs`: `migrate_worktree_quota_fields` (step 83) surfaces
+  the four new fields as commented advisory text on an existing active `[worktree]` table
 
 ### `zeph-subagent`
 
@@ -310,33 +354,50 @@ New file `crates/zeph-config/src/worktree.rs`:
 - `SubAgentManager` gains `Option<Arc<WorktreeManager>>` (set at bootstrap when enabled)
 - `spawn` path: if `worktree_manager.is_some()` AND `def.permissions.worktree` → acquire `CwdGuard`, create worktree, set cwd, build system prompt using worktree path, run agent, restore on teardown
 - `build_filtered_executor`: when `def.permissions.worktree`, append `"set_working_directory"` to `disallowed_tools`
+- `manager/spawn.rs`'s `wm.create(&task_id).await.map_err(|e| SubAgentError::WorktreeSetup(e.to_string()))?`
+  is the INV-4 hard-fail path; `WorktreeError::QuotaExceeded`'s `Display` message reaches the
+  user through this conversion like every other `WorktreeError` variant already does (#5924)
 
 ### Binary Bootstrap
 
 - Construct `WorktreeManager` during agent setup from `config.worktree` + detected repo root
 - Run capability probe when `worktree.enabled = true`
 - Inject `WorktreeManager` into `SubAgentManager`
+- Call `agent_setup::spawn_worktree_reconcile` immediately after injection (#5924): runs the
+  startup sweep inline (if `reconcile_on_startup`) and registers the periodic sweep task via
+  `TaskSupervisor` (if `auto_reconcile_secs > 0`). `src/runner.rs` is currently the only
+  construction site for the worktree manager; any future ACP/daemon/serve worktree wiring calls
+  the same helper rather than duplicating the sequencing
 
 ### CLI
 
 - Add `WorktreeCommand { List, Clean }` under `zeph worktree` (or extend `zeph agents`)
 - `--worktree-base-ref <fresh|head>` session override flag
+- `zeph worktree list` additionally prints a `format_usage_summary` footer line (worktree count,
+  total MB, `max_worktrees`/`disk_quota_mb` status) computed via a fresh `disk_usage()` call
+  (#5924)
 
-### `--init` Wizard (#4656, #4847)
+### `--init` Wizard (#4656, #4847, #5924)
 
 `step_worktree()` is added to the interactive configuration wizard. The step asks the user:
 1. Whether to enable worktree isolation (`worktree.enabled`)
 2. Which background isolation mode to use (`bg_isolation: None | Worktree`) — deferred child-process isolation knob
 3. Which base ref to use (`base_ref: head | fresh`)
+4. Maximum concurrent worktrees (blank = unlimited)
+5. Disk quota across all worktrees in MB (blank = no accounting)
+6. Periodic reconcile+quota sweep interval in seconds (`0` = disabled)
 
 `build_config()` maps the wizard state to `WorktreeConfig`. The `[worktree]` section is emitted
-only when the user opts in (`enabled = true`). Two unit tests cover the disabled-default path
-and the enabled+None+Fresh path.
+only when the user opts in (`enabled = true`). Unit tests cover the disabled-default path, the
+enabled+None+Fresh path, and the enabled-with-quota-fields path.
 
 ### TUI
 
 - Command palette: `/worktree list`, `/worktree clean`
 - Status spinner during worktree create/remove: "Creating worktree for {agent_id}…"
+- Sweep status line surfaced through the same status channel the memory-maintenance loops use,
+  gated to fire only when a sweep actually reclaimed a worktree or found a breached quota — a
+  clean sweep is silent (#5924)
 
 ---
 
@@ -351,6 +412,7 @@ and the enabled+None+Fresh path.
 | Root outside repo | `RootOutsideRepo` | "Worktree root resolves outside the repository: {path}" |
 | Worktree path exists | `PathExists` | "Worktree path already exists: {path}" |
 | `git` not on PATH or too old | Detected in probe | "git ≥ 2.5 is required; found: {version}" |
+| `max_worktrees` reached | `QuotaExceeded` | "Worktree limit reached ({current}/{max}); run `zeph worktree clean` or raise `worktree.max_worktrees`" |
 
 ---
 
@@ -380,3 +442,9 @@ See `.local/testing/playbooks/worktree.md` for concrete scenarios:
 - Cancellation mid-run (expect cwd restored, worktree removed)
 - Crash simulation (worktree clean reconciles stale entries)
 - Concurrent plain agent during active worktree agent (expect serialisation)
+
+See `.local/testing/playbooks/worktree-disk-quota.md` (#5924) for the disk-quota +
+auto-reconcile scenarios: admission rejection at `max_worktrees`, `disk_quota_mb` evaluated on
+the startup sweep even with the periodic task disabled, prunable-only startup reclaim, the
+periodic `TaskSupervisor` task, status-indicator firing/silence, and config migration of
+existing `[worktree]` tables.

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -2711,6 +2711,138 @@ pub(crate) fn spawn_memory_maintenance_loops(
     }
 }
 
+/// Runs the optional startup reconcile-and-quota sweep and, when enabled, registers the
+/// periodic reconcile task through `TaskSupervisor` (#5924). This is the single wiring
+/// seam for the `zeph-worktree` disk-quota + auto-reconcile feature: `src/runner.rs` is
+/// currently the only construction site for the worktree manager (`acp.rs`, `daemon.rs`,
+/// and `serve/` have no worktree references today), so calling this helper right after
+/// `SubAgentManager::set_worktree_manager` keeps a future ACP/daemon/serve wiring a
+/// one-line addition rather than a fourth near-identical copy — the "wire-X-into-
+/// acp/serve/daemon" defect class this project has hit 19+ times (see
+/// `.claude/rules/continuous-improvement.md`).
+///
+/// The startup sweep (`cfg.reconcile_on_startup`, default `true`) is awaited inline so a
+/// crash-recovered reclaim or a breached quota is visible before the caller proceeds —
+/// mirroring `probe_capabilities`/`WorktreeManager::new`, which are already awaited at
+/// this point in `runner.rs`. It only ever removes worktrees git itself reports as
+/// `prunable` (spec-063 INV-5/INV-6), so it is safe to run unconditionally at every
+/// launch.
+///
+/// The periodic task (`cfg.auto_reconcile_secs > 0`) is registered under the
+/// `worktree_reconcile` name with `RestartPolicy::Restart { max: 5, base_delay: 30s }` so
+/// a transient git failure inside one tick does not permanently kill the loop.
+///
+/// `status_tx`, when `Some`, receives a short status line **only** when a sweep actually
+/// reclaims a worktree or detects a breached quota — a clean sweep stays silent, per the
+/// TUI Rule against surfacing noise on every clean launch (critic gap M7).
+pub(crate) async fn spawn_worktree_reconcile(
+    wm: &Arc<zeph_worktree::DefaultWorktreeManager>,
+    cfg: &zeph_config::WorktreeConfig,
+    supervisor: &zeph_common::TaskSupervisor,
+    status_tx: Option<&tokio::sync::mpsc::UnboundedSender<String>>,
+) {
+    if cfg.reconcile_on_startup {
+        run_worktree_sweep(wm, status_tx, "startup").await;
+    }
+
+    if cfg.auto_reconcile_secs > 0 {
+        let wm = Arc::clone(wm);
+        let interval_secs = cfg.auto_reconcile_secs;
+        let status_tx = status_tx.cloned();
+        let cancel = supervisor.cancellation_token();
+        supervisor.spawn(zeph_common::TaskDescriptor {
+            name: "worktree_reconcile",
+            restart: zeph_common::RestartPolicy::Restart {
+                max: 5,
+                base_delay: std::time::Duration::from_secs(30),
+            },
+            factory: move || {
+                worktree_reconcile_loop(
+                    Arc::clone(&wm),
+                    interval_secs,
+                    status_tx.clone(),
+                    cancel.clone(),
+                )
+            },
+        });
+    }
+}
+
+/// Periodic reconcile-and-quota sweep loop, supervised via [`spawn_worktree_reconcile`].
+///
+/// Skips the immediate first tick — the startup sweep (if enabled) already covered
+/// launch-time recovery; the periodic task's job is the *next* `interval_secs` boundary.
+async fn worktree_reconcile_loop(
+    wm: Arc<zeph_worktree::DefaultWorktreeManager>,
+    interval_secs: u64,
+    status_tx: Option<tokio::sync::mpsc::UnboundedSender<String>>,
+    cancel: tokio_util::sync::CancellationToken,
+) {
+    let mut ticker = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
+    ticker.tick().await;
+
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => {
+                tracing::debug!("worktree reconcile loop shutting down");
+                return;
+            }
+            _ = ticker.tick() => {}
+        }
+        run_worktree_sweep(&wm, status_tx.as_ref(), "periodic").await;
+    }
+}
+
+/// Runs one [`WorktreeManager::sweep`][zeph_worktree::WorktreeManager::sweep] pass and
+/// surfaces a status line only when something was actually reclaimed or a quota is
+/// actually breached (critic gap M7) — a clean sweep logs at `debug` only.
+async fn run_worktree_sweep(
+    wm: &zeph_worktree::DefaultWorktreeManager,
+    status_tx: Option<&tokio::sync::mpsc::UnboundedSender<String>>,
+    trigger: &str,
+) {
+    match wm.sweep().await {
+        Ok(status) if status.reclaimed > 0 || status.is_over_quota() => {
+            let msg = format_quota_status_message(&status);
+            tracing::warn!(trigger, %msg, "worktree sweep: action needed");
+            if let Some(tx) = status_tx {
+                let _ = tx.send(msg);
+            }
+        }
+        Ok(_) => {
+            tracing::debug!(trigger, "worktree sweep: clean, nothing to report");
+        }
+        Err(e) => {
+            tracing::warn!(trigger, error = %e, "worktree sweep failed");
+        }
+    }
+}
+
+/// Formats a [`zeph_worktree::QuotaStatus`] into the one-line status message shown to the
+/// user (TUI status channel and CLI/log warning).
+fn format_quota_status_message(status: &zeph_worktree::QuotaStatus) -> String {
+    let mut parts = Vec::new();
+    if status.reclaimed > 0 {
+        parts.push(format!("reclaimed {} stale worktree(s)", status.reclaimed));
+    }
+    if status.over_count {
+        parts.push(format!(
+            "count over quota ({}/{})",
+            status.count,
+            status.max_worktrees.unwrap_or_default()
+        ));
+    }
+    if status.over_disk {
+        let used_mb = status.total_bytes / 1_048_576;
+        let quota_mb = status.disk_quota_bytes.unwrap_or_default() / 1_048_576;
+        parts.push(format!("disk usage over quota ({used_mb}MB/{quota_mb}MB)"));
+    }
+    format!(
+        "Worktrees: {} — run `zeph worktree clean`",
+        parts.join(", ")
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;

--- a/src/commands/worktree.rs
+++ b/src/commands/worktree.rs
@@ -69,6 +69,12 @@ pub(crate) async fn handle_worktree_command(
                         }
                     }
                 }
+                let count = active.len() + stale.len();
+                let usage = wm.disk_usage().await?;
+                println!(
+                    "\n{}",
+                    zeph_worktree::format_usage_summary(&usage, count, &config.worktree)
+                );
             }
         }
         WorktreeCommand::Clean { force } => {

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -290,6 +290,13 @@ pub(crate) struct WizardState {
     pub(crate) worktree_enabled: bool,
     pub(crate) worktree_bg_isolation: BgIsolation,
     pub(crate) worktree_base_ref: WorktreeBaseRef,
+    // Worktree disk-quota + auto-reconcile (#5924)
+    /// `None` = unlimited concurrent worktrees.
+    pub(crate) worktree_max_worktrees: Option<usize>,
+    /// `None` = no disk-usage accounting.
+    pub(crate) worktree_disk_quota_mb: Option<u64>,
+    /// `0` = periodic reconcile sweep disabled.
+    pub(crate) worktree_auto_reconcile_secs: u64,
     // Durable execution layer (spec-064, #4949)
     /// The durable section as configured by the wizard (the AEAD key is stored separately in the
     /// vault, never inline).
@@ -518,6 +525,9 @@ impl Default for WizardState {
             worktree_enabled: false,
             worktree_bg_isolation: BgIsolation::Worktree,
             worktree_base_ref: WorktreeBaseRef::Head,
+            worktree_max_worktrees: None,
+            worktree_disk_quota_mb: None,
+            worktree_auto_reconcile_secs: 0,
             durable: zeph_core::config::DurableConfig::default(),
             durable_key_b64: None,
             caveman_default_on: false,
@@ -1050,6 +1060,10 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
         config.worktree.enabled = true;
         config.worktree.bg_isolation = state.worktree_bg_isolation;
         config.worktree.base_ref = state.worktree_base_ref.clone();
+        // Worktree disk-quota + auto-reconcile (#5924)
+        config.worktree.max_worktrees = state.worktree_max_worktrees;
+        config.worktree.disk_quota_mb = state.worktree_disk_quota_mb;
+        config.worktree.auto_reconcile_secs = state.worktree_auto_reconcile_secs;
     }
 
     // Durable execution layer (spec-064, #4949). The AEAD key lives only in the vault.
@@ -3266,6 +3280,32 @@ mod tests {
         assert!(config.worktree.enabled);
         assert_eq!(config.worktree.bg_isolation, BgIsolation::None);
         assert!(matches!(config.worktree.base_ref, WorktreeBaseRef::Fresh));
+    }
+
+    /// Regression test for #5924: disabled state leaves the quota fields at their
+    /// `WorktreeConfig::default()` values (unlimited / no accounting / sweep off).
+    #[test]
+    fn build_config_worktree_disabled_leaves_quota_fields_default() {
+        let state = WizardState::default();
+        let config = build_config(&state);
+        assert_eq!(config.worktree.max_worktrees, None);
+        assert_eq!(config.worktree.disk_quota_mb, None);
+        assert_eq!(config.worktree.auto_reconcile_secs, 0);
+    }
+
+    #[test]
+    fn build_config_worktree_enabled_with_quota_fields() {
+        let state = WizardState {
+            worktree_enabled: true,
+            worktree_max_worktrees: Some(5),
+            worktree_disk_quota_mb: Some(2048),
+            worktree_auto_reconcile_secs: 3600,
+            ..WizardState::default()
+        };
+        let config = build_config(&state);
+        assert_eq!(config.worktree.max_worktrees, Some(5));
+        assert_eq!(config.worktree.disk_quota_mb, Some(2048));
+        assert_eq!(config.worktree.auto_reconcile_secs, 3600);
     }
 
     // ── #4981: api_key_env_var sanitization edge cases ──────────────────────

--- a/src/init/worktree.rs
+++ b/src/init/worktree.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use dialoguer::{Confirm, Select};
+use dialoguer::{Confirm, Input, Select};
 use zeph_config::{BgIsolation, WorktreeBaseRef};
 
 use super::WizardState;
@@ -66,6 +66,98 @@ pub(super) fn step_worktree(state: &mut WizardState) -> anyhow::Result<()> {
         _ => BgIsolation::Worktree,
     };
 
+    println!(
+        "\n-- Worktree disk quota + auto-reconcile (#5924) --\n\
+         Cap concurrent worktrees and/or total disk usage, and optionally run a periodic \
+         reconcile sweep that reclaims worktrees git itself reports as abandoned. Leave a \
+         field blank to disable that particular cap.\n"
+    );
+
+    let max_worktrees_raw: String = Input::new()
+        .with_prompt("Maximum concurrent worktrees (blank = unlimited)")
+        .allow_empty(true)
+        .validate_with(|s: &String| -> Result<(), String> {
+            parse_optional_nonzero::<usize>(s).map(|_| ())
+        })
+        .interact_text()?;
+    state.worktree_max_worktrees =
+        parse_optional_nonzero(&max_worktrees_raw).map_err(|e| anyhow::anyhow!(e))?;
+
+    let disk_quota_raw: String = Input::new()
+        .with_prompt("Disk quota across all worktrees, in MB (blank = no accounting)")
+        .allow_empty(true)
+        .validate_with(|s: &String| -> Result<(), String> {
+            parse_optional_nonzero::<u64>(s).map(|_| ())
+        })
+        .interact_text()?;
+    state.worktree_disk_quota_mb =
+        parse_optional_nonzero(&disk_quota_raw).map_err(|e| anyhow::anyhow!(e))?;
+
+    state.worktree_auto_reconcile_secs = Input::new()
+        .with_prompt("Periodic reconcile+quota sweep interval, in seconds (0 = disabled, or >= 60)")
+        .default(0_u64)
+        .validate_with(|v: &u64| -> Result<(), String> {
+            if (1..60).contains(v) {
+                Err(
+                    "must be 0 (disabled) or >= 60 — a short interval runs a full filesystem \
+                     walk in a tight loop"
+                        .to_owned(),
+                )
+            } else {
+                Ok(())
+            }
+        })
+        .interact_text()?;
+
     println!();
     Ok(())
+}
+
+/// Parses an optional positive integer field: blank input means "unset" (`None`); a `0`
+/// is rejected (matches `Config::validate`'s rejection of `Some(0)` for `max_worktrees`/
+/// `disk_quota_mb` — see `crates/zeph-config/src/loader.rs`) so the wizard cannot emit a
+/// self-contradictory config.
+fn parse_optional_nonzero<T>(input: &str) -> Result<Option<T>, String>
+where
+    T: std::str::FromStr + PartialEq + Default,
+{
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let value: T = trimmed
+        .parse()
+        .map_err(|_| format!("'{trimmed}' is not a valid positive integer"))?;
+    if value == T::default() {
+        return Err("must be > 0, or blank for unlimited/no accounting".to_owned());
+    }
+    Ok(Some(value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_optional_nonzero_blank_is_none() {
+        assert_eq!(parse_optional_nonzero::<usize>(""), Ok(None));
+        assert_eq!(parse_optional_nonzero::<usize>("   "), Ok(None));
+    }
+
+    #[test]
+    fn parse_optional_nonzero_positive_value_ok() {
+        assert_eq!(parse_optional_nonzero::<usize>("5"), Ok(Some(5)));
+        assert_eq!(parse_optional_nonzero::<u64>("2048"), Ok(Some(2048)));
+    }
+
+    #[test]
+    fn parse_optional_nonzero_rejects_zero() {
+        assert!(parse_optional_nonzero::<usize>("0").is_err());
+        assert!(parse_optional_nonzero::<u64>("0").is_err());
+    }
+
+    #[test]
+    fn parse_optional_nonzero_rejects_non_numeric() {
+        assert!(parse_optional_nonzero::<usize>("abc").is_err());
+    }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -3090,8 +3090,19 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
             )
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?;
-            mgr.set_worktree_manager(std::sync::Arc::new(wm));
+            let wm = std::sync::Arc::new(wm);
+            mgr.set_worktree_manager(std::sync::Arc::clone(&wm));
             tracing::info!("worktree subsystem initialised");
+            // #5924: startup reconcile-and-quota sweep + optional periodic sweep, via the
+            // shared `agent_setup::spawn_worktree_reconcile` helper (also the wiring seam
+            // for any future ACP/daemon/serve worktree support).
+            crate::agent_setup::spawn_worktree_reconcile(
+                &wm,
+                &agents_config.worktree,
+                &supervisor,
+                Some(&agent_status_tx),
+            )
+            .await;
         }
 
         let agent = agent.with_orchestration(config.orchestration.clone(), agents_config, mgr);


### PR DESCRIPTION
## Summary

- Adds 4 new `WorktreeConfig` fields: `max_worktrees`, `disk_quota_mb`, `auto_reconcile_secs`, `reconcile_on_startup`
- Automatic reclamation is prunable-only (spec-063 INV-5/INV-6) — never force-removes an intact worktree, since that could destroy another concurrent session's uncommitted work
- `create()` enforces a soft admission cap via a new `QuotaExceeded` error when `max_worktrees` is set
- Disk usage accounting runs off the hot path via `spawn_blocking`, surfaced consistently in both the CLI (`zeph worktree list`) and the agent-side `/worktree list` command
- Periodic reconciliation runs through `TaskSupervisor::spawn` (never a raw `tokio::spawn`); a startup sweep runs by default
- Config validation rejects combinations that would leave `disk_quota_mb` silently inert, and rejects an `auto_reconcile_secs` floor below 60s to avoid runaway FS-walk frequency
- `--init` wizard prompts and a `--migrate-config` step added for the new fields
- `specs/063-worktree-subsystem/spec.md` updated with the new INV-6 invariant

Closes #5924

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (13336 passed / 0 failed / 35 skipped)
- [x] `cargo test --doc` (54 new doc-tests pass)
- [x] rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace ...`)
- [x] `gitleaks protect --staged`
- [x] Unit tests cover: quota validation boundaries, admission cap, prunable-only reclaim (incl. a real-git integration test proving an intact worktree with uncommitted changes is never force-removed), config migration, `--init` wizard
- [ ] Live-session verification of the `TaskSupervisor` periodic tick and the `QuotaExceeded`-on-subagent-spawn error path — tracked in `.local/testing/playbooks/worktree-disk-quota.md` and `.local/testing/coverage-status.md` (both `Untested`, next CI cycle)