### PR TITLE
refactor(scheduler): route DynSchedulerExecutor through DynExecutor erasure path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   before. `--migrate-config` drops any leftover `require_tls`/`ssrf_protection` keys from an
   existing `[a2a]` table, warning the user, without erroring (#5885).
 
+- **ACP**: removed `DynSchedulerExecutor`, a hand-maintained `ToolExecutor` wrapper around
+  `Arc<SchedulerExecutor>` that forwarded 9 of the trait's 13 methods (omitting
+  `execute_confirmed`, `set_skill_env`, `set_effective_trust`, `is_tool_retryable`) — the 8th+
+  recurrence of the "leaf type gains a trait method, some Arc wrapper silently drifts" defect
+  class (#5899/#5905/#5906/#5985). The scheduler's ACP tool executor is now wired through the
+  existing `zeph_tools::DynExecutor`/`ErasedToolExecutor` erasure path (already used by every
+  other dynamically-composed executor), which forwards all 13 methods by construction — no
+  bespoke wrapper to drift. `DynSchedulerExecutor` was `pub(crate)`, not a public API, so this
+  is an internal refactor with no behavior change (#6000).
+
 ### Docs
 
 - **LLM**: `AnyProvider`/`Router`/`Triage`'s `capability_delegation_advisory()` rustdoc comments

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -1869,8 +1869,7 @@ async fn spawn_acp_agent(
             agent = agent.with_custom_task_rx(rx);
         }
         if let Some(sched_exec) = scheduler_executor {
-            agent = agent
-                .add_tool_executor(crate::scheduler_executor::DynSchedulerExecutor(sched_exec));
+            agent = agent.add_tool_executor(zeph_tools::DynExecutor(sched_exec));
         }
     }
 

--- a/src/scheduler_executor.rs
+++ b/src/scheduler_executor.rs
@@ -516,52 +516,6 @@ impl ToolExecutor for SchedulerExecutor {
     zeph_tools::tool_executor_no_inner_defaults!();
 }
 
-/// `Arc`-wrapper so `SchedulerExecutor` can be shared across ACP sessions without `Clone`.
-#[cfg(feature = "acp")]
-pub(crate) struct DynSchedulerExecutor(pub(crate) std::sync::Arc<SchedulerExecutor>);
-
-#[cfg(feature = "acp")]
-impl ToolExecutor for DynSchedulerExecutor {
-    async fn execute(&self, response: &str) -> Result<Option<ToolOutput>, ToolError> {
-        self.0.execute(response).await
-    }
-
-    fn tool_definitions(&self) -> Vec<ToolDef> {
-        self.0.tool_definitions()
-    }
-
-    async fn execute_tool_call(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
-        self.0.execute_tool_call(call).await
-    }
-
-    fn requires_confirmation(&self, call: &ToolCall) -> bool {
-        self.0.requires_confirmation(call)
-    }
-
-    async fn execute_tool_call_confirmed(
-        &self,
-        call: &ToolCall,
-    ) -> Result<Option<ToolOutput>, ToolError> {
-        self.0.execute_tool_call_confirmed(call).await
-    }
-
-    fn checkpoint_undo(&self, n: usize) -> zeph_tools::CheckpointActionResult {
-        self.0.checkpoint_undo(n)
-    }
-
-    fn checkpoint_redo(&self) -> zeph_tools::CheckpointActionResult {
-        self.0.checkpoint_redo()
-    }
-
-    fn checkpoint_list(&self) -> zeph_tools::CheckpointListResult {
-        self.0.checkpoint_list()
-    }
-
-    fn is_tool_speculatable(&self, tool_id: &str) -> bool {
-        self.0.is_tool_speculatable(tool_id)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -754,6 +708,17 @@ mod tests {
     async fn tool_definitions_count() {
         let (exec, _rx) = make_executor().await;
         assert_eq!(exec.tool_definitions().len(), 4);
+    }
+
+    #[cfg(feature = "acp")]
+    #[tokio::test]
+    async fn dyn_executor_erasure_path_dispatches() {
+        let (exec, _rx) = make_executor().await;
+        let dyn_exec = zeph_tools::DynExecutor(Arc::new(exec));
+        assert_eq!(dyn_exec.tool_definitions().len(), 4);
+        let call = make_call("list_tasks", serde_json::json!({}));
+        let result = dyn_exec.execute_tool_call(&call).await.unwrap().unwrap();
+        assert!(result.summary.contains("No active scheduled tasks"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Deletes `DynSchedulerExecutor` (`src/scheduler_executor.rs`), a hand-maintained `Arc<SchedulerExecutor>` `ToolExecutor` wrapper that forwarded only 9 of the trait's 13 methods (omitting `execute_confirmed`, `set_skill_env`, `set_effective_trust`, `is_tool_retryable`) — structurally identical to the `Arc<ShellExecutor>` anti-pattern that caused a real bug in #5985, and the 8th+ recurrence of this defect class (#5899/#5905/#5906/#5985).
- Rewires the single call site in `src/acp.rs` to use the existing `zeph_tools::DynExecutor`/`ErasedToolExecutor` erasure adapter instead — already the standard mechanism for every other dynamically-composed `ToolExecutor` in the codebase, forwarding all 13 methods by construction rather than requiring hand-maintained per-method overrides.
- Adds one test (`dyn_executor_erasure_path_dispatches`) verifying the erasure path stays live for the scheduler.
- No behavior change: `DynSchedulerExecutor` was `pub(crate)`, not part of the public API, and the 4 methods it never forwarded still resolve to the same trait defaults via the new path.

Scope was deliberately kept to `DynSchedulerExecutor` only. `Arc<ShellExecutor>` (the #5985/#5998 fix) already forwards all 13 methods correctly and was left untouched to avoid unrelated scope creep.

Closes #6000

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13443 passed, 35 skipped
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] Verified zero remaining references to `DynSchedulerExecutor` workspace-wide
- [x] New test dispatches a real `list_tasks` call through the erasure path and asserts on response content