### PR TITLE
docs(book): fix stale claude-sonnet-4-5 model IDs in 5 files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Docs**: fixed 11 stale Claude model ID examples across 5 mdBook pages (`acp.md`,
+  `sub-agents.md`, `experiments.md`, `wizard.md`, `configuration.md`) that still used the
+  outdated `claude-sonnet-4-5`/`claude-sonnet-4-20250514` naming (incorrectly pairing the
+  Sonnet 4.5 generation name with the Sonnet 4 base-release date) — missed by the #5901/#5902
+  sweeps, which only covered `book/src/advanced/context.md`. Replaced with the dateless
+  `claude-sonnet-5` convention established there. Documentation-only change, no source code
+  modified (#6147).
 - **Dependencies**: `Cargo.lock` had drifted — `rmcp` was pinned to `2.0.0` while crates.io's
   latest release within the existing `^2.0.0` manifest range (`Cargo.toml` unchanged) had moved to
   `2.2.0`. Updated the lockfile to `rmcp 2.2.0` / `rmcp-macros 2.2.0`; `sse-stream` also bumped to

--- a/book/src/advanced/acp.md
+++ b/book/src/advanced/acp.md
@@ -139,7 +139,7 @@ max_sessions = 4
 session_idle_timeout_secs = 1800
 terminal_timeout_secs = 120
 # permission_file = "~/.config/zeph/acp-permissions.toml"
-# available_models = ["claude:claude-sonnet-4-5", "ollama:llama3"]
+# available_models = ["claude:claude-sonnet-5", "ollama:llama3"]
 # transport = "stdio"             # "stdio", "http", or "both"
 # http_bind = "127.0.0.1:8080"
 ```
@@ -589,7 +589,7 @@ Each config option is assigned a category for IDE grouping:
 
 | Option | Category | Values |
 |--------|----------|--------|
-| `model` | `Model` | Model identifiers (e.g., `claude:claude-sonnet-4-5`, `ollama:llama2`) |
+| `model` | `Model` | Model identifiers (e.g., `claude:claude-sonnet-5`, `ollama:llama2`) |
 | `temperature` | `Model` | Presets: `precise` (0.2), `balanced` (0.7), `creative` (1.0) |
 | `thinking` | `ThoughtLevel` | Extended thinking mode (if supported by the model) |
 | `auto_approve` | `Other` | Boolean approval for automated actions |
@@ -660,7 +660,7 @@ If you configure `available_models`, the IDE can switch between LLM providers at
 ```toml
 [acp]
 available_models = [
-  "claude:claude-sonnet-4-5",
+  "claude:claude-sonnet-5",
   "openai:gpt-4o",
   "ollama:qwen3:14b",
 ]

--- a/book/src/advanced/sub-agents.md
+++ b/book/src/advanced/sub-agents.md
@@ -150,7 +150,7 @@ You are a helpful assistant. Complete the given task concisely.
 ---
 name: code-reviewer
 description: Reviews code changes for correctness and style
-model: claude-sonnet-4-20250514
+model: claude-sonnet-5
 background: false
 max_turns: 10
 memory: project
@@ -300,7 +300,7 @@ Use the `zeph agents` subcommand to list, inspect, create, edit, and delete sub-
 ```
 $ zeph agents list
 NAME             SCOPE                    DESCRIPTION                       MODEL
-code-reviewer    project/code-reviewer…   Reviews code for correctness      claude-sonnet-4-20250514
+code-reviewer    project/code-reviewer…   Reviews code for correctness      claude-sonnet-5
 test-writer      user/test-writer.md      Generates unit tests              -
 ```
 
@@ -311,7 +311,7 @@ $ zeph agents show code-reviewer
 Name:        code-reviewer
 Description: Reviews code for correctness
 Source:      project/code-reviewer.md
-Model:       claude-sonnet-4-20250514
+Model:       claude-sonnet-5
 Mode:        Default
 Max turns:   10
 Background:  false
@@ -327,7 +327,7 @@ You are a code reviewer...
 $ zeph agents create reviewer --description "Code review helper"
 Created .zeph/agents/reviewer.md
 
-$ zeph agents create reviewer --description "Code review helper" --model claude-sonnet-4-20250514
+$ zeph agents create reviewer --description "Code review helper" --model claude-sonnet-5
 Created .zeph/agents/reviewer.md
 
 $ zeph agents create reviewer --description "Global helper" --dir ~/.config/zeph/agents/

--- a/book/src/concepts/experiments.md
+++ b/book/src/concepts/experiments.md
@@ -265,7 +265,7 @@ Add an `[experiments]` section to `config.toml`:
 ```toml
 [experiments]
 enabled = true
-# eval_model = "claude-sonnet-4-20250514"  # Model for LLM-as-judge evaluation (default: agent's model)
+# eval_model = "claude-sonnet-5"  # Model for LLM-as-judge evaluation (default: agent's model)
 # benchmark_file = "benchmarks/eval.toml"  # Prompt set for A/B comparison
 max_experiments = 20                       # Max variations per session (default: 20, range: 1-1000)
 max_wall_time_secs = 3600                  # Wall-clock budget per session in seconds (default: 3600, range: 60-86400)
@@ -386,7 +386,7 @@ Only one experiment session can run at a time. Starting a new session while one 
 The `zeph init` wizard includes an experiments step (after the scheduler section). It prompts:
 
 1. **Enable autonomous experiments** — master switch (`enabled` field, default: no).
-2. **Judge model** — model used for LLM-as-judge evaluation (`eval_model`, default: `claude-sonnet-4-20250514`).
+2. **Judge model** — model used for LLM-as-judge evaluation (`eval_model`, default: `claude-sonnet-5`).
 3. **Schedule automatic runs** — enable cron-based experiment sessions (`schedule.enabled`, default: no).
 4. **Cron schedule** — 5-field cron expression (`schedule.cron`, default: `0 3 * * *`).
 

--- a/book/src/getting-started/wizard.md
+++ b/book/src/getting-started/wizard.md
@@ -138,7 +138,7 @@ Configure the Thompson Sampling model router (requires `router` feature):
 Configure autonomous self-experimentation:
 
 - **Enable autonomous experiments** — toggle the experiment engine on/off (default: disabled)
-- **Judge model** — model used for LLM-as-judge evaluation (default: `claude-sonnet-4-20250514`)
+- **Judge model** — model used for LLM-as-judge evaluation (default: `claude-sonnet-5`)
 - **Schedule automatic runs** — enable cron-based experiment sessions (default: disabled)
 - **Cron schedule** — 5-field cron expression for scheduled runs (default: `0 3 * * *`, daily at 03:00)
 

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -695,7 +695,7 @@ broadcast_capacity = 256           # Skill/config reload broadcast backlog share
 # permission_file = "~/.config/zeph/acp-permissions.toml"  # Path to persisted permission decisions
 # auth_bearer_token = ""           # Bearer token for ACP HTTP/WS auth (env: ZEPH_ACP_AUTH_TOKEN); omit for open mode (local use only)
 discovery_enabled = true           # Expose GET /.well-known/acp.json manifest endpoint (default: true)
-available_models = []              # Models advertised to IDE for switching: ["claude:claude-sonnet-4-5", "ollama:llama3"] (default: [])
+available_models = []              # Models advertised to IDE for switching: ["claude:claude-sonnet-5", "ollama:llama3"] (default: [])
 additional_directories = []        # Extra workspace directories ACP clients may reference (default: [])
 auth_methods = ["agent"]           # Auth methods advertised in initialize (currently only "agent" supported) (default: ["agent"])
 message_ids_enabled = true         # Echo PromptRequest.message_id onto responses (requires unstable-message-id feature) (default: true)
@@ -804,7 +804,7 @@ output_dir = "/absolute/path/to/debug"  # Optional override; omit to use the pla
 # Requires `experiments` feature.
 # [experiments]
 # enabled = false
-# eval_model = "claude-sonnet-4-20250514"  # Model for LLM-as-judge (default: agent's model)
+# eval_model = "claude-sonnet-5"  # Model for LLM-as-judge (default: agent's model)
 # benchmark_file = "benchmarks/eval.toml"  # Prompt set for A/B comparison
 # max_experiments = 20                     # Max variations per session (default: 20)
 # max_wall_time_secs = 3600               # Wall-clock budget per session (default: 3600)


### PR DESCRIPTION
## Summary

- The #5901/#5902 sweeps fixed stale Claude model ID examples (`claude-sonnet-4-5-20250514`, which incorrectly pairs the Sonnet 4.5 generation name with the Sonnet 4 base-release date) but only covered `book/src/advanced/context.md`.
- This PR fixes the same defect class in the 5 remaining files identified by the tester in #6147: `acp.md`, `sub-agents.md`, `experiments.md`, `wizard.md`, `configuration.md`.
- All 11 occurrences of `claude-sonnet-4-5` / `claude-sonnet-4-20250514` are replaced with the dateless `claude-sonnet-5` convention already established in `context.md`.
- Documentation-only change (`book/src/`); no source code, config schema, or build system affected.

## Follow-up (not in scope)

Review surfaced 5 additional `claude-opus-4-5` references in `acp.md` that also look stale against a current `claude-opus-4-8` example elsewhere in the same file — same defect class, different substring, outside #6147's stated scope. Will file a separate follow-up issue.

Closes #6147

## Test plan

- [x] `grep -rn "sonnet-4-5\|sonnet-4-20250514\|claude-sonnet-4-5" book/src/` returns zero hits after the change
- [x] `git diff` reviewed — every changed line is a mechanical ID substitution, no unrelated changes
- [x] Cross-checked target format against `book/src/advanced/context.md` (the established post-#5902 convention)
- [x] Spot-checked surrounding context in `sub-agents.md` and `acp.md` (tables, CLI-output blocks, TOML) for correctness after substitution
- [x] `gitleaks protect --staged` — no leaks
- N/A: fmt/clippy/nextest/rustdoc gates — docs-only change, no source touched