### PR TITLE
chore(agent-tools): remove unused zeph-* dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2152,6 +2152,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `chore(scheduler)`: removed the unused `blake3` and `uuid` dependencies from
   `crates/zeph-scheduler/Cargo.toml` — neither was referenced anywhere in the crate's source
   (#6098).
+- `chore(agent-tools)`: removed 7 unused `zeph-*` dependencies (`zeph-agent-persistence`,
+  `zeph-config`, `zeph-context`, `zeph-mcp`, `zeph-orchestration`, `zeph-sanitizer`,
+  `zeph-skills`) from `crates/zeph-agent-tools/Cargo.toml` — leftover scaffolding from the
+  abandoned `ToolDispatcher` extraction (#3516, closed) with zero references in `src/`.
+  Narrowed the `sqlite`/`postgres` feature gates to forward only to `zeph-tools`, the sole
+  remaining backend-gated dependency (#6084).
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10710,15 +10710,8 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "zeph-agent-persistence",
  "zeph-common",
- "zeph-config",
- "zeph-context",
  "zeph-llm",
- "zeph-mcp",
- "zeph-orchestration",
- "zeph-sanitizer",
- "zeph-skills",
  "zeph-tools",
 ]
 

--- a/crates/zeph-agent-tools/Cargo.toml
+++ b/crates/zeph-agent-tools/Cargo.toml
@@ -19,25 +19,17 @@ serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
 tracing.workspace = true
-zeph-agent-persistence.workspace = true
 zeph-common.workspace = true
-zeph-config.workspace = true
-zeph-context.workspace = true
 zeph-llm.workspace = true
-zeph-mcp.workspace = true
-zeph-orchestration.workspace = true
-zeph-sanitizer.workspace = true
-zeph-skills.workspace = true
 zeph-tools.workspace = true
 
 [features]
-# `zeph-mcp`/`zeph-orchestration`/`zeph-sanitizer`/`zeph-skills`/`zeph-tools`/
-# `zeph-agent-persistence` (and transitively `zeph-db`) require a backend to compile;
+# `zeph-tools` (and transitively `zeph-db`) requires a backend to compile;
 # default to `sqlite` so this crate builds in isolation, and expose `postgres` for
 # PostgreSQL deployments (#4956).
 default = ["sqlite"]
-sqlite = ["zeph-mcp/sqlite", "zeph-orchestration/sqlite", "zeph-sanitizer/sqlite", "zeph-skills/sqlite", "zeph-tools/sqlite", "zeph-agent-persistence/sqlite"]
-postgres = ["zeph-mcp/postgres", "zeph-orchestration/postgres", "zeph-sanitizer/postgres", "zeph-skills/postgres", "zeph-tools/postgres", "zeph-agent-persistence/postgres"]
+sqlite = ["zeph-tools/sqlite"]
+postgres = ["zeph-tools/postgres"]
 
 [lints]
 workspace = true

--- a/crates/zeph-agent-tools/README.md
+++ b/crates/zeph-agent-tools/README.md
@@ -59,15 +59,15 @@ from referencing `zeph_core::channel::Channel` directly from inside the dispatch
 
 | Feature | Default | Description |
 |---------|---------|-------------|
-| `sqlite` | on | SQLite backend forwarded to `zeph-mcp`, `zeph-orchestration`, `zeph-sanitizer`, `zeph-skills`, `zeph-tools`, and `zeph-agent-persistence` |
-| `postgres` | off | PostgreSQL backend forwarded to the same downstream crates |
+| `sqlite` | on | SQLite backend, forwarded to `zeph-tools/sqlite` |
+| `postgres` | off | PostgreSQL backend, forwarded to `zeph-tools/postgres` |
 
 A storage backend must be selected for the crate to compile; `sqlite` is the default.
 
-> **Note:** This crate is Phase 2 scaffolding (issue #3516). The `AgentChannel` trait and
-> borrowed event carriers are complete. Full `ToolDispatcher` extraction from `zeph-core` is
-> tracked as a follow-up once the persistence extraction (#3515) lands and integration tests
-> are stable.
+> **Note:** This crate is Phase 2 scaffolding from issue #3516 (closed). The `AgentChannel`
+> trait and borrowed event carriers are complete, but no `zeph-core` adapter currently
+> implements them and no `ToolDispatcher` extraction has landed. Re-opening this work would
+> require a new tracking issue.
 
 ## License
 


### PR DESCRIPTION
## Summary
- `crates/zeph-agent-tools/Cargo.toml` declared 10 direct `zeph-*` dependencies but the crate's source only references 3 (`zeph-common`, `zeph-llm`, `zeph-tools`) — the other 7 were stranded scaffolding from the abandoned `ToolDispatcher` extraction (issue #3516, closed) and pulled a nontrivial unused transitive subtree into standalone builds.
- Removes `zeph-agent-persistence`, `zeph-config`, `zeph-context`, `zeph-mcp`, `zeph-orchestration`, `zeph-sanitizer`, `zeph-skills` from `[dependencies]`, and narrows the `sqlite`/`postgres` feature gates to forward only to `zeph-tools`.
- Updates `README.md` (Features table + stale #3516 status note) and `CHANGELOG.md` accordingly.

Closes #6084

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (13434 passed, 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo check -p zeph-agent-tools --features sqlite` / `--no-default-features --features postgres`
- [x] `cargo test --doc -p zeph-agent-tools` / `cargo nextest run -p zeph-agent-tools --features sqlite` (29/29)
- [x] Confirmed no remaining references to the removed crates anywhere in `crates/zeph-agent-tools/src/`
- [x] Confirmed no other workspace crate depends on `zeph-agent-tools`'s narrowed feature aliases (only `zeph-core` depends on this crate, and it already forwards `zeph-tools/sqlite`+`postgres` directly)