### PR TITLE
refactor(core): extract shared Agent skill-config builder chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   re-invoking git. `reconcile()`, `clean()`, and `disk_usage()` keep their exact public
   signatures and behavior for direct callers — this is a pure internal call-graph refactor
   with no observable behavior change (#6205).
+- **Core**: extracted `Agent::with_skill_config` and `Agent::with_skill_coldstart`, bundling
+  the skill-matching/grouping/provider-name/semantic-scan setter chain and the hot-reload/
+  plugin-dirs/managed-dir setter chain that were each copy-pasted near-verbatim across all
+  four `Agent` construction entry points (`src/runner.rs`, `src/daemon.rs`,
+  `src/serve/agent_factory.rs`, `src/acp.rs`). Each duplicate had independently shipped a
+  swapped- or missing-argument regression at some point (#5819, #5867, #5827); the field
+  mapping now lives in one place. `SkillConfigParams` (re-exported at the `zeph_core` crate
+  root) carries the four-call chain's arguments, with a `From<&SkillsConfig>` conversion for
+  call sites that hold a full config. Pure internal refactor — every config value reaches the
+  exact same setter with the exact same value as before at all four sites, verified by the
+  existing end-to-end regression tests, which all pass unchanged (#5887).
 
 ### Removed
 

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -57,7 +57,7 @@ use super::session_config::{AgentSessionConfig, CONTEXT_BUDGET_RESERVE_RATIO};
 use crate::agent::state::ProviderConfigSnapshot;
 use crate::channel::Channel;
 use crate::config::{
-    CompressionConfig, LearningConfig, ProviderEntry, ProviderName, SecurityConfig,
+    CompressionConfig, LearningConfig, ProviderEntry, ProviderName, SecurityConfig, SkillsConfig,
     StoreRoutingConfig, TimeoutConfig,
 };
 use crate::config_watcher::ConfigEvent;
@@ -78,6 +78,59 @@ pub enum BuildError {
     /// pass a provider pool via `with_provider_pool`.
     #[error("no LLM provider configured (set via with_*_provider or with_provider_pool)")]
     MissingProviders,
+}
+
+/// Skill-subsystem config values applied identically at every `Agent` construction entry point.
+///
+/// Bundles the fields consumed by [`Agent::with_skill_matching_config`],
+/// [`Agent::with_skill_group_config`], [`Agent::with_skill_provider_names`], and
+/// [`Agent::with_semantic_scan`] for use with [`Agent::with_skill_config`], which applies all
+/// four in one call. This deduplicates the 4-call chain that was independently copy-pasted
+/// across `src/runner.rs`, `src/daemon.rs`, `src/serve/agent_factory.rs`, and `src/acp.rs` — each
+/// site had shipped a swapped- or missing-argument regression at some point (#5819, #5867,
+/// #5827) because the mapping had to be kept in sync by hand in four places.
+#[derive(Debug, Clone)]
+pub struct SkillConfigParams {
+    /// See [`Agent::with_skill_matching_config`]'s `disambiguation_threshold` parameter.
+    pub disambiguation_threshold: f32,
+    /// See [`Agent::with_skill_matching_config`]'s `two_stage_matching` parameter.
+    pub two_stage_matching: bool,
+    /// See [`Agent::with_skill_matching_config`]'s `confusability_threshold` parameter.
+    pub confusability_threshold: f32,
+    /// See [`Agent::with_skill_group_config`]'s `group_structured` parameter.
+    pub group_structured: bool,
+    /// See [`Agent::with_skill_group_config`]'s `support_similarity_threshold` parameter.
+    pub support_similarity_threshold: f32,
+    /// See [`Agent::with_skill_group_config`]'s `min_injection_score` parameter.
+    pub min_injection_score: f32,
+    /// See [`Agent::with_skill_provider_names`]'s `generation_provider_name` parameter.
+    pub generation_provider_name: String,
+    /// See [`Agent::with_skill_provider_names`]'s `disambiguate_provider_name` parameter.
+    pub disambiguate_provider_name: String,
+    /// See [`Agent::with_semantic_scan`]'s `enabled` parameter.
+    pub semantic_scan: bool,
+    /// See [`Agent::with_semantic_scan`]'s `provider_name` parameter.
+    pub semantic_scan_provider_name: String,
+}
+
+/// Extracts the fields [`Agent::with_skill_config`] needs from a full `[skills]` config
+/// section — the shape available at `src/runner.rs`'s and `src/daemon.rs`'s call sites, which
+/// hold the whole `Config` rather than pre-extracted scalars.
+impl From<&SkillsConfig> for SkillConfigParams {
+    fn from(skills: &SkillsConfig) -> Self {
+        Self {
+            disambiguation_threshold: skills.disambiguation_threshold,
+            two_stage_matching: skills.two_stage_matching,
+            confusability_threshold: skills.confusability_threshold,
+            group_structured: skills.group_structured,
+            support_similarity_threshold: skills.support_similarity_threshold,
+            min_injection_score: skills.min_injection_score,
+            generation_provider_name: skills.generation_provider.as_str().to_owned(),
+            disambiguate_provider_name: skills.disambiguate_provider.as_str().to_owned(),
+            semantic_scan: skills.semantic_scan,
+            semantic_scan_provider_name: skills.semantic_scan_provider.as_str().to_owned(),
+        }
+    }
 }
 
 impl<C: Channel> Agent<C> {
@@ -459,6 +512,72 @@ impl<C: Channel> Agent<C> {
         self.services.skill.semantic_scan = enabled;
         self.services.skill.semantic_scan_provider = provider_name.into();
         self
+    }
+
+    /// Configure skill matching, grouping, provider names, and semantic scan in one call.
+    ///
+    /// Chains [`Agent::with_skill_matching_config`], [`Agent::with_skill_group_config`],
+    /// [`Agent::with_skill_provider_names`], and [`Agent::with_semantic_scan`] using the exact
+    /// field mapping shared by every `Agent` construction entry point (CLI, daemon, `/sessions`,
+    /// ACP). Use this instead of calling the four setters individually — see
+    /// [`SkillConfigParams`]'s doc comment for why that duplication was a recurring regression
+    /// source (#5819, #5867, #5827).
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let agent = Agent::new(provider, channel, registry, None, 5, executor)
+    ///     .apply_session_config(session_cfg)
+    ///     .with_skill_config(SkillConfigParams::from(&config.skills))
+    ///     .build()?;
+    /// ```
+    #[must_use]
+    pub fn with_skill_config(self, params: SkillConfigParams) -> Self {
+        self.with_skill_matching_config(
+            params.disambiguation_threshold,
+            params.two_stage_matching,
+            params.confusability_threshold,
+        )
+        .with_skill_group_config(
+            params.group_structured,
+            params.support_similarity_threshold,
+            params.min_injection_score,
+        )
+        .with_skill_provider_names(
+            params.generation_provider_name,
+            params.disambiguate_provider_name,
+        )
+        .with_semantic_scan(params.semantic_scan, params.semantic_scan_provider_name)
+    }
+
+    /// Configure skill hot-reload, the plugin-directory supplier, and the managed-skills
+    /// directory in one call.
+    ///
+    /// Chains [`Agent::with_skill_reload`], [`Agent::with_plugin_dirs_supplier`], and
+    /// [`Agent::with_managed_skills_dir`] — the "cold start" trio called together by every
+    /// non-`/sessions` `Agent` construction entry point (`src/runner.rs`, `src/daemon.rs`,
+    /// `src/acp.rs`). `src/serve/agent_factory.rs` does not hot-reload skills for
+    /// `/sessions`-created agents, so it does not call this.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let agent = Agent::new(provider, channel, registry, None, 5, executor)
+    ///     .with_skill_config(params)
+    ///     .with_skill_coldstart(skill_paths, reload_rx, plugin_dirs_supplier, managed_dir)
+    ///     .build()?;
+    /// ```
+    #[must_use]
+    pub fn with_skill_coldstart(
+        self,
+        paths: Vec<PathBuf>,
+        reload_rx: mpsc::Receiver<SkillEvent>,
+        plugin_dirs_supplier: impl Fn() -> Vec<PathBuf> + Send + Sync + 'static,
+        managed_dir: PathBuf,
+    ) -> Self {
+        self.with_skill_reload(paths, reload_rx)
+            .with_plugin_dirs_supplier(plugin_dirs_supplier)
+            .with_managed_skills_dir(managed_dir)
     }
 
     /// Override the embedding model name used for skill matching.
@@ -3433,6 +3552,109 @@ mod tests {
         assert!(
             agent.services.skill.confusability_threshold.abs() < f32::EPSILON,
             "with_skill_matching_config must clamp confusability below 0.0"
+        );
+    }
+
+    /// Unit-level counterpart to the `#5819`/`#5867`/`#5827` end-to-end regression tests in
+    /// `src/runner.rs`, `src/daemon.rs`, `src/serve/agent_factory.rs`, and `src/acp.rs`: those
+    /// tests exercise a whole call site's config wiring through observable `Agent` behavior, so
+    /// they still pass unchanged now that every site delegates to `with_skill_config`. This test
+    /// instead pins down `with_skill_config` itself — every field of `SkillConfigParams` set to a
+    /// value distinct from every other field, so a swapped assignment inside the combinator's
+    /// four delegated calls would be caught here even if it happened to still satisfy one of the
+    /// site-level assertions.
+    #[test]
+    fn with_skill_config_wires_all_fields() {
+        let agent = make_agent().with_skill_config(SkillConfigParams {
+            disambiguation_threshold: 0.11,
+            two_stage_matching: true,
+            confusability_threshold: 0.22,
+            group_structured: true,
+            support_similarity_threshold: 0.33,
+            min_injection_score: 0.44,
+            generation_provider_name: "gen".to_owned(),
+            disambiguate_provider_name: "dis".to_owned(),
+            semantic_scan: true,
+            semantic_scan_provider_name: "scan".to_owned(),
+        });
+
+        let skill = &agent.services.skill;
+        assert!((skill.disambiguation_threshold - 0.11).abs() < f32::EPSILON);
+        assert!(skill.two_stage_matching);
+        assert!((skill.confusability_threshold - 0.22).abs() < f32::EPSILON);
+        assert!(skill.group_structured);
+        assert!((skill.support_similarity_threshold - 0.33).abs() < f32::EPSILON);
+        assert!((skill.min_injection_score - 0.44).abs() < f32::EPSILON);
+        assert_eq!(skill.generation_provider_name, "gen");
+        assert_eq!(skill.disambiguate_provider_name, "dis");
+        assert!(skill.semantic_scan);
+        assert_eq!(skill.semantic_scan_provider, "scan");
+    }
+
+    /// `SkillConfigParams::from(&SkillsConfig)` must map every field to the same-named field on
+    /// `SkillsConfig` (not a neighboring one) — the shape `src/runner.rs` and `src/daemon.rs` rely
+    /// on to build `SkillConfigParams` from a full `[skills]` config section.
+    #[test]
+    fn skill_config_params_from_skills_config_maps_fields() {
+        let mut skills = crate::config::Config::default().skills;
+        skills.disambiguation_threshold = 0.11;
+        skills.two_stage_matching = true;
+        skills.confusability_threshold = 0.22;
+        skills.group_structured = true;
+        skills.support_similarity_threshold = 0.33;
+        skills.min_injection_score = 0.44;
+        skills.generation_provider = "gen".into();
+        skills.disambiguate_provider = "dis".into();
+        skills.semantic_scan = true;
+        skills.semantic_scan_provider = "scan".into();
+
+        let params = SkillConfigParams::from(&skills);
+        assert!((params.disambiguation_threshold - 0.11).abs() < f32::EPSILON);
+        assert!(params.two_stage_matching);
+        assert!((params.confusability_threshold - 0.22).abs() < f32::EPSILON);
+        assert!(params.group_structured);
+        assert!((params.support_similarity_threshold - 0.33).abs() < f32::EPSILON);
+        assert!((params.min_injection_score - 0.44).abs() < f32::EPSILON);
+        assert_eq!(params.generation_provider_name, "gen");
+        assert_eq!(params.disambiguate_provider_name, "dis");
+        assert!(params.semantic_scan);
+        assert_eq!(params.semantic_scan_provider_name, "scan");
+    }
+
+    #[test]
+    fn with_skill_coldstart_wires_all_three_setters() {
+        let (_tx, rx) = mpsc::channel(1);
+        let managed_dir = std::env::temp_dir().join("with_skill_coldstart_wires_all_three_setters");
+        let paths = vec![
+            PathBuf::from("/tmp/skills-a"),
+            PathBuf::from("/tmp/skills-b"),
+        ];
+
+        let agent = make_agent().with_skill_coldstart(
+            paths.clone(),
+            rx,
+            || vec![PathBuf::from("/tmp/plugin-skills")],
+            managed_dir.clone(),
+        );
+
+        let skill = &agent.services.skill;
+        assert_eq!(
+            skill.skill_paths, paths,
+            "with_skill_coldstart must set skill_paths via with_skill_reload"
+        );
+        assert!(
+            skill.skill_reload_rx.is_some(),
+            "with_skill_coldstart must set skill_reload_rx via with_skill_reload"
+        );
+        let supplier = skill
+            .plugin_dirs_supplier
+            .as_ref()
+            .expect("with_skill_coldstart must set plugin_dirs_supplier");
+        assert_eq!(supplier(), vec![PathBuf::from("/tmp/plugin-skills")]);
+        assert_eq!(
+            skill.managed_dir,
+            Some(managed_dir),
+            "with_skill_coldstart must set managed_dir via with_managed_skills_dir"
         );
     }
 

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod agent_supervisor;
 mod autodream;
 mod autonomous_turn;
 mod builder;
+pub use builder::SkillConfigParams;
 #[cfg(feature = "cocoon")]
 mod cocoon_cmd;
 mod command_context_impls;

--- a/crates/zeph-core/src/lib.rs
+++ b/crates/zeph-core/src/lib.rs
@@ -112,6 +112,7 @@ pub use zeph_common::text;
 pub mod testing;
 
 pub use agent::Agent;
+pub use agent::SkillConfigParams;
 pub use agent::error::AgentError;
 pub use agent::session_config::{AgentSessionConfig, CONTEXT_BUDGET_RESERVE_RATIO};
 pub use agent::state::AdversarialPolicyInfo;

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -1756,18 +1756,18 @@ async fn spawn_acp_agent(
             tool_executor,
         )
         .apply_session_config(session_config)
-        .with_skill_matching_config(
-            skill_disambiguation_threshold,
-            skill_two_stage_matching,
-            skill_confusability_threshold,
-        )
-        .with_skill_group_config(
-            skill_group_structured,
-            skill_support_similarity_threshold,
-            skill_min_injection_score,
-        )
-        .with_skill_provider_names(skill_generation_provider, skill_disambiguate_provider)
-        .with_semantic_scan(semantic_scan, semantic_scan_provider)
+        .with_skill_config(zeph_core::SkillConfigParams {
+            disambiguation_threshold: skill_disambiguation_threshold,
+            two_stage_matching: skill_two_stage_matching,
+            confusability_threshold: skill_confusability_threshold,
+            group_structured: skill_group_structured,
+            support_similarity_threshold: skill_support_similarity_threshold,
+            min_injection_score: skill_min_injection_score,
+            generation_provider_name: skill_generation_provider,
+            disambiguate_provider_name: skill_disambiguate_provider,
+            semantic_scan,
+            semantic_scan_provider_name: semantic_scan_provider,
+        })
         .with_trust_config(d.trust_config.clone())
         .with_trust_snapshot(Arc::clone(&trust_snapshot))
         .with_quality_pipeline(d.quality_pipeline.clone())
@@ -1779,9 +1779,12 @@ async fn spawn_acp_agent(
             d.rl_warmup_updates,
         )
         .with_working_dir(session_ctx.working_dir.clone())
-        .with_skill_reload(skill_paths, reload_rx)
-        .with_plugin_dirs_supplier(move || plugin_dirs_supplier())
-        .with_managed_skills_dir(managed_skills_dir)
+        .with_skill_coldstart(
+            skill_paths,
+            reload_rx,
+            move || plugin_dirs_supplier(),
+            managed_skills_dir,
+        )
         .with_shutdown(shutdown_rx)
         .with_config_reload(config_path, config_reload_rx)
         .with_plugins_dir(

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -328,27 +328,13 @@ where
         deps.tool_executor,
     )
     .apply_session_config(deps.session_config)
-    .with_skill_matching_config(
-        config.skills.disambiguation_threshold,
-        config.skills.two_stage_matching,
-        config.skills.confusability_threshold,
+    .with_skill_config(zeph_core::SkillConfigParams::from(&config.skills))
+    .with_skill_coldstart(
+        deps.skill_paths,
+        deps.reload_rx,
+        deps.plugin_dirs_supplier,
+        crate::bootstrap::managed_skills_dir(),
     )
-    .with_skill_group_config(
-        config.skills.group_structured,
-        config.skills.support_similarity_threshold,
-        config.skills.min_injection_score,
-    )
-    .with_skill_provider_names(
-        config.skills.generation_provider.as_str().to_owned(),
-        config.skills.disambiguate_provider.as_str().to_owned(),
-    )
-    .with_semantic_scan(
-        config.skills.semantic_scan,
-        config.skills.semantic_scan_provider.as_str(),
-    )
-    .with_skill_reload(deps.skill_paths, deps.reload_rx)
-    .with_plugin_dirs_supplier(deps.plugin_dirs_supplier)
-    .with_managed_skills_dir(crate::bootstrap::managed_skills_dir())
     .with_trust_config(config.skills.trust.clone())
     .with_trust_snapshot(deps.trust_snapshot)
     .with_memory(

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -299,27 +299,13 @@ where
     )
     .apply_session_config(deps.session_config)
     .with_active_provider_name(deps.active_provider_name)
-    .with_skill_matching_config(
-        config.skills.disambiguation_threshold,
-        config.skills.two_stage_matching,
-        config.skills.confusability_threshold,
+    .with_skill_config(zeph_core::SkillConfigParams::from(&config.skills))
+    .with_skill_coldstart(
+        deps.skill_paths,
+        deps.reload_rx,
+        deps.plugin_dirs_supplier,
+        crate::bootstrap::managed_skills_dir(),
     )
-    .with_skill_group_config(
-        config.skills.group_structured,
-        config.skills.support_similarity_threshold,
-        config.skills.min_injection_score,
-    )
-    .with_skill_provider_names(
-        config.skills.generation_provider.as_str().to_owned(),
-        config.skills.disambiguate_provider.as_str().to_owned(),
-    )
-    .with_semantic_scan(
-        config.skills.semantic_scan,
-        config.skills.semantic_scan_provider.as_str(),
-    )
-    .with_skill_reload(deps.skill_paths, deps.reload_rx)
-    .with_plugin_dirs_supplier(deps.plugin_dirs_supplier)
-    .with_managed_skills_dir(crate::bootstrap::managed_skills_dir())
     .with_trust_config(config.skills.trust.clone())
     .with_trust_snapshot(deps.trust_snapshot)
     .with_memory(

--- a/src/serve/agent_factory.rs
+++ b/src/serve/agent_factory.rs
@@ -208,21 +208,18 @@ pub(crate) async fn build_agent_factory(
             zeph_tools::DynExecutor(final_tool_executor),
         )
         .apply_session_config(deps.session_config)
-        .with_skill_matching_config(
-            deps.skill_disambiguation_threshold,
-            deps.skill_two_stage_matching,
-            deps.skill_confusability_threshold,
-        )
-        .with_skill_group_config(
-            deps.skill_group_structured,
-            deps.skill_support_similarity_threshold,
-            deps.skill_min_injection_score,
-        )
-        .with_skill_provider_names(
-            deps.skill_generation_provider,
-            deps.skill_disambiguate_provider,
-        )
-        .with_semantic_scan(deps.semantic_scan, deps.semantic_scan_provider)
+        .with_skill_config(zeph_core::SkillConfigParams {
+            disambiguation_threshold: deps.skill_disambiguation_threshold,
+            two_stage_matching: deps.skill_two_stage_matching,
+            confusability_threshold: deps.skill_confusability_threshold,
+            group_structured: deps.skill_group_structured,
+            support_similarity_threshold: deps.skill_support_similarity_threshold,
+            min_injection_score: deps.skill_min_injection_score,
+            generation_provider_name: deps.skill_generation_provider,
+            disambiguate_provider_name: deps.skill_disambiguate_provider,
+            semantic_scan: deps.semantic_scan,
+            semantic_scan_provider_name: deps.semantic_scan_provider,
+        })
         .with_trust_config(deps.trust_config)
         // #6046: wire this session's SkillTrustSnapshot (from build_skill_executors above),
         // matching src/acp.rs/src/daemon.rs — without this, SkillLoaderExecutor/


### PR DESCRIPTION
## Summary

- Extract `Agent::with_skill_config(SkillConfigParams)` and `Agent::with_skill_coldstart(...)` in `crates/zeph-core/src/agent/builder.rs`, deduplicating the skill-matching/grouping/provider-name/semantic-scan setter chain (and the hot-reload/plugin-dirs/managed-dir setter chain) that was copy-pasted near-verbatim across all four `Agent` construction entry points.
- Rewire `src/runner.rs`, `src/daemon.rs`, `src/acp.rs`, `src/serve/agent_factory.rs` to call the shared helper(s) instead of repeating every field. `with_skill_coldstart` is used at 3 of 4 sites (`serve/agent_factory.rs` never called the cold-start trio, unchanged).
- Add `SkillConfigParams` (re-exported at the `zeph_core` crate root) plus `From<&SkillsConfig>` for the two call sites that hold a full config.
- Pure internal refactor — every config value reaches the exact same setter with the exact same value as before at all four sites; the existing #5819/#5867/#5827 regression tests at each site pass unchanged, plus 3 new unit tests directly on the new helpers.

Closes #5887

## Why

Each of the 4 duplicated call sites had independently shipped a swapped- or missing-argument regression at some point (#5819, #5867, #5827), each fixed separately rather than deduplicated. This factors the field mapping into one place so a future 5th skill-config knob only needs to be added once, with one shared regression test instead of 4 near-duplicates per site.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (13435 passed, 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `gitleaks protect --staged --no-banner --redact`
- [x] All 7 pre-existing #5819/#5867/#5827 regression tests across the 4 call sites still pass unchanged
- [x] 3 new unit tests on `with_skill_config`/`with_skill_coldstart`/`SkillConfigParams::from` covering the field-mapping/swap risk in isolation
- [x] Adversarial critique pass (independent verification of all 4 sites' field mappings, byte-for-byte) — no findings
- [x] Rebased on latest `main`, clean build after rebase

## Follow-up

Filing a separate P3 issue for a pre-existing (not introduced by this PR) coverage gap: `src/acp.rs`'s `spawn_acp_agent` has no real-`Agent`-level regression test exercising the `with_skill_config` call inside it (coverage stops at deps-assembly). Closing it properly means extracting `spawn_acp_agent`'s session-setup, out of scope for this pure-refactor PR.