### PR TITLE
feat(session): add /cd command and --safe-mode troubleshooting flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+### Added
+
+- **CLI**: added `--safe-mode` (and `ZEPH_SAFE_MODE` environment variable) — starts a session
+  with `ZEPH.md`/`CLAUDE.md`/`AGENTS.md` project instructions, plugins, skills, hooks, and MCP
+  servers all disabled at once, so a user can quickly confirm whether one of those
+  customizations is causing a reported problem before bisecting sources manually. Distinct
+  from the existing `--bare` flag, which skips memory/tool-registry/background-task overhead
+  instead of customization sources — the two flags are independent and composable. Gated at
+  all six session entry points (CLI/TUI runner, daemon, standalone ACP, ACP-HTTP, and
+  `zeph serve-sessions` with and without `--acp`); session-scoped only, never persisted to
+  `config.toml` (#6031).
+- **Commands**: added `/cd [path]` — switch the session's primary working directory without
+  restarting, reusing the same path-resolution and post-change pipeline (`cwd_changed` hooks,
+  repo-map invalidation, CLAUDE.md/AGENTS.md re-discovery) the LLM-invoked `set_working_directory`
+  tool already uses. No argument reports the current working directory. Reachable identically
+  from CLI, TUI, and ACP. Instruction re-discovery is skipped in a `--safe-mode` session so `/cd`
+  cannot silently re-load project instructions and defeat the flag. Conversation history, active
+  goals, and skill state are preserved across the switch (#6032).
+
 ### Changed
 
 - **BREAKING**: `CommandHandler::requires_auth()` now defaults to `true` (fail-closed),

--- a/crates/zeph-commands/src/commands.rs
+++ b/crates/zeph-commands/src/commands.rs
@@ -145,6 +145,13 @@ pub const COMMANDS: &[CommandInfo] = &[
         category: SlashCategory::Session,
         feature_gate: Some("session"),
     },
+    CommandInfo {
+        name: "/cd",
+        args: "[path]",
+        description: "Change the session's working directory (no arg: show current)",
+        category: SlashCategory::Session,
+        feature_gate: None,
+    },
     // --- Configuration (model/provider) ---
     CommandInfo {
         name: "/model",

--- a/crates/zeph-commands/src/handlers/cd.rs
+++ b/crates/zeph-commands/src/handlers/cd.rs
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Working-directory switch command: `/cd`.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use crate::context::CommandContext;
+use crate::{CommandError, CommandHandler, CommandOutput, SlashCategory};
+
+/// Switch the session's primary working directory, or report the current one (#6032).
+///
+/// User-facing entry point into the same mechanism the LLM-invoked `set_working_directory`
+/// tool already uses — reachable identically from CLI, TUI, and ACP via the shared slash
+/// dispatch path. Conversation history, active goals, and skill state are preserved; only
+/// cwd-derived state (file-tool root, repo-map, and — unless `--safe-mode` is active —
+/// CLAUDE.md/AGENTS.md instructions) is affected.
+pub struct CdCommand;
+
+impl CommandHandler<CommandContext<'_>> for CdCommand {
+    fn name(&self) -> &'static str {
+        "/cd"
+    }
+
+    fn description(&self) -> &'static str {
+        "Change the session's working directory (no arg: show current)"
+    }
+
+    fn args_hint(&self) -> &'static str {
+        "[path]"
+    }
+
+    fn category(&self) -> SlashCategory {
+        SlashCategory::Session
+    }
+
+    fn requires_auth(&self) -> bool {
+        true
+    }
+
+    fn handle<'a>(
+        &'a self,
+        ctx: &'a mut CommandContext<'_>,
+        args: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<CommandOutput, CommandError>> + Send + 'a>> {
+        // No handler-level span here: `change_working_directory` already opens
+        // `core.commands.cd` per NFR-004 — a second nested `commands.cd.handle` span around
+        // this thin delegation would be redundant tracing overhead.
+        Box::pin(async move {
+            let result = ctx.agent.change_working_directory(args).await?;
+            Ok(CommandOutput::Message(result))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::handlers::test_helpers::{MockDebug, MockMessages, MockSession, make_ctx};
+    use crate::sink::NullSink;
+
+    #[test]
+    fn cd_name_and_description() {
+        assert_eq!(CdCommand.name(), "/cd");
+        assert!(!CdCommand.description().is_empty());
+    }
+
+    #[test]
+    fn cd_requires_auth() {
+        assert!(CdCommand.requires_auth());
+    }
+
+    #[tokio::test]
+    async fn cd_returns_message() {
+        let mut sink = NullSink;
+        let mut debug = MockDebug;
+        let mut messages = MockMessages;
+        let session = MockSession;
+        let mut agent = crate::NullAgent;
+        let mut ctx = make_ctx(&mut sink, &mut debug, &mut messages, &session, &mut agent);
+        // NullAgent's default change_working_directory returns an error — verifies the
+        // handler propagates it rather than swallowing it.
+        let out = CdCommand.handle(&mut ctx, "").await;
+        assert!(out.is_err());
+    }
+}

--- a/crates/zeph-commands/src/handlers/mod.rs
+++ b/crates/zeph-commands/src/handlers/mod.rs
@@ -13,6 +13,7 @@ pub mod acp;
 pub mod agent_cmd;
 pub mod agents_fleet;
 pub mod caveman;
+pub mod cd;
 pub mod checkpoint;
 #[cfg(feature = "cocoon")]
 pub mod cocoon;

--- a/crates/zeph-commands/src/traits/agent.rs
+++ b/crates/zeph-commands/src/traits/agent.rs
@@ -17,7 +17,7 @@
 //!
 //! ## Implementors
 //!
-//! `zeph-core::agent::Agent<C>` implements `AgentAccess` in `command_context_impls.rs`.
+//! `zeph-core::agent::Agent<C>` implements `AgentAccess` in `agent_access_impl.rs`.
 //!
 //! [`CommandContext`]: crate::context::CommandContext
 
@@ -643,6 +643,31 @@ pub trait AgentAccess: Send {
     ) -> Pin<Box<dyn Future<Output = Result<Option<String>, CommandError>> + Send + 'a>> {
         let _ = force;
         Box::pin(async { Ok(None) })
+    }
+
+    // ----- /cd -----
+
+    /// Change the session's primary working directory, or report the current one when
+    /// `path` is empty (#6032, FR-009).
+    ///
+    /// Reuses `zeph_tools::resolve_and_set_cwd` — the same path-resolution logic the
+    /// LLM-invoked `set_working_directory` tool uses — then runs the agent's
+    /// `check_cwd_changed` post-change pipeline (repo-map invalidation, `cwd_changed` hooks,
+    /// and — unless the session is in `--safe-mode` — CLAUDE.md/AGENTS.md instruction
+    /// re-discovery). `/cd` is an additive user-facing entry point into that existing
+    /// mechanism, not a parallel implementation.
+    ///
+    /// Returns a confirmation string with the new (or current) absolute working directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` when `path` does not resolve to an existing, readable directory.
+    fn change_working_directory<'a>(
+        &'a mut self,
+        path: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {
+        let _ = path;
+        Box::pin(async move { Err(CommandError::new("/cd is not supported in this context")) })
     }
 }
 

--- a/crates/zeph-common/src/lib.rs
+++ b/crates/zeph-common/src/lib.rs
@@ -32,6 +32,7 @@ pub mod quarantine;
 pub mod sanitize;
 pub mod secret;
 pub mod secrets;
+pub mod security;
 pub mod security_event;
 pub mod spawner;
 pub mod task_supervisor;

--- a/crates/zeph-common/src/security.rs
+++ b/crates/zeph-common/src/security.rs
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shared sandbox-boundary check for `allowed_paths`-style path validation.
+//!
+//! Extracted from the near-identical `validate_path` bodies in
+//! `zeph-tools::file::FileExecutor` and `zeph-tools::diagnostics::DiagnosticsExecutor` (#6032
+//! SEC-2) so every caller enforcing an `allowed_paths` sandbox — including
+//! `zeph-tools::cwd::resolve_and_set_cwd`, the third caller this module was extracted for —
+//! shares one canonical `starts_with`-against-allowed-roots check instead of three
+//! textually-similar-but-independently-maintained copies.
+//!
+//! Deliberately does **not** own path *resolution* strategy (tilde-expansion, relative-path
+//! joining, or symlink-tolerant canonicalization of a not-yet-existing target): callers differ
+//! legitimately there — `FileExecutor` must tolerate a nonexistent target (writing a new
+//! file), while `DiagnosticsExecutor` and `resolve_and_set_cwd` require the target to already
+//! exist. Only the final containment check — the actual security invariant — is shared.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Returns `true` if `canonical` is contained within (or equal to) at least one of
+/// `allowed_paths`.
+///
+/// `canonical` must already be canonicalized (symlinks resolved) by the caller — this
+/// function performs no filesystem access itself, so it is safe to call on a path that does
+/// not fully exist yet (e.g. `FileExecutor`'s ancestor-resolved-but-not-yet-created target).
+#[must_use]
+pub fn is_path_within(canonical: &Path, allowed_paths: &[PathBuf]) -> bool {
+    allowed_paths.iter().any(|a| canonical.starts_with(a))
+}
+
+/// Canonicalize `path` (which must already exist) and verify it falls within one of
+/// `allowed_paths`.
+///
+/// Convenience wrapper around [`is_path_within`] for the common case of a target that must
+/// already exist (e.g. a directory to `cd` into, or a file to run diagnostics against) —
+/// callers whose target may not yet exist (e.g. a new file being written) must canonicalize
+/// via their own symlink-tolerant strategy and call [`is_path_within`] directly instead.
+///
+/// # Errors
+///
+/// Returns [`io::ErrorKind::NotFound`] (via [`Path::canonicalize`]) if `path` does not exist,
+/// or [`io::ErrorKind::PermissionDenied`] if the canonicalized path falls outside every entry
+/// in `allowed_paths`.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_common::security::validate_path_within;
+///
+/// let dir = tempfile::tempdir().unwrap();
+/// // Callers canonicalize `allowed_paths` up front (as `FileExecutor::new` does) so this
+/// // comparison is not defeated by a symlinked temp root (e.g. macOS `/tmp` -> `/private/tmp`).
+/// let allowed = vec![dir.path().canonicalize().unwrap()];
+/// let result = validate_path_within(dir.path(), &allowed);
+/// assert!(result.is_ok());
+/// ```
+pub fn validate_path_within(path: &Path, allowed_paths: &[PathBuf]) -> io::Result<PathBuf> {
+    let canonical = path.canonicalize()?;
+    if !is_path_within(&canonical, allowed_paths) {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "path '{}' is outside the allowed sandbox",
+                canonical.display()
+            ),
+        ));
+    }
+    Ok(canonical)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_path_within_true_for_exact_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let allowed = vec![dir.path().to_path_buf()];
+        assert!(is_path_within(dir.path(), &allowed));
+    }
+
+    #[test]
+    fn is_path_within_true_for_nested_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let allowed = vec![dir.path().to_path_buf()];
+        let nested = dir.path().join("a").join("b");
+        assert!(is_path_within(&nested, &allowed));
+    }
+
+    #[test]
+    fn is_path_within_false_for_sibling_outside_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let sibling = tempfile::tempdir().unwrap();
+        let allowed = vec![dir.path().to_path_buf()];
+        assert!(!is_path_within(sibling.path(), &allowed));
+    }
+
+    #[test]
+    fn is_path_within_true_when_any_of_multiple_roots_matches() {
+        let dir_a = tempfile::tempdir().unwrap();
+        let dir_b = tempfile::tempdir().unwrap();
+        let allowed = vec![dir_a.path().to_path_buf(), dir_b.path().to_path_buf()];
+        assert!(is_path_within(dir_b.path(), &allowed));
+    }
+
+    #[test]
+    fn validate_path_within_ok_for_existing_path_inside_root() {
+        let dir = tempfile::tempdir().unwrap();
+        // Canonicalize the allowed root up front — mirrors `FileExecutor::new`/
+        // `DiagnosticsExecutor::new`'s real construction pattern, and avoids a false
+        // rejection on platforms where the tempdir root is itself a symlink (e.g. macOS
+        // `/tmp` -> `/private/tmp`).
+        let allowed = vec![dir.path().canonicalize().unwrap()];
+        let result = validate_path_within(dir.path(), &allowed);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_path_within_rejects_path_outside_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let allowed = vec![dir.path().canonicalize().unwrap()];
+        let result = validate_path_within(outside.path(), &allowed);
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn validate_path_within_errors_on_nonexistent_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let allowed = vec![dir.path().canonicalize().unwrap()];
+        let missing = dir.path().join("does-not-exist");
+        let result = validate_path_within(&missing, &allowed);
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+}

--- a/crates/zeph-config/src/cli.rs
+++ b/crates/zeph-config/src/cli.rs
@@ -11,9 +11,16 @@ use serde::{Deserialize, Serialize};
 /// effect on Telegram, Discord, Slack, or ACP sessions.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(default)]
+#[allow(clippy::struct_excessive_bools)] // config struct — boolean flags are idiomatic for TOML-deserialized configuration
 pub struct CliConfig {
     /// Enable bare mode (skip skills, memory, MCP, scheduler, watchers).
     pub bare: bool,
+    /// Enable safe mode (skip ZEPH.md/CLAUDE.md/AGENTS.md, plugins, skills,
+    /// hooks, and MCP servers for this session). Session-scoped only — never
+    /// persisted to `config.toml` (`#[serde(skip)]`), mirroring `--bare`'s
+    /// troubleshooting-flag precedent but gating a disjoint set of subsystems.
+    #[serde(skip)]
+    pub safe_mode: bool,
     /// Emit structured JSON events (JSONL) to stdout. Forces logs to stderr.
     pub json: bool,
     /// Auto-approve trust-gate prompts (`-y` / `--auto`).

--- a/crates/zeph-config/src/env.rs
+++ b/crates/zeph-config/src/env.rs
@@ -115,6 +115,11 @@ impl Config {
     }
 
     fn apply_env_overrides_core_1b(&mut self) {
+        if let Ok(v) = std::env::var("ZEPH_SAFE_MODE")
+            && let Ok(enabled) = v.parse::<bool>()
+        {
+            self.cli.safe_mode = enabled;
+        }
         if let Ok(v) = std::env::var("ZEPH_SKILLS_MAX_ACTIVE")
             && let Ok(n) = v.parse::<usize>()
             && let Some(nz) = NonZeroUsize::new(n)

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -1874,6 +1874,54 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
                 .map_err(|e| CommandError::new(e.to_string()))
         })
     }
+
+    // ----- /cd -----
+
+    fn change_working_directory<'a>(
+        &'a mut self,
+        path: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, CommandError>> + Send + 'a>> {
+        Box::pin(
+            async move {
+                let path = path.trim();
+                if path.is_empty() {
+                    let cwd = std::env::current_dir().map_err(|e| {
+                        CommandError::new(format!("failed to read current working directory: {e}"))
+                    })?;
+                    return Ok(format!("Current working directory: {}", cwd.display()));
+                }
+                // Reuses the same path-resolution + `set_current_dir` logic as the
+                // LLM-invoked `set_working_directory` tool (#6032 FR-001/FR-011) — no
+                // parallel implementation. `allowed_paths` empty means no build site has set
+                // it yet; default to `[cwd]` rather than "allow every path", matching
+                // `FileExecutor::new`/`SetCwdExecutor::new`'s convention (SEC-2).
+                let allowed_paths: Vec<std::path::PathBuf> =
+                    if self.services.tool_state.allowed_paths.is_empty() {
+                        // Canonicalize for byte-for-byte parity with `FileExecutor::new`/
+                        // `SetCwdExecutor::new`'s fallback, which both canonicalize their
+                        // default `[cwd]` entry (`.map(|p| p.canonicalize().unwrap_or(p))`).
+                        std::env::current_dir()
+                            .map(|p| p.canonicalize().unwrap_or(p))
+                            .into_iter()
+                            .collect()
+                    } else {
+                        self.services.tool_state.allowed_paths.clone()
+                    };
+                let new_cwd = zeph_tools::resolve_and_set_cwd(path, &allowed_paths)
+                    .map_err(|e| CommandError::new(format!("cannot change to '{path}': {e}")))?;
+                // Drives the same post-change pipeline the tool-invoked path gets for free
+                // after a tool batch (`tier_loop.rs`) — a bare slash command must call it
+                // explicitly (FR-002/FR-003/FR-004): mirror-update, `cwd_changed` hooks,
+                // repo-map invalidation, and (unless safe-mode) instruction re-discovery.
+                self.check_cwd_changed().await;
+                Ok(format!(
+                    "Working directory changed to: {}",
+                    new_cwd.display()
+                ))
+            }
+            .instrument(tracing::info_span!("core.commands.cd")),
+        )
+    }
 }
 
 impl<C: Channel> Agent<C> {

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -664,6 +664,33 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Set whether the agent is running in `--safe-mode` (#6031).
+    ///
+    /// Safe mode disables ZEPH.md/CLAUDE.md/AGENTS.md discovery, plugins, skills, hooks, and
+    /// MCP servers at startup — a distinct troubleshooting isolation flag from `--bare`'s
+    /// memory/tool-registry test-mode behavior. Read by `check_cwd_changed` to gate whether a
+    /// `/cd`-triggered directory change (#6032) re-runs instruction discovery.
+    #[must_use]
+    pub fn with_safe_mode(mut self, safe_mode: bool) -> Self {
+        self.runtime.config.safe_mode = safe_mode;
+        self
+    }
+
+    /// Set the sandbox root(s) `/cd` (and any other agent-invoked cwd change) is validated
+    /// against (#6032 SEC-2).
+    ///
+    /// Should be the same `config.tools.shell.allowed_paths` passed to
+    /// `FileExecutor::new`/`DiagnosticsExecutor::new`/`SetCwdExecutor::new` at the same
+    /// build site, so all cwd/file-path sandboxes agree on one boundary. An empty `Vec`
+    /// (the default if this is never called) is treated as "default to `[cwd]`" by
+    /// `AgentAccess::change_working_directory`, matching `FileExecutor::new`'s convention —
+    /// not "allow every path".
+    #[must_use]
+    pub fn with_allowed_paths(mut self, allowed_paths: Vec<std::path::PathBuf>) -> Self {
+        self.services.tool_state.allowed_paths = allowed_paths;
+        self
+    }
+
     /// Configure channel identity for per-channel UX preference persistence (#3308, #4654).
     ///
     /// `channel_type` must match the active I/O channel name (`"cli"`, `"tui"`, `"telegram"`,

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -913,6 +913,13 @@ impl<C: Channel> Agent<C> {
         // BLOCK 3: volatile — dynamic per-turn content, never cached
         system_prompt.push_str("\n<!-- cache:volatile -->");
 
+        // #6032 S1: working_directory changes on every `/cd` — kept out of the stable
+        // `<environment>` block (`EnvironmentContext::format_cacheable`) and emitted here so a
+        // directory switch only re-caches this volatile tail, not the (larger, more expensive)
+        // stable block.
+        system_prompt.push_str("\n\nworking_directory: ");
+        system_prompt.push_str(&cwd.display().to_string());
+
         // Inject learned user preferences after the volatile marker so they
         // do not invalidate the stable/semi-stable cache blocks (S2 fix).
         self.inject_learned_preferences(&mut system_prompt).await;

--- a/crates/zeph-core/src/agent/context/tests/compaction_guards_and_consolidation_tests.rs
+++ b/crates/zeph-core/src/agent/context/tests/compaction_guards_and_consolidation_tests.rs
@@ -910,6 +910,43 @@ async fn rebuild_system_prompt_cache_markers_count() {
     );
 }
 
+/// #6032 S1 regression: `working_directory:` must live in the volatile tail (after
+/// `<!-- cache:volatile -->`), never in the stable block (before `<!-- cache:stable -->`).
+/// A `/cd` directory switch must not re-cache the stable block just because the cwd line
+/// moved — this test pins the placement so a future change reverting the fix fails CI
+/// instead of only being caught in a live manual check.
+#[tokio::test]
+async fn rebuild_system_prompt_working_directory_is_in_volatile_tail() {
+    use zeph_skills::registry::SkillRegistry;
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = SkillRegistry::default();
+    let executor = MockToolExecutor::no_tools();
+
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+    agent.rebuild_system_prompt("test query").await;
+
+    let prompt = &agent.msg.messages[0].content;
+    let stable_pos = prompt
+        .find("<!-- cache:stable -->")
+        .expect("cache:stable marker must be present");
+    let volatile_pos = prompt
+        .find("<!-- cache:volatile -->")
+        .expect("cache:volatile marker must be present");
+    let cwd_pos = prompt
+        .find("working_directory:")
+        .expect("working_directory: line must be present");
+
+    assert!(
+        cwd_pos > volatile_pos,
+        "working_directory: (pos {cwd_pos}) must appear AFTER cache:volatile (pos {volatile_pos})"
+    );
+    assert!(
+        cwd_pos > stable_pos,
+        "working_directory: (pos {cwd_pos}) must not appear before cache:stable (pos {stable_pos})"
+    );
+}
+
 // T-06: H1 regression — ProbeRejected must NOT trigger Exhausted transition.
 //
 // Design invariant (H1 fix): when the compaction probe rejects a summary,

--- a/crates/zeph-core/src/agent/hooks_dispatch.rs
+++ b/crates/zeph-core/src/agent/hooks_dispatch.rs
@@ -90,6 +90,29 @@ impl<C: Channel> Agent<C> {
             }
         }
 
+        // #6032 FR-003: invalidate the cached repo-map so it regenerates lazily from the new
+        // cwd on next prompt assembly (`assembly.rs`) — not gated by safe-mode, repo-map is not
+        // a customization source. No eager rebuild here; cheap `Option` clear.
+        self.channel
+            .send_status_best_effort("Re-scoping repo map\u{2026}")
+            .await;
+        self.services.index.cached_repo_map = None;
+
+        // #6032 FR-004: re-run CLAUDE.md/AGENTS.md instruction discovery against the new cwd —
+        // gated on `!safe_mode` (#6031 S3): a --safe-mode session must never silently re-load
+        // project instructions via /cd, which would defeat the flag.
+        if self.runtime.config.safe_mode {
+            tracing::debug!("safe mode active: skipping instruction re-discovery after cwd change");
+        } else if self.runtime.instructions.reload_state.is_some() {
+            self.channel
+                .send_status_best_effort("Re-discovering project instructions\u{2026}")
+                .await;
+            if let Some(ref mut state) = self.runtime.instructions.reload_state {
+                state.base_dir.clone_from(&current);
+            }
+            self.reload_instructions().await;
+        }
+
         self.channel.send_status_best_effort("").await;
     }
     /// Handle a `FileChangedEvent` from the file watcher.
@@ -180,6 +203,130 @@ mod tests {
     use std::collections::HashMap;
 
     use super::insert_main_agent_ctx;
+    #[allow(clippy::wildcard_imports)]
+    use crate::agent::agent_tests::*;
+
+    /// Helper: point the agent's `last_known_cwd` at `from` and the real process cwd at `to`,
+    /// so the next `check_cwd_changed()` call detects a change. Restores the original process
+    /// cwd on drop-equivalent (explicit restore at the end of each test) — nextest runs each
+    /// test in its own process, so this does not race concurrent tests.
+    fn simulate_cwd_change(
+        agent: &mut Agent<MockChannel>,
+        from: &std::path::Path,
+        to: &std::path::Path,
+    ) {
+        agent.runtime.lifecycle.last_known_cwd = from.to_path_buf();
+        std::env::set_current_dir(to).unwrap();
+    }
+
+    /// #6032 FR-003: repo-map cache invalidation must happen on every cwd change,
+    /// unconditionally — not gated by safe-mode (repo-map is not a customization source).
+    #[tokio::test]
+    async fn check_cwd_changed_invalidates_repo_map_cache() {
+        let original_cwd = std::env::current_dir().unwrap();
+        let harness = QuickTestAgent::minimal("ok");
+        let mut agent = harness.agent;
+        agent.services.index.cached_repo_map = Some((
+            "<repo_map>stale</repo_map>".to_owned(),
+            std::time::Instant::now(),
+        ));
+
+        let from = tempfile::tempdir().unwrap();
+        let to = tempfile::tempdir().unwrap();
+        simulate_cwd_change(&mut agent, from.path(), to.path());
+
+        agent.check_cwd_changed().await;
+
+        assert!(
+            agent.services.index.cached_repo_map.is_none(),
+            "cached_repo_map must be cleared after a cwd change"
+        );
+
+        let _ = std::env::set_current_dir(&original_cwd);
+    }
+
+    /// #6032 FR-004 / #6031 S3: instruction re-discovery must be skipped entirely when the
+    /// session is in `--safe-mode` — a `/cd` (or agent-invoked `set_working_directory`) must
+    /// never silently re-load CLAUDE.md/AGENTS.md and defeat the flag.
+    #[tokio::test]
+    async fn check_cwd_changed_skips_instruction_redisovery_when_safe_mode_active() {
+        let original_cwd = std::env::current_dir().unwrap();
+        let harness = QuickTestAgent::minimal("ok");
+        let mut agent = harness.agent;
+        agent.runtime.config.safe_mode = true;
+
+        let from = tempfile::tempdir().unwrap();
+        let to = tempfile::tempdir().unwrap();
+        std::fs::write(to.path().join("zeph.md"), "# target-dir instructions").unwrap();
+
+        agent.runtime.instructions.reload_state =
+            Some(crate::instructions::InstructionReloadState {
+                base_dir: from.path().to_path_buf(),
+                provider_kinds: vec![crate::config::ProviderKind::Claude],
+                explicit_files: Vec::new(),
+                auto_detect: false,
+            });
+        let sentinel_blocks = vec![crate::instructions::InstructionBlock {
+            source: from.path().join("zeph.md"),
+            content: "# original instructions (must survive)".to_owned(),
+        }];
+        agent.runtime.instructions.blocks = sentinel_blocks.clone();
+
+        simulate_cwd_change(&mut agent, from.path(), to.path());
+        agent.check_cwd_changed().await;
+
+        assert_eq!(
+            agent.runtime.instructions.blocks.len(),
+            sentinel_blocks.len(),
+            "instruction blocks must be unchanged when safe_mode is active"
+        );
+        assert_eq!(
+            agent.runtime.instructions.blocks[0].content, sentinel_blocks[0].content,
+            "safe-mode session must not pick up the new directory's zeph.md"
+        );
+
+        let _ = std::env::set_current_dir(&original_cwd);
+    }
+
+    /// Regression baseline for the test above: outside safe-mode, `/cd` DOES re-discover
+    /// instructions from the new directory.
+    #[tokio::test]
+    async fn check_cwd_changed_rediscovers_instructions_when_not_safe_mode() {
+        let original_cwd = std::env::current_dir().unwrap();
+        let harness = QuickTestAgent::minimal("ok");
+        let mut agent = harness.agent;
+        assert!(!agent.runtime.config.safe_mode);
+
+        let from = tempfile::tempdir().unwrap();
+        let to = tempfile::tempdir().unwrap();
+        std::fs::write(to.path().join("zeph.md"), "# target-dir instructions").unwrap();
+
+        agent.runtime.instructions.reload_state =
+            Some(crate::instructions::InstructionReloadState {
+                base_dir: from.path().to_path_buf(),
+                provider_kinds: vec![crate::config::ProviderKind::Claude],
+                explicit_files: Vec::new(),
+                auto_detect: false,
+            });
+        agent.runtime.instructions.blocks = Vec::new();
+
+        simulate_cwd_change(&mut agent, from.path(), to.path());
+        agent.check_cwd_changed().await;
+
+        assert_eq!(
+            agent.runtime.instructions.blocks.len(),
+            1,
+            "instructions must be re-discovered from the new cwd"
+        );
+        assert!(
+            agent.runtime.instructions.blocks[0]
+                .content
+                .contains("target-dir instructions"),
+            "re-discovered block must come from the new directory's zeph.md"
+        );
+
+        let _ = std::env::set_current_dir(&original_cwd);
+    }
 
     #[test]
     fn insert_main_agent_ctx_always_sets_agent_type() {

--- a/crates/zeph-core/src/agent/skill_reload.rs
+++ b/crates/zeph-core/src/agent/skill_reload.rs
@@ -173,6 +173,16 @@ impl<C: Channel> Agent<C> {
     }
     #[tracing::instrument(name = "core.agent.reload_skills", skip_all, level = "debug")]
     pub(super) async fn reload_skills(&mut self) {
+        // #6031: single DRY choke point for the skill-hot-reload gate — covers every entry
+        // point (runner/daemon/acp/serve) at once, instead of patching each `SkillWatcher`
+        // call site individually. Without this, a session that correctly started with an
+        // empty registry (daemon/acp/serve's `build_shared_core` gate) would still silently
+        // re-populate it from disk on the first skill-file change, defeating safe-mode for
+        // the rest of the session.
+        if self.runtime.config.safe_mode {
+            tracing::debug!("safe mode active: skipping skill hot-reload");
+            return;
+        }
         let old_fp = self.services.skill.fingerprint();
         let reload_paths = if let Some(ref supplier) = self.services.skill.plugin_dirs_supplier {
             let plugin_dirs = supplier();

--- a/crates/zeph-core/src/agent/slash_commands.rs
+++ b/crates/zeph-core/src/agent/slash_commands.rs
@@ -719,6 +719,7 @@ pub(crate) fn build_agent_command_registry<'ctx>()
         agent_cmd::AgentCommand,
         agents_fleet::AgentsFleetCommand,
         caveman::CavemanCommand,
+        cd::CdCommand,
         checkpoint::{RedoCommand, UndoCommand},
         compaction::{CompactCommand, NewConversationCommand, RecapCommand},
         conv::ConvCommand,
@@ -744,6 +745,7 @@ pub(crate) fn build_agent_command_registry<'ctx>()
 
     let mut agent_reg = CommandRegistry::new();
     agent_reg.register(CavemanCommand);
+    agent_reg.register(CdCommand);
     agent_reg.register(MemoryCommand);
     agent_reg.register(GraphCommand);
     agent_reg.register(KnowledgeSlashCommand);

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -326,6 +326,15 @@ pub(crate) struct RuntimeConfig {
     /// consolidation, skill trace-extraction, shutdown summary, session digest) apply the
     /// same gating instead of firing unconditional LLM calls at session end.
     pub(crate) bare: bool,
+    /// Set from `config.cli.safe_mode` (`--safe-mode` / `ZEPH_SAFE_MODE`, #6031).
+    ///
+    /// Distinct from `bare`: safe mode disables ZEPH.md/CLAUDE.md/AGENTS.md discovery,
+    /// plugins, skills, hooks, and MCP servers for troubleshooting isolation, rather than
+    /// `bare`'s memory/tool-registry/background-task test-mode behavior. Read by
+    /// `check_cwd_changed` (#6032) to gate whether a `/cd`-triggered directory change
+    /// re-runs instruction discovery — a safe-mode session must never silently re-load
+    /// project instructions mid-session, which would defeat the flag.
+    pub(crate) safe_mode: bool,
 }
 
 /// Groups feedback detection subsystems: correction detector, judge detector, and LLM classifier.
@@ -812,6 +821,13 @@ pub(crate) struct ToolState {
     /// Last tool executed per skill in the current turn, keyed by skill name.
     /// Used as `prev_tool` for PASTE pattern transition recording.
     pub(crate) last_tool_per_skill: HashMap<String, String>,
+    /// `config.tools.shell.allowed_paths`, mirrored here so `AgentAccess::change_working_directory`
+    /// (#6032 SEC-2) can validate a `/cd` target against the same sandbox boundary
+    /// `FileExecutor`/`DiagnosticsExecutor`/`SetCwdExecutor` already enforce, via
+    /// `zeph_common::security::validate_path_within`. Empty means "no session has set it yet";
+    /// callers treat empty the same way `FileExecutor::new` does (default to `[cwd]`), not as
+    /// "allow every path".
+    pub(crate) allowed_paths: Vec<std::path::PathBuf>,
 }
 
 /// Groups per-session I/O and policy state.
@@ -1286,6 +1302,7 @@ impl Default for RuntimeConfig {
             restoring_provider: false,
             goals: GoalRuntimeConfig::default(),
             bare: false,
+            safe_mode: false,
         }
     }
 }

--- a/crates/zeph-core/src/agent/state/tests.rs
+++ b/crates/zeph-core/src/agent/state/tests.rs
@@ -121,6 +121,7 @@ fn make_runtime_config() -> RuntimeConfig {
         restoring_provider: false,
         goals: crate::agent::state::GoalRuntimeConfig::default(),
         bare: false,
+        safe_mode: false,
     }
 }
 

--- a/crates/zeph-core/src/agent/tests/agent_tests/hot_reload_and_dispatch_tests.rs
+++ b/crates/zeph-core/src/agent/tests/agent_tests/hot_reload_and_dispatch_tests.rs
@@ -151,6 +151,127 @@ async fn reload_skills_offloads_registry_load_and_reflects_new_skills() {
     );
 }
 
+/// #6031: `reload_skills()` must be a no-op when `runtime.config.safe_mode` is set — the
+/// single DRY choke point covering every entry point (runner/daemon/acp/serve) at once, so a
+/// session that correctly started with an empty registry does not silently re-populate it
+/// from disk on the first skill-file change.
+#[tokio::test]
+async fn reload_skills_is_noop_when_safe_mode_active() {
+    let harness = QuickTestAgent::minimal("ok");
+    let mut agent = harness.agent;
+    agent.runtime.config.safe_mode = true;
+
+    let names_before: Vec<String> = agent
+        .services
+        .skill
+        .registry
+        .read()
+        .all_meta()
+        .iter()
+        .map(|m| m.name.clone())
+        .collect();
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let skill_dir = temp_dir.path().join("hot-reload-skill");
+    std::fs::create_dir(&skill_dir).unwrap();
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nname: hot-reload-skill\ndescription: A skill added via hot reload\n---\nSkill body",
+    )
+    .unwrap();
+    agent.services.skill.skill_paths = vec![temp_dir.path().to_path_buf()];
+
+    agent.reload_skills().await;
+
+    let names_after: Vec<String> = agent
+        .services
+        .skill
+        .registry
+        .read()
+        .all_meta()
+        .iter()
+        .map(|m| m.name.clone())
+        .collect();
+    assert_eq!(
+        names_after, names_before,
+        "safe-mode session must not re-populate the skill registry from disk"
+    );
+}
+
+// --- change_working_directory (#6032 / SEC-2) ---
+
+/// FR-009: `/cd` with no argument reports the current cwd without mutating any state.
+#[tokio::test]
+async fn change_working_directory_empty_arg_reports_current_cwd() {
+    use zeph_commands::traits::agent::AgentAccess;
+
+    let harness = QuickTestAgent::minimal("ok");
+    let mut agent = harness.agent;
+    let original_cwd = std::env::current_dir().unwrap();
+
+    let result = agent.change_working_directory("").await.unwrap();
+
+    assert!(result.contains(&original_cwd.display().to_string()));
+    assert_eq!(std::env::current_dir().unwrap(), original_cwd);
+}
+
+/// SEC-2: a `/cd` target outside `services.tool_state.allowed_paths` must be rejected and
+/// must not mutate the process cwd — mirrors spec 063 FR-001/"Never": `/cd` must not become a
+/// bypass for the per-path file sandbox.
+#[tokio::test]
+async fn change_working_directory_rejects_path_outside_allowed_paths() {
+    use zeph_commands::traits::agent::AgentAccess;
+
+    let harness = QuickTestAgent::minimal("ok");
+    let mut agent = harness.agent;
+    let original_cwd = std::env::current_dir().unwrap();
+
+    let allowed_root = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    agent.services.tool_state.allowed_paths = vec![allowed_root.path().to_path_buf()];
+
+    let result = agent
+        .change_working_directory(outside.path().to_str().unwrap())
+        .await;
+
+    assert!(result.is_err(), "cd outside allowed_paths must be rejected");
+    assert_eq!(
+        std::env::current_dir().unwrap(),
+        original_cwd,
+        "process cwd must be unchanged after a rejected /cd"
+    );
+}
+
+/// A `/cd` target inside `allowed_paths` succeeds and drives the full post-change pipeline
+/// (`check_cwd_changed`): `env_context.working_dir` and `runtime.lifecycle.last_known_cwd`
+/// both reflect the new directory.
+#[tokio::test]
+async fn change_working_directory_allows_path_inside_allowed_paths() {
+    use zeph_commands::traits::agent::AgentAccess;
+
+    let harness = QuickTestAgent::minimal("ok");
+    let mut agent = harness.agent;
+    let original_cwd = std::env::current_dir().unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let canonical_dir = dir.path().canonicalize().unwrap();
+    agent.services.tool_state.allowed_paths = vec![canonical_dir.clone()];
+
+    let result = agent
+        .change_working_directory(dir.path().to_str().unwrap())
+        .await
+        .unwrap();
+
+    assert!(result.contains(&canonical_dir.display().to_string()));
+    assert_eq!(agent.runtime.lifecycle.last_known_cwd, canonical_dir);
+    assert_eq!(
+        agent.services.session.env_context.working_dir,
+        canonical_dir.display().to_string()
+    );
+
+    let _ = std::env::set_current_dir(&original_cwd);
+}
+
 /// `/plugins list` is registered in the agent-command registry (fix for #3215).
 /// The command must be routed — agent exits cleanly and the channel receives a reply.
 #[tokio::test]

--- a/crates/zeph-core/src/context.rs
+++ b/crates/zeph-core/src/context.rs
@@ -80,6 +80,14 @@ pub fn build_system_prompt(skills_prompt: &str, env: Option<&EnvironmentContext>
 /// Instruction file content is user-editable and must NOT be placed in the stable
 /// cache block. It is injected here, in the dynamic/volatile section, so that
 /// prompt-caching (epic #1082) is not disrupted.
+///
+/// When `env` is `Some`, the emitted `<environment>` block omits `working_directory`
+/// (see [`EnvironmentContext::format_cacheable`]) — the caller is responsible for
+/// appending a `working_directory:` line to the actual volatile tail (after Claude's
+/// `<!-- cache:volatile -->` marker), which today is only `assemble_final_system_prompt`
+/// (`agent/context/assembly.rs`). Any other caller passing `env: Some(..)` without also
+/// appending that line would silently drop `working_directory` from the assembled prompt
+/// entirely (#6032 S1) — currently safe because every other call site passes `env: None`.
 #[must_use]
 pub fn build_system_prompt_with_instructions(
     skills_prompt: &str,
@@ -91,7 +99,7 @@ pub fn build_system_prompt_with_instructions(
         .iter()
         .map(|b| b.source.display().to_string().len() + b.content.len() + 30)
         .sum();
-    let dynamic_len = env.map_or(0, |e| e.format().len() + 2)
+    let dynamic_len = env.map_or(0, |e| e.format_cacheable().len() + 2)
         + instructions_len
         + if skills_prompt.is_empty() {
             0
@@ -102,8 +110,11 @@ pub fn build_system_prompt_with_instructions(
     prompt.push_str(base);
 
     if let Some(env) = env {
+        // #6032 S1: `working_directory` is omitted here (see `format_cacheable`) and
+        // emitted separately in the volatile tail by `assemble_final_system_prompt`, so a
+        // `/cd` directory switch does not bust this stable cache block.
         prompt.push_str("\n\n");
-        prompt.push_str(&env.format());
+        prompt.push_str(&env.format_cacheable());
     }
 
     // Instruction blocks are placed after env context (volatile, user-editable content).
@@ -204,6 +215,25 @@ impl EnvironmentContext {
         use std::fmt::Write;
         let mut out = String::from("<environment>\n");
         let _ = writeln!(out, "  working_directory: {}", self.working_dir);
+        let _ = writeln!(out, "  os: {}", self.os);
+        let _ = writeln!(out, "  model: {}", self.model_name);
+        if let Some(ref branch) = self.git_branch {
+            let _ = writeln!(out, "  git_branch: {branch}");
+        }
+        out.push_str("</environment>");
+        out
+    }
+
+    /// Like [`format`](Self::format) but omits `working_directory` (#6032, S1 cache fix).
+    ///
+    /// Used to build the cacheable (pre-`cache:stable`) portion of the system prompt.
+    /// `working_directory` changes on every `/cd` and is emitted separately in the volatile
+    /// tail (after `<!-- cache:volatile -->`) so a directory switch does not bust the stable
+    /// prompt-cache block for `os`/`model`/`git_branch`, which rarely change mid-session.
+    #[must_use]
+    pub fn format_cacheable(&self) -> String {
+        use std::fmt::Write;
+        let mut out = String::from("<environment>\n");
         let _ = writeln!(out, "  os: {}", self.os);
         let _ = writeln!(out, "  model: {}", self.model_name);
         if let Some(ref branch) = self.git_branch {

--- a/crates/zeph-core/src/json_event_sink.rs
+++ b/crates/zeph-core/src/json_event_sink.rs
@@ -36,6 +36,9 @@ pub enum JsonEvent<'a> {
         version: &'a str,
         bare: bool,
         auto: bool,
+        /// `--safe-mode`/`ZEPH_SAFE_MODE` (#6031): customizations (ZEPH.md/CLAUDE.md/AGENTS.md,
+        /// plugins, skills, hooks, MCP servers) are disabled for this session.
+        safe_mode: bool,
     },
     /// User input received from stdin.
     Query { text: &'a str, queue_len: usize },
@@ -153,11 +156,13 @@ mod tests {
             version: "0.1.0",
             bare: true,
             auto: false,
+            safe_mode: false,
         };
         let s = serde_json::to_string(&event).unwrap();
         assert!(s.contains("\"event\":\"boot\""));
         assert!(s.contains("\"version\":\"0.1.0\""));
         assert!(s.contains("\"bare\":true"));
+        assert!(s.contains("\"safe_mode\":false"));
     }
 
     #[test]

--- a/crates/zeph-tools/src/cwd.rs
+++ b/crates/zeph-tools/src/cwd.rs
@@ -27,13 +27,78 @@ struct SetCwdParams {
     path: String,
 }
 
+/// Resolve `path` (expanding `~`, and resolving relative paths against the current cwd),
+/// verify it falls within `allowed_paths`, and change the process working directory to it.
+/// Returns the new absolute (canonicalized) cwd on success.
+///
+/// Shared by [`SetCwdExecutor`] (the LLM-invoked `set_working_directory` tool) and the
+/// user-invoked `/cd` slash command (`zeph-core`'s `AgentAccess::change_working_directory`) —
+/// both entry points into the same underlying mechanism, per #6032 FR-001/FR-011: `/cd` must
+/// not duplicate this resolution logic.
+///
+/// Per spec 063 FR-001/"Never" (SEC-2): `/cd` "must not become a bypass for the per-path file
+/// read sandbox" — the sandbox check runs *before* `set_current_dir`, so a rejected path never
+/// mutates the process cwd. `allowed_paths` uses the same `zeph_common::security` containment
+/// check as `FileExecutor`/`DiagnosticsExecutor`; an empty slice matches those callers'
+/// convention (see [`SetCwdExecutor::new`]) rather than allowing every path.
+///
+/// # Errors
+///
+/// Returns [`std::io::Error`] if the target path does not exist, is not a directory, is not
+/// readable (mirrors `std::env::set_current_dir`'s error contract — see
+/// `set_cwd_errors_on_nonexistent_path`), or falls outside `allowed_paths`
+/// (`io::ErrorKind::PermissionDenied`).
+pub fn resolve_and_set_cwd(path: &str, allowed_paths: &[PathBuf]) -> std::io::Result<PathBuf> {
+    let target = expand_tilde(PathBuf::from(path));
+
+    // Resolve relative paths against current cwd before changing.
+    let resolved = if target.is_absolute() {
+        target
+    } else {
+        std::env::current_dir()?.join(target)
+    };
+
+    let canonical = zeph_common::security::validate_path_within(&resolved, allowed_paths)?;
+    std::env::set_current_dir(&canonical)?;
+    Ok(canonical)
+}
+
 /// Tool executor that changes the agent process working directory.
 ///
 /// Implements the `set_working_directory` tool. The LLM calls this when it needs
 /// to change context for a series of operations. Shell `cd` inside child processes
 /// has no effect on the agent's cwd — this tool is the only persistent mechanism.
-#[derive(Debug, Default)]
-pub struct SetCwdExecutor;
+///
+/// Sandboxed to `allowed_paths` (#6032 SEC-2), mirroring [`crate::file::FileExecutor`] and
+/// [`crate::diagnostics::DiagnosticsExecutor`] — a `cd` outside the configured sandbox is
+/// rejected rather than silently permitted, closing a gap the LLM-invoked tool previously
+/// shared with `/cd` before this fix.
+#[derive(Debug)]
+pub struct SetCwdExecutor {
+    allowed_paths: Vec<PathBuf>,
+}
+
+impl SetCwdExecutor {
+    /// Create a new executor sandboxed to `allowed_paths`.
+    ///
+    /// An empty `allowed_paths` defaults to `[current_dir]`, matching
+    /// [`crate::file::FileExecutor::new`]/[`crate::diagnostics::DiagnosticsExecutor::new`]'s
+    /// convention — not "allow every path".
+    #[must_use]
+    pub fn new(allowed_paths: Vec<PathBuf>) -> Self {
+        let paths = if allowed_paths.is_empty() {
+            vec![std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))]
+        } else {
+            allowed_paths.into_iter().map(expand_tilde).collect()
+        };
+        Self {
+            allowed_paths: paths
+                .into_iter()
+                .map(|p| p.canonicalize().unwrap_or(p))
+                .collect(),
+        }
+    }
+}
 
 impl ToolExecutor for SetCwdExecutor {
     async fn execute_tool_call(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
@@ -41,20 +106,8 @@ impl ToolExecutor for SetCwdExecutor {
             return Ok(None);
         }
         let params: SetCwdParams = deserialize_params(&call.params)?;
-        let target = expand_tilde(PathBuf::from(&params.path));
-
-        // Resolve relative paths against current cwd before changing.
-        let resolved = if target.is_absolute() {
-            target
-        } else {
-            std::env::current_dir()
-                .map_err(ToolError::Execution)?
-                .join(target)
-        };
-
-        std::env::set_current_dir(&resolved).map_err(ToolError::Execution)?;
-
-        let new_cwd = std::env::current_dir().map_err(ToolError::Execution)?;
+        let new_cwd =
+            resolve_and_set_cwd(&params.path, &self.allowed_paths).map_err(ToolError::Execution)?;
         let summary = new_cwd.display().to_string();
 
         Ok(Some(ToolOutput {
@@ -118,7 +171,7 @@ mod tests {
     async fn set_cwd_changes_process_cwd() {
         let original_cwd = std::env::current_dir().unwrap();
         let dir = tempfile::tempdir().unwrap();
-        let executor = SetCwdExecutor;
+        let executor = SetCwdExecutor::new(vec![dir.path().to_path_buf()]);
         let call = make_call(dir.path().to_str().unwrap());
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_some());
@@ -145,7 +198,7 @@ mod tests {
             .expect("failed to create temp dir under home");
         let dir_name = subdir.path().file_name().unwrap().to_str().unwrap();
 
-        let executor = SetCwdExecutor;
+        let executor = SetCwdExecutor::new(vec![subdir.path().to_path_buf()]);
         let call = make_call(&format!("~/{dir_name}"));
         let result = executor.execute_tool_call(&call).await.unwrap();
         assert!(result.is_some());
@@ -163,7 +216,7 @@ mod tests {
 
     #[tokio::test]
     async fn set_cwd_returns_none_for_unknown_tool() {
-        let executor = SetCwdExecutor;
+        let executor = SetCwdExecutor::new(vec![]);
         let call = ToolCall {
             tool_id: ToolName::new("other_tool"),
             params: serde_json::Map::new(),
@@ -179,15 +232,69 @@ mod tests {
 
     #[tokio::test]
     async fn set_cwd_errors_on_nonexistent_path() {
-        let executor = SetCwdExecutor;
+        let executor = SetCwdExecutor::new(vec![]);
         let call = make_call("/nonexistent/path/that/does/not/exist");
         let result = executor.execute_tool_call(&call).await;
         assert!(result.is_err());
     }
 
+    // --- sandbox enforcement regression (#6032 SEC-2) ---
+
+    #[tokio::test]
+    async fn set_cwd_rejects_path_outside_allowed_paths() {
+        let original_cwd = std::env::current_dir().unwrap();
+        let allowed_root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let executor = SetCwdExecutor::new(vec![allowed_root.path().to_path_buf()]);
+
+        let call = make_call(outside.path().to_str().unwrap());
+        let result = executor.execute_tool_call(&call).await;
+
+        assert!(
+            result.is_err(),
+            "cd to a directory outside allowed_paths must be rejected"
+        );
+        assert_eq!(
+            std::env::current_dir().unwrap(),
+            original_cwd,
+            "process cwd must be unchanged after a rejected cd"
+        );
+    }
+
+    #[test]
+    fn resolve_and_set_cwd_rejects_path_outside_allowed_paths() {
+        let original_cwd = std::env::current_dir().unwrap();
+        let allowed_root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let allowed = vec![allowed_root.path().canonicalize().unwrap()];
+
+        let result = resolve_and_set_cwd(outside.path().to_str().unwrap(), &allowed);
+
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+        assert_eq!(
+            std::env::current_dir().unwrap(),
+            original_cwd,
+            "process cwd must be unchanged after a rejected cd"
+        );
+    }
+
+    #[test]
+    fn resolve_and_set_cwd_allows_path_inside_allowed_paths() {
+        let original_cwd = std::env::current_dir().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let allowed = vec![dir.path().canonicalize().unwrap()];
+
+        let result = resolve_and_set_cwd(dir.path().to_str().unwrap(), &allowed);
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), dir.path().canonicalize().unwrap());
+        let _ = std::env::set_current_dir(&original_cwd);
+    }
+
     #[test]
     fn tool_definitions_contains_set_working_directory() {
-        let executor = SetCwdExecutor;
+        let executor = SetCwdExecutor::new(vec![]);
         let defs = executor.tool_definitions();
         assert_eq!(defs.len(), 1);
         assert_eq!(defs[0].id.as_ref(), TOOL_NAME);

--- a/crates/zeph-tools/src/diagnostics.rs
+++ b/crates/zeph-tools/src/diagnostics.rs
@@ -93,18 +93,27 @@ impl DiagnosticsExecutor {
                 .unwrap_or_else(|_| PathBuf::from("."))
                 .join(path)
         };
-        let canonical = resolved.canonicalize().map_err(|e| {
-            ToolError::Execution(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                format!("path not found: {}: {e}", resolved.display()),
-            ))
-        })?;
-        if !self.allowed_paths.iter().any(|a| canonical.starts_with(a)) {
-            return Err(ToolError::SandboxViolation {
-                path: canonical.display().to_string(),
-            });
-        }
-        Ok(canonical)
+        // #6032 SEC-2: shared canonicalize-then-containment-check, used identically by
+        // `FileExecutor` (via `is_path_within` on its own ancestor-resolved path) and
+        // `resolve_and_set_cwd`.
+        zeph_common::security::validate_path_within(&resolved, &self.allowed_paths).map_err(|e| {
+            match e.kind() {
+                std::io::ErrorKind::NotFound => ToolError::Execution(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("path not found: {}: {e}", resolved.display()),
+                )),
+                // The path exists (NotFound already excluded above) but escapes
+                // `allowed_paths` — re-canonicalize to report the symlink-resolved form,
+                // matching the pre-#6032 SEC-2 behavior of this error message.
+                _ => ToolError::SandboxViolation {
+                    path: resolved
+                        .canonicalize()
+                        .unwrap_or(resolved)
+                        .display()
+                        .to_string(),
+                },
+            }
+        })
     }
 }
 

--- a/crates/zeph-tools/src/file.rs
+++ b/crates/zeph-tools/src/file.rs
@@ -190,8 +190,11 @@ impl FileExecutor {
                 .join(path)
         };
         let normalized = normalize_path(&resolved);
+        // Ancestor-resolved rather than a plain `canonicalize()` (via
+        // `zeph_common::security::validate_path_within`) because the target may not exist
+        // yet (writing a new file) — only the shared containment check is reused (#6032 SEC-2).
         let canonical = resolve_via_ancestors(&normalized);
-        if !self.allowed_paths.iter().any(|a| canonical.starts_with(a)) {
+        if !zeph_common::security::is_path_within(&canonical, &self.allowed_paths) {
             return Err(ToolError::SandboxViolation {
                 path: canonical.display().to_string(),
             });

--- a/crates/zeph-tools/src/lib.rs
+++ b/crates/zeph-tools/src/lib.rs
@@ -108,7 +108,7 @@ pub use compression::{
     IdentityCompressor, OutputCompressor, RuleBasedCompressor, safe_compile,
 };
 pub use config::{build_permission_policy, validate_sandbox_denied_domains};
-pub use cwd::SetCwdExecutor;
+pub use cwd::{SetCwdExecutor, resolve_and_set_cwd};
 pub use diagnostics::DiagnosticsExecutor;
 pub use error_taxonomy::{
     ErrorDomain, ToolErrorCategory, ToolErrorFeedback, ToolInvocationPhase, classify_http_status,

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -197,7 +197,14 @@ pub(crate) async fn build_shared_core(
     let (provider, _status_tx, _status_rx) = app.build_provider().await?;
     let embedding_provider = crate::bootstrap::create_embedding_provider(app.config(), &provider);
     let budget_tokens = app.auto_budget_tokens(&provider);
-    let registry = std::sync::Arc::new(parking_lot::RwLock::new(app.build_registry()));
+    // Safe-mode gate (#6031): shared by ACP and `serve` (both build agents from this
+    // `SharedCore`) — an empty registry with no matching disables skill loading/matching for
+    // both entry points from this one seam, mirroring `runner.rs`'s `exec_mode.bare` gate.
+    let registry = std::sync::Arc::new(parking_lot::RwLock::new(if app.config().cli.safe_mode {
+        zeph_skills::registry::SkillRegistry::empty()
+    } else {
+        app.build_registry()
+    }));
     let memory = std::sync::Arc::new(app.build_memory(&provider, supervisor).await?);
 
     let all_meta_owned: Vec<zeph_skills::loader::SkillMeta> =
@@ -472,6 +479,13 @@ pub(crate) struct SharedAgentDeps {
     tool_filter_config: zeph_core::config::ToolFilterConfig,
 
     hooks_config: zeph_core::config::HooksConfig,
+    /// Safe-mode gate (#6031): when `true`, `spawn_acp_agent` skips `with_hooks_config` for
+    /// every session built from this shared deps bundle.
+    safe_mode: bool,
+    /// `config.tools.shell.allowed_paths` (#6032 SEC-2), wired into every session's `Agent`
+    /// via `Agent::with_allowed_paths` so `/cd` is validated against the same sandbox
+    /// boundary `FileExecutor`/`DiagnosticsExecutor`/`SetCwdExecutor` already enforce.
+    cwd_allowed_paths: Vec<std::path::PathBuf>,
 
     // ACP-specific fields (transport-level; not agent-level)
     acp_agent_name: String,
@@ -641,6 +655,12 @@ async fn build_acp_deps(
     }
 
     let config = app.config();
+    if config.cli.safe_mode {
+        tracing::info!(
+            "safe mode active: ZEPH.md/CLAUDE.md/AGENTS.md, plugins, skills, hooks, and MCP \
+             servers are disabled for this session"
+        );
+    }
 
     // #5914/#5979/#6180: memory maintenance loops, via the shared
     // `agent_setup::spawn_memory_maintenance_loops` (also used by `src/runner.rs`,
@@ -744,7 +764,13 @@ async fn build_acp_deps(
                 .await;
         std::sync::Arc::new(builder)
     };
-    let (mcp_tools, _mcp_outcomes) = mcp_manager.connect_all().await;
+    // Safe-mode gate (#6031): shared by standalone `--acp` and `serve --acp` (both call
+    // `build_acp_deps`) — mirrors `agent_setup::build_tool_setup`'s runner-path gate.
+    let (mcp_tools, _mcp_outcomes) = if config.cli.safe_mode {
+        (Vec::new(), Vec::new())
+    } else {
+        mcp_manager.connect_all().await
+    };
     let mcp_shared_tools = std::sync::Arc::new(RwLock::new(mcp_tools.clone()));
     let mcp_executor =
         zeph_mcp::McpToolExecutor::new(mcp_manager.clone(), mcp_shared_tools.clone());
@@ -760,6 +786,13 @@ async fn build_acp_deps(
         shell_executor,
         scrape_executor,
         diagnostics_executor,
+        config
+            .tools
+            .shell
+            .allowed_paths
+            .iter()
+            .map(PathBuf::from)
+            .collect(),
     );
     let index_provider = crate::bootstrap::resolve_index_embed_provider(config, provider.clone());
     let inner_executor: std::sync::Arc<dyn zeph_tools::ErasedToolExecutor> = {
@@ -1127,6 +1160,14 @@ async fn build_acp_deps(
         guardrail_provider: app.build_guardrail_provider(),
         audit_logger: acp_audit_logger,
         hooks_config: config.hooks.clone(),
+        safe_mode: config.cli.safe_mode,
+        cwd_allowed_paths: config
+            .tools
+            .shell
+            .allowed_paths
+            .iter()
+            .map(std::path::PathBuf::from)
+            .collect(),
         session_config,
         session_persistence_config: config.session.clone(),
         resume_condenser: resume_condenser_built,
@@ -1351,6 +1392,8 @@ async fn spawn_acp_agent(
     let scheduler_custom_tx = d.scheduler_custom_tx.clone();
 
     let hooks_config = d.hooks_config.clone();
+    let safe_mode = d.safe_mode;
+    let cwd_allowed_paths = d.cwd_allowed_paths.clone();
     let tool_filter_config = d.tool_filter_config.clone();
 
     // Cloned before `acp_ctx` is destructured into individual per-session executors below
@@ -1769,6 +1812,8 @@ async fn spawn_acp_agent(
             channel_provider_persistence,
             channel_persist_provider_overrides,
         )
+        .with_safe_mode(safe_mode)
+        .with_allowed_paths(cwd_allowed_paths)
         .maybe_init_tool_schema_filter(tool_filter_config, provider.clone()),
     )
     .await;
@@ -1938,7 +1983,9 @@ async fn spawn_acp_agent(
                 .0;
     }
 
-    agent = agent.with_hooks_config(&hooks_config);
+    if !safe_mode {
+        agent = agent.with_hooks_config(&hooks_config);
+    }
     // Spec 050 Phase 2 (#5913): wire ShadowSentinel into the agent so begin_turn() calls
     // advance_turn(), matching src/runner.rs.
     if let Some(sentinel) = shadow_sentinel_arc {
@@ -2257,6 +2304,7 @@ fn collect_project_rules(skill_paths: &[PathBuf]) -> Vec<PathBuf> {
 ///
 /// Returns an error if the agent stack cannot be built or the transport fails.
 #[cfg(feature = "acp")]
+#[allow(clippy::too_many_arguments)] // CLI/env passthrough for one session-bootstrap call; grouping into a struct would not reduce complexity
 pub(crate) async fn run_acp_server(
     config_path: Option<&std::path::Path>,
     vault_backend: Option<&str>,
@@ -2265,10 +2313,11 @@ pub(crate) async fn run_acp_server(
     cli_additional_dirs: Vec<std::path::PathBuf>,
     cli_auth_methods: Vec<String>,
     cli_message_ids: Option<bool>,
+    safe_mode: bool,
 ) -> anyhow::Result<()> {
     use std::sync::Arc;
 
-    let app = AppBuilder::new(config_path, vault_backend, vault_key, vault_path).await?;
+    let app = AppBuilder::new(config_path, vault_backend, vault_key, vault_path, safe_mode).await?;
     let (mut deps, _keepalive) = Box::pin(build_acp_deps(&app, None, None)).await?;
     let available_models = std::sync::Arc::clone(&deps.acp_available_models);
     let provider = deps.provider.clone();
@@ -2372,11 +2421,12 @@ pub(crate) async fn run_acp_http_server(
     vault_path: Option<&std::path::Path>,
     bind_override: Option<&str>,
     auth_token_override: Option<String>,
+    safe_mode: bool,
 ) -> anyhow::Result<()> {
     use std::sync::Arc;
     use tokio::sync::RwLock;
 
-    let app = AppBuilder::new(config_path, vault_backend, vault_key, vault_path).await?;
+    let app = AppBuilder::new(config_path, vault_backend, vault_key, vault_path, safe_mode).await?;
     log_acp_runtime_paths(app.config(), app.config_path());
     let bind_addr = bind_override.map_or_else(|| app.config().acp.http_bind.clone(), str::to_owned);
 
@@ -2892,6 +2942,7 @@ mod tests {
             shell_executor,
             scrape_executor,
             diagnostics_executor,
+            vec![],
         );
         let policy =
             zeph_tools::PermissionPolicy::default().with_autonomy(zeph_tools::AutonomyLevel::Full);
@@ -2941,6 +2992,7 @@ mod tests {
             shell_executor,
             scrape_executor,
             diagnostics_executor,
+            vec![],
         );
         // Default PermissionPolicy: Supervised autonomy, no explicit rules configured —
         // the exact real-world "user never set tools.permissions" scenario #5575 covers.
@@ -3107,6 +3159,7 @@ mod tests {
             shell_executor,
             scrape_executor,
             diagnostics_executor,
+            vec![],
         );
         let policy =
             zeph_tools::PermissionPolicy::default().with_autonomy(zeph_tools::AutonomyLevel::Full);
@@ -3182,6 +3235,7 @@ mod tests {
             shell_executor,
             scrape_executor,
             diagnostics_executor,
+            vec![],
         );
         let policy =
             zeph_tools::PermissionPolicy::default().with_autonomy(zeph_tools::AutonomyLevel::Full);
@@ -3337,6 +3391,7 @@ mod tests {
             shell_executor,
             scrape_executor,
             diagnostics_executor,
+            vec![],
         );
         let policy =
             zeph_tools::PermissionPolicy::default().with_autonomy(zeph_tools::AutonomyLevel::Full);
@@ -3517,6 +3572,7 @@ mod tests {
             shell_executor,
             scrape_executor,
             diagnostics_executor,
+            vec![],
         );
         let (trust_gated, _mcp_ids_handle) = crate::agent_setup::apply_common_tool_gating(
             zeph_tools::DynExecutor(Arc::new(base_executor)),
@@ -3597,6 +3653,7 @@ mod tests {
             shell_executor,
             scrape_executor,
             diagnostics_executor,
+            vec![],
         );
         let policy =
             zeph_tools::PermissionPolicy::default().with_autonomy(zeph_tools::AutonomyLevel::Full);

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -427,6 +427,7 @@ pub(crate) async fn build_tool_setup(
     permission_policy: zeph_tools::PermissionPolicy,
     with_tool_events: bool,
     bare: bool,
+    safe_mode: bool,
     runtime_ctx: RuntimeContext,
     age_vault: Option<&Arc<std::sync::RwLock<zeph_core::vault::AgeVaultProvider>>>,
     status_tx: Option<tokio::sync::mpsc::UnboundedSender<String>>,
@@ -567,7 +568,9 @@ pub(crate) async fn build_tool_setup(
         }
     }
     let mcp_manager = Arc::new(mcp_manager_builder);
-    let (mcp_tools, mcp_outcomes) = if bare {
+    // `safe_mode` (#6031) skips the connection, same as `bare` — independent gates, union
+    // applied here.
+    let (mcp_tools, mcp_outcomes) = if bare || safe_mode {
         (Vec::new(), Vec::new())
     } else {
         let result = mcp_manager.connect_all().await;
@@ -579,7 +582,7 @@ pub(crate) async fn build_tool_setup(
     let mcp_tool_rx = mcp_manager.subscribe_tool_changes();
     // Take the elicitation receiver before Arc-wrapping the manager.
     let mcp_elicitation_rx = mcp_manager.take_elicitation_rx();
-    if !bare {
+    if !bare && !safe_mode {
         // Spawn the background task that processes tools/list_changed events.
         mcp_manager.spawn_refresh_task(supervisor);
     }
@@ -599,6 +602,13 @@ pub(crate) async fn build_tool_setup(
         shell_executor,
         scrape_executor,
         diagnostics_executor,
+        config
+            .tools
+            .shell
+            .allowed_paths
+            .iter()
+            .map(PathBuf::from)
+            .collect(),
     );
     let composite = zeph_tools::CompositeExecutor::new(base_executor, mcp_executor);
     let (executor, taco_compressor) =
@@ -1714,6 +1724,7 @@ pub(crate) fn build_base_executor_chain<F, S, W>(
     shell_executor: S,
     scrape_executor: W,
     diagnostics_executor: zeph_tools::DiagnosticsExecutor,
+    cwd_allowed_paths: Vec<PathBuf>,
 ) -> zeph_tools::CompositeExecutor<
     F,
     zeph_tools::CompositeExecutor<
@@ -1739,7 +1750,7 @@ where
             zeph_tools::CompositeExecutor::new(
                 scrape_executor,
                 zeph_tools::CompositeExecutor::new(
-                    zeph_tools::SetCwdExecutor,
+                    zeph_tools::SetCwdExecutor::new(cwd_allowed_paths),
                     diagnostics_executor,
                 ),
             ),
@@ -2873,7 +2884,7 @@ mod tests {
         let file_executor = zeph_tools::FileExecutor::new(vec![]);
         let shell_executor = zeph_tools::ShellExecutor::new(&config.tools.shell);
         let scrape_executor = zeph_tools::WebScrapeExecutor::new(&config.tools.scrape);
-        let cwd_executor = zeph_tools::SetCwdExecutor;
+        let cwd_executor = zeph_tools::SetCwdExecutor::new(vec![]);
         let diagnostics_executor = build_diagnostics_executor(&config);
         let base_executor = zeph_tools::CompositeExecutor::new(
             file_executor,
@@ -2910,6 +2921,7 @@ mod tests {
             shell_executor,
             scrape_executor,
             diagnostics_executor,
+            vec![],
         );
 
         // Must exist on disk (DiagnosticsExecutor canonicalizes before the sandbox

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -188,6 +188,13 @@ impl AppBuilder {
     ///
     /// CLI-provided overrides take priority over environment variables and config.
     ///
+    /// `safe_mode` disables plugin auto-update and plugin config overlay for this
+    /// session (troubleshooting isolation, see `--safe-mode`/`ZEPH_SAFE_MODE`).
+    /// Callers resolve `flag || env` before calling; `Config::load` above already
+    /// applies the `ZEPH_SAFE_MODE` env overlay, so the two signals are OR'd
+    /// together into `config.cli.safe_mode` rather than one silently overriding
+    /// the other.
+    ///
     /// # Errors
     ///
     /// Returns [`BootstrapError`] if config loading, validation, vault backend parsing,
@@ -197,9 +204,11 @@ impl AppBuilder {
         vault_override: Option<&str>,
         vault_key_override: Option<&Path>,
         vault_path_override: Option<&Path>,
+        safe_mode: bool,
     ) -> Result<Self, BootstrapError> {
         let config_path = resolve_config_path(config_override);
         let mut config = Config::load(&config_path)?;
+        config.cli.safe_mode |= safe_mode;
         config.validate()?;
         config.llm.check_legacy_format()?;
 
@@ -250,11 +259,13 @@ impl AppBuilder {
             .resolve_secrets_masked(vault.as_ref(), secret_registry.as_ref())
             .await?;
 
-        run_plugin_auto_updates(&config).await;
-
-        let resolved_overlay =
+        let resolved_overlay = if config.cli.safe_mode {
+            zeph_plugins::ResolvedOverlay::default()
+        } else {
+            run_plugin_auto_updates(&config).await;
             zeph_plugins::apply_plugin_config_overlays(&mut config, &plugins_dir())
-                .map_err(|e| BootstrapError::Provider(format!("plugin overlay merge: {e}")))?;
+                .map_err(|e| BootstrapError::Provider(format!("plugin overlay merge: {e}")))?
+        };
 
         let qdrant_ops = build_qdrant_ops(&config)?;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -258,6 +258,15 @@ pub(crate) struct Cli {
     #[arg(long)]
     pub(crate) bare: bool,
 
+    /// Safe mode: start this session with ZEPH.md/CLAUDE.md/AGENTS.md project
+    /// instructions, plugins, skills, hooks, and MCP servers all disabled, to
+    /// isolate whether a customization is causing unwanted behavior. Distinct
+    /// from `--bare`, which skips memory/tool-registry/background-task overhead
+    /// instead — the two flags are independent and composable. Session-scoped
+    /// only; never persisted to config.toml. Equivalent to `ZEPH_SAFE_MODE=true`.
+    #[arg(long)]
+    pub(crate) safe_mode: bool,
+
     /// Emit structured JSON events to stdout (JSONL, one event per line).
     /// Safe for piping into `jq`. Forces all log output to stderr.
     /// Mutually exclusive with `--tui` and `--acp`.

--- a/src/commands/ingest.rs
+++ b/src/commands/ingest.rs
@@ -16,7 +16,9 @@ pub(crate) async fn handle_ingest(
     collection: String,
     config_path: Option<&Path>,
 ) -> anyhow::Result<()> {
-    let app = AppBuilder::new(config_path, None, None, None).await?;
+    // Non-interactive data command (Qdrant ingestion), not a troubleshooting session with
+    // customization sources to isolate — `safe_mode` is deliberately `false`, not omitted.
+    let app = AppBuilder::new(config_path, None, None, None, false).await?;
     let config = app.config();
 
     let qdrant = QdrantOps::new(

--- a/src/commands/knowledge.rs
+++ b/src/commands/knowledge.rs
@@ -267,7 +267,7 @@ async fn resolve_effective_max(max_documents: usize, config_path: Option<&Path>)
     if max_documents > 0 {
         return max_documents;
     }
-    AppBuilder::new(config_path, None, None, None)
+    AppBuilder::new(config_path, None, None, None, false)
         .await
         .map_or(0, |a| a.config().knowledge.max_documents)
 }
@@ -668,7 +668,7 @@ async fn build_ingest_resources(
     provider_override: Option<&str>,
     yes: bool,
 ) -> anyhow::Result<(IngestionPipeline, IngestLedger, String, String)> {
-    let app = AppBuilder::new(config_path, None, None, None).await?;
+    let app = AppBuilder::new(config_path, None, None, None, false).await?;
     let config = app.config();
     let qdrant = QdrantOps::new(
         &config.memory.qdrant_url,
@@ -932,7 +932,7 @@ async fn run_graph_ingest(
     root: &Path,
     config_path: Option<&Path>,
 ) -> anyhow::Result<()> {
-    let app = AppBuilder::new(config_path, None, None, None).await?;
+    let app = AppBuilder::new(config_path, None, None, None, false).await?;
     let config = app.config();
 
     // Enforce transcript_scope (INV-6: only "current-project" is supported).
@@ -1542,7 +1542,7 @@ async fn handle_external_agent_ingest(
     println!("  Ingesting {total} document(s) into knowledge graph…");
 
     // Phase 3: write to graph via SemanticMemory.
-    let app = AppBuilder::new(config_path, None, None, None).await?;
+    let app = AppBuilder::new(config_path, None, None, None, false).await?;
     let app_config = app.config();
     let (provider, _status_tx, _status_rx) = app.build_provider().await?;
     // #5444 S1: build_memory (via attach_reasoning_memory) would otherwise destructively
@@ -1706,7 +1706,7 @@ async fn handle_rollback(
     yes: bool,
     config_path: Option<&Path>,
 ) -> anyhow::Result<()> {
-    let app = AppBuilder::new(config_path, None, None, None).await?;
+    let app = AppBuilder::new(config_path, None, None, None, false).await?;
     let config = app.config();
 
     let store = SqliteStore::new(&config.memory.sqlite_path)
@@ -1794,7 +1794,7 @@ async fn handle_rollback(
 ///
 /// Returns an error when config loading or database access fails.
 async fn handle_status(config_path: Option<&Path>) -> anyhow::Result<()> {
-    let app = AppBuilder::new(config_path, None, None, None).await?;
+    let app = AppBuilder::new(config_path, None, None, None, false).await?;
     let config = app.config();
 
     let store = SqliteStore::new(&config.memory.sqlite_path)
@@ -2463,7 +2463,7 @@ collection = "{collection}"
         let dir = tempfile::tempdir().unwrap();
         let config_path = write_ollama_test_config(dir.path(), "unused_collection", Some("embed"));
 
-        let app = AppBuilder::new(Some(&config_path), None, None, None)
+        let app = AppBuilder::new(Some(&config_path), None, None, None, false)
             .await
             .expect("AppBuilder::new should succeed with a valid ollama-only config");
         let config = app.config();
@@ -2488,7 +2488,7 @@ collection = "{collection}"
         let dir = tempfile::tempdir().unwrap();
         let config_path = write_ollama_test_config(dir.path(), "unused_collection", None);
 
-        let app = AppBuilder::new(Some(&config_path), None, None, None)
+        let app = AppBuilder::new(Some(&config_path), None, None, None, false)
             .await
             .expect("AppBuilder::new should succeed with a valid ollama-only config");
         let config = app.config();
@@ -2778,7 +2778,7 @@ collection = "zeph_test_reasoning_guard_unused_documents"
         let _ = qdrant.delete_collection(collection).await;
         qdrant.ensure_collection(collection, 4).await.unwrap();
 
-        let app = AppBuilder::new(Some(&config_path), None, None, None)
+        let app = AppBuilder::new(Some(&config_path), None, None, None, false)
             .await
             .expect("AppBuilder::new should succeed with a valid ollama+qdrant config");
         let config = app.config();
@@ -2834,7 +2834,7 @@ collection = "zeph_test_reasoning_guard_unused_documents"
         // memory.reasoning.enabled defaults to false.
         let config_path = write_ollama_test_config(dir.path(), "unused_collection", Some("embed"));
 
-        let app = AppBuilder::new(Some(&config_path), None, None, None)
+        let app = AppBuilder::new(Some(&config_path), None, None, None, false)
             .await
             .expect("AppBuilder::new should succeed with a valid ollama-only config");
         let config = app.config();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -390,6 +390,16 @@ where
     )
     .with_embedding_provider(deps.embedding_provider.clone())
     .with_provider_pool(config.llm.providers.clone(), deps.provider_config_snapshot)
+    .with_safe_mode(config.cli.safe_mode)
+    .with_allowed_paths(
+        config
+            .tools
+            .shell
+            .allowed_paths
+            .iter()
+            .map(PathBuf::from)
+            .collect(),
+    )
     .maybe_init_tool_schema_filter(config.agent.tool_filter.clone(), deps.embedding_provider)
     .await
 }
@@ -400,10 +410,11 @@ pub(crate) async fn run_daemon(
     vault: Option<&str>,
     vault_key: Option<&std::path::Path>,
     vault_path: Option<&std::path::Path>,
+    safe_mode: bool,
 ) -> anyhow::Result<()> {
     use zeph_core::daemon::{ComponentHandle, DaemonSupervisor, PidGuard};
 
-    let app = AppBuilder::new(config_path, vault, vault_key, vault_path).await?;
+    let app = AppBuilder::new(config_path, vault, vault_key, vault_path, safe_mode).await?;
     let config = app.config();
 
     // Atomically acquire the daemon pid file lock — fails fast with `AlreadyRunning` if another
@@ -411,13 +422,25 @@ pub(crate) async fn run_daemon(
     let pid_guard = PidGuard::acquire(&config.daemon.pid_file)
         .map_err(|e| anyhow::anyhow!("failed to acquire daemon pid file lock: {e}"))?;
     tracing::info!(pid_file = %config.daemon.pid_file, "daemon started");
+    if config.cli.safe_mode {
+        tracing::info!(
+            "safe mode active: ZEPH.md/CLAUDE.md/AGENTS.md, plugins, skills, hooks, and MCP \
+             servers are disabled for this session"
+        );
+    }
 
     let (provider, status_tx, _status_rx) = app.build_provider().await?;
     let embed_model = app.embedding_model();
     let embedding_provider = crate::bootstrap::create_embedding_provider(app.config(), &provider);
     let budget_tokens = app.auto_budget_tokens(&provider);
 
-    let registry = std::sync::Arc::new(RwLock::new(app.build_registry()));
+    // Safe-mode gate (#6031): empty registry with no matching disables skill loading/matching,
+    // mirroring `runner.rs`'s `exec_mode.bare` gate and `acp::build_shared_core`'s safe-mode gate.
+    let registry = std::sync::Arc::new(RwLock::new(if config.cli.safe_mode {
+        zeph_skills::registry::SkillRegistry::empty()
+    } else {
+        app.build_registry()
+    }));
     let mem_cancel = tokio_util::sync::CancellationToken::new();
     let mem_supervisor = zeph_common::TaskSupervisor::new(mem_cancel.clone());
     let memory = std::sync::Arc::new(app.build_memory(&provider, &mem_supervisor).await?);
@@ -622,7 +645,13 @@ pub(crate) async fn run_daemon(
     )
     .await;
     let mcp_manager = std::sync::Arc::new(mcp_manager_builder);
-    let (mcp_tools, _mcp_outcomes) = mcp_manager.connect_all().await;
+    // Safe-mode gate (#6031): daemon had no prior bare-mode gate on MCP connections either —
+    // this is a fresh gate, mirroring `agent_setup::build_tool_setup`'s runner-path gate.
+    let (mcp_tools, _mcp_outcomes) = if config.cli.safe_mode {
+        (Vec::new(), Vec::new())
+    } else {
+        mcp_manager.connect_all().await
+    };
     // Retain a reference for explicit pre-shutdown so child processes are killed while the
     // tokio runtime is still live (fixes #2693: ChildWithCleanup::drop races with shutdown).
     let shutdown_mcp_manager = std::sync::Arc::clone(&mcp_manager);
@@ -640,6 +669,13 @@ pub(crate) async fn run_daemon(
         shell_executor,
         scrape_executor,
         diagnostics_executor,
+        config
+            .tools
+            .shell
+            .allowed_paths
+            .iter()
+            .map(PathBuf::from)
+            .collect(),
     );
     let memory_executor = zeph_core::memory_tools::MemoryToolExecutor::with_validator(
         std::sync::Arc::clone(&memory),
@@ -1066,12 +1102,17 @@ pub(crate) async fn run_daemon(
         agent
     };
 
-    let mut agent = agent
-        .with_document_config(config.memory.documents.clone())
-        .with_hooks_config(&config.hooks)
-        // Keep TrustGateExecutor's MCP tool-id registry in sync with MCP servers connected
-        // after startup (#5747) — without this, check_tool_refresh has no handle to update.
-        .with_mcp_tool_ids_handle(mcp_ids_handle);
+    let agent = agent.with_document_config(config.memory.documents.clone());
+    // Safe-mode gate (#6031): daemon had no prior bare-mode gate on hooks (unlike
+    // `runner.rs`'s `exec_mode.bare`) — this is a fresh gate, safe-mode only.
+    let agent = if config.cli.safe_mode {
+        agent
+    } else {
+        agent.with_hooks_config(&config.hooks)
+    };
+    // Keep TrustGateExecutor's MCP tool-id registry in sync with MCP servers connected
+    // after startup (#5747) — without this, check_tool_refresh has no handle to update.
+    let mut agent = agent.with_mcp_tool_ids_handle(mcp_ids_handle);
 
     // Spec 050 Phase 2 (#5913): wire ShadowSentinel into the agent so begin_turn() calls
     // advance_turn(), matching src/runner.rs and src/acp.rs.
@@ -1319,7 +1360,9 @@ mod tests {
             matcher: Some(zeph_skills::matcher::SkillMatcherBackend::InMemory(
                 inner_matcher,
             )),
-            tool_executor: zeph_tools::DynExecutor(std::sync::Arc::new(zeph_tools::SetCwdExecutor)),
+            tool_executor: zeph_tools::DynExecutor(std::sync::Arc::new(
+                zeph_tools::SetCwdExecutor::new(vec![]),
+            )),
             session_config,
             skill_paths: Vec::new(),
             reload_rx,
@@ -1408,7 +1451,9 @@ mod tests {
             matcher: Some(zeph_skills::matcher::SkillMatcherBackend::InMemory(
                 inner_matcher,
             )),
-            tool_executor: zeph_tools::DynExecutor(std::sync::Arc::new(zeph_tools::SetCwdExecutor)),
+            tool_executor: zeph_tools::DynExecutor(std::sync::Arc::new(
+                zeph_tools::SetCwdExecutor::new(vec![]),
+            )),
             session_config,
             skill_paths: Vec::new(),
             reload_rx,
@@ -1486,7 +1531,9 @@ mod tests {
                 zeph_skills::registry::SkillRegistry::empty(),
             )),
             matcher: None,
-            tool_executor: zeph_tools::DynExecutor(std::sync::Arc::new(zeph_tools::SetCwdExecutor)),
+            tool_executor: zeph_tools::DynExecutor(std::sync::Arc::new(
+                zeph_tools::SetCwdExecutor::new(vec![]),
+            )),
             session_config,
             skill_paths: Vec::new(),
             reload_rx,
@@ -1545,6 +1592,7 @@ mod tests {
             shell_executor,
             scrape_executor,
             diagnostics_executor,
+            vec![],
         );
         let policy =
             zeph_tools::PermissionPolicy::default().with_autonomy(zeph_tools::AutonomyLevel::Full);
@@ -1596,6 +1644,7 @@ mod tests {
             shell_executor,
             scrape_executor,
             diagnostics_executor,
+            vec![],
         );
         // Default PermissionPolicy: Supervised autonomy, no explicit rules configured —
         // the exact real-world "user never set tools.permissions" scenario #5575 covers.
@@ -1771,6 +1820,7 @@ mod tests {
             shell_executor,
             scrape_executor,
             diagnostics_executor,
+            vec![],
         );
         let policy =
             zeph_tools::PermissionPolicy::default().with_autonomy(zeph_tools::AutonomyLevel::Full);
@@ -1954,6 +2004,7 @@ mod tests {
             shell_executor,
             scrape_executor,
             diagnostics_executor,
+            vec![],
         );
         let policy =
             zeph_tools::PermissionPolicy::default().with_autonomy(zeph_tools::AutonomyLevel::Full);
@@ -2008,6 +2059,7 @@ mod tests {
             shell_executor,
             scrape_executor,
             diagnostics_executor,
+            vec![],
         );
         let policy =
             zeph_tools::PermissionPolicy::default().with_autonomy(zeph_tools::AutonomyLevel::Full);
@@ -2089,6 +2141,7 @@ mod tests {
             shell_executor,
             scrape_executor,
             diagnostics_executor,
+            vec![],
         );
         let (trust_gated, _mcp_ids_handle) = agent_setup::apply_common_tool_gating(
             zeph_tools::DynExecutor(std::sync::Arc::new(base_executor)),
@@ -2171,6 +2224,7 @@ mod tests {
             shell_executor,
             scrape_executor,
             diagnostics_executor,
+            vec![],
         );
         let policy =
             zeph_tools::PermissionPolicy::default().with_autonomy(zeph_tools::AutonomyLevel::Full);

--- a/src/execution_mode.rs
+++ b/src/execution_mode.rs
@@ -13,8 +13,10 @@ use crate::cli::Cli;
 /// falls back to the config value. A config value of `true` therefore activates
 /// the mode even when the flag is not passed — useful for scripting environments.
 #[derive(Clone, Copy, Debug, Default)]
+#[allow(clippy::struct_excessive_bools)] // runtime state — boolean flags are idiomatic here
 pub(crate) struct ExecutionMode {
     pub(crate) bare: bool,
+    pub(crate) safe_mode: bool,
     pub(crate) json: bool,
     pub(crate) auto: bool,
 }
@@ -24,10 +26,27 @@ impl ExecutionMode {
     pub(crate) fn from_cli_and_config(cli: &Cli, cfg: &Config) -> Self {
         Self {
             bare: cli.bare || cfg.cli.bare,
+            safe_mode: cli.safe_mode || cfg.cli.safe_mode,
             json: cli.json || cfg.cli.json,
             auto: cli.auto || cfg.cli.auto,
         }
     }
+}
+
+/// Resolve the `--safe-mode` CLI flag against the `ZEPH_SAFE_MODE` environment variable.
+///
+/// Used by session entry points (`daemon`, `acp`, `serve`) that call `AppBuilder::new`
+/// directly, before config is loaded — so only the env var (not `config.cli.safe_mode`) is
+/// available to OR against the flag at this point. `AppBuilder::new` itself ORs the resolved
+/// value into `config.cli.safe_mode` (which the `Config::load` env overlay may have already
+/// set), so all three sources — flag, env, and any config default — converge downstream
+/// regardless of which combination triggered activation here.
+pub(crate) fn resolve_safe_mode_flag(cli_flag: bool) -> bool {
+    cli_flag
+        || std::env::var("ZEPH_SAFE_MODE")
+            .ok()
+            .and_then(|v| v.parse::<bool>().ok())
+            .unwrap_or(false)
 }
 
 #[cfg(test)]
@@ -41,7 +60,7 @@ mod tests {
     #[test]
     fn all_false_by_default() {
         let mode = ExecutionMode::default();
-        assert!(!mode.bare && !mode.json && !mode.auto);
+        assert!(!mode.bare && !mode.safe_mode && !mode.json && !mode.auto);
     }
 
     #[test]
@@ -50,8 +69,61 @@ mod tests {
         cli.bare = true;
         let mode = ExecutionMode::from_cli_and_config(&cli, &Config::default());
         assert!(mode.bare);
+        assert!(!mode.safe_mode);
         assert!(!mode.json);
         assert!(!mode.auto);
+    }
+
+    #[test]
+    fn cli_safe_mode_flag_activates_safe_mode() {
+        let mut cli = default_cli();
+        cli.safe_mode = true;
+        let mode = ExecutionMode::from_cli_and_config(&cli, &Config::default());
+        assert!(mode.safe_mode);
+        assert!(!mode.bare);
+    }
+
+    #[test]
+    fn config_safe_mode_activates_safe_mode() {
+        let mut cfg = Config::default();
+        cfg.cli.safe_mode = true;
+        let mode = ExecutionMode::from_cli_and_config(&default_cli(), &cfg);
+        assert!(mode.safe_mode);
+        assert!(!mode.bare);
+    }
+
+    #[test]
+    fn bare_and_safe_mode_compose_independently() {
+        let mut cli = default_cli();
+        cli.bare = true;
+        cli.safe_mode = true;
+        let mode = ExecutionMode::from_cli_and_config(&cli, &Config::default());
+        assert!(mode.bare);
+        assert!(mode.safe_mode);
+    }
+
+    #[test]
+    fn resolve_safe_mode_flag_true_short_circuits_env_read() {
+        // `true` must not depend on `ZEPH_SAFE_MODE` being unset — safe to run unguarded.
+        assert!(resolve_safe_mode_flag(true));
+    }
+
+    #[test]
+    #[serial_test::serial(zeph_safe_mode_env)]
+    // std::env::set_var / remove_var are unsafe in Rust 2024 edition; guarded by #[serial]
+    // above (mirrors src/bootstrap/tests.rs's identical precedent).
+    #[allow(unsafe_code)]
+    fn resolve_safe_mode_flag_reads_env_when_flag_false() {
+        // SAFETY: guarded by `#[serial]` on this env-var-scoped lock name — no other test in
+        // this process touches `ZEPH_SAFE_MODE` concurrently.
+        unsafe {
+            std::env::set_var("ZEPH_SAFE_MODE", "true");
+        }
+        assert!(resolve_safe_mode_flag(false));
+        unsafe {
+            std::env::remove_var("ZEPH_SAFE_MODE");
+        }
+        assert!(!resolve_safe_mode_flag(false));
     }
 
     #[test]
@@ -99,6 +171,6 @@ mod tests {
     #[test]
     fn cli_overrides_config_when_both_false_still_false() {
         let mode = ExecutionMode::from_cli_and_config(&default_cli(), &Config::default());
-        assert!(!mode.bare && !mode.json && !mode.auto);
+        assert!(!mode.bare && !mode.safe_mode && !mode.json && !mode.auto);
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -271,6 +271,7 @@ where
     tiered_retrieval_classifier_provider: Option<std::sync::Arc<LlmAnyProvider>>,
     tiered_retrieval_validator_provider: Option<std::sync::Arc<LlmAnyProvider>>,
     bare_mode: bool,
+    safe_mode: bool,
 }
 
 /// Build the `Agent` from the `AgentBuilder` construction chain used by the CLI bootstrap path
@@ -280,6 +281,7 @@ where
 /// Only the core `Agent::new_with_registry_arc(...)...await` wiring lives here — feature-gated
 /// post-processing (MCP wiring, provider pool, debug dumper, preloaded history, etc.) stays in
 /// `run()`, matching how `build_agent_factory`'s returned closure covers only the core wiring too.
+#[allow(clippy::too_many_lines)] // strictly sequential AgentBuilder chain — one call per config field, splitting would not reduce complexity
 async fn build_agent<C, F>(deps: BuildAgentDeps<'_, F>, channel: C) -> Agent<C>
 where
     C: zeph_core::channel::Channel,
@@ -380,6 +382,16 @@ where
     )
     .with_embedding_provider(deps.embedding_provider.clone())
     .with_bare_mode(deps.bare_mode)
+    .with_safe_mode(deps.safe_mode)
+    .with_allowed_paths(
+        config
+            .tools
+            .shell
+            .allowed_paths
+            .iter()
+            .map(std::path::PathBuf::from)
+            .collect(),
+    )
     .maybe_init_tool_schema_filter(config.agent.tool_filter.clone(), deps.embedding_provider)
     .await
 }
@@ -436,6 +448,7 @@ async fn run_configured_acp_autostart(cli: &Cli, transport: AcpTransport) -> any
     let vault_backend = cli.vault.clone();
     let vault_key = cli.vault_key.clone();
     let vault_path = cli.vault_path.clone();
+    let safe_mode = crate::execution_mode::resolve_safe_mode_flag(cli.safe_mode);
 
     match transport {
         AcpTransport::Stdio => {
@@ -447,6 +460,7 @@ async fn run_configured_acp_autostart(cli: &Cli, transport: AcpTransport) -> any
                 Vec::new(),
                 Vec::new(),
                 None,
+                safe_mode,
             ))
             .await
         }
@@ -459,6 +473,7 @@ async fn run_configured_acp_autostart(cli: &Cli, transport: AcpTransport) -> any
                 vault_path.as_deref(),
                 None,
                 None,
+                safe_mode,
             ))
             .await
         }
@@ -473,6 +488,7 @@ async fn run_configured_acp_autostart(cli: &Cli, transport: AcpTransport) -> any
                     Vec::new(),
                     Vec::new(),
                     None,
+                    safe_mode,
                 ) => result,
                 result = run_acp_http_server(
                     config_path.as_deref(),
@@ -481,6 +497,7 @@ async fn run_configured_acp_autostart(cli: &Cli, transport: AcpTransport) -> any
                     vault_path.as_deref(),
                     None,
                     None,
+                    safe_mode,
                 ) => result,
             }
         }
@@ -498,6 +515,7 @@ async fn run_configured_acp_autostart(cli: &Cli, transport: AcpTransport) -> any
                 Vec::new(),
                 Vec::new(),
                 None,
+                safe_mode,
             ))
             .await
         }
@@ -516,6 +534,7 @@ async fn run_configured_acp_autostart(cli: &Cli, transport: AcpTransport) -> any
                 Vec::new(),
                 Vec::new(),
                 None,
+                safe_mode,
             ))
             .await
         }
@@ -925,6 +944,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
                     vault_backend: cli.vault.clone(),
                     vault_key: cli.vault_key.clone(),
                     vault_path: cli.vault_path.clone(),
+                    safe_mode: crate::execution_mode::resolve_safe_mode_flag(cli.safe_mode),
                 },
                 cli.config.as_deref(),
             )
@@ -1139,6 +1159,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
             cli.vault.as_deref(),
             cli.vault_key.as_deref(),
             cli.vault_path.as_deref(),
+            crate::execution_mode::resolve_safe_mode_flag(cli.safe_mode),
         ))
         .await;
     }
@@ -1166,6 +1187,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
             cli.acp_additional_dir,
             cli.acp_auth_method,
             cli_message_ids,
+            crate::execution_mode::resolve_safe_mode_flag(cli.safe_mode),
         ))
         .await;
     }
@@ -1179,6 +1201,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
             cli.vault_path.as_deref(),
             cli.acp_http_bind.as_deref(),
             cli.acp_auth_token,
+            crate::execution_mode::resolve_safe_mode_flag(cli.safe_mode),
         ))
         .await;
     }
@@ -1196,6 +1219,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         cli.vault.as_deref(),
         cli.vault_key.as_deref(),
         cli.vault_path.as_deref(),
+        crate::execution_mode::resolve_safe_mode_flag(cli.safe_mode),
     )
     .await?;
 
@@ -1406,7 +1430,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
     #[cfg(not(feature = "tui"))]
     let with_tool_events = false;
 
-    let registry = if exec_mode.bare {
+    let registry = if exec_mode.bare || exec_mode.safe_mode {
         zeph_skills::registry::SkillRegistry::empty()
     } else {
         app.build_registry()
@@ -1559,6 +1583,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
             permission_policy.clone(),
             with_tool_events,
             exec_mode.bare,
+            exec_mode.safe_mode,
             runtime_ctx,
             app.age_vault_arc(),
             Some(agent_status_tx.clone()),
@@ -1574,6 +1599,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         permission_policy.clone(),
         with_tool_events,
         exec_mode.bare,
+        exec_mode.safe_mode,
         runtime_ctx,
         app.age_vault_arc(),
         Some(agent_status_tx.clone()),
@@ -1743,9 +1769,23 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
             version: env!("CARGO_PKG_VERSION"),
             bare: exec_mode.bare,
             auto: exec_mode.auto,
+            safe_mode: exec_mode.safe_mode,
         });
     } else if is_cli {
         println!("zeph v{}", env!("CARGO_PKG_VERSION"));
+    }
+    // FR-008 (#6031): clear startup log line + CLI banner distinguishing safe mode from
+    // `--bare` (NFR-001) — a user running a "clean agent" test must not mistake the result
+    // for representative behavior.
+    if exec_mode.safe_mode {
+        tracing::info!(
+            "safe mode active: ZEPH.md/CLAUDE.md/AGENTS.md, plugins, skills, hooks, and MCP \
+             servers are disabled for this session (see --bare for the separate memory/tool- \
+             registry test mode)"
+        );
+        if is_cli && json_sink.is_none() {
+            println!("Safe mode: customizations disabled (ZEPH.md, plugins, skills, hooks, MCP)");
+        }
     }
 
     // Determine channel name before channel is consumed by Agent::new.
@@ -2498,6 +2538,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
             tiered_retrieval_classifier_provider,
             tiered_retrieval_validator_provider,
             bare_mode: exec_mode.bare,
+            safe_mode: exec_mode.safe_mode,
         },
         channel,
     )
@@ -2623,14 +2664,6 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
     provider_kinds.sort_unstable_by_key(|k| k.as_str());
     provider_kinds.dedup_by_key(|k| k.as_str());
 
-    let instruction_blocks = zeph_core::instructions::load_instructions_async(
-        instruction_base.clone(),
-        provider_kinds.clone(),
-        explicit_instruction_files.clone(),
-        config.agent.instruction_auto_detect,
-    )
-    .await;
-
     let instruction_reload_state = zeph_core::instructions::InstructionReloadState {
         base_dir: instruction_base.clone(),
         provider_kinds: provider_kinds.clone(),
@@ -2638,54 +2671,78 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         auto_detect: config.agent.instruction_auto_detect,
     };
 
-    // Collect parent directories of candidate instruction files to watch.
-    // Only include dirs within the canonical project root to avoid watching external paths.
-    let canonical_base = tokio::fs::canonicalize(&instruction_base)
-        .await
-        .unwrap_or_else(|_| instruction_base.clone());
-    let mut watch_dirs: Vec<std::path::PathBuf> = Vec::new();
-    watch_dirs.push(instruction_base.clone());
-    watch_dirs.push(instruction_base.join(".zeph"));
-    if config.agent.instruction_auto_detect {
-        watch_dirs.push(instruction_base.join(".claude"));
-        watch_dirs.push(instruction_base.join(".claude").join("rules"));
-    }
-    for p in &explicit_instruction_files {
-        let abs = if p.is_absolute() {
-            p.clone()
-        } else {
-            instruction_base.join(p)
-        };
-        // Boundary-check: only watch dirs within the project root.
-        if let Some(parent) = abs.parent() {
-            let canonical_parent = tokio::fs::canonicalize(parent).await;
-            if let Ok(canonical_parent) = canonical_parent
-                && canonical_parent.starts_with(&canonical_base)
-            {
-                watch_dirs.push(parent.to_path_buf());
+    // Safe-mode gate (#6031, FR-001): skip instruction discovery entirely — not merely
+    // ignore the result — so ZEPH.md/CLAUDE.md/AGENTS.md are never read from disk and no
+    // filesystem watcher is started. `instruction_reload_state` is still built above (it's
+    // pure data, no I/O) so `/cd` (#6032) has a well-formed `base_dir` to re-point if the
+    // session later drops out of safe mode via a restart.
+    let (instruction_blocks, _instruction_watcher) = if exec_mode.safe_mode {
+        tracing::info!(
+            "safe mode: skipping ZEPH.md/CLAUDE.md/AGENTS.md instruction discovery and watcher"
+        );
+        let (tx2, _rx2) = tokio::sync::mpsc::channel(1);
+        let watcher = zeph_core::instructions::InstructionWatcher::start(&[], tx2, &supervisor)
+            .expect("empty-path watcher always succeeds");
+        (Vec::new(), watcher)
+    } else {
+        let instruction_blocks = zeph_core::instructions::load_instructions_async(
+            instruction_base.clone(),
+            provider_kinds.clone(),
+            explicit_instruction_files.clone(),
+            config.agent.instruction_auto_detect,
+        )
+        .await;
+
+        // Collect parent directories of candidate instruction files to watch.
+        // Only include dirs within the canonical project root to avoid watching external paths.
+        let canonical_base = tokio::fs::canonicalize(&instruction_base)
+            .await
+            .unwrap_or_else(|_| instruction_base.clone());
+        let mut watch_dirs: Vec<std::path::PathBuf> = Vec::new();
+        watch_dirs.push(instruction_base.clone());
+        watch_dirs.push(instruction_base.join(".zeph"));
+        if config.agent.instruction_auto_detect {
+            watch_dirs.push(instruction_base.join(".claude"));
+            watch_dirs.push(instruction_base.join(".claude").join("rules"));
+        }
+        for p in &explicit_instruction_files {
+            let abs = if p.is_absolute() {
+                p.clone()
+            } else {
+                instruction_base.join(p)
+            };
+            // Boundary-check: only watch dirs within the project root.
+            if let Some(parent) = abs.parent() {
+                let canonical_parent = tokio::fs::canonicalize(parent).await;
+                if let Ok(canonical_parent) = canonical_parent
+                    && canonical_parent.starts_with(&canonical_base)
+                {
+                    watch_dirs.push(parent.to_path_buf());
+                }
             }
         }
-    }
-    watch_dirs.sort();
-    watch_dirs.dedup();
+        watch_dirs.sort();
+        watch_dirs.dedup();
 
-    let _instruction_watcher = if watch_dirs.is_empty() {
-        tracing::debug!("no instruction watch dirs, hot-reload disabled");
-        let (tx2, _rx2) = tokio::sync::mpsc::channel(1);
-        zeph_core::instructions::InstructionWatcher::start(&[], tx2, &supervisor)
-            .expect("empty-path watcher always succeeds")
-    } else {
-        zeph_core::instructions::InstructionWatcher::start(
-            &watch_dirs,
-            instruction_reload_tx,
-            &supervisor,
-        )
-        .unwrap_or_else(|e| {
-            tracing::warn!(error = %e, "instruction watcher failed, hot-reload disabled");
+        let watcher = if watch_dirs.is_empty() {
+            tracing::debug!("no instruction watch dirs, hot-reload disabled");
             let (tx2, _rx2) = tokio::sync::mpsc::channel(1);
             zeph_core::instructions::InstructionWatcher::start(&[], tx2, &supervisor)
                 .expect("empty-path watcher always succeeds")
-        })
+        } else {
+            zeph_core::instructions::InstructionWatcher::start(
+                &watch_dirs,
+                instruction_reload_tx,
+                &supervisor,
+            )
+            .unwrap_or_else(|e| {
+                tracing::warn!(error = %e, "instruction watcher failed, hot-reload disabled");
+                let (tx2, _rx2) = tokio::sync::mpsc::channel(1);
+                zeph_core::instructions::InstructionWatcher::start(&[], tx2, &supervisor)
+                    .expect("empty-path watcher always succeeds")
+            })
+        };
+        (instruction_blocks, watcher)
     };
 
     let agent = agent
@@ -2843,14 +2900,16 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
     let agent = agent_setup::apply_mcp_pruning(agent, config);
     let agent = agent_setup::apply_mcp_discovery(agent, config);
 
-    // Wire LSP context injection hooks when the feature is enabled and configured.
-    let agent = if config.lsp.enabled {
+    // Wire LSP context injection hooks when the feature is enabled and configured. Also gated
+    // by safe-mode (#6031): LSP hover/diagnostics auto-injection is a customization-adjacent
+    // source the flag must isolate, even though `--bare` never gated it.
+    let agent = if config.lsp.enabled && !exec_mode.safe_mode {
         let runner = zeph_core::lsp_hooks::LspHookRunner::new(lsp_mcp_manager, config.lsp.clone());
         agent.with_lsp_hooks(runner)
     } else {
         agent
     };
-    let agent = if exec_mode.bare {
+    let agent = if exec_mode.bare || exec_mode.safe_mode {
         agent
     } else {
         agent.with_hooks_config(&config.hooks)
@@ -4431,7 +4490,9 @@ mod tests {
             matcher: Some(zeph_skills::matcher::SkillMatcherBackend::InMemory(
                 inner_matcher,
             )),
-            tool_executor: zeph_tools::DynExecutor(std::sync::Arc::new(zeph_tools::SetCwdExecutor)),
+            tool_executor: zeph_tools::DynExecutor(std::sync::Arc::new(
+                zeph_tools::SetCwdExecutor::new(vec![]),
+            )),
             session_config,
             active_provider_name: "test".to_owned(),
             skill_paths: Vec::new(),
@@ -4456,6 +4517,7 @@ mod tests {
             tiered_retrieval_classifier_provider: None,
             tiered_retrieval_validator_provider: None,
             bare_mode: false,
+            safe_mode: false,
         };
 
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
@@ -4520,7 +4582,9 @@ mod tests {
             matcher: Some(zeph_skills::matcher::SkillMatcherBackend::InMemory(
                 inner_matcher,
             )),
-            tool_executor: zeph_tools::DynExecutor(std::sync::Arc::new(zeph_tools::SetCwdExecutor)),
+            tool_executor: zeph_tools::DynExecutor(std::sync::Arc::new(
+                zeph_tools::SetCwdExecutor::new(vec![]),
+            )),
             session_config,
             active_provider_name: "test".to_owned(),
             skill_paths: Vec::new(),
@@ -4545,6 +4609,7 @@ mod tests {
             tiered_retrieval_classifier_provider: None,
             tiered_retrieval_validator_provider: None,
             bare_mode: false,
+            safe_mode: false,
         };
 
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);

--- a/src/serve/agent_factory.rs
+++ b/src/serve/agent_factory.rs
@@ -247,7 +247,14 @@ pub(crate) async fn build_agent_factory(
         .with_provider_pool(deps.provider_pool, deps.provider_config_snapshot)
         // #5951: wire the self-check quality pipeline, matching src/runner.rs/src/acp.rs/
         // src/daemon.rs.
-        .with_quality_pipeline(deps.quality_pipeline);
+        .with_quality_pipeline(deps.quality_pipeline)
+        // #6031: propagate safe-mode onto this session's Agent so check_cwd_changed's /cd
+        // (#6032) instruction-re-discovery gate is correctly set, matching
+        // src/runner.rs/src/acp.rs/src/daemon.rs.
+        .with_safe_mode(deps.safe_mode)
+        // #6032 SEC-2: sandbox `/cd` to the same allowed_paths as the file/shell/diagnostics
+        // executors, matching src/runner.rs/src/acp.rs/src/daemon.rs.
+        .with_allowed_paths(deps.allowed_paths);
         if !preloaded_messages.is_empty() {
             agent = agent.with_preloaded_messages(preloaded_messages);
         }
@@ -827,7 +834,7 @@ mod tests {
             rl_persist_interval: 0,
             rl_warmup_updates: 0,
             rl_head: None,
-            tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
+            tool_executor: Arc::new(zeph_tools::SetCwdExecutor::new(vec![])),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
             audit_logger: None,
@@ -848,6 +855,8 @@ mod tests {
             ),
             trajectory_sentinel_config: zeph_config::TrajectorySentinelConfig::default(),
             quality_pipeline: None,
+            safe_mode: false,
+            allowed_paths: vec![],
         };
 
         let build_agent = Box::pin(build_agent_factory(deps, session_id.clone(), cid)).await;
@@ -914,7 +923,7 @@ mod tests {
             rl_persist_interval: 0,
             rl_warmup_updates: 0,
             rl_head: None,
-            tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
+            tool_executor: Arc::new(zeph_tools::SetCwdExecutor::new(vec![])),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
             audit_logger: None,
@@ -939,6 +948,8 @@ mod tests {
             ),
             trajectory_sentinel_config: zeph_config::TrajectorySentinelConfig::default(),
             quality_pipeline: None,
+            safe_mode: false,
+            allowed_paths: vec![],
         };
 
         let build_agent = Box::pin(build_agent_factory(deps, session_id.clone(), cid)).await;
@@ -1028,7 +1039,7 @@ mod tests {
             rl_persist_interval: 0,
             rl_warmup_updates: 0,
             rl_head: None,
-            tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
+            tool_executor: Arc::new(zeph_tools::SetCwdExecutor::new(vec![])),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
             audit_logger: None,
@@ -1049,6 +1060,8 @@ mod tests {
             ),
             trajectory_sentinel_config: zeph_config::TrajectorySentinelConfig::default(),
             quality_pipeline: None,
+            safe_mode: false,
+            allowed_paths: vec![],
         };
 
         let build_agent = Box::pin(build_agent_factory(deps, session_id.clone(), cid)).await;
@@ -1127,7 +1140,7 @@ mod tests {
             rl_persist_interval: 0,
             rl_warmup_updates: 0,
             rl_head: None,
-            tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
+            tool_executor: Arc::new(zeph_tools::SetCwdExecutor::new(vec![])),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
             audit_logger: None,
@@ -1148,6 +1161,8 @@ mod tests {
             ),
             trajectory_sentinel_config: zeph_config::TrajectorySentinelConfig::default(),
             quality_pipeline: None,
+            safe_mode: false,
+            allowed_paths: vec![],
         };
 
         let build_agent = Box::pin(build_agent_factory(deps, session_id.clone(), cid)).await;
@@ -1225,7 +1240,7 @@ mod tests {
             rl_persist_interval: 5,
             rl_warmup_updates: 3,
             rl_head: Some(zeph_skills::rl_head::RoutingHead::new(8)),
-            tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
+            tool_executor: Arc::new(zeph_tools::SetCwdExecutor::new(vec![])),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
             audit_logger: None,
@@ -1246,6 +1261,8 @@ mod tests {
             ),
             trajectory_sentinel_config: zeph_config::TrajectorySentinelConfig::default(),
             quality_pipeline: None,
+            safe_mode: false,
+            allowed_paths: vec![],
         };
 
         let build_agent = Box::pin(build_agent_factory(deps, session_id.clone(), cid)).await;
@@ -1320,7 +1337,7 @@ mod tests {
             rl_persist_interval: 0,
             rl_warmup_updates: 0,
             rl_head: None,
-            tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
+            tool_executor: Arc::new(zeph_tools::SetCwdExecutor::new(vec![])),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
             audit_logger: None,
@@ -1341,6 +1358,8 @@ mod tests {
             ),
             trajectory_sentinel_config: zeph_config::TrajectorySentinelConfig::default(),
             quality_pipeline: None,
+            safe_mode: false,
+            allowed_paths: vec![],
         };
 
         let build_agent = Box::pin(build_agent_factory(deps, session_id.clone(), cid)).await;
@@ -1397,7 +1416,7 @@ mod tests {
             rl_persist_interval: 0,
             rl_warmup_updates: 0,
             rl_head: None,
-            tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
+            tool_executor: Arc::new(zeph_tools::SetCwdExecutor::new(vec![])),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default()
                 .with_autonomy(zeph_tools::AutonomyLevel::Full),
@@ -1419,6 +1438,8 @@ mod tests {
             ),
             trajectory_sentinel_config: zeph_config::TrajectorySentinelConfig::default(),
             quality_pipeline: None,
+            safe_mode: false,
+            allowed_paths: vec![],
         }
     }
 
@@ -1593,7 +1614,7 @@ mod tests {
             Arc::new(parking_lot::Mutex::new(Vec::new()));
 
         let gated = gate_serve_session_executor(
-            Arc::new(zeph_tools::SetCwdExecutor),
+            Arc::new(zeph_tools::SetCwdExecutor::new(vec![])),
             &zeph_tools::PermissionPolicy::default().with_autonomy(zeph_tools::AutonomyLevel::Full),
             &policy_gate_pieces,
             None,

--- a/src/serve/deps.rs
+++ b/src/serve/deps.rs
@@ -166,6 +166,14 @@ pub(crate) struct ServeAgentDeps {
     /// work, so it does not need to be rebuilt per session. `agent_factory::build_agent_factory`
     /// attaches it via `Agent::with_quality_pipeline`, mirroring `src/runner.rs`.
     pub(crate) quality_pipeline: Option<Arc<zeph_core::quality::SelfCheckPipeline>>,
+    /// Safe-mode gate (#6031): `config.cli.safe_mode`, wired into every session's `Agent` via
+    /// `Agent::with_safe_mode` so `check_cwd_changed`'s `/cd` (#6032) instruction-re-discovery
+    /// gate is correctly set for serve-built agents, matching `runner.rs`/`daemon.rs`/`acp.rs`.
+    pub(crate) safe_mode: bool,
+    /// `config.tools.shell.allowed_paths` (#6032 SEC-2), wired into every session's `Agent`
+    /// via `Agent::with_allowed_paths` so `/cd` is validated against the same sandbox
+    /// boundary `FileExecutor`/`DiagnosticsExecutor`/`SetCwdExecutor` already enforce.
+    pub(crate) allowed_paths: Vec<PathBuf>,
 }
 
 /// Assemble [`ServeAgentDeps`] once at `zeph serve-sessions` startup, plus the resolved bearer
@@ -186,10 +194,11 @@ pub(crate) async fn build_serve_deps(
     vault_backend: Option<&str>,
     vault_key: Option<&std::path::Path>,
     vault_path: Option<&std::path::Path>,
+    safe_mode: bool,
 ) -> anyhow::Result<(ServeAgentDeps, Option<String>)> {
     use crate::bootstrap::AppBuilder;
 
-    let app = AppBuilder::new(config_path, vault_backend, vault_key, vault_path).await?;
+    let app = AppBuilder::new(config_path, vault_backend, vault_key, vault_path, safe_mode).await?;
     let auth_token = resolve_auth_token(&app).await;
 
     let cancel = tokio_util::sync::CancellationToken::new();
@@ -216,6 +225,12 @@ pub(crate) async fn assemble_serve_deps(
     supervisor: &zeph_common::task_supervisor::TaskSupervisor,
 ) -> anyhow::Result<ServeAgentDeps> {
     let config = app.config();
+    if config.cli.safe_mode {
+        tracing::info!(
+            "safe mode active: plugins and skills are disabled for every session built from \
+             this serve-sessions process (serve wires no hooks or MCP tools yet)"
+        );
+    }
     let (tool_executor, permission_policy, audit_logger) =
         build_tool_executor(config, supervisor).await?;
     // R2 (SEC-H1): built once, eagerly, here — its outputs (`PolicyEnforcer`/`PolicyValidator`/
@@ -472,6 +487,14 @@ pub(crate) async fn assemble_serve_deps(
         shadow_sentinel_probe_provider,
         trajectory_sentinel_config,
         quality_pipeline,
+        safe_mode: config.cli.safe_mode,
+        allowed_paths: config
+            .tools
+            .shell
+            .allowed_paths
+            .iter()
+            .map(PathBuf::from)
+            .collect(),
     })
 }
 
@@ -572,7 +595,15 @@ async fn build_tool_executor(
             .map(PathBuf::from)
             .collect(),
     );
-    let cwd_executor = zeph_tools::SetCwdExecutor;
+    let cwd_executor = zeph_tools::SetCwdExecutor::new(
+        config
+            .tools
+            .shell
+            .allowed_paths
+            .iter()
+            .map(PathBuf::from)
+            .collect(),
+    );
     let base: Arc<dyn ErasedToolExecutor> = Arc::new(zeph_tools::CompositeExecutor::new(
         file_executor,
         zeph_tools::CompositeExecutor::new(

--- a/src/serve/handlers.rs
+++ b/src/serve/handlers.rs
@@ -538,7 +538,7 @@ mod tests {
             rl_persist_interval: 0,
             rl_warmup_updates: 0,
             rl_head: None,
-            tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
+            tool_executor: Arc::new(zeph_tools::SetCwdExecutor::new(vec![])),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
             audit_logger: None,
@@ -562,6 +562,8 @@ mod tests {
             ),
             trajectory_sentinel_config: zeph_config::TrajectorySentinelConfig::default(),
             quality_pipeline: None,
+            safe_mode: false,
+            allowed_paths: vec![],
         };
         AppState {
             registry: Arc::new(LiveSessionRegistry::new()),

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -74,6 +74,11 @@ pub(crate) struct ServeSessionsArgs {
     pub(crate) vault_key: Option<std::path::PathBuf>,
     /// `--vault-path` — path to the age-encrypted secrets file.
     pub(crate) vault_path: Option<std::path::PathBuf>,
+    /// Resolved `--safe-mode` flag (already OR'd with `ZEPH_SAFE_MODE` by the caller) —
+    /// disables plugin loading (`AppBuilder::new`) and the skill registry
+    /// (`crate::acp::build_shared_core`) for every session this `serve-sessions` process
+    /// builds. Serve wires no hooks or MCP tools today, so there is nothing else to gate here.
+    pub(crate) safe_mode: bool,
 }
 
 /// Shared HTTP handler state.
@@ -149,6 +154,7 @@ pub(crate) async fn handle_serve_sessions_command(
         args.vault_backend.as_deref(),
         args.vault_key.as_deref(),
         args.vault_path.as_deref(),
+        args.safe_mode,
     ))
     .await?;
 
@@ -215,6 +221,7 @@ async fn run_serve_with_acp(
         args.vault_backend.as_deref(),
         args.vault_key.as_deref(),
         args.vault_path.as_deref(),
+        args.safe_mode,
     )
     .await?;
     let serve_config = app.config().serve.clone();

--- a/src/serve/test_support.rs
+++ b/src/serve/test_support.rs
@@ -126,7 +126,7 @@ impl ServeTestHarness {
             rl_persist_interval: 0,
             rl_warmup_updates: 0,
             rl_head: None,
-            tool_executor: Arc::new(zeph_tools::SetCwdExecutor),
+            tool_executor: Arc::new(zeph_tools::SetCwdExecutor::new(vec![])),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
             audit_logger: None,
@@ -150,6 +150,8 @@ impl ServeTestHarness {
             ),
             trajectory_sentinel_config: zeph_config::TrajectorySentinelConfig::default(),
             quality_pipeline: None,
+            safe_mode: false,
+            allowed_paths: vec![],
         };
 
         let state = AppState {


### PR DESCRIPTION
## Summary

- Adds a user-facing `/cd <path>` slash command (CLI/TUI/ACP), routed through the existing `set_working_directory`/`check_cwd_changed` pipeline. Invalidates the repo-map memo and re-runs CLAUDE.md/AGENTS.md discovery on a directory change, while preserving the cached system-prompt block (`working_directory:` moved into the volatile tail rather than adding a new cache-control block, so a `/cd` between directories with unchanged instructions keeps the expensive cached block intact).
- Adds a `--safe-mode` flag (and `ZEPH_SAFE_MODE` env var) that disables project-context loading, plugins, skills (including hot-reload), hooks, and MCP servers for the current session only — distinct from the existing `--bare` test-isolation mode. Gated consistently across all six session entry points: CLI/TUI runner, daemon, standalone ACP, ACP-HTTP, and `zeph serve-sessions` with and without `--acp`. Never persisted to `config.toml`.
- `/cd`'s instruction re-discovery is skipped in a `--safe-mode` session, so `/cd` cannot silently re-enable a disabled customization source.
- Path resolution for `/cd` and the pre-existing `set_working_directory` tool now validates against the shell sandbox's `allowed_paths` via a new shared `zeph_common::security` module (also used by `FileExecutor`/`DiagnosticsExecutor`, replacing their previous independent implementations of the same check).

## Design process

Went through 3 rounds of architecture critique before implementation (prompt-cache block budget, `AppBuilder::new` plugin-gating structure, safe-mode/`/cd` cross-feature interaction, and `serve/` entry-point completeness — this project's tracked "wire-X-into-serve" defect class). Post-implementation: 4 parallel validators (tests, performance, security, adversarial critique) found and the developer fixed 2 real defects — `runner.rs`'s skill registry wasn't gated on safe-mode despite its own status banner claiming otherwise, and the skill hot-reload watcher wasn't gated on safe-mode in any entry point. Code review found and the developer fixed a `clippy::struct_excessive_bools` regression plus 2 further clippy errors only reachable once the workspace build got past that blocker.

## Test plan

- [x] Full workspace `cargo nextest` (13307 tests) passing
- [x] `cargo +nightly fmt --check`, `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`, rustdoc gate, `cargo test --doc --workspace` all clean
- [x] Live multi-turn session against the real Claude API, including a `/cd` invocation, to verify the prompt-cache change against an actual captured request payload (LLM Serialization Gate)
- [x] New unit tests for `check_cwd_changed` (repo-map invalidation, safe-mode-gated instruction re-discovery), `Agent::change_working_directory` (no-arg report, invalid-path rejection, valid-path pipeline trigger), and a regression assertion pinning `working_directory:` to the volatile cache block
- [x] Testing playbook and coverage-status.md rows added

Closes #6032
Closes #6031