### PR TITLE
build(deps): bump rmcp to 2.2.0 to resolve Cargo.lock drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Dependencies**: `Cargo.lock` had drifted — `rmcp` was pinned to `2.0.0` while crates.io's
+  latest release within the existing `^2.0.0` manifest range (`Cargo.toml` unchanged) had moved to
+  `2.2.0`. Updated the lockfile to `rmcp 2.2.0` / `rmcp-macros 2.2.0`; `sse-stream` also bumped to
+  `0.2.4` (required — rmcp 2.2.0's `transport-streamable-http-client-reqwest` feature path calls
+  `SseStream::from_bytes_stream`, added in `sse-stream` 0.2.4, which is not present in 0.2.3;
+  rmcp's own manifest constraint of `sse-stream = "0.2"` under-specifies this, so a plain
+  `cargo update -p rmcp` alone resolves to a broken combination — tracked upstream separately).
+  Picks up rmcp's 2.1.0/2.2.0 fixes: reject auth servers lacking S256 PKCE support (2.2.0, #955),
+  block redirect header leaks (2.1.0, #936), make `AsyncRwTransport::receive` cancel-safe
+  (#941/#947), fail orphaned streamable HTTP responses on reinit (#914), and negotiate protocol
+  version in the handler (#930). No source changes required in `crates/zeph-mcp` (#5897).
 - **Docs**: `specs/010-security/spec.md` and `specs/014-a2a/spec.md` described two different IBCT
   (Invocation-Bound Capability Token) wire formats, and neither fully matched the actual
   implementation in `crates/zeph-a2a/src/ibct.rs`. Reconciled both specs against `ibct.rs` and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
  "x11rb",
 ]
 
@@ -1327,7 +1327,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2144,7 +2144,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2436,7 +2436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3651,7 +3651,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4781,7 +4781,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4911,7 +4911,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.17",
  "http",
@@ -6132,7 +6132,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6170,9 +6170,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6718,9 +6718,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52d21e5b342699bc4de690e6104fc4e43255e4e8420ff0f2cbb963aac09da6f"
+checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6747,9 +6747,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c68cec74c5b3ac73ff46375ae49e161637bda80bba70f0d5db641583bb308ee"
+checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -6872,7 +6872,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6940,7 +6940,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7884,9 +7884,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+checksum = "39f24a9b78c40b90817bbcd1821c74ddfd74916aadd29403d001532a9195532d"
 dependencies = [
  "bytes",
  "futures-util",
@@ -8356,7 +8356,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9956,7 +9956,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `Cargo.lock` had drifted: `rmcp` was pinned to `2.0.0` while the existing `^2.0.0` manifest range in `Cargo.toml` already permitted `2.2.0`. Updated the lockfile only — `Cargo.toml` unchanged.
- Also bumps `sse-stream` 0.2.3 -> 0.2.4, which is required: rmcp 2.2.0's `transport-streamable-http-client-reqwest` feature path calls `SseStream::from_bytes_stream`, added in `sse-stream` 0.2.4. rmcp's own manifest under-specifies this dependency as `sse-stream = "0.2"`, so a plain `cargo update -p rmcp` alone resolves to the broken 0.2.3 combination. Will file a follow-up issue upstream against `modelcontextprotocol/rust-sdk` to tighten that constraint.
- The rmcp/sse-stream bump also triggers a resolver-forced set of sub-dependency version changes across ~13 unrelated packages (`windows-sys`, `socket2`, `base64` inside `oauth2`) — these are downgrades to still-maintained, non-advisory versions, confirmed behaviorally inert and reproducible byte-for-byte from a clean checkout using only `cargo update -p rmcp` + `cargo update -p sse-stream`. `cargo deny check advisories` is clean (only the two pre-existing, already-tracked unmaintained-crate advisories: RUSTSEC-2026-0173, RUSTSEC-2025-0134).
- Picks up upstream security-relevant fixes: reject auth servers lacking S256 PKCE support (2.2.0, #955), block redirect header leaks (2.1.0, #936) — zeph already has independent redirect-header stripping in `crates/zeph-mcp/src/oauth.rs`, so #936 is complementary defense-in-depth. Also: cancel-safe `AsyncRwTransport::receive` (#941/#947), fail orphaned streamable HTTP responses on reinit (#914), negotiate protocol version in handler (#930).
- No zeph source changes required.

Closes #5897

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13338 passed, 0 failed, 35 skipped
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-mcp` — 536 passed, 0 failed
- [x] `cargo test --doc -p zeph-mcp` — 11 passed, 1 ignored
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo deny check advisories` — clean, only pre-existing tracked advisories
- [x] `gitleaks protect --staged` — clean