### PR TITLE
docs(book): fix stale claude-opus-4-5 model IDs in acp.md (#6211)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   sweeps, which only covered `book/src/advanced/context.md`. Replaced with the dateless
   `claude-sonnet-5` convention established there. Documentation-only change, no source code
   modified (#6147).
+- **Docs**: fixed stale `claude-opus-4-5` model ID references in `book/src/advanced/acp.md`
+  (4 occurrences in code examples and configuration tables), updated to `claude-opus-4-8`
+  for consistency. Documentation-only change (#6211).
 - **Dependencies**: `Cargo.lock` had drifted — `rmcp` was pinned to `2.0.0` while crates.io's
   latest release within the existing `^2.0.0` manifest range (`Cargo.toml` unchanged) had moved to
   `2.2.0`. Updated the lockfile to `rmcp 2.2.0` / `rmcp-macros 2.2.0`; `sse-stream` also bumped to

--- a/book/src/advanced/acp.md
+++ b/book/src/advanced/acp.md
@@ -574,7 +574,7 @@ When a config option is changed via `set_session_config_option`, Zeph emits a `C
     "update": {
       "type": "config_option_update",
       "options": [
-        { "id": "model", "value": "claude:claude-opus-4-5", "category": "model" }
+        { "id": "model", "value": "claude:claude-opus-4-8", "category": "model" }
       ]
     }
   }
@@ -1034,14 +1034,14 @@ When `unstable-session-model` is compiled in, the IDE can request a model change
 
 ```jsonc
 // IDE → Zeph
-{ "method": "set_session_model", "params": { "session_id": "...", "model": "claude:claude-opus-4-5" } }
+{ "method": "set_session_model", "params": { "session_id": "...", "model": "claude:claude-opus-4-8" } }
 
 // Zeph emits a SetSessionModel notification
 {
   "method": "notifications/session",
   "params": {
     "session_id": "...",
-    "update": { "type": "set_session_model", "model": "claude:claude-opus-4-5" }
+    "update": { "type": "set_session_model", "model": "claude:claude-opus-4-8" }
   }
 }
 ```
@@ -1222,7 +1222,7 @@ Advertised commands:
 | Command | Description |
 |---------|-------------|
 | `/help` | List all available slash commands |
-| `/model` | Show the current model or switch to a different one (`/model claude:claude-opus-4-5`) |
+| `/model` | Show the current model or switch to a different one (`/model claude:claude-opus-4-8`) |
 | `/mode` | Show or change the session mode (`/mode architect`) |
 | `/clear` | Clear the conversation history for the current session |
 | `/compact` | Summarize and compress the conversation history to reduce token usage |


### PR DESCRIPTION
## Summary
- Fixed 4 stale `claude-opus-4-5` model ID references in `book/src/advanced/acp.md` (lines 577, 1037, 1044, 1225), updated to `claude-opus-4-8` for consistency with the reference example already in the file.
- Documentation-only change, no source code modified.

Closes #6211

## Test plan
- [x] `grep -rn "claude-opus-4-5" book/` returns zero hits
- [x] Reference entry at acp.md:306 (`claude-opus-4-8`) confirmed untouched
- [x] `mdbook build` succeeds (only a pre-existing unrelated warning in changelog.md)
- [x] Scope check: only `CHANGELOG.md` and `book/src/advanced/acp.md` touched