### PR TITLE
test(subagent): close coverage/doc gaps from #5991/#5993 review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   promise on resume cannot be a live duplicate child (spec-064 INV-9). No functional change
   (#6010).
 
+### Testing
+
+- **zeph-subagent**: added test coverage for two gaps flagged in the review of #6123
+  (sub-agent secret-delivery TTL re-check and per-task secret-request lookup): a
+  `granted_secrets` map holding both an expired and a live grant now has a regression test
+  confirming eviction removes only the expired entry and the live one stays attached to the
+  tool call context (`mixed_expired_and_live_secrets_expired_evicted_live_survives`); and
+  `SubAgentManager::deliver_secret` now has a test exercising its own `expires_at()` call
+  site directly — approving a grant with a near-zero TTL, letting it elapse, then confirming
+  delivery is refused (`deliver_secret_denies_grant_expired_before_delivery`). Also documented
+  (no behavior change) that `PermissionGrants::expires_at`'s first-match semantics for
+  duplicate same-key grants is intentionally fail-safe (earlier eviction only, never later),
+  and that the TTL-only eviction in `handle_tool_step` does not cover an explicit mid-loop
+  grant revoke — currently unreachable since every `revoke_all()` call site pairs with
+  `cancel.cancel()` or runs only after the loop has reported a terminal status (#6124).
+
 ### Fixed
 
 - **Docs**: fixed 11 stale Claude model ID examples across 5 mdBook pages (`acp.md`,

--- a/crates/zeph-subagent/src/agent_loop.rs
+++ b/crates/zeph-subagent/src/agent_loop.rs
@@ -558,6 +558,12 @@ async fn handle_tool_step(
                 // Re-check the TTL live before every tool call rather than trusting the
                 // one-time gate at delivery time: a long-running turn loop can otherwise keep
                 // using a secret well after its grant expired (issue #5991).
+                //
+                // This only reacts to TTL expiry, not to an explicit mid-loop revoke of a
+                // single grant — currently unreachable since every `revoke_all()` call site
+                // either fires `cancel.cancel()` alongside it or only runs once the loop has
+                // already reported a terminal status (see manager/collect.rs, manager/spawn.rs,
+                // manager/mod.rs's `Drop for SubAgentHandle`).
                 granted_secrets.retain(|_, granted| !granted.is_expired());
                 let exec_ctx = if granted_secrets.is_empty() {
                     None
@@ -1162,6 +1168,79 @@ mod handle_tool_step_granted_secrets_tests {
         assert!(
             granted_secrets.is_empty(),
             "an expired grant must be evicted from the local cache"
+        );
+    }
+
+    #[tokio::test]
+    async fn mixed_expired_and_live_secrets_expired_evicted_live_survives() {
+        // Regression guard for #6124: a `granted_secrets` map holding both an expired and
+        // a live grant at once must evict only the expired entry — the live one must
+        // survive eviction and still be attached to the tool call context.
+        let recorder = Arc::new(RecordingExecutor::default());
+        let executor = FilteredToolExecutor::new(
+            Arc::clone(&recorder) as Arc<dyn ErasedToolExecutor>,
+            ToolPolicy::InheritAll,
+        );
+        let hooks = SubagentHooks::default();
+        let mut messages = Vec::new();
+        let mut granted_secrets = HashMap::new();
+        granted_secrets.insert(
+            "EXPIRED_KEY".to_owned(),
+            GrantedSecret {
+                value: Secret::new("expired-value"),
+                expires_at: Instant::now().checked_sub(Duration::from_secs(1)).unwrap(),
+            },
+        );
+        granted_secrets.insert(
+            "LIVE_KEY".to_owned(),
+            GrantedSecret {
+                value: Secret::new("live-value"),
+                expires_at: Instant::now() + Duration::from_mins(5),
+            },
+        );
+
+        let sanitizer = ContentSanitizer::new(&zeph_config::ContentIsolationConfig::default());
+
+        let no_tool = handle_tool_step(
+            &executor,
+            tool_use_response(),
+            &mut messages,
+            &hooks,
+            "task-1",
+            "bot",
+            &sanitizer,
+            &mut granted_secrets,
+        )
+        .await;
+        assert!(!no_tool, "a tool call was made");
+
+        assert_eq!(
+            granted_secrets.len(),
+            1,
+            "only the expired grant should be evicted"
+        );
+        assert!(
+            !granted_secrets.contains_key("EXPIRED_KEY"),
+            "expired grant must be evicted"
+        );
+        assert!(
+            granted_secrets.contains_key("LIVE_KEY"),
+            "live grant must survive eviction"
+        );
+
+        let calls = recorder.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        let context = calls[0]
+            .context
+            .as_ref()
+            .expect("the live grant must still produce a Some(ExecutionContext)");
+        assert_eq!(
+            context.env_overrides().get("LIVE_KEY").map(String::as_str),
+            Some("live-value")
+        );
+        assert!(
+            context.env_overrides().get("EXPIRED_KEY").is_none(),
+            "expired grant must not be attached to the tool call context"
         );
     }
 }

--- a/crates/zeph-subagent/src/grants.rs
+++ b/crates/zeph-subagent/src/grants.rs
@@ -207,6 +207,12 @@ impl PermissionGrants {
     /// TTL locally on every subsequent tool call, without needing further access to this
     /// `PermissionGrants` instance (which stays on the manager side, not the spawned loop task).
     ///
+    /// If duplicate grants exist for the same `kind`, this returns the *first* match's
+    /// expiry rather than the latest (max) one. This is intentionally fail-safe: it can
+    /// only cause an earlier-than-necessary secret eviction in the sub-agent loop, never
+    /// a later one, so it is not a security concern — just a minor inefficiency in the
+    /// rare duplicate-grant case.
+    ///
     /// # Examples
     ///
     /// ```rust

--- a/crates/zeph-subagent/src/manager/tests.rs
+++ b/crates/zeph-subagent/src/manager/tests.rs
@@ -319,6 +319,30 @@ async fn deliver_secret_after_approval_sends_value_over_channel() {
     );
 }
 
+#[tokio::test]
+async fn deliver_secret_denies_grant_expired_before_delivery() {
+    // Regression coverage for #6124 item 2: approve_secret with a very short TTL, let it
+    // elapse, then confirm deliver_secret's own `expires_at()` call site refuses delivery
+    // through the real code path (not just PermissionGrants's own unit tests in grants.rs).
+    let mut mgr = make_manager();
+    mgr.definitions.push(def_with_secrets());
+
+    let task_id = do_spawn(&mut mgr, "bot", "work").await.unwrap();
+    mgr.approve_secret(&task_id, "api-key", std::time::Duration::from_millis(1))
+        .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let err = mgr
+        .deliver_secret(
+            &task_id,
+            "api-key",
+            zeph_common::secret::Secret::new("sekrit"),
+        )
+        .unwrap_err();
+    assert_matches!(err, SubAgentError::Invalid(_));
+}
+
 #[test]
 fn deliver_secret_unknown_task_id_returns_not_found() {
     let mut mgr = make_manager();


### PR DESCRIPTION
## Summary

- Adds `mixed_expired_and_live_secrets_expired_evicted_live_survives` in `agent_loop.rs`, proving the TTL-eviction `retain()` in `handle_tool_step` removes only expired grants while a live grant's secret remains injected via `ExecutionContext`.
- Adds `deliver_secret_denies_grant_expired_before_delivery` in `manager/tests.rs`, exercising the real `deliver_secret` -> `PermissionGrants::expires_at` call site and asserting delivery is refused (`SubAgentError::Invalid`) when the grant's TTL has already elapsed at delivery time.
- Documents (code comment) that TTL-only eviction does not react to mid-loop grant revocation — traced all `revoke_all` call sites and confirmed this is currently unreachable in production.
- Documents (doc comment) that `PermissionGrants::expires_at`'s first-match semantics are intentionally fail-safe (can only evict earlier-or-equal to the true max-expiry authorization window, never later).

None of these are behavior changes to the shipped fix in PR #6123 — this closes the 4 non-blocking coverage/doc items its reviewer flagged rather than filing them separately.

Closes #6124

## Test plan

- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-subagent` — 441/441 pass, including both new tests
- [x] Independently verified both new tests are non-shallow and non-flaky (tester + adversarial critic passes, verdict: approved)
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13432/13432 pass
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] `cargo test --doc -p zeph-subagent` — 27/27 pass
- [x] `gitleaks protect --staged --no-banner --redact` — no leaks
- [x] `.local/testing/coverage-status.md` and `.local/testing/playbooks/subagent-secret-delivery.md` updated in place