### PR TITLE
fix(tools): clamp shell fallback cwd into sandbox for path-token-free commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Docs**: fixed stale `claude-opus-4-5` model ID references in `book/src/advanced/acp.md`
   (4 occurrences in code examples and configuration tables), updated to `claude-opus-4-8`
   for consistency. Documentation-only change (#6211).
+- **Security (shell sandbox)**: `ShellExecutor::resolve_context`'s no-`cwd_override` fallback
+  branch started the subprocess from the raw, unvalidated `std::env::current_dir()` with no
+  check against `allowed_paths`, while the `cwd_override` branch already canonicalized and
+  validated. When `allowed_paths` was configured non-empty and the real process cwd fell
+  outside every allowed root (a non-default launch/config), commands whose file references
+  were all bare filenames or absent (`ls`, `pwd`, `cat foo` — bare filenames are not extracted
+  as path tokens by `extract_paths`) could read/list outside the intended sandbox. Fixed by
+  clamping the fallback cwd into the sandbox (first allowed root, preferring a directory entry)
+  whenever the canonicalized process cwd is outside `allowed_paths`, reusing the shared
+  `zeph_common::security::is_path_within` validator; absolute path tokens in commands were
+  never affected (already canonicalized and rejected by `validate_sandbox_with_cwd`). Clamping
+  rather than rejecting avoids turning common bare commands into hard sandbox-violation errors
+  (#6208).
 - **Dependencies**: `Cargo.lock` had drifted — `rmcp` was pinned to `2.0.0` while crates.io's
   latest release within the existing `^2.0.0` manifest range (`Cargo.toml` unchanged) had moved to
   `2.2.0`. Updated the lockfile to `rmcp 2.2.0` / `rmcp-macros 2.2.0`; `sse-stream` also bumped to

--- a/crates/zeph-tools/src/shell/mod.rs
+++ b/crates/zeph-tools/src/shell/mod.rs
@@ -35,6 +35,7 @@ use serde::Deserialize;
 use arc_swap::ArcSwap;
 use parking_lot::{Mutex, RwLock};
 
+use zeph_common::security::is_path_within;
 use zeph_common::{TaskSupervisor, ToolName};
 
 use crate::audit::{AuditEntry, AuditLogger, AuditResult, chrono_now};
@@ -1477,7 +1478,7 @@ impl ShellExecutor {
             }
             canonical
         } else {
-            std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+            self.clamped_process_cwd()
         };
 
         Ok(ResolvedContext {
@@ -1486,6 +1487,30 @@ impl ShellExecutor {
             name: resolved_name,
             trusted,
         })
+    }
+
+    /// Resolve the process cwd for the no-`cwd_override` fallback, clamped into the
+    /// sandbox when it falls outside `allowed_paths` (#6208).
+    ///
+    /// Returns the raw process cwd unchanged when no sandbox is configured, or when
+    /// the (canonicalized) process cwd already lies within `allowed_paths`. Otherwise
+    /// confines the fallback to the first allowed root (preferring one that is
+    /// actually a directory) so that path-token-free and bare-filename commands
+    /// (`ls`, `pwd`, `cat foo`) cannot read/write outside the intended sandbox.
+    fn clamped_process_cwd(&self) -> PathBuf {
+        let process_cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        if self.allowed_paths_canonical.is_empty() {
+            return process_cwd;
+        }
+        let canon = canonicalize_or_nearest_ancestor(&process_cwd);
+        if is_path_within(&canon, &self.allowed_paths_canonical) {
+            return canon;
+        }
+        self.allowed_paths_canonical
+            .iter()
+            .find(|p| p.is_dir())
+            .unwrap_or(&self.allowed_paths_canonical[0])
+            .clone()
     }
 
     fn validate_sandbox_with_cwd(

--- a/crates/zeph-tools/src/shell/tests.rs
+++ b/crates/zeph-tools/src/shell/tests.rs
@@ -2962,11 +2962,23 @@ mod resolve_context {
     // --- CWD resolution ---
 
     #[test]
-    fn no_context_uses_process_cwd() {
+    fn no_context_clamps_cwd_when_process_cwd_outside_sandbox() {
+        // Regression test for #6208: the fallback branch (no `cwd_override`) must not
+        // start the subprocess from the raw, unvalidated process cwd when it falls
+        // outside `allowed_paths` — it must clamp into the sandbox instead.
         let dir = tempfile::tempdir().unwrap();
+        let dir_canonical = dir.path().canonicalize().unwrap();
         let executor = executor_for_dir(&dir);
+        assert_ne!(
+            std::env::current_dir().unwrap(),
+            dir_canonical,
+            "test tempdir must differ from process cwd for this assertion to be meaningful"
+        );
         let resolved = executor.resolve_context(None).unwrap();
-        assert_eq!(resolved.cwd, std::env::current_dir().unwrap());
+        assert_eq!(
+            resolved.cwd, dir_canonical,
+            "no-context fallback must clamp into the sandbox when process cwd is outside allowed_paths (#6208)"
+        );
     }
 
     #[test]
@@ -3344,12 +3356,20 @@ mod resolve_context {
 
     #[tokio::test]
     #[cfg(not(target_os = "windows"))]
-    async fn tool_call_without_context_uses_process_cwd() {
+    async fn tool_call_without_context_clamps_cwd_when_process_cwd_outside_sandbox() {
+        // Regression test for #6208: a bare command with zero path tokens (`pwd`) and
+        // no `cwd_override` must run inside the sandbox, not the raw process cwd.
         use crate::executor::ToolExecutor;
         use zeph_common::ToolName;
 
         let dir = tempfile::tempdir().unwrap();
+        let dir_canonical = dir.path().canonicalize().unwrap();
         let executor = executor_for_dir(&dir);
+        assert_ne!(
+            std::env::current_dir().unwrap(),
+            dir_canonical,
+            "test tempdir must differ from process cwd for this assertion to be meaningful"
+        );
         let call = ToolCall {
             tool_id: ToolName::new("bash"),
             params: {
@@ -3367,10 +3387,12 @@ mod resolve_context {
             skill_name: None,
         };
         let output = executor.execute_tool_call(&call).await.unwrap().unwrap();
-        let expected = std::env::current_dir().unwrap();
         assert!(
-            output.summary.contains(expected.to_string_lossy().as_ref()),
-            "pwd without context must reflect process cwd, got: {}",
+            output
+                .summary
+                .contains(dir_canonical.to_string_lossy().as_ref()),
+            "pwd without context must be confined to the sandbox root when process cwd is \
+             outside allowed_paths (#6208), got: {}",
             output.summary
         );
     }


### PR DESCRIPTION
Closes #6208

## Summary

`ShellExecutor::resolve_context`'s no-`cwd_override` fallback branch started the subprocess from the raw, unvalidated `std::env::current_dir()`, with no check against `allowed_paths` — unlike the explicit `cwd_override` branch, which already validates via `zeph_common::security::validate_path_within` (added in #6207).

`validate_sandbox_with_cwd` already canonicalizes and validates every path token referenced in a shell command, so commands like `cat ./bar` were already caught. The residual gap only affected commands whose file references were bare filenames or absent entirely (`ls`, `pwd`, `cat foo` — bare filenames are not extracted as path tokens by `extract_paths`): when the real process cwd fell outside a non-empty `allowed_paths`, such commands could silently read/list outside the intended sandbox.

A naive fix attempted during #6207 (reject when the raw cwd is outside `allowed_paths`) broke `arc_wrapped_executor_forwards_checkpoint_methods`, a test that deliberately scopes `allowed_paths` to a tempdir while the process cwd is outside it, but only ever references absolute in-sandbox paths.

This PR fixes it by **clamping** the fallback cwd into the sandbox (first allowed root, preferring a directory entry) instead of rejecting, reusing the shared `zeph_common::security::is_path_within` validator. Clamping only changes the *starting* directory when it's out of sandbox; it never rejects a command, so the existing test's absolute-path commands are unaffected.

## Changes

- `crates/zeph-tools/src/shell/mod.rs`: added `clamped_process_cwd()` helper, used by the `resolve_context` fallback branch.
- `crates/zeph-tools/src/shell/tests.rs`: rewrote 2 pre-existing tests that encoded the previous (buggy) assumption to assert the corrected clamped behavior — they now serve as regression coverage for #6208.
- `CHANGELOG.md`: added entry under `[Unreleased]/Fixed`.
- `.local/testing/playbooks/filesystem-access.md` (main repo): added a live-testing scenario for this fix.
- `.local/testing/coverage-status.md` (main repo): added a row for this fix, status `Untested` pending live verification.

## Test plan

- [x] `cargo nextest run -p zeph-tools` — 1377/1377 passed, including `arc_wrapped_executor_forwards_checkpoint_methods` (confirmed unaffected)
- [x] New regression tests reproduce the original gap (bare command, zero path tokens, `allowed_paths` narrower than process cwd, no `cwd_override`) and fail if the fix is reverted
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13411/13411 passed (one pre-existing unrelated flake in `zeph-core::debug_dump::tests::memcot_state_null_when_absent`, isolated 5/5 pass, confirmed unrelated to this diff)
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace ...`)

## Follow-up

`spawn_background`/`validate_sandbox`/`run_background_task` (context-less, no production call sites) bypass `resolve_context` and use the raw process cwd directly. Not a live vulnerability, but flagged for defense-in-depth; will file a separate follow-up issue.