### PR TITLE
feat(orchestration): implement deterministic ensemble-merge for PlanVerifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   input-history search; a match inside a currently-collapsed tool-output block scrolls
   to the message's visible anchor rather than a position that assumes the block is
   expanded (#6023).
+- **Orchestration**: added opt-in ORCH-style deterministic verifier ensemble-merge for
+  `PlanVerifier` per-task completeness verification (`[orchestration.ensemble]`, spec
+  073-orch-ensemble-merge, arXiv:2602.01797, #6232). When `enabled = true` and `verify = true`,
+  the `SchedulerAction::Verify` handler fans a single verification task out to every configured
+  provider member (`members`, validated odd-length and `>= 3` at config load to guarantee a
+  strict majority with no ties) in parallel via inline `futures::future::join_all` — no new
+  `tokio::spawn` site — and merges independent ballots via a pure, deterministic binary-majority
+  vote (`zeph_orchestration::ensemble::merge`). Errored/timed-out members are excluded from the
+  ballot, never counted as a fail-open vote. Merged `confidence` is always the mean of the
+  winning side's own self-reported confidence — never the ballot agreement ratio, which stays
+  internal-only telemetry (`MergeOutcome`) and is surfaced via `/status` alongside a
+  telemetry-only per-member EMA agreement tracker. Below-quorum responses fall back
+  automatically to the existing single-provider `verify_provider` path (including its fail-open
+  behavior), incrementing an `ensemble_degraded` counter. `enabled = false` (the default)
+  reproduces the pre-existing single-provider `PlanVerifier::verify()` path byte-for-byte.
+  `replan()` remains unchanged and always runs on the single-provider path. `--init` wizard
+  prompt added; `--migrate-config` step 86 adds a commented `[orchestration.ensemble]` advisory
+  block to existing configs for discoverability.
 - **Memory**: added MemGuard-inspired type-aware retrieval composition (`[memory.type_aware_compose]`,
   spec 064, #6086). Retrieval-only, fetch-time gate on `schedule_context_fetchers`: a new
   `FunctionalType` enum (`episodic` / `user_fact` / `behavioral_rule` / `reasoning_strategy` /

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10531,6 +10531,7 @@ dependencies = [
  "tracing-chrome",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "tracing-test",
  "url",
  "uuid",
  "wiremock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -425,6 +425,7 @@ serial_test.workspace = true
 sqlx.workspace = true
 tempfile.workspace = true
 tower = { workspace = true, features = ["util"] }
+tracing-test.workspace = true
 wiremock.workspace = true
 zeph-core.workspace = true
 zeph-llm = { workspace = true, features = ["testing"] }

--- a/book/src/concepts/task-orchestration.md
+++ b/book/src/concepts/task-orchestration.md
@@ -203,6 +203,37 @@ Verification never blocks graph execution. Downstream tasks are unblocked immedi
 
 When `verify_provider` is empty, verification uses the agent's primary provider.
 
+### Ensemble Verification (ORCH)
+
+Opt-in, default off. Based on ORCH (arXiv:2602.01797): instead of a single verifier call, N
+configured provider members independently judge the same task output in parallel, and a pure,
+deterministic binary-majority vote produces the `VerificationResult` — trading a bounded, opt-in
+cost increase for higher confidence on this one decision.
+
+```toml
+[orchestration.ensemble]
+enabled = true
+verify = true
+members = ["fast", "quality", "cheap"]   # odd length, >= 3, no duplicates
+```
+
+- `members.len()` is validated odd and `>= 3` at config load — this guarantees a strict
+  majority with no ties by construction.
+- Each member is called in parallel (never sequentially) and independently timed out via
+  `member_timeout_secs` (falls back to `verifier_timeout_secs` when `0`).
+- Members that error or time out are **excluded** from the vote — never counted as a fail-open
+  `complete: true` ballot.
+- The merged `confidence` is the mean of the **winning side's** self-reported confidence values
+  — never the ballot agreement ratio (which is telemetry-only and never gates `replan`).
+- When fewer than quorum (`members.len() / 2 + 1`) members respond, verification falls back to
+  the single-provider `verify_provider` path automatically, incrementing a
+  `ensemble_degraded` counter (visible in `/status`).
+- A telemetry-only per-member EMA agreement tracker (`ema_alpha`, `ema_decay`,
+  `min_observations`) is recorded for diagnostics but never gates which members are dispatched.
+
+`replan()` itself always runs on the single-provider path — the ensemble only covers the
+initial completeness verdict, not remediation-task generation.
+
 ## Execution
 
 Once a `TaskGraph` is validated and persisted, the **DAG scheduler** drives execution by producing actions for the caller to perform.

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -769,6 +769,19 @@ aggregator_max_tokens = 4096            # Token budget for the aggregation LLM c
 # ttl_days = 30                         # Days since last access before eviction (default: 30)
 # max_templates = 100                    # Maximum cached templates (default: 100)
 
+# ORCH-style deterministic verifier ensemble-merge (arXiv:2602.01797), opt-in, default off.
+# When enabled, PlanVerifier's per-task completeness check runs through N provider members in
+# parallel instead of one, merging independent ballots via deterministic binary majority vote.
+# See specs/073-orch-ensemble-merge/spec.md for the full design.
+[orchestration.ensemble]
+# enabled = false                       # Resolve ensemble members at bootstrap (default: false)
+# verify = false                        # Use the ensemble for PlanVerifier per-task verification (default: false; requires enabled = true)
+# members = ["fast", "quality", "cheap"]  # Provider names from [[llm.providers]]; must be odd-length and >= 3, no duplicates
+# ema_alpha = 0.3                       # EMA smoothing factor for per-member agreement tracking [0.0, 1.0] (default: 0.3)
+# ema_decay = 0.95                      # Decay-toward-neutral-prior factor [0.0, 1.0] (default: 0.95)
+# min_observations = 5                  # Minimum observations before a member's EMA score is considered meaningful (default: 5)
+# member_timeout_secs = 0               # Per-member LLM call timeout; 0 = fall back to verifier_timeout_secs (default: 0)
+
 [gateway]
 enabled = false
 bind = "127.0.0.1"

--- a/config/default.toml
+++ b/config/default.toml
@@ -1145,6 +1145,24 @@ verify_completeness = false
 # Timeout in seconds for verifier LLM calls (0 rejected by validation). Default: 30.
 # verifier_timeout_secs = 30
 
+# ORCH-style deterministic verifier ensemble-merge (arXiv:2602.01797), opt-in, default off.
+# See specs/073-orch-ensemble-merge/spec.md.
+[orchestration.ensemble]
+# Resolve ensemble members at bootstrap. Default: false.
+# enabled = false
+# Use the ensemble for PlanVerifier per-task verification (requires enabled = true). Default: false.
+# verify = false
+# Provider names from [[llm.providers]]. Must be odd-length and >= 3, no duplicates.
+# members = ["fast", "quality", "cheap"]
+# EMA smoothing factor for per-member agreement tracking [0.0, 1.0]. Default: 0.3.
+# ema_alpha = 0.3
+# Decay-toward-neutral-prior factor [0.0, 1.0]. Default: 0.95.
+# ema_decay = 0.95
+# Minimum observations before a member's EMA score is considered meaningful. Default: 5.
+# min_observations = 5
+# Per-member LLM call timeout in seconds; 0 = fall back to verifier_timeout_secs. Default: 0.
+# member_timeout_secs = 0
+
 [classifiers]
 # Enable ML-backed classifiers (requires the `classifiers` feature at compile time).
 # When false, all classifier code is bypassed and existing regex detection runs unchanged.

--- a/crates/zeph-config/src/experiment.rs
+++ b/crates/zeph-config/src/experiment.rs
@@ -184,6 +184,18 @@ fn default_verifier_timeout_secs() -> u64 {
     30
 }
 
+fn default_ensemble_ema_alpha() -> f64 {
+    0.3
+}
+
+fn default_ensemble_ema_decay() -> f64 {
+    0.95
+}
+
+fn default_ensemble_min_observations() -> u32 {
+    5
+}
+
 fn default_plan_cache_similarity_threshold() -> f32 {
     0.90
 }
@@ -251,6 +263,66 @@ impl PlanCacheConfig {
             ));
         }
         Ok(())
+    }
+}
+
+/// Configuration for ORCH-style deterministic verifier ensemble-merge
+/// (`[orchestration.ensemble]` TOML section, spec `073-orch-ensemble-merge`).
+///
+/// Opt-in and default-`OFF`: when `enabled = false` (the default), `PlanVerifier::verify()`
+/// behaves byte-for-byte identically to the single-provider path — no ensemble code runs.
+///
+/// `size` and `min_quorum` are intentionally NOT configurable fields — both are always
+/// derived from `members.len()` (`quorum = members.len() / 2 + 1`) so they can never drift
+/// out of sync with the member list.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct EnsembleConfig {
+    /// Enable ensemble machinery (member resolution at bootstrap). Default: `false`.
+    ///
+    /// Separate from `verify` so the ensemble can be resolved/warmed without yet being used
+    /// for verification decisions.
+    pub enabled: bool,
+    /// Use the ensemble for `PlanVerifier` per-task verification. Default: `false`.
+    ///
+    /// Requires `enabled = true`. When `false` (even with `enabled = true`), the
+    /// `SchedulerAction::Verify` handler still uses the single-provider `verify_provider`
+    /// path — `verify` is the per-target activation flag.
+    pub verify: bool,
+    /// Provider names from `[[llm.providers]]`, one per ensemble member.
+    ///
+    /// Validated at config load time (when `enabled && verify`) to be odd-length, `>= 3`,
+    /// and free of duplicates — this guarantees a strict majority with no ties by
+    /// construction. Default: empty.
+    pub members: Vec<String>,
+    /// EMA smoothing factor for `EnsembleTracker`'s per-member agreement score, in `[0.0, 1.0]`.
+    /// Higher values weight the most recent observation more heavily. Default: `0.3`.
+    #[serde(default = "default_ensemble_ema_alpha")]
+    pub ema_alpha: f64,
+    /// Decay-toward-neutral-prior factor for `EnsembleTracker`, in `[0.0, 1.0]`. Default: `0.95`.
+    #[serde(default = "default_ensemble_ema_decay")]
+    pub ema_decay: f64,
+    /// Minimum recorded observations before `EnsembleTracker::ema()` returns a score instead
+    /// of `None` (cold-start gate). Default: `5`.
+    #[serde(default = "default_ensemble_min_observations")]
+    pub min_observations: u32,
+    /// Per-member `chat_typed` call timeout in seconds. `0` = fall back to
+    /// `verifier_timeout_secs`. Default: `0`.
+    #[serde(default)]
+    pub member_timeout_secs: u64,
+}
+
+impl Default for EnsembleConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            verify: false,
+            members: Vec::new(),
+            ema_alpha: default_ensemble_ema_alpha(),
+            ema_decay: default_ensemble_ema_decay(),
+            min_observations: default_ensemble_min_observations(),
+            member_timeout_secs: 0,
+        }
     }
 }
 
@@ -455,6 +527,11 @@ pub struct OrchestrationConfig {
     /// Set to `0` is rejected by `Config::validate()`.
     #[serde(default = "default_verifier_timeout_secs")]
     pub verifier_timeout_secs: u64,
+
+    /// ORCH-style deterministic verifier ensemble-merge configuration. Default: disabled.
+    /// See `specs/073-orch-ensemble-merge/spec.md`.
+    #[serde(default)]
+    pub ensemble: EnsembleConfig,
 }
 
 impl Default for OrchestrationConfig {
@@ -498,6 +575,7 @@ impl Default for OrchestrationConfig {
             aggregator_timeout_secs: default_aggregator_timeout_secs(),
             planner_timeout_secs: default_planner_timeout_secs(),
             verifier_timeout_secs: default_verifier_timeout_secs(),
+            ensemble: EnsembleConfig::default(),
         }
     }
 }
@@ -742,6 +820,57 @@ mod tests {
             "missing field must use default 0.7, got {}",
             cfg.completeness_threshold
         );
+    }
+
+    #[test]
+    fn ensemble_config_default_is_disabled() {
+        let cfg = EnsembleConfig::default();
+        assert!(!cfg.enabled);
+        assert!(!cfg.verify);
+        assert!(cfg.members.is_empty());
+        assert!((cfg.ema_alpha - 0.3).abs() < f64::EPSILON);
+        assert!((cfg.ema_decay - 0.95).abs() < f64::EPSILON);
+        assert_eq!(cfg.min_observations, 5);
+        assert_eq!(cfg.member_timeout_secs, 0);
+    }
+
+    #[test]
+    fn orchestration_config_ensemble_is_disabled_by_default() {
+        assert!(!OrchestrationConfig::default().ensemble.enabled);
+    }
+
+    #[test]
+    fn ensemble_config_serde_round_trip() {
+        let toml_in = r#"
+            enabled = true
+            verify = true
+            members = ["fast", "quality", "cheap"]
+            ema_alpha = 0.4
+            ema_decay = 0.9
+            min_observations = 10
+            member_timeout_secs = 15
+        "#;
+        let cfg: EnsembleConfig = toml::from_str(toml_in).expect("deserialize");
+        assert!(cfg.enabled);
+        assert!(cfg.verify);
+        assert_eq!(cfg.members, vec!["fast", "quality", "cheap"]);
+        assert!((cfg.ema_alpha - 0.4).abs() < f64::EPSILON);
+
+        let serialized = toml::to_string(&cfg).expect("serialize");
+        let cfg2: EnsembleConfig = toml::from_str(&serialized).expect("re-deserialize");
+        assert_eq!(cfg2.members, cfg.members);
+        assert_eq!(cfg2.member_timeout_secs, 15);
+    }
+
+    #[test]
+    fn ensemble_config_missing_section_uses_defaults() {
+        // OrchestrationConfig has #[serde(default)] on the whole struct, and `ensemble` has
+        // #[serde(default)] too — an existing config with no [orchestration.ensemble] table
+        // at all must parse to the disabled default (no migration step required).
+        let toml_in = "enabled = true\n";
+        let cfg: OrchestrationConfig = toml::from_str(toml_in).expect("deserialize");
+        assert!(!cfg.ensemble.enabled);
+        assert!(cfg.ensemble.members.is_empty());
     }
 
     #[test]

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -135,8 +135,8 @@ pub use dump_format::DumpFormat;
 pub use durable::{DurableBackend, DurableConfig, RetentionPolicy};
 pub use execution::{EnvironmentConfig, ExecutionConfig};
 pub use experiment::{
-    AdaptOrchConfig, AssetSensitivity, ExperimentConfig, ExperimentSchedule, FailureStrategy,
-    OrchestrationConfig, PlanCacheConfig,
+    AdaptOrchConfig, AssetSensitivity, EnsembleConfig, ExperimentConfig, ExperimentSchedule,
+    FailureStrategy, OrchestrationConfig, PlanCacheConfig,
 };
 pub use features::{
     CavemanConfig, CompressionSpectrumConfig, CostConfig, DaemonConfig, DebugConfig, GatewayConfig,

--- a/crates/zeph-config/src/loader.rs
+++ b/crates/zeph-config/src/loader.rs
@@ -361,6 +361,41 @@ impl Config {
                 "orchestration.completeness_threshold must be in [0.0, 1.0], got {ct}"
             )));
         }
+        // Ensemble member-list shape is only meaningful once the ensemble is actually wired
+        // into a verification decision (`enabled && verify`) — an unused/staged config with
+        // an invalid `members` list must not block startup (spec 073 FR-014).
+        let ensemble = &self.orchestration.ensemble;
+        if ensemble.enabled && ensemble.verify {
+            let n = ensemble.members.len();
+            if n.is_multiple_of(2) || n < 3 {
+                return Err(ConfigError::Validation(format!(
+                    "orchestration.ensemble.members must be odd and >= 3, got {n}"
+                )));
+            }
+            let unique: std::collections::HashSet<&str> =
+                ensemble.members.iter().map(String::as_str).collect();
+            if unique.len() != ensemble.members.len() {
+                return Err(ConfigError::Validation(
+                    "orchestration.ensemble.members contains a duplicate provider name".into(),
+                ));
+            }
+            // Defense-in-depth (security P3): EnsembleTracker's EMA params are telemetry-only
+            // in PR-1 and never gate a verification/dispatch decision, but an out-of-range value
+            // would still produce a meaningless displayed score and could bias a future phase
+            // that wires EMA into member selection.
+            let alpha = ensemble.ema_alpha;
+            if !alpha.is_finite() || !(0.0..=1.0).contains(&alpha) {
+                return Err(ConfigError::Validation(format!(
+                    "orchestration.ensemble.ema_alpha must be in [0.0, 1.0], got {alpha}"
+                )));
+            }
+            let decay = ensemble.ema_decay;
+            if !decay.is_finite() || !(0.0..=1.0).contains(&decay) {
+                return Err(ConfigError::Validation(format!(
+                    "orchestration.ensemble.ema_decay must be in [0.0, 1.0], got {decay}"
+                )));
+            }
+        }
         // Cascade chain threshold must not be 1 — that would abort on every single failure.
         if self.orchestration.cascade_chain_threshold == 1 {
             return Err(ConfigError::Validation(
@@ -1504,5 +1539,149 @@ weight = 0.3
         );
         let reparsed: Config = toml::from_str(&dumped).expect("reparse dumped defaults");
         assert!(reparsed.validate().is_ok());
+    }
+
+    // --- orchestration.ensemble validation (spec 073-orch-ensemble-merge, M5/M7) ---
+
+    fn config_with_ensemble(enabled: bool, verify: bool, members: Vec<&str>) -> Config {
+        let mut cfg = Config::default();
+        cfg.orchestration.ensemble.enabled = enabled;
+        cfg.orchestration.ensemble.verify = verify;
+        cfg.orchestration.ensemble.members = members.into_iter().map(String::from).collect();
+        cfg
+    }
+
+    #[test]
+    fn ensemble_default_config_validates_trivially() {
+        assert!(Config::default().validate().is_ok());
+    }
+
+    #[test]
+    fn ensemble_disabled_skips_member_list_validation() {
+        // enabled=false: an invalid members list must not block startup.
+        let cfg = config_with_ensemble(false, false, vec!["a", "b"]);
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn ensemble_enabled_but_not_verify_skips_member_list_validation() {
+        // enabled=true, verify=false: still an unused/staged config, checks skipped.
+        let cfg = config_with_ensemble(true, false, vec!["a", "b"]);
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn ensemble_active_even_length_members_rejected() {
+        let cfg = config_with_ensemble(true, true, vec!["a", "b"]);
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("must be odd and >= 3"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn ensemble_active_short_members_rejected() {
+        let cfg = config_with_ensemble(true, true, vec!["a"]);
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("must be odd and >= 3"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn ensemble_active_duplicate_members_rejected() {
+        let cfg = config_with_ensemble(true, true, vec!["a", "b", "a"]);
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("duplicate provider name"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn ensemble_active_valid_odd_unique_members_accepted() {
+        let cfg = config_with_ensemble(true, true, vec!["a", "b", "c"]);
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn ensemble_active_valid_five_members_accepted() {
+        let cfg = config_with_ensemble(true, true, vec!["a", "b", "c", "d", "e"]);
+        assert!(cfg.validate().is_ok());
+    }
+
+    // --- ema_alpha / ema_decay range validation (security P3) ---
+
+    #[test]
+    fn ensemble_active_ema_alpha_above_one_rejected() {
+        let mut cfg = config_with_ensemble(true, true, vec!["a", "b", "c"]);
+        cfg.orchestration.ensemble.ema_alpha = 1.5;
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("ema_alpha"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn ensemble_active_ema_alpha_negative_rejected() {
+        let mut cfg = config_with_ensemble(true, true, vec!["a", "b", "c"]);
+        cfg.orchestration.ensemble.ema_alpha = -0.1;
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("ema_alpha"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn ensemble_active_ema_alpha_nan_rejected() {
+        let mut cfg = config_with_ensemble(true, true, vec!["a", "b", "c"]);
+        cfg.orchestration.ensemble.ema_alpha = f64::NAN;
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("ema_alpha"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn ensemble_active_ema_decay_above_one_rejected() {
+        let mut cfg = config_with_ensemble(true, true, vec!["a", "b", "c"]);
+        cfg.orchestration.ensemble.ema_decay = 1.1;
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("ema_decay"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn ensemble_active_ema_decay_negative_rejected() {
+        let mut cfg = config_with_ensemble(true, true, vec!["a", "b", "c"]);
+        cfg.orchestration.ensemble.ema_decay = -0.1;
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("ema_decay"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn ensemble_active_ema_boundaries_zero_and_one_accepted() {
+        let mut cfg = config_with_ensemble(true, true, vec!["a", "b", "c"]);
+        cfg.orchestration.ensemble.ema_alpha = 0.0;
+        cfg.orchestration.ensemble.ema_decay = 1.0;
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn ensemble_disabled_skips_ema_range_validation() {
+        // enabled=false: an out-of-range EMA param must not block startup.
+        let mut cfg = config_with_ensemble(false, false, vec![]);
+        cfg.orchestration.ensemble.ema_alpha = 5.0;
+        assert!(cfg.validate().is_ok());
     }
 }

--- a/crates/zeph-config/src/migrate/features.rs
+++ b/crates/zeph-config/src/migrate/features.rs
@@ -814,6 +814,56 @@ pub fn migrate_orchestration_asset_sensitivity(
     })
 }
 
+/// Step 86 — add a commented-out `[orchestration.ensemble]` advisory block for ORCH-style
+/// deterministic verifier ensemble-merge, if absent (spec 073, #6232).
+///
+/// All `EnsembleConfig` fields have `#[serde(default)]` so existing configs parse without
+/// changes even without this step — this exists purely for discoverability on config upgrade,
+/// mirroring [`migrate_orchestration_persistence`] and [`migrate_memory_type_aware_compose_config`](super::migrate_memory_type_aware_compose_config).
+///
+/// # Errors
+///
+/// Returns [`MigrateError`] if `toml_src` fails to parse as TOML.
+pub fn migrate_orchestration_ensemble(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    // Idempotency: comments are invisible to toml_edit, so check the raw source.
+    if section_header_present(toml_src, "orchestration.ensemble")
+        || toml_src.contains("[orchestration.ensemble]")
+    {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let doc = toml_src.parse::<toml_edit::DocumentMut>()?;
+    if !doc.contains_key("orchestration") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "\n# ORCH-style deterministic verifier ensemble-merge — off by default (spec 073, #6232)\n\
+         # [orchestration.ensemble]\n\
+         # enabled = false\n\
+         # verify = false\n\
+         # members = []                 # odd length, >= 3, no duplicates, from [[llm.providers]]\n\
+         # ema_alpha = 0.3\n\
+         # ema_decay = 0.95\n\
+         # min_observations = 5\n\
+         # member_timeout_secs = 0      # 0 = fall back to verifier_timeout_secs\n";
+    let raw = doc.to_string();
+    let output = format!("{raw}{comment}");
+
+    Ok(MigrationResult {
+        output,
+        changed_count: 1,
+        sections_changed: vec!["orchestration.ensemble".to_owned()],
+    })
+}
+
 /// Step 78 — add a commented-out `[skills.registry]` section with defaults if absent
 /// (spec-045, #5869).
 ///

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -24,9 +24,9 @@ pub use features::{
     migrate_autodream_config, migrate_caveman_config, migrate_compression_predictor_config,
     migrate_deep_link_config, migrate_five_signal_config, migrate_goals_config,
     migrate_knowledge_config, migrate_magic_docs_config, migrate_microcompact_config,
-    migrate_orchestration_asset_sensitivity, migrate_orchestration_persistence,
-    migrate_skill_trust_require_check, migrate_skills_registry, migrate_tui_delights,
-    migrate_tui_mouse, migrate_tui_theme_config, migrate_tui_theme_defaults,
+    migrate_orchestration_asset_sensitivity, migrate_orchestration_ensemble,
+    migrate_orchestration_persistence, migrate_skill_trust_require_check, migrate_skills_registry,
+    migrate_tui_delights, migrate_tui_mouse, migrate_tui_theme_config, migrate_tui_theme_defaults,
 };
 pub use infra::*;
 /// Advisory `GonkaGate` migration is crate-internal (registered via the [`MIGRATIONS`] registry).
@@ -612,9 +612,9 @@ use steps::{
     MigrateMemoryHebbianConsolidation, MigrateMemoryHebbianSpread, MigrateMemoryPersonaConfig,
     MigrateMemoryReasoning, MigrateMemoryReasoningJudge, MigrateMemoryRetrieval,
     MigrateMemoryRetrievalQueryBias, MigrateMemoryTypeAwareCompose, MigrateMicrocompactConfig,
-    MigrateNliConfig, MigrateOrchestrationAssetSensitivity, MigrateOrchestrationPersistence,
-    MigrateOrchestratorProvider, MigrateOtelFilter, MigratePiiFilterNames,
-    MigratePlannerModelToProvider, MigratePolicyProviderAndUtilityWindow,
+    MigrateNliConfig, MigrateOrchestrationAssetSensitivity, MigrateOrchestrationEnsemble,
+    MigrateOrchestrationPersistence, MigrateOrchestratorProvider, MigrateOtelFilter,
+    MigratePiiFilterNames, MigratePlannerModelToProvider, MigratePolicyProviderAndUtilityWindow,
     MigrateProviderMaxConcurrent, MigrateQdrantApiKey, MigrateQdrantTimeoutSecs,
     MigrateQualityConfig, MigrateSandboxConfig, MigrateSandboxEgressFilter, MigrateSchedulerDaemon,
     MigrateSecretMaskingConfig, MigrateServeConfig, MigrateSessionPersistProviderOverrides,
@@ -627,7 +627,7 @@ use steps::{
     MigrateWorktreeConfig, MigrateWorktreeGitTimeout, MigrateWorktreeQuotaFields,
 };
 
-/// Ordered registry of all sequential migration steps (steps 1–84).
+/// Ordered registry of all sequential migration steps (steps 1–86).
 ///
 /// Each entry wraps the corresponding free function and is evaluated lazily at first access.
 /// The ordering is chronological; the dispatch loop in `src/commands/migrate.rs` iterates
@@ -786,6 +786,9 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             // Step 85 — add [memory.type_aware_compose] advisory block for MemGuard
             // type-aware retrieval composition (spec 064, #6086)
             Box::new(MigrateMemoryTypeAwareCompose),
+            // Step 86 — add [orchestration.ensemble] advisory block for ORCH-style
+            // deterministic verifier ensemble-merge (spec 073, #6232)
+            Box::new(MigrateOrchestrationEnsemble),
         ]
     });
 

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -51,7 +51,9 @@
 //! step 84 drops the inert `require_tls`/`ssrf_protection` keys from an existing active
 //! `[a2a]` table (#5885);
 //! step 85 adds a commented `[memory.type_aware_compose]` advisory block for `MemGuard`
-//! type-aware retrieval composition (spec 064, #6086).
+//! type-aware retrieval composition (spec 064, #6086);
+//! step 86 adds a commented `[orchestration.ensemble]` advisory block for ORCH-style
+//! deterministic verifier ensemble-merge (spec 073, #6232).
 //!
 //! Each struct is a zero-size type that delegates to the corresponding free function in
 //! `super`. They exist solely to satisfy the object-safe [`super::Migration`] trait so the
@@ -77,12 +79,12 @@ use super::{
     migrate_memory_reasoning_judge_config, migrate_memory_retrieval_config,
     migrate_memory_retrieval_query_bias, migrate_memory_type_aware_compose_config,
     migrate_microcompact_config, migrate_nli_config, migrate_orchestration_asset_sensitivity,
-    migrate_orchestration_orchestrator_provider, migrate_orchestration_persistence,
-    migrate_otel_filter, migrate_pii_filter_names, migrate_planner_model_to_provider,
-    migrate_policy_provider_and_utility_window, migrate_provider_max_concurrent,
-    migrate_qdrant_api_key, migrate_qdrant_timeout_secs, migrate_quality_config,
-    migrate_sandbox_config, migrate_sandbox_egress_filter, migrate_scheduler_daemon_config,
-    migrate_secret_masking_config, migrate_serve_config,
+    migrate_orchestration_ensemble, migrate_orchestration_orchestrator_provider,
+    migrate_orchestration_persistence, migrate_otel_filter, migrate_pii_filter_names,
+    migrate_planner_model_to_provider, migrate_policy_provider_and_utility_window,
+    migrate_provider_max_concurrent, migrate_qdrant_api_key, migrate_qdrant_timeout_secs,
+    migrate_quality_config, migrate_sandbox_config, migrate_sandbox_egress_filter,
+    migrate_scheduler_daemon_config, migrate_secret_masking_config, migrate_serve_config,
     migrate_session_persist_provider_overrides, migrate_session_persistence_config,
     migrate_session_provider_persistence, migrate_session_recap_config,
     migrate_shadow_sentinel_config, migrate_shell_checkpoints_config, migrate_shell_transactional,
@@ -1056,5 +1058,18 @@ impl Migration for MigrateMemoryTypeAwareCompose {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_memory_type_aware_compose_config(toml_src)
+    }
+}
+
+/// Step 86 — adds a commented `[orchestration.ensemble]` advisory block for ORCH-style
+/// deterministic verifier ensemble-merge (spec 073, #6232).
+pub(super) struct MigrateOrchestrationEnsemble;
+impl Migration for MigrateOrchestrationEnsemble {
+    fn name(&self) -> &'static str {
+        "migrate_orchestration_ensemble"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_orchestration_ensemble(toml_src)
     }
 }

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -9,8 +9,8 @@ use super::*;
 fn migrations_registry_has_all_steps() {
     assert_eq!(
         MIGRATIONS.len(),
-        85,
-        "MIGRATIONS registry must contain all 85 sequential steps"
+        86,
+        "MIGRATIONS registry must contain all 86 sequential steps"
     );
     for m in MIGRATIONS.iter() {
         assert!(
@@ -1111,6 +1111,42 @@ fn migrate_memory_type_aware_compose_config_noop_when_active_section_present() {
 }
 
 #[test]
+fn migrate_orchestration_ensemble_idempotent_on_commented_output() {
+    let base = "[orchestration]\nenabled = true\n";
+    let first = migrate_orchestration_ensemble(base).unwrap();
+    assert_eq!(first.changed_count, 1);
+    assert!(first.output.contains("# [orchestration.ensemble]"));
+    assert!(first.output.contains("# enabled = false"));
+    assert!(first.output.contains("# verify = false"));
+    let second = migrate_orchestration_ensemble(&first.output).unwrap();
+    assert_eq!(second.changed_count, 0, "second run must not double-append");
+    assert_eq!(second.output, first.output);
+}
+
+#[test]
+fn migrate_orchestration_ensemble_noop_when_orchestration_section_absent() {
+    let base = "[agent]\nname = \"Zeph\"\n";
+    let result = migrate_orchestration_ensemble(base).unwrap();
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, base);
+}
+
+#[test]
+fn migrate_orchestration_ensemble_noop_when_active_section_present() {
+    let base = "[orchestration]\nenabled = true\n\n[orchestration.ensemble]\nenabled = true\n";
+    let result = migrate_orchestration_ensemble(base).unwrap();
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, base);
+}
+
+#[test]
+fn migrate_orchestration_ensemble_sections_changed_reports_key() {
+    let base = "[orchestration]\nenabled = true\n";
+    let result = migrate_orchestration_ensemble(base).unwrap();
+    assert_eq!(result.sections_changed, vec!["orchestration.ensemble"]);
+}
+
+#[test]
 fn migrate_microcompact_config_idempotent_on_commented_output() {
     let base = "[memory]\ndb_path = \"~/.zeph/memory.db\"\n";
     let first = migrate_microcompact_config(base).unwrap();
@@ -1781,7 +1817,7 @@ fn migrate_focus_auto_consolidate_noop_when_only_commented_section() {
 
 #[test]
 fn registry_has_fifty_entries() {
-    assert_eq!(MIGRATIONS.len(), 85);
+    assert_eq!(MIGRATIONS.len(), 86);
 }
 
 #[test]
@@ -1906,6 +1942,7 @@ fn registry_preserves_order_matches_dispatch() {
         "migrate_worktree_quota_fields",
         "migrate_a2a_server_remove_inert_fields",
         "migrate_memory_type_aware_compose_config",
+        "migrate_orchestration_ensemble",
     ];
     let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
     assert_eq!(actual, expected);

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -727,6 +727,18 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Set the resolved ensemble members for ORCH-style deterministic verifier
+    /// ensemble-merge (spec `073-orch-ensemble-merge`).
+    ///
+    /// Each pair is a `[[llm.providers]]` name and its resolved provider. Empty by default —
+    /// `SchedulerAction::Verify` only takes the ensemble branch when this is non-empty AND
+    /// `[orchestration.ensemble].enabled && verify` are both set.
+    #[must_use]
+    pub fn with_ensemble_members(mut self, members: Vec<(String, AnyProvider)>) -> Self {
+        self.services.orchestration.ensemble_members = members;
+        self
+    }
+
     /// Set the `AdaptOrch` topology advisor.
     ///
     /// When set, `handle_plan_goal_as_string` calls `advisor.recommend()` before planning

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -319,7 +319,9 @@ impl<C: crate::channel::Channel> Agent<C> {
         task_count: usize,
         cancel_token: CancellationToken,
     ) -> Result<zeph_orchestration::GraphStatus, error::AgentError> {
-        use zeph_orchestration::{PlanVerifier, SchedulerAction};
+        use zeph_orchestration::{
+            EnsembleAttempt, EnsembleTracker, EnsembleVerifier, PlanVerifier, SchedulerAction,
+        };
 
         let mut spawn_counter: usize = 0;
 
@@ -327,6 +329,9 @@ impl<C: crate::channel::Channel> Agent<C> {
             std::collections::HashSet::new();
 
         let mut plan_verifier: Option<PlanVerifier<zeph_llm::any::AnyProvider>> = None;
+        // ORCH-style deterministic verifier ensemble-merge (spec 073-orch-ensemble-merge).
+        // `None` when disabled or before the first `Verify` action of the session.
+        let mut ensemble_verifier: Option<EnsembleVerifier> = None;
         let mut stdin_closed = false;
         // In-flight dedupe for VerifyPredicate actions (S9): prevents double-charging
         // the LLM when tick() re-emits the same task before the previous eval completes.
@@ -480,7 +485,128 @@ impl<C: crate::channel::Channel> Agent<C> {
                         let task = scheduler.graph().tasks.get(task_id.index()).cloned();
 
                         if let Some(task) = task {
-                            let result = verifier.verify(&task, &output).await;
+                            let ensemble_cfg = &orch_config.ensemble;
+                            let resolved_count = self.services.orchestration.ensemble_members.len();
+                            // The odd/>=3 invariant is validated at config load for the
+                            // *configured* member list (spec 073 FR-014), but bootstrap-time
+                            // provider resolution can shrink the *effective* set below it
+                            // (critic S1) — gate on the resolved count's shape, not merely
+                            // non-empty, so a degenerate/even effective ensemble can never run.
+                            let effective_ensemble_valid =
+                                !resolved_count.is_multiple_of(2) && resolved_count >= 3;
+                            let use_ensemble = ensemble_cfg.enabled
+                                && ensemble_cfg.verify
+                                && effective_ensemble_valid;
+
+                            if ensemble_cfg.enabled
+                                && ensemble_cfg.verify
+                                && !effective_ensemble_valid
+                            {
+                                self.update_metrics(|m| {
+                                    m.orchestration.ensemble_degraded_total += 1;
+                                });
+                                tracing::warn!(
+                                    task_id = %task_id,
+                                    resolved_count,
+                                    configured_count = ensemble_cfg.members.len(),
+                                    "ensemble effective member count is not odd/>=3 after \
+                                     bootstrap resolution — falling back to single-provider \
+                                     verify"
+                                );
+                            }
+
+                            let result = if use_ensemble {
+                                let member_timeout_secs = if ensemble_cfg.member_timeout_secs > 0 {
+                                    ensemble_cfg.member_timeout_secs
+                                } else {
+                                    orch_config.verifier_timeout_secs
+                                };
+                                let ensemble_sanitizer: std::sync::Arc<
+                                    dyn zeph_common::OutputSanitizer,
+                                > = std::sync::Arc::new(self.services.security.sanitizer.clone());
+                                let ev = ensemble_verifier.get_or_insert_with(|| {
+                                    EnsembleVerifier::new(
+                                        self.services.orchestration.ensemble_members.clone(),
+                                        std::time::Duration::from_secs(member_timeout_secs),
+                                        EnsembleTracker::new(
+                                            ensemble_cfg.ema_alpha,
+                                            ensemble_cfg.ema_decay,
+                                            ensemble_cfg.min_observations,
+                                        ),
+                                    )
+                                });
+
+                                match ev.verify(&task, &output, &ensemble_sanitizer).await {
+                                    EnsembleAttempt::Merged { result, outcome } => {
+                                        tracing::debug!(
+                                            task_id = %task_id,
+                                            complete = result.complete,
+                                            confidence = result.confidence,
+                                            agreement_ratio = outcome.agreement_ratio,
+                                            tie_broken = outcome.tie_broken,
+                                            "ensemble per-task verification result"
+                                        );
+                                        if let Some(ref tracker) = self.runtime.metrics.cost_tracker
+                                        {
+                                            for usage in ev.last_usage() {
+                                                let member_provider = self
+                                                    .services
+                                                    .orchestration
+                                                    .ensemble_members
+                                                    .iter()
+                                                    .find(|(name, _)| name == &usage.member);
+                                                let (provider_kind, model) = member_provider
+                                                    .map_or(
+                                                        ("cloud", usage.member.as_str()),
+                                                        |(_, p)| {
+                                                            (
+                                                                p.provider_kind_str(),
+                                                                p.model_identifier(),
+                                                            )
+                                                        },
+                                                    );
+                                                tracker.record_usage(
+                                                    &usage.member,
+                                                    provider_kind,
+                                                    model,
+                                                    usage.input_tokens,
+                                                    0,
+                                                    0,
+                                                    usage.output_tokens,
+                                                );
+                                            }
+                                        }
+                                        let member_stats = ev.tracker().snapshot();
+                                        self.update_metrics(|m| {
+                                            m.orchestration.ensemble_last_agreement_ratio =
+                                                Some(outcome.agreement_ratio);
+                                            m.orchestration.ensemble_member_stats = member_stats;
+                                        });
+                                        result
+                                    }
+                                    EnsembleAttempt::QuorumNotMet {
+                                        responded,
+                                        quorum,
+                                        configured,
+                                    } => {
+                                        self.update_metrics(|m| {
+                                            m.orchestration.ensemble_degraded_total += 1;
+                                        });
+                                        tracing::warn!(
+                                            task_id = %task_id,
+                                            responded,
+                                            quorum,
+                                            configured,
+                                            "ensemble quorum not met — falling back to \
+                                             single-provider verify"
+                                        );
+                                        verifier.verify(&task, &output).await
+                                    }
+                                }
+                            } else {
+                                verifier.verify(&task, &output).await
+                            };
+
                             tracing::debug!(
                                 task_id = %task_id,
                                 complete = result.complete,

--- a/crates/zeph-core/src/agent/slash_commands.rs
+++ b/crates/zeph-core/src/agent/slash_commands.rs
@@ -232,6 +232,12 @@ impl<C: crate::channel::Channel> Agent<C> {
             metrics.orch_failed,
             metrics.orch_skipped,
         );
+        append_ensemble_section(
+            &mut out,
+            metrics.ensemble_degraded,
+            metrics.ensemble_agreement_ratio,
+            &metrics.ensemble_member_stats,
+        );
         append_pruning_section(
             &mut out,
             self.context_manager.compression.pruning_strategy,
@@ -805,6 +811,9 @@ struct StatusMetrics {
     orch_completed: u64,
     orch_failed: u64,
     orch_skipped: u64,
+    ensemble_degraded: u64,
+    ensemble_agreement_ratio: Option<f64>,
+    ensemble_member_stats: Vec<(String, f64, u64)>,
     provider_breakdown: Vec<(String, crate::cost::ProviderUsage)>,
 }
 
@@ -825,6 +834,9 @@ fn collect_status_metrics(
             orch_completed: m.orchestration.tasks_completed,
             orch_failed: m.orchestration.tasks_failed,
             orch_skipped: m.orchestration.tasks_skipped,
+            ensemble_degraded: m.orchestration.ensemble_degraded_total,
+            ensemble_agreement_ratio: m.orchestration.ensemble_last_agreement_ratio,
+            ensemble_member_stats: m.orchestration.ensemble_member_stats.clone(),
             provider_breakdown: m.provider_cost_breakdown.clone(),
         }
     } else {
@@ -840,6 +852,9 @@ fn collect_status_metrics(
             orch_completed: 0,
             orch_failed: 0,
             orch_skipped: 0,
+            ensemble_degraded: 0,
+            ensemble_agreement_ratio: None,
+            ensemble_member_stats: vec![],
             provider_breakdown: vec![],
         }
     }
@@ -894,6 +909,32 @@ fn append_orchestration_section(
         if orch_skipped > 0 {
             let _ = writeln!(out, "  Skipped:   {orch_skipped}");
         }
+    }
+}
+
+/// Append ensemble-verified plan verification stats (spec `073-orch-ensemble-merge`) to the
+/// `/status` output. Silent (no section printed) when the ensemble has never run — the
+/// member-stats list is empty and no member has ever cast a ballot.
+fn append_ensemble_section(
+    out: &mut String,
+    ensemble_degraded: u64,
+    ensemble_agreement_ratio: Option<f64>,
+    ensemble_member_stats: &[(String, f64, u64)],
+) {
+    use std::fmt::Write;
+    if ensemble_member_stats.is_empty() && ensemble_degraded == 0 {
+        return;
+    }
+    let _ = writeln!(out);
+    let _ = writeln!(out, "Ensemble verify:");
+    if let Some(ratio) = ensemble_agreement_ratio {
+        let _ = writeln!(out, "  Last agreement: {:.0}%", ratio * 100.0);
+    }
+    if ensemble_degraded > 0 {
+        let _ = writeln!(out, "  Degraded:  {ensemble_degraded} (quorum fallback)");
+    }
+    for (member, score, observations) in ensemble_member_stats {
+        let _ = writeln!(out, "  {member:<16} ema={score:.2} (n={observations})");
     }
 }
 

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -658,6 +658,16 @@ pub(crate) struct OrchestrationState {
     /// Provider for predicate gate evaluation. `None` falls back to `orchestrator_provider`
     /// then `verify_provider` then primary.
     pub(crate) predicate_provider: Option<AnyProvider>,
+    /// Resolved ensemble members for ORCH-style deterministic verifier ensemble-merge
+    /// (spec `073-orch-ensemble-merge`). Each entry pairs the `[[llm.providers]]` name with
+    /// its resolved provider — kept as pairs (not a bare `Vec<AnyProvider>`) so a partial
+    /// bootstrap-time resolution failure can never desynchronize a ballot's `member` name
+    /// from the wrong config entry.
+    ///
+    /// Empty when `[orchestration.ensemble].enabled = false` (the default) or when no member
+    /// resolved successfully. `SchedulerAction::Verify` only takes the ensemble branch when
+    /// this is non-empty.
+    pub(crate) ensemble_members: Vec<(String, AnyProvider)>,
     /// Graph waiting for `/plan confirm` before execution starts.
     pub(crate) pending_graph: Option<zeph_orchestration::TaskGraph>,
     /// Cancellation token for the currently executing plan. `None` when no plan is running.

--- a/crates/zeph-core/src/agent/tests/ensemble_scheduler_loop_tests.rs
+++ b/crates/zeph-core/src/agent/tests/ensemble_scheduler_loop_tests.rs
@@ -1,0 +1,346 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Integration tests for the ensemble branch of `SchedulerAction::Verify` in
+//! `scheduler_loop.rs` (spec `073-orch-ensemble-merge`, tasks.md T4.5-T4.7).
+//!
+//! The `EnsembleVerifier`-level tests in `zeph-orchestration::ensemble::verifier` cover the
+//! same logical scenarios (full-quorum merge, quorum-fallback) at the merge/mock-provider
+//! layer. These tests exercise the layer above: the `use_ensemble` gating condition itself,
+//! the `ensemble_degraded_total`/`ensemble_last_agreement_ratio`/`ensemble_member_stats`
+//! metrics wiring, and the default-off regression at the `Agent::run_scheduler_loop` seam.
+
+use crate::agent::agent_tests::*;
+use zeph_config::EnsembleConfig;
+use zeph_llm::LlmError;
+use zeph_llm::any::AnyProvider;
+use zeph_llm::mock::MockProvider;
+use zeph_orchestration::{
+    DagScheduler, GraphStatus, RuleBasedRouter, TaskEvent, TaskGraph, TaskNode, TaskOutcome,
+    TaskStatus,
+};
+
+/// Build a graph with a single task already `Running` with `assigned_agent` set, so
+/// `DagScheduler::resume_from` reconstructs the `running` map and a `TaskEvent` for that
+/// handle is accepted by `process_event` on the very first `tick()`.
+fn running_task_graph(handle_id: &str) -> TaskGraph {
+    let mut graph = TaskGraph::new("ensemble verify test goal");
+    let mut node = TaskNode::new(0, "task-0", "produce output");
+    node.status = TaskStatus::Running;
+    node.assigned_agent = Some(handle_id.to_owned());
+    graph.tasks.push(node);
+    graph.status = GraphStatus::Running;
+    graph
+}
+
+fn base_orchestration_config() -> crate::config::OrchestrationConfig {
+    crate::config::OrchestrationConfig {
+        enabled: true,
+        verify_completeness: true,
+        ..crate::config::OrchestrationConfig::default()
+    }
+}
+
+fn complete_json() -> String {
+    r#"{"complete": true, "gaps": [], "confidence": 0.9}"#.to_string()
+}
+
+/// T4.7 (blocking acceptance criterion): with `[orchestration.ensemble].enabled = false` (the
+/// default), the `SchedulerAction::Verify` handler must take the pre-existing single-provider
+/// path — `ensemble_degraded_total` and `ensemble_last_agreement_ratio` must never be touched.
+#[cfg(feature = "scheduler")]
+#[tokio::test]
+async fn default_off_regression_never_touches_ensemble_metrics() {
+    let config = base_orchestration_config(); // ensemble.enabled = false (default)
+    let graph = running_task_graph("handle-1");
+    let mut scheduler =
+        DagScheduler::resume_from(graph, &config, Box::new(RuleBasedRouter), vec![], None).unwrap();
+    scheduler
+        .event_sender()
+        .try_send(TaskEvent {
+            task_id: zeph_orchestration::TaskId(0),
+            agent_handle_id: "handle-1".to_owned(),
+            outcome: TaskOutcome::Completed {
+                output: "task output".into(),
+                artifacts: vec![],
+            },
+        })
+        .unwrap();
+
+    let provider = mock_provider(vec![complete_json()]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    let (metrics_tx, metrics_rx) = watch::channel(MetricsSnapshot::default());
+    let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor)
+        .with_metrics(metrics_tx);
+    agent.services.orchestration.orchestration_config = config;
+
+    let token = tokio_util::sync::CancellationToken::new();
+    let status = agent
+        .run_scheduler_loop(&mut scheduler, 1, token)
+        .await
+        .unwrap();
+
+    assert_eq!(status, GraphStatus::Completed);
+    let snapshot = metrics_rx.borrow().clone();
+    assert_eq!(
+        snapshot.orchestration.ensemble_degraded_total, 0,
+        "default-off path must never increment ensemble_degraded_total"
+    );
+    assert!(
+        snapshot
+            .orchestration
+            .ensemble_last_agreement_ratio
+            .is_none(),
+        "default-off path must never populate ensemble_last_agreement_ratio"
+    );
+    assert!(snapshot.orchestration.ensemble_member_stats.is_empty());
+}
+
+/// T4.5: full quorum (3 of 3 members agree `complete: true`) merges through the ensemble path
+/// end-to-end and updates `ensemble_last_agreement_ratio` without incrementing
+/// `ensemble_degraded_total`.
+#[cfg(feature = "scheduler")]
+#[tokio::test]
+async fn full_quorum_ensemble_path_updates_agreement_ratio() {
+    let config = crate::config::OrchestrationConfig {
+        ensemble: EnsembleConfig {
+            enabled: true,
+            verify: true,
+            members: vec!["m1".into(), "m2".into(), "m3".into()],
+            ..EnsembleConfig::default()
+        },
+        ..base_orchestration_config()
+    };
+    let graph = running_task_graph("handle-1");
+    let mut scheduler =
+        DagScheduler::resume_from(graph, &config, Box::new(RuleBasedRouter), vec![], None).unwrap();
+    scheduler
+        .event_sender()
+        .try_send(TaskEvent {
+            task_id: zeph_orchestration::TaskId(0),
+            agent_handle_id: "handle-1".to_owned(),
+            outcome: TaskOutcome::Completed {
+                output: "task output".into(),
+                artifacts: vec![],
+            },
+        })
+        .unwrap();
+
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    let (metrics_tx, metrics_rx) = watch::channel(MetricsSnapshot::default());
+    let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor)
+        .with_metrics(metrics_tx)
+        .with_ensemble_members(vec![
+            (
+                "m1".to_owned(),
+                AnyProvider::Mock(MockProvider::with_responses(vec![complete_json()])),
+            ),
+            (
+                "m2".to_owned(),
+                AnyProvider::Mock(MockProvider::with_responses(vec![complete_json()])),
+            ),
+            (
+                "m3".to_owned(),
+                AnyProvider::Mock(MockProvider::with_responses(vec![complete_json()])),
+            ),
+        ]);
+    agent.services.orchestration.orchestration_config = config;
+
+    let token = tokio_util::sync::CancellationToken::new();
+    let status = agent
+        .run_scheduler_loop(&mut scheduler, 1, token)
+        .await
+        .unwrap();
+
+    assert_eq!(status, GraphStatus::Completed);
+    let snapshot = metrics_rx.borrow().clone();
+    assert_eq!(
+        snapshot.orchestration.ensemble_degraded_total, 0,
+        "full-quorum merge must not be counted as degraded"
+    );
+    assert_eq!(
+        snapshot.orchestration.ensemble_last_agreement_ratio,
+        Some(1.0),
+        "unanimous 3-of-3 agreement must be recorded"
+    );
+    assert_eq!(snapshot.orchestration.ensemble_member_stats.len(), 3);
+}
+
+/// T4.6 / T5.6: below-quorum (2 of 3 members error) falls back to the single-provider path
+/// and increments `ensemble_degraded_total` exactly once.
+#[cfg(feature = "scheduler")]
+#[tokio::test]
+async fn quorum_fallback_increments_degraded_counter_and_uses_single_provider_result() {
+    let config = crate::config::OrchestrationConfig {
+        ensemble: EnsembleConfig {
+            enabled: true,
+            verify: true,
+            members: vec!["m1".into(), "m2".into(), "m3".into()],
+            ..EnsembleConfig::default()
+        },
+        ..base_orchestration_config()
+    };
+    let graph = running_task_graph("handle-1");
+    let mut scheduler =
+        DagScheduler::resume_from(graph, &config, Box::new(RuleBasedRouter), vec![], None).unwrap();
+    scheduler
+        .event_sender()
+        .try_send(TaskEvent {
+            task_id: zeph_orchestration::TaskId(0),
+            agent_handle_id: "handle-1".to_owned(),
+            outcome: TaskOutcome::Completed {
+                output: "task output".into(),
+                artifacts: vec![],
+            },
+        })
+        .unwrap();
+
+    // Primary provider is the single-provider fallback target (verify_provider unset).
+    let provider = mock_provider(vec![complete_json()]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    let (metrics_tx, metrics_rx) = watch::channel(MetricsSnapshot::default());
+    let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor)
+        .with_metrics(metrics_tx)
+        .with_ensemble_members(vec![
+            (
+                "m1".to_owned(),
+                AnyProvider::Mock(MockProvider::with_responses(vec![complete_json()])),
+            ),
+            (
+                "m2".to_owned(),
+                AnyProvider::Mock(MockProvider::default().with_errors(vec![LlmError::Unavailable])),
+            ),
+            (
+                "m3".to_owned(),
+                AnyProvider::Mock(MockProvider::default().with_errors(vec![LlmError::Unavailable])),
+            ),
+        ]);
+    agent.services.orchestration.orchestration_config = config;
+
+    let token = tokio_util::sync::CancellationToken::new();
+    let status = agent
+        .run_scheduler_loop(&mut scheduler, 1, token)
+        .await
+        .unwrap();
+
+    assert_eq!(status, GraphStatus::Completed);
+    let snapshot = metrics_rx.borrow().clone();
+    assert_eq!(
+        snapshot.orchestration.ensemble_degraded_total, 1,
+        "below-quorum (1 of 3 responders) must increment the degraded counter exactly once"
+    );
+    assert!(
+        snapshot
+            .orchestration
+            .ensemble_last_agreement_ratio
+            .is_none(),
+        "a quorum-fallback round must not populate ensemble_last_agreement_ratio \
+         (that field is only set on a successful merge)"
+    );
+}
+
+/// S1 fix regression: a bootstrap-resolved `ensemble_members` set that is even-length or `< 3`
+/// (simulating a partial resolution failure that shrank the *configured* odd/>=3 list down to
+/// a structurally invalid *effective* count) must be rejected by the `effective_ensemble_valid`
+/// gate in `scheduler_loop.rs` **before** `EnsembleVerifier::verify()` is ever constructed or
+/// called — not merely fall back after dispatching to the shrunk set and losing quorum.
+///
+/// This is distinct from `quorum_fallback_increments_degraded_counter_and_uses_single_provider_result`,
+/// which exercises the pre-existing runtime `EnsembleAttempt::QuorumNotMet` branch (all resolved
+/// members are dispatched to, but too few respond). Both branches increment the same
+/// `ensemble_degraded_total` counter, so the counter alone cannot distinguish them — proving
+/// this test exercises the *new* S1 gate specifically requires proving the shrunk-set members
+/// were never dispatched to at all, via `MockProvider::with_concurrency_tracking`'s peak-call
+/// counter (monotonic: once incremented by a `chat()` call, it never resets to 0).
+#[cfg(feature = "scheduler")]
+#[tokio::test]
+async fn bootstrap_shrunk_ensemble_falls_back_before_verify_dispatch() {
+    use std::sync::atomic::Ordering;
+
+    let config = crate::config::OrchestrationConfig {
+        ensemble: EnsembleConfig {
+            enabled: true,
+            verify: true,
+            // Configured list is odd/>=3 (would pass load-time validation); the *resolved*
+            // set below is deliberately shrunk to 2 (even), simulating one member failing to
+            // resolve at bootstrap (critic S1).
+            members: vec!["m1".into(), "m2".into(), "m3".into()],
+            ..EnsembleConfig::default()
+        },
+        ..base_orchestration_config()
+    };
+    let graph = running_task_graph("handle-1");
+    let mut scheduler =
+        DagScheduler::resume_from(graph, &config, Box::new(RuleBasedRouter), vec![], None).unwrap();
+    scheduler
+        .event_sender()
+        .try_send(TaskEvent {
+            task_id: zeph_orchestration::TaskId(0),
+            agent_handle_id: "handle-1".to_owned(),
+            outcome: TaskOutcome::Completed {
+                output: "task output".into(),
+                artifacts: vec![],
+            },
+        })
+        .unwrap();
+
+    // Primary provider is the single-provider fallback target (verify_provider unset).
+    let provider = mock_provider(vec![complete_json()]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    let (metrics_tx, metrics_rx) = watch::channel(MetricsSnapshot::default());
+
+    let (m1_provider, m1_peak) =
+        MockProvider::with_responses(vec![complete_json()]).with_concurrency_tracking();
+    let (m2_provider, m2_peak) =
+        MockProvider::with_responses(vec![complete_json()]).with_concurrency_tracking();
+
+    let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor)
+        .with_metrics(metrics_tx)
+        // Only 2 members resolved (even, < the configured 3) — the bootstrap-shrunk effective
+        // ensemble the S1 fix must reject before any dispatch.
+        .with_ensemble_members(vec![
+            ("m1".to_owned(), AnyProvider::Mock(m1_provider)),
+            ("m2".to_owned(), AnyProvider::Mock(m2_provider)),
+        ]);
+    agent.services.orchestration.orchestration_config = config;
+
+    let token = tokio_util::sync::CancellationToken::new();
+    let status = agent
+        .run_scheduler_loop(&mut scheduler, 1, token)
+        .await
+        .unwrap();
+
+    assert_eq!(status, GraphStatus::Completed);
+    let snapshot = metrics_rx.borrow().clone();
+    assert_eq!(
+        snapshot.orchestration.ensemble_degraded_total, 1,
+        "an even-length (2) effective ensemble must trigger the S1 shrinkage-guard fallback"
+    );
+    assert!(
+        snapshot
+            .orchestration
+            .ensemble_last_agreement_ratio
+            .is_none()
+    );
+    assert_eq!(
+        m1_peak.load(Ordering::SeqCst),
+        0,
+        "member m1 must never be dispatched to — the S1 gate rejects the shrunk effective \
+         ensemble before EnsembleVerifier::verify() is ever called"
+    );
+    assert_eq!(
+        m2_peak.load(Ordering::SeqCst),
+        0,
+        "member m2 must never be dispatched to — the S1 gate rejects the shrunk effective \
+         ensemble before EnsembleVerifier::verify() is ever called"
+    );
+}

--- a/crates/zeph-core/src/agent/tests/mod.rs
+++ b/crates/zeph-core/src/agent/tests/mod.rs
@@ -12,6 +12,8 @@ mod compaction_e2e;
 #[cfg(test)]
 mod confirmation_propagation_tests;
 #[cfg(test)]
+mod ensemble_scheduler_loop_tests;
+#[cfg(test)]
 mod flush_orphaned_tests;
 #[cfg(test)]
 mod inline_tool_loop_tests;

--- a/crates/zeph-core/src/metrics.rs
+++ b/crates/zeph-core/src/metrics.rs
@@ -105,6 +105,18 @@ pub struct OrchestrationMetrics {
     pub tasks_completed: u64,
     pub tasks_failed: u64,
     pub tasks_skipped: u64,
+    /// Number of times ensemble-verified plan verification fell back to the single-provider
+    /// path because fewer than quorum members responded (spec `073-orch-ensemble-merge`).
+    /// Always `0` when `[orchestration.ensemble]` is disabled.
+    pub ensemble_degraded_total: u64,
+    /// `agreement_ratio` from the most recent successfully merged ensemble verification.
+    /// `None` until the first ensemble merge completes, or when ensemble verification is
+    /// disabled. Telemetry only — never used for `should_replan` (see `MergeOutcome`).
+    pub ensemble_last_agreement_ratio: Option<f64>,
+    /// Per-member `(name, EMA agreement score, observation count)` snapshot from the
+    /// `EnsembleTracker`, for CLI/TUI stats surfacing. Empty when ensemble verification is
+    /// disabled or no member has been observed yet.
+    pub ensemble_member_stats: Vec<(String, f64, u64)>,
 }
 
 #[non_exhaustive]

--- a/crates/zeph-orchestration/Cargo.toml
+++ b/crates/zeph-orchestration/Cargo.toml
@@ -16,6 +16,7 @@ readme = "README.md"
 blake3.workspace = true
 chrono = { workspace = true, features = ["clock"] }
 dirs.workspace = true
+futures = { workspace = true, optional = true }
 parking_lot.workspace = true
 rand.workspace = true
 rand_distr.workspace = true
@@ -46,7 +47,7 @@ zeph-memory.workspace = true
 [features]
 sqlite = ["zeph-db/sqlite", "zeph-durable/sqlite", "zeph-memory/sqlite", "zeph-subagent/sqlite"]
 postgres = ["zeph-db/postgres", "zeph-durable/postgres", "zeph-memory/postgres", "zeph-subagent/postgres"]
-llm-planning = ["dep:zeph-llm"]
+llm-planning = ["dep:zeph-llm", "dep:futures"]
 # Enables test utilities and testcontainers for PostgreSQL integration tests.
 # Implies `llm-planning`: the only test-utils-gated suite (postgres_integration.rs)
 # exercises `PlanCache`, which lives behind that feature.

--- a/crates/zeph-orchestration/src/ensemble/merge.rs
+++ b/crates/zeph-orchestration/src/ensemble/merge.rs
@@ -1,0 +1,311 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Pure, deterministic binary-majority merge of ensemble verification ballots.
+//!
+//! This module is the ORCH (arXiv:2602.01797) merge step, scoped to `PlanVerifier`
+//! gap-severity verification. [`merge`] has no I/O, no async, and no randomness —
+//! it is a pure function of its input, which is what makes the ensemble path
+//! deterministic and unit-testable in isolation from any LLM provider.
+
+use crate::verifier::Gap;
+
+/// One ensemble member's independent judgment on a single verification task.
+///
+/// Produced from a successful `chat_typed::<VerificationResult>` response. Members that
+/// errored or timed out never produce a `Ballot` — they are excluded from the vote entirely
+/// (never cast as a fail-open `complete: true` vote).
+#[derive(Debug, Clone)]
+pub struct Ballot {
+    /// Name of the `[[llm.providers]]` entry that produced this ballot.
+    pub member: String,
+    /// This member's verdict on whether the task output is complete.
+    pub complete: bool,
+    /// This member's own self-reported confidence (0.0-1.0).
+    pub confidence: f64,
+    /// Gaps this member identified. Only included in [`MergeOutcome::gaps`] when this
+    /// ballot is on the winning side.
+    pub gaps: Vec<Gap>,
+}
+
+/// Result of merging a set of [`Ballot`]s.
+///
+/// Internal to the ensemble subsystem — `agreement_ratio` and `tie_broken` are diagnostic
+/// fields that must never be copied into `VerificationResult` (doing so would invert the
+/// downstream `should_replan` gate; see spec 073 §4 "Never").
+#[derive(Debug, Clone)]
+pub struct MergeOutcome {
+    /// Majority verdict on task completeness.
+    pub complete: bool,
+    /// Union of `gaps` from every ballot on the winning side, verbatim (no dedup).
+    pub gaps: Vec<Gap>,
+    /// Arithmetic mean of `confidence` from ballots on the winning side only.
+    ///
+    /// This is the value that becomes `VerificationResult.confidence` — never
+    /// `agreement_ratio`.
+    pub merged_confidence: f64,
+    /// Fraction of ballots that agreed with the winning verdict. Telemetry only.
+    pub agreement_ratio: f64,
+    /// `true` when the vote was an exact tie, resolved by the fail-safe `complete = false`
+    /// default. Only reachable with an even ballot count (partial member failure).
+    pub tie_broken: bool,
+}
+
+/// Merge independent ensemble ballots into a single deterministic outcome.
+///
+/// Binary majority vote on [`Ballot::complete`]. On an exact tie (only reachable with an
+/// even `ballots.len()` after partial member failure/exclusion) the fail-safe verdict is
+/// `complete = false` — preferring a replan over silently accepting an uncertain result.
+///
+/// `gaps` is the verbatim union of the winning side's gaps (no dedup/reconciliation).
+/// `merged_confidence` is the arithmetic mean of the winning side's self-reported
+/// `confidence` values.
+///
+/// Pure function: no I/O, no async, no randomness. Callers are responsible for ensuring
+/// `ballots` is non-empty (the ensemble quorum check guarantees this in practice) — an
+/// empty slice returns a degenerate `complete: false` outcome rather than panicking.
+///
+/// # Examples
+///
+/// ```rust
+/// use zeph_orchestration::ensemble::{Ballot, merge};
+///
+/// let ballots = vec![
+///     Ballot { member: "a".into(), complete: true, confidence: 0.9, gaps: vec![] },
+///     Ballot { member: "b".into(), complete: true, confidence: 0.8, gaps: vec![] },
+///     Ballot { member: "c".into(), complete: false, confidence: 0.5, gaps: vec![] },
+/// ];
+/// let outcome = merge(&ballots);
+/// assert!(outcome.complete);
+/// assert!((outcome.merged_confidence - 0.85).abs() < 1e-9);
+/// ```
+#[must_use]
+pub fn merge(ballots: &[Ballot]) -> MergeOutcome {
+    let total = ballots.len();
+    if total == 0 {
+        return MergeOutcome {
+            complete: false,
+            gaps: Vec::new(),
+            merged_confidence: 0.0,
+            agreement_ratio: 0.0,
+            tie_broken: false,
+        };
+    }
+
+    let votes_true = ballots.iter().filter(|b| b.complete).count();
+    let votes_false = total - votes_true;
+
+    let (winner, tie_broken) = if votes_true > total / 2 {
+        (true, false)
+    } else if votes_false > total / 2 {
+        (false, false)
+    } else {
+        // Exact tie: only reachable with an even ballot count. Fail-safe toward replan.
+        (false, true)
+    };
+
+    let winning: Vec<&Ballot> = ballots.iter().filter(|b| b.complete == winner).collect();
+    let winning_count = winning.len();
+
+    let gaps: Vec<Gap> = winning
+        .iter()
+        .flat_map(|b| b.gaps.iter().cloned())
+        .collect();
+
+    #[allow(clippy::cast_precision_loss)]
+    let merged_confidence = if winning_count == 0 {
+        0.0
+    } else {
+        winning.iter().map(|b| b.confidence).sum::<f64>() / winning_count as f64
+    };
+
+    #[allow(clippy::cast_precision_loss)]
+    let agreement_ratio = winning_count as f64 / total as f64;
+
+    MergeOutcome {
+        complete: winner,
+        gaps,
+        merged_confidence,
+        agreement_ratio,
+        tie_broken,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::verifier::GapSeverity;
+
+    fn ballot(member: &str, complete: bool, confidence: f64, gaps: Vec<Gap>) -> Ballot {
+        Ballot {
+            member: member.to_string(),
+            complete,
+            confidence,
+            gaps,
+        }
+    }
+
+    fn gap(desc: &str, severity: GapSeverity) -> Gap {
+        Gap {
+            description: desc.to_string(),
+            severity,
+        }
+    }
+
+    #[test]
+    fn unanimous_complete() {
+        let ballots = vec![
+            ballot("a", true, 0.9, vec![]),
+            ballot("b", true, 0.8, vec![]),
+            ballot("c", true, 0.95, vec![]),
+        ];
+        let outcome = merge(&ballots);
+        assert!(outcome.complete);
+        assert!(outcome.gaps.is_empty());
+        assert!((outcome.merged_confidence - 0.883_333_333_333_333_3).abs() < 1e-9);
+        assert!((outcome.agreement_ratio - 1.0).abs() < 1e-9);
+        assert!(!outcome.tie_broken);
+    }
+
+    #[test]
+    fn unanimous_incomplete() {
+        let g = gap("missing tests", GapSeverity::Critical);
+        let ballots = vec![
+            ballot("a", false, 0.5, vec![g.clone()]),
+            ballot("b", false, 0.6, vec![g.clone()]),
+            ballot("c", false, 0.4, vec![g]),
+        ];
+        let outcome = merge(&ballots);
+        assert!(!outcome.complete);
+        assert_eq!(outcome.gaps.len(), 3);
+        assert!((outcome.merged_confidence - 0.5).abs() < 1e-9);
+        assert!((outcome.agreement_ratio - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn two_of_three_split_complete_wins() {
+        let ballots = vec![
+            ballot("a", true, 0.9, vec![]),
+            ballot("b", true, 0.7, vec![]),
+            ballot("c", false, 0.3, vec![gap("gap", GapSeverity::Minor)]),
+        ];
+        let outcome = merge(&ballots);
+        assert!(outcome.complete);
+        assert!(outcome.gaps.is_empty(), "loser's gaps must not appear");
+        assert!((outcome.merged_confidence - 0.8).abs() < 1e-9);
+        assert!((outcome.agreement_ratio - 2.0 / 3.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn two_of_three_split_incomplete_wins() {
+        let g = gap("critical gap", GapSeverity::Critical);
+        let ballots = vec![
+            ballot("a", false, 0.4, vec![g.clone()]),
+            ballot("b", false, 0.6, vec![g]),
+            ballot("c", true, 0.95, vec![]),
+        ];
+        let outcome = merge(&ballots);
+        assert!(!outcome.complete);
+        assert_eq!(outcome.gaps.len(), 2);
+        assert!((outcome.merged_confidence - 0.5).abs() < 1e-9);
+        assert!((outcome.agreement_ratio - 2.0 / 3.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn exact_tie_is_fail_safe_incomplete() {
+        // Even ballot count (2) after a member was excluded from a configured N=3.
+        let ballots = vec![
+            ballot("a", true, 0.9, vec![]),
+            ballot("b", false, 0.5, vec![]),
+        ];
+        let outcome = merge(&ballots);
+        assert!(!outcome.complete, "tie must fail-safe to complete=false");
+        assert!(outcome.tie_broken);
+        assert!((outcome.merged_confidence - 0.5).abs() < 1e-9);
+        assert!((outcome.agreement_ratio - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn single_ballot_edge_case() {
+        let ballots = vec![ballot("a", true, 0.77, vec![])];
+        let outcome = merge(&ballots);
+        assert!(outcome.complete);
+        assert!((outcome.merged_confidence - 0.77).abs() < 1e-9);
+        assert!((outcome.agreement_ratio - 1.0).abs() < 1e-9);
+        assert!(!outcome.tie_broken);
+    }
+
+    #[test]
+    fn empty_ballots_edge_case() {
+        // Unreachable in practice (quorum check guarantees >= 1 ballot before merge() is
+        // called), but must not panic.
+        let outcome = merge(&[]);
+        assert!(!outcome.complete);
+        assert!(outcome.gaps.is_empty());
+        assert!((outcome.merged_confidence).abs() < 1e-9);
+        assert!((outcome.agreement_ratio).abs() < 1e-9);
+        assert!(!outcome.tie_broken);
+    }
+
+    /// S4 regression: unanimous incomplete+critical must NOT be inverted relative to a
+    /// disagreeing panel. `merged_confidence` must be the mean of winning-side self-reported
+    /// confidence, never `agreement_ratio` — using `agreement_ratio` here would make the
+    /// unanimous case (`agreement_ratio=1.0`) look MORE confident than it should, suppressing
+    /// replan when it should trigger it.
+    #[test]
+    fn s4_regression_unanimous_vs_split_confidence_not_agreement_ratio() {
+        let critical_gap = gap("critical gap", GapSeverity::Critical);
+
+        // 3-of-3 unanimous incomplete, low self-reported confidence.
+        let unanimous = vec![
+            ballot("a", false, 0.3, vec![critical_gap.clone()]),
+            ballot("b", false, 0.35, vec![critical_gap.clone()]),
+            ballot("c", false, 0.25, vec![critical_gap.clone()]),
+        ];
+        let unanimous_outcome = merge(&unanimous);
+        assert!((unanimous_outcome.agreement_ratio - 1.0).abs() < 1e-9);
+        // merged_confidence must be the LOW mean of self-reported values, not the HIGH
+        // agreement_ratio of 1.0.
+        assert!((unanimous_outcome.merged_confidence - 0.3).abs() < 1e-9);
+        assert!(unanimous_outcome.merged_confidence < unanimous_outcome.agreement_ratio);
+
+        // Hand-compute should_replan using the same gate as scheduler_loop.rs.
+        let threshold = 0.7_f64;
+        let should_replan_unanimous = !unanimous_outcome.complete
+            && unanimous_outcome.merged_confidence < threshold
+            && unanimous_outcome
+                .gaps
+                .iter()
+                .any(|g| g.severity == GapSeverity::Critical);
+        assert!(
+            should_replan_unanimous,
+            "unanimous low-confidence incomplete verdict must trigger replan, not be \
+             suppressed by a high agreement_ratio"
+        );
+
+        // 2-of-3 split incomplete, for contrast — same shape of assertion.
+        let split = vec![
+            ballot("a", false, 0.3, vec![critical_gap.clone()]),
+            ballot("b", false, 0.35, vec![critical_gap]),
+            ballot("c", true, 0.9, vec![]),
+        ];
+        let split_outcome = merge(&split);
+        assert!((split_outcome.agreement_ratio - 2.0 / 3.0).abs() < 1e-9);
+        assert!((split_outcome.merged_confidence - 0.325).abs() < 1e-9);
+    }
+
+    /// M6 regression: an excluded (errored/timed-out) member must never contribute a
+    /// spurious `0.0` to the confidence mean — it must simply be absent from `ballots`.
+    #[test]
+    fn m6_regression_excluded_member_not_zero_padded() {
+        // Simulates: N=3 configured, member "c" errored and was never turned into a Ballot.
+        let ballots = vec![
+            ballot("a", true, 0.9, vec![]),
+            ballot("b", true, 0.8, vec![]),
+        ];
+        let outcome = merge(&ballots);
+        assert!(outcome.complete);
+        // Mean of {0.9, 0.8} = 0.85, NOT mean of {0.9, 0.8, 0.0} = 0.5667.
+        assert!((outcome.merged_confidence - 0.85).abs() < 1e-9);
+    }
+}

--- a/crates/zeph-orchestration/src/ensemble/mod.rs
+++ b/crates/zeph-orchestration/src/ensemble/mod.rs
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! ORCH-style deterministic multi-agent ensemble-merge (arXiv:2602.01797), scoped to
+//! [`crate::verifier::PlanVerifier`] gap-severity verification.
+//!
+//! N configured provider members independently classify the same completed-task output in
+//! parallel; a pure, deterministic binary-majority merge ([`merge::merge`]) produces the
+//! single `VerificationResult` the existing `should_replan` gate already consumes. See
+//! `specs/073-orch-ensemble-merge/spec.md` for the full design.
+//!
+//! Gated behind the `llm-planning` feature (same gate as [`crate::verifier`], whose `Gap` type
+//! this module reuses).
+
+pub mod merge;
+pub mod tracker;
+pub mod verifier;
+
+pub use merge::{Ballot, MergeOutcome, merge};
+pub use tracker::EnsembleTracker;
+pub use verifier::{EnsembleAttempt, EnsembleVerifier, MemberUsage};

--- a/crates/zeph-orchestration/src/ensemble/tracker.rs
+++ b/crates/zeph-orchestration/src/ensemble/tracker.rs
@@ -1,0 +1,213 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Telemetry-only per-member agreement tracker for the verifier ensemble.
+//!
+//! [`EnsembleTracker`] records, per ensemble member, how often that member's ballot agreed
+//! with the merged majority verdict, as a decayed exponential moving average (EMA). It exists
+//! purely for observability (CLI/TUI stats surfacing, diagnosing a misbehaving member) — in
+//! PR-1 it is **never** consulted to decide which members are dispatched in a given round.
+//! Re-introducing EMA-gated subset selection requires a ground-truth reward signal that does
+//! not exist yet (spec 073 §4 "Ask First"; critic finding S2 — gating on this tracker's score
+//! creates a consensus-collapse feedback loop).
+
+use std::collections::HashMap;
+
+/// Neutral prior score for a member with no (or insufficient) observations.
+const NEUTRAL_PRIOR: f64 = 0.5;
+
+#[derive(Debug, Clone)]
+struct EmaEntry {
+    score: f64,
+    observations: u64,
+}
+
+/// Decayed-EMA tracker of per-member agreement-with-majority rate.
+///
+/// Deliberately a new, small, deterministic type rather than a generalization of RAPS's
+/// `ReputationTracker` (Beta/Thompson-coupled, provider-scoped) or `AdaptOrch` (stochastic
+/// topology bandit) — see spec 073 §3.4 for the full rationale.
+#[derive(Debug, Clone)]
+pub struct EnsembleTracker {
+    scores: HashMap<String, EmaEntry>,
+    alpha: f64,
+    decay: f64,
+    min_observations: u32,
+}
+
+impl EnsembleTracker {
+    /// Create a new tracker.
+    ///
+    /// `alpha` weights the newest observation in the EMA update; `decay` pulls a member's
+    /// score toward the neutral prior (`0.5`) on every observation, so a member that stops
+    /// responding gradually reverts to "unknown" rather than keeping a stale score forever.
+    /// `min_observations` gates [`Self::ema`] — a member's score is not considered
+    /// meaningful until it has been observed at least this many times.
+    #[must_use]
+    pub fn new(alpha: f64, decay: f64, min_observations: u32) -> Self {
+        Self {
+            scores: HashMap::new(),
+            alpha,
+            decay,
+            min_observations,
+        }
+    }
+
+    /// Record whether `member`'s ballot agreed with the merged majority verdict.
+    ///
+    /// Decay-then-EMA update: the existing score first decays toward the neutral prior, then
+    /// blends in the new observation. This means a member observed for the first time starts
+    /// from the neutral prior rather than from `agreed`'s raw `0.0`/`1.0`, avoiding a
+    /// single-observation score swing to either extreme.
+    pub fn record(&mut self, member: &str, agreed: bool) {
+        let value = if agreed { 1.0 } else { 0.0 };
+        let entry = self.scores.entry(member.to_owned()).or_insert(EmaEntry {
+            score: NEUTRAL_PRIOR,
+            observations: 0,
+        });
+        let decayed = self.decay * entry.score + (1.0 - self.decay) * NEUTRAL_PRIOR;
+        entry.score = self.alpha * value + (1.0 - self.alpha) * decayed;
+        entry.observations += 1;
+    }
+
+    /// Current EMA score for `member`, or `None` if it has fewer than `min_observations`
+    /// recorded observations (cold-start gate) or has never been observed.
+    #[must_use]
+    pub fn ema(&self, member: &str) -> Option<f64> {
+        self.scores.get(member).and_then(|e| {
+            if e.observations >= u64::from(self.min_observations) {
+                Some(e.score)
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Snapshot of every tracked member's current score and observation count, for CLI/TUI
+    /// stats surfacing. Includes cold-start members (score below `min_observations`) with
+    /// their raw score — callers wanting the cold-start-gated view should use [`Self::ema`]
+    /// per member instead.
+    ///
+    /// Sorted by member name for stable display order — `scores` is a `HashMap`, so without
+    /// sorting, CLI/TUI stats rows would reorder non-deterministically between renders.
+    #[must_use]
+    pub fn snapshot(&self) -> Vec<(String, f64, u64)> {
+        let mut rows: Vec<(String, f64, u64)> = self
+            .scores
+            .iter()
+            .map(|(member, entry)| (member.clone(), entry.score, entry.observations))
+            .collect();
+        rows.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        rows
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cold_start_gate_returns_none_below_min_observations() {
+        let mut tracker = EnsembleTracker::new(0.3, 0.95, 5);
+        for _ in 0..4 {
+            tracker.record("a", true);
+        }
+        assert_eq!(tracker.ema("a"), None);
+    }
+
+    #[test]
+    fn cold_start_gate_returns_some_at_min_observations() {
+        let mut tracker = EnsembleTracker::new(0.3, 0.95, 5);
+        for _ in 0..5 {
+            tracker.record("a", true);
+        }
+        assert!(tracker.ema("a").is_some());
+    }
+
+    #[test]
+    fn unobserved_member_returns_none() {
+        let tracker = EnsembleTracker::new(0.3, 0.95, 1);
+        assert_eq!(tracker.ema("never-seen"), None);
+    }
+
+    #[test]
+    fn ema_trends_toward_agreement() {
+        let mut tracker = EnsembleTracker::new(0.5, 1.0, 1);
+        // decay=1.0 isolates the pure EMA update (no prior-decay component).
+        for _ in 0..20 {
+            tracker.record("a", true);
+        }
+        let score = tracker.ema("a").unwrap();
+        assert!(score > 0.99, "score should converge near 1.0, got {score}");
+    }
+
+    #[test]
+    fn ema_trends_toward_disagreement() {
+        let mut tracker = EnsembleTracker::new(0.5, 1.0, 1);
+        for _ in 0..20 {
+            tracker.record("a", false);
+        }
+        let score = tracker.ema("a").unwrap();
+        assert!(score < 0.01, "score should converge near 0.0, got {score}");
+    }
+
+    #[test]
+    fn decay_pulls_stale_score_toward_neutral_prior() {
+        // alpha=0 means the new observation contributes nothing; only decay acts.
+        let mut tracker = EnsembleTracker::new(0.5, 0.9, 1);
+        tracker.record("a", true); // first obs: score = 0.5*1.0 + 0.5*0.5 = 0.75
+        let after_first = tracker.ema("a").unwrap();
+        assert!((after_first - 0.75).abs() < 1e-9);
+
+        // Repeated `false` observations should decay the score back down, not stay pinned.
+        for _ in 0..10 {
+            tracker.record("a", false);
+        }
+        let after_many_false = tracker.ema("a").unwrap();
+        assert!(after_many_false < after_first);
+    }
+
+    #[test]
+    fn observations_increment_monotonically() {
+        let mut tracker = EnsembleTracker::new(0.3, 0.95, 1);
+        tracker.record("a", true);
+        tracker.record("a", false);
+        tracker.record("a", true);
+        let snapshot = tracker.snapshot();
+        let (_, _, obs) = snapshot.iter().find(|(m, _, _)| m == "a").unwrap();
+        assert_eq!(*obs, 3);
+    }
+
+    #[test]
+    fn snapshot_includes_all_members() {
+        let mut tracker = EnsembleTracker::new(0.3, 0.95, 1);
+        tracker.record("a", true);
+        tracker.record("b", false);
+        let snapshot = tracker.snapshot();
+        assert_eq!(snapshot.len(), 2);
+    }
+
+    /// M1 regression: `snapshot()` must return a deterministic, name-sorted order regardless
+    /// of `HashMap` iteration order — otherwise CLI/TUI stats rows reorder between renders.
+    #[test]
+    fn snapshot_is_sorted_by_member_name() {
+        let mut tracker = EnsembleTracker::new(0.3, 0.95, 1);
+        // Insert in reverse-alphabetical order so a passing test proves sorting, not luck.
+        tracker.record("zeta", true);
+        tracker.record("mid", false);
+        tracker.record("alpha", true);
+        let snapshot = tracker.snapshot();
+        let names: Vec<&str> = snapshot.iter().map(|(m, _, _)| m.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "mid", "zeta"]);
+    }
+
+    #[test]
+    fn no_select_subset_method_exists() {
+        // Compile-time guard, not a runtime assertion: EnsembleTracker must expose only
+        // `record`/`ema`/`snapshot` — no `select_subset` (critic finding S2). This test
+        // documents the invariant; a `select_subset` addition would not fail this test but
+        // would be caught in code review per spec 073 §4 "Never".
+        let tracker = EnsembleTracker::new(0.3, 0.95, 5);
+        assert!(tracker.snapshot().is_empty());
+    }
+}

--- a/crates/zeph-orchestration/src/ensemble/verifier.rs
+++ b/crates/zeph-orchestration/src/ensemble/verifier.rs
@@ -1,0 +1,422 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! N-fold parallel dispatch and deterministic merge for ensemble-verified plan verification.
+//!
+//! [`EnsembleVerifier`] fans a single verification task out to every configured ensemble
+//! member in parallel via `futures::future::join_all`, awaited inline on the caller's already
+//! -supervised task (never a new `tokio::spawn` — spec `039-background-task-supervisor`,
+//! NFR-AS-01). Errored/timed-out members are excluded from the ballot set entirely (never a
+//! spurious fail-open `complete: true` vote — critic finding M6). When fewer than quorum
+//! members respond, [`EnsembleAttempt::QuorumNotMet`] signals the caller to fall back to the
+//! existing single-provider `PlanVerifier::verify()` path unchanged.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::future::join_all;
+use tracing::Instrument as _;
+use zeph_common::OutputSanitizer;
+use zeph_llm::any::AnyProvider;
+use zeph_llm::provider::LlmProvider;
+
+use crate::graph::TaskNode;
+use crate::verifier::{VerificationResult, build_verify_prompt};
+
+use super::merge::{Ballot, MergeOutcome, merge};
+use super::tracker::EnsembleTracker;
+
+/// Estimated token usage for a single ensemble member's verification call.
+///
+/// Uses the same chars/4 estimation heuristic already used elsewhere in this codebase
+/// (`zeph-llm/src/claude/cache.rs`, `zeph-orchestration/src/aggregator.rs`) rather than a
+/// precise tokenizer — `PlanVerifier::verify()` does not record usage today, so this is
+/// net-new, best-effort instrumentation (FR-016), not a copy of an exact existing mechanism.
+#[derive(Debug, Clone)]
+pub struct MemberUsage {
+    /// Name of the `[[llm.providers]]` entry this usage is attributed to.
+    pub member: String,
+    /// Estimated input (prompt) tokens.
+    pub input_tokens: u64,
+    /// Estimated output (completion) tokens.
+    pub output_tokens: u64,
+}
+
+/// Outcome of a single [`EnsembleVerifier::verify`] attempt.
+pub enum EnsembleAttempt {
+    /// Quorum was met and ballots were merged.
+    Merged {
+        /// The `VerificationResult` for the caller's `should_replan` gate. Contains only
+        /// `complete`/`gaps`/`confidence` — `agreement_ratio` and `tie_broken` never leave
+        /// `MergeOutcome`.
+        result: VerificationResult,
+        /// Full merge outcome, including telemetry-only fields, for observability.
+        outcome: MergeOutcome,
+    },
+    /// Fewer than `quorum` members responded. The caller must fall back to the existing
+    /// single-provider `PlanVerifier::verify()` path (including its own fail-open behavior)
+    /// and increment the `ensemble_degraded` counter.
+    QuorumNotMet {
+        /// Number of members that responded successfully (before the quorum check).
+        responded: usize,
+        /// Minimum responders required (`members.len() / 2 + 1`).
+        quorum: usize,
+        /// Total configured members for this ensemble.
+        configured: usize,
+    },
+}
+
+/// N-fold parallel verifier: dispatches the same task to every configured ensemble member
+/// and merges their independent ballots deterministically.
+pub struct EnsembleVerifier {
+    /// (provider name, resolved provider) pairs, in configured order. A name-provider pair
+    /// (not a bare `Vec<AnyProvider>`) so a partial bootstrap-time resolution failure cannot
+    /// desynchronize `Ballot.member`/`EnsembleTracker.record` from the wrong config entry.
+    members: Vec<(String, AnyProvider)>,
+    member_timeout: Duration,
+    tracker: EnsembleTracker,
+    /// Per-member usage estimates from the most recent `verify()` call. Read by the caller
+    /// (which owns the `CostTracker`) after each call; cleared and repopulated on the next.
+    last_usage: Vec<MemberUsage>,
+}
+
+impl EnsembleVerifier {
+    /// Create a new `EnsembleVerifier` from resolved members, a per-member call timeout, and
+    /// a tracker (fresh or carried over from a prior verifier instance).
+    #[must_use]
+    pub fn new(
+        members: Vec<(String, AnyProvider)>,
+        member_timeout: Duration,
+        tracker: EnsembleTracker,
+    ) -> Self {
+        Self {
+            members,
+            member_timeout,
+            tracker,
+            last_usage: Vec::new(),
+        }
+    }
+
+    /// Number of configured members.
+    #[must_use]
+    pub fn member_count(&self) -> usize {
+        self.members.len()
+    }
+
+    /// Minimum number of responders required for quorum (`members.len() / 2 + 1`).
+    #[must_use]
+    pub fn quorum(&self) -> usize {
+        self.members.len() / 2 + 1
+    }
+
+    /// Read-only access to the agreement tracker, for CLI/TUI stats surfacing.
+    #[must_use]
+    pub fn tracker(&self) -> &EnsembleTracker {
+        &self.tracker
+    }
+
+    /// Per-member usage estimates from the most recent `verify()` call.
+    #[must_use]
+    pub fn last_usage(&self) -> &[MemberUsage] {
+        &self.last_usage
+    }
+
+    /// Fan a single verification task out to every configured member in parallel and merge
+    /// the responses.
+    ///
+    /// Each member call is independently wrapped in `tokio::time::timeout(member_timeout,
+    /// ...)` (NFR-AS-03). Errored/timed-out members are excluded from the ballot set — never
+    /// cast as a fail-open vote (M6): `PlanVerifier::fail_open()` is reserved for the
+    /// ensemble-level below-quorum fallback the caller performs on
+    /// [`EnsembleAttempt::QuorumNotMet`], not for an individual member.
+    #[tracing::instrument(
+        name = "orchestration.ensemble.verify",
+        skip(self, output, sanitizer),
+        fields(task.id = %task.id, members = self.members.len())
+    )]
+    pub async fn verify(
+        &mut self,
+        task: &TaskNode,
+        output: &str,
+        sanitizer: &Arc<dyn OutputSanitizer>,
+    ) -> EnsembleAttempt {
+        let configured = self.members.len();
+        let quorum = self.quorum();
+        let member_timeout = self.member_timeout;
+        let messages = build_verify_prompt(task, output, sanitizer);
+        #[allow(clippy::cast_possible_truncation)]
+        let input_chars: usize = messages.iter().map(|m| m.content.chars().count()).sum();
+
+        let calls = self.members.iter().map(|(name, provider)| {
+            let member_name = name.clone();
+            let provider = provider.clone();
+            let messages = messages.clone();
+            let span = tracing::info_span!(
+                "orchestration.ensemble.verify_member",
+                member = %member_name
+            );
+            async move {
+                let call = provider.chat_typed::<VerificationResult>(&messages);
+                let outcome = tokio::time::timeout(member_timeout, call).await;
+                (member_name, outcome)
+            }
+            .instrument(span)
+        });
+
+        let responses = join_all(calls).await;
+
+        let mut ballots = Vec::with_capacity(responses.len());
+        let mut usage = Vec::with_capacity(responses.len());
+        for (member, outcome) in responses {
+            match outcome {
+                Ok(Ok(vr)) => {
+                    // 4 chars-per-token estimate (consistent with the codebase's existing
+                    // heuristic elsewhere — no exact tokenizer is available for chat_typed's
+                    // already-deserialized response).
+                    let output_chars = serde_json::to_string(&vr).map_or(0, |s| s.chars().count());
+                    usage.push(MemberUsage {
+                        member: member.clone(),
+                        input_tokens: (input_chars / 4) as u64,
+                        output_tokens: (output_chars / 4) as u64,
+                    });
+                    ballots.push(Ballot {
+                        member,
+                        complete: vr.complete,
+                        confidence: vr.confidence,
+                        gaps: vr.gaps,
+                    });
+                }
+                Ok(Err(e)) => {
+                    tracing::warn!(
+                        member = %member,
+                        error = %e,
+                        task_id = %task.id,
+                        "ensemble member LLM call failed — excluded from ballot (M6)"
+                    );
+                }
+                Err(_elapsed) => {
+                    tracing::warn!(
+                        member = %member,
+                        timeout_secs = member_timeout.as_secs(),
+                        task_id = %task.id,
+                        "ensemble member timed out — excluded from ballot (M6)"
+                    );
+                }
+            }
+        }
+        self.last_usage = usage;
+
+        if ballots.len() < quorum {
+            return EnsembleAttempt::QuorumNotMet {
+                responded: ballots.len(),
+                quorum,
+                configured,
+            };
+        }
+
+        let outcome = merge(&ballots);
+        for ballot in &ballots {
+            self.tracker
+                .record(&ballot.member, ballot.complete == outcome.complete);
+        }
+
+        let result = VerificationResult {
+            complete: outcome.complete,
+            gaps: outcome.gaps.clone(),
+            confidence: outcome.merged_confidence,
+        };
+
+        EnsembleAttempt::Merged { result, outcome }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::TaskId;
+    use zeph_common::IdentitySanitizer;
+    use zeph_llm::LlmError;
+    use zeph_llm::mock::MockProvider;
+
+    fn test_sanitizer() -> Arc<dyn OutputSanitizer> {
+        Arc::new(IdentitySanitizer)
+    }
+
+    fn test_task() -> TaskNode {
+        let mut n = TaskNode::new(0, "write code", "write the implementation");
+        n.id = TaskId(0);
+        n
+    }
+
+    fn ok_provider(response: String) -> AnyProvider {
+        AnyProvider::Mock(MockProvider::with_responses(vec![response]))
+    }
+
+    fn err_provider() -> AnyProvider {
+        AnyProvider::Mock(MockProvider::default().with_errors(vec![LlmError::Unavailable]))
+    }
+
+    fn slow_provider(response: String, delay_ms: u64) -> AnyProvider {
+        AnyProvider::Mock(MockProvider::with_responses(vec![response]).with_delay(delay_ms))
+    }
+
+    fn complete_json(confidence: f64) -> String {
+        format!(r#"{{"complete": true, "gaps": [], "confidence": {confidence}}}"#)
+    }
+
+    fn incomplete_json(confidence: f64) -> String {
+        format!(
+            r#"{{"complete": false, "gaps": [{{"description": "gap", "severity": "critical"}}], "confidence": {confidence}}}"#
+        )
+    }
+
+    #[tokio::test]
+    async fn full_quorum_all_agree_merges_correctly() {
+        let members = vec![
+            ("a".to_string(), ok_provider(complete_json(0.9))),
+            ("b".to_string(), ok_provider(complete_json(0.8))),
+            ("c".to_string(), ok_provider(complete_json(0.95))),
+        ];
+        let mut verifier = EnsembleVerifier::new(
+            members,
+            Duration::from_secs(5),
+            EnsembleTracker::new(0.3, 0.95, 5),
+        );
+        let task = test_task();
+        match verifier.verify(&task, "output", &test_sanitizer()).await {
+            EnsembleAttempt::Merged { result, outcome } => {
+                assert!(result.complete);
+                assert!((result.confidence - 0.883_333_333_333_333_3).abs() < 1e-6);
+                assert!((outcome.agreement_ratio - 1.0).abs() < 1e-9);
+            }
+            EnsembleAttempt::QuorumNotMet { .. } => panic!("expected quorum to be met"),
+        }
+        assert_eq!(verifier.last_usage().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn quorum_not_met_when_two_of_three_error() {
+        let members = vec![
+            ("a".to_string(), ok_provider(complete_json(0.9))),
+            ("b".to_string(), err_provider()),
+            ("c".to_string(), err_provider()),
+        ];
+        let mut verifier = EnsembleVerifier::new(
+            members,
+            Duration::from_secs(5),
+            EnsembleTracker::new(0.3, 0.95, 5),
+        );
+        let task = test_task();
+        match verifier.verify(&task, "output", &test_sanitizer()).await {
+            EnsembleAttempt::QuorumNotMet {
+                responded,
+                quorum,
+                configured,
+            } => {
+                assert_eq!(responded, 1);
+                assert_eq!(quorum, 2);
+                assert_eq!(configured, 3);
+            }
+            EnsembleAttempt::Merged { .. } => panic!("expected quorum not met"),
+        }
+    }
+
+    /// M6 acceptance test: N=3, 1 member errors, merge proceeds over the 2 responders and the
+    /// confidence mean excludes the errored member (not zero-padded).
+    #[tokio::test]
+    async fn m6_one_of_three_errors_merge_proceeds_over_responders() {
+        let members = vec![
+            ("a".to_string(), ok_provider(complete_json(0.9))),
+            ("b".to_string(), ok_provider(complete_json(0.8))),
+            ("c".to_string(), err_provider()),
+        ];
+        let mut verifier = EnsembleVerifier::new(
+            members,
+            Duration::from_secs(5),
+            EnsembleTracker::new(0.3, 0.95, 5),
+        );
+        let task = test_task();
+        match verifier.verify(&task, "output", &test_sanitizer()).await {
+            EnsembleAttempt::Merged { result, .. } => {
+                assert!(result.complete);
+                // Mean of {0.9, 0.8} = 0.85, not mean of {0.9, 0.8, 0.0}.
+                assert!((result.confidence - 0.85).abs() < 1e-9);
+            }
+            EnsembleAttempt::QuorumNotMet { .. } => panic!("2 of 3 responders meets quorum=2"),
+        }
+        assert_eq!(
+            verifier.last_usage().len(),
+            2,
+            "errored member has no usage record"
+        );
+    }
+
+    #[tokio::test]
+    async fn member_timeout_excludes_from_ballot() {
+        let members = vec![
+            ("fast".to_string(), ok_provider(complete_json(0.9))),
+            (
+                "slow".to_string(),
+                slow_provider(complete_json(0.9), 60_000),
+            ),
+            ("fast2".to_string(), ok_provider(complete_json(0.8))),
+        ];
+        let mut verifier = EnsembleVerifier::new(
+            members,
+            Duration::from_millis(50),
+            EnsembleTracker::new(0.3, 0.95, 5),
+        );
+        let task = test_task();
+        match verifier.verify(&task, "output", &test_sanitizer()).await {
+            EnsembleAttempt::Merged { result, .. } => {
+                assert!(result.complete);
+                assert!((result.confidence - 0.85).abs() < 1e-9);
+            }
+            EnsembleAttempt::QuorumNotMet { .. } => panic!("2 of 3 responders meets quorum=2"),
+        }
+    }
+
+    #[tokio::test]
+    async fn split_verdict_incomplete_wins_triggers_replan_shape() {
+        let members = vec![
+            ("a".to_string(), ok_provider(incomplete_json(0.4))),
+            ("b".to_string(), ok_provider(incomplete_json(0.6))),
+            ("c".to_string(), ok_provider(complete_json(0.95))),
+        ];
+        let mut verifier = EnsembleVerifier::new(
+            members,
+            Duration::from_secs(5),
+            EnsembleTracker::new(0.3, 0.95, 5),
+        );
+        let task = test_task();
+        match verifier.verify(&task, "output", &test_sanitizer()).await {
+            EnsembleAttempt::Merged { result, outcome } => {
+                assert!(!result.complete);
+                assert_eq!(result.gaps.len(), 2);
+                assert!((result.confidence - 0.5).abs() < 1e-9);
+                assert!((outcome.agreement_ratio - 2.0 / 3.0).abs() < 1e-9);
+            }
+            EnsembleAttempt::QuorumNotMet { .. } => panic!("expected quorum to be met"),
+        }
+    }
+
+    #[tokio::test]
+    async fn tracker_records_agreement_after_merge() {
+        let members = vec![
+            ("agrees".to_string(), ok_provider(complete_json(0.9))),
+            ("agrees2".to_string(), ok_provider(complete_json(0.8))),
+            ("disagrees".to_string(), ok_provider(incomplete_json(0.5))),
+        ];
+        let mut verifier = EnsembleVerifier::new(
+            members,
+            Duration::from_secs(5),
+            EnsembleTracker::new(1.0, 1.0, 1),
+        );
+        let task = test_task();
+        let _ = verifier.verify(&task, "output", &test_sanitizer()).await;
+
+        assert!((verifier.tracker().ema("agrees").unwrap() - 1.0).abs() < 1e-9);
+        assert!((verifier.tracker().ema("agrees2").unwrap() - 1.0).abs() < 1e-9);
+        assert!((verifier.tracker().ema("disagrees").unwrap() - 0.0).abs() < 1e-9);
+    }
+}

--- a/crates/zeph-orchestration/src/lib.rs
+++ b/crates/zeph-orchestration/src/lib.rs
@@ -91,6 +91,8 @@ pub mod adaptorch;
 #[cfg(feature = "llm-planning")]
 pub mod aggregator;
 #[cfg(feature = "llm-planning")]
+pub mod ensemble;
+#[cfg(feature = "llm-planning")]
 pub mod plan_cache;
 #[cfg(feature = "llm-planning")]
 pub mod planner;
@@ -119,6 +121,8 @@ pub use topology::{
 pub use adaptorch::{AdaptOrchMetrics, AdvisorVerdict, TaskClass, TopologyAdvisor, TopologyHint};
 #[cfg(feature = "llm-planning")]
 pub use aggregator::{Aggregator, LlmAggregator};
+#[cfg(feature = "llm-planning")]
+pub use ensemble::{Ballot, EnsembleAttempt, EnsembleTracker, EnsembleVerifier, MergeOutcome};
 #[cfg(feature = "llm-planning")]
 pub use plan_cache::{
     PlanCache, PlanCacheError, PlanTemplate, TemplateTask, normalize_goal, plan_with_cache,

--- a/crates/zeph-orchestration/src/scheduler/mod.rs
+++ b/crates/zeph-orchestration/src/scheduler/mod.rs
@@ -820,6 +820,7 @@ mod tests {
             aggregator_timeout_secs: 60,
             planner_timeout_secs: 120,
             verifier_timeout_secs: 30,
+            ensemble: Default::default(),
         }
     }
 

--- a/crates/zeph-orchestration/src/verifier.rs
+++ b/crates/zeph-orchestration/src/verifier.rs
@@ -469,7 +469,12 @@ struct ReplanTask {
     agent_hint: Option<String>,
 }
 
-fn build_verify_prompt(
+/// Build the per-task completeness-verification prompt.
+///
+/// `pub(crate)` so [`crate::ensemble::verifier::EnsembleVerifier`] can reuse the exact same
+/// prompt for every ensemble member — the ensemble path must ask an identical question of each
+/// member, differing only in which provider answers it.
+pub(crate) fn build_verify_prompt(
     task: &TaskNode,
     output: &str,
     sanitizer: &Arc<dyn OutputSanitizer>,

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -443,6 +443,7 @@ pub(crate) struct SharedAgentDeps {
     probe_provider: Option<zeph_llm::any::AnyProvider>,
     planner_provider: Option<zeph_llm::any::AnyProvider>,
     verify_provider: Option<zeph_llm::any::AnyProvider>,
+    ensemble_members: Vec<(String, zeph_llm::any::AnyProvider)>,
     orchestrator_provider: Option<zeph_llm::any::AnyProvider>,
     predicate_provider: Option<zeph_llm::any::AnyProvider>,
     quarantine_provider: Option<(zeph_llm::any::AnyProvider, zeph_sanitizer::QuarantineConfig)>,
@@ -1154,6 +1155,7 @@ async fn build_acp_deps(
         probe_provider: app.build_probe_provider(),
         planner_provider: app.build_planner_provider(),
         verify_provider: app.build_verify_provider(),
+        ensemble_members: app.build_ensemble_members(),
         orchestrator_provider: app.build_orchestrator_provider(),
         predicate_provider: app.build_predicate_provider(),
         quarantine_provider: app.build_quarantine_provider(),
@@ -1535,6 +1537,7 @@ async fn spawn_acp_agent(
     let probe_provider = d.probe_provider.clone();
     let planner_provider = d.planner_provider.clone();
     let verify_provider = d.verify_provider.clone();
+    let ensemble_members = d.ensemble_members.clone();
     let orchestrator_provider = d.orchestrator_provider.clone();
     let predicate_provider = d.predicate_provider.clone();
     let quarantine_provider = d.quarantine_provider.clone();
@@ -2074,6 +2077,8 @@ async fn spawn_acp_agent(
     if let Some(vp) = verify_provider {
         agent = agent.with_verify_provider(vp);
     }
+
+    agent = agent.with_ensemble_members(ensemble_members);
 
     if let Some(op) = orchestrator_provider {
         agent = agent.with_orchestrator_provider(op);

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -1933,6 +1933,59 @@ impl AppBuilder {
             }
         }
     }
+    /// Resolve `[orchestration.ensemble] members` into providers for ORCH-style deterministic
+    /// verifier ensemble-merge (spec `073-orch-ensemble-merge`).
+    ///
+    /// Returns an empty `Vec` when `[orchestration.ensemble].enabled = false` (the default).
+    /// A member name that fails to resolve is logged and excluded (log-and-continue, mirroring
+    /// `build_verify_provider`) — this shrinks the effective ensemble at startup rather than
+    /// failing bootstrap; the runtime quorum check in `EnsembleVerifier::verify` is what
+    /// ultimately decides whether the shrunk set is still usable. This is distinct from the
+    /// load-time shape validation (`members` odd/>=3/no-duplicate), which catches config
+    /// defects, not provider-resolution failures.
+    #[tracing::instrument(name = "orch.ensemble.resolve_members", skip(self))]
+    pub fn build_ensemble_members(&self) -> Vec<(String, AnyProvider)> {
+        if !self.config.orchestration.ensemble.enabled {
+            return Vec::new();
+        }
+        let configured = &self.config.orchestration.ensemble.members;
+        let resolved: Vec<(String, AnyProvider)> = configured
+            .iter()
+            .filter_map(|name| match create_named_provider(name, &self.config) {
+                Ok(p) => {
+                    tracing::info!(provider = %name, "ensemble member configured");
+                    Some((name.clone(), p))
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        provider = %name,
+                        error = %e,
+                        "ensemble member resolution failed — excluded from ensemble"
+                    );
+                    None
+                }
+            })
+            .collect();
+
+        // Informational only (critic S1): load-time validation guarantees the *configured*
+        // `members` list is odd/>=3, but a resolution failure here can shrink the *effective*
+        // set below that invariant. The runtime quorum/parity guard in the scheduler loop's
+        // `SchedulerAction::Verify` handler is what actually prevents a degenerate effective
+        // ensemble from running (and is where `ensemble_degraded` is signalled) — this warning
+        // exists purely to surface the shrinkage as early as possible, at startup.
+        if resolved.len() != configured.len() {
+            tracing::warn!(
+                configured_count = configured.len(),
+                resolved_count = resolved.len(),
+                "ensemble member resolution shrank the effective member count below the \
+                 configured list — the scheduler loop falls back to single-provider verify \
+                 unless the resolved count is still odd and >= 3"
+            );
+        }
+
+        resolved
+    }
+
     /// Build the predicate evaluation provider from `[orchestration] predicate_provider`.
     ///
     /// Returns `None` when `predicate_provider` is empty (falls back to `orchestrator_provider`

--- a/src/bootstrap/tests.rs
+++ b/src/bootstrap/tests.rs
@@ -959,3 +959,69 @@ fn build_judge_provider_both_empty_returns_none() {
         "Empty judge_provider and judge_model must return None"
     );
 }
+
+// ── build_ensemble_members (spec 073-orch-ensemble-merge, T3.4) ──────────────
+
+fn make_builder_with_ensemble_config(
+    enabled: bool,
+    members: Vec<&str>,
+    providers: Vec<ProviderEntry>,
+) -> super::AppBuilder {
+    let mut config = zeph_core::config::Config::load(Path::new("/nonexistent")).unwrap();
+    config.orchestration.ensemble.enabled = enabled;
+    config.orchestration.ensemble.members = members.into_iter().map(String::from).collect();
+    config.llm.providers = providers;
+    super::AppBuilder::for_test(config)
+}
+
+#[test]
+fn build_ensemble_members_disabled_returns_empty_vec() {
+    let b = make_builder_with_ensemble_config(
+        false,
+        vec!["a", "b", "c"],
+        vec![ollama_entry("a"), ollama_entry("b"), ollama_entry("c")],
+    );
+    assert!(
+        b.build_ensemble_members().is_empty(),
+        "enabled=false must resolve zero members regardless of the configured list"
+    );
+}
+
+#[test]
+fn build_ensemble_members_all_valid_names_resolves_full_vec() {
+    let b = make_builder_with_ensemble_config(
+        true,
+        vec!["a", "b", "c"],
+        vec![ollama_entry("a"), ollama_entry("b"), ollama_entry("c")],
+    );
+    let members = b.build_ensemble_members();
+    assert_eq!(members.len(), 3);
+    let names: Vec<&str> = members.iter().map(|(n, _)| n.as_str()).collect();
+    assert_eq!(names, vec!["a", "b", "c"]);
+}
+
+#[test]
+#[tracing_test::traced_test]
+fn build_ensemble_members_one_unresolvable_name_shrinks_vec_and_warns() {
+    let b = make_builder_with_ensemble_config(
+        true,
+        vec!["a", "missing", "c"],
+        vec![ollama_entry("a"), ollama_entry("c")],
+    );
+    let members = b.build_ensemble_members();
+    assert_eq!(
+        members.len(),
+        2,
+        "the unresolvable member must be excluded, not substituted"
+    );
+    let names: Vec<&str> = members.iter().map(|(n, _)| n.as_str()).collect();
+    assert_eq!(names, vec!["a", "c"]);
+    assert!(
+        logs_contain("ensemble member resolution failed"),
+        "a per-member resolution failure must log a warning"
+    );
+    assert!(
+        logs_contain("ensemble member resolution shrank the effective member count"),
+        "shrinkage below the configured count must log a bootstrap-level warning (critic S1)"
+    );
+}

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1021,6 +1021,8 @@ pub(crate) async fn run_daemon(
     } else {
         agent
     };
+    let ensemble_members = app.build_ensemble_members();
+    let agent = agent.with_ensemble_members(ensemble_members);
     let orchestrator_provider = app.build_orchestrator_provider();
     let agent = if let Some(op) = orchestrator_provider {
         agent.with_orchestrator_provider(op)

--- a/src/init/agents.rs
+++ b/src/init/agents.rs
@@ -78,10 +78,55 @@ pub(super) fn step_orchestration(state: &mut WizardState) -> anyhow::Result<()> 
             )
             .default(true)
             .interact()?;
+
+        step_ensemble_verify(state)?;
     }
 
     println!();
     Ok(())
+}
+
+/// Prompt for ORCH-style deterministic verifier ensemble-merge (spec
+/// `073-orch-ensemble-merge`), opt-in and nested under orchestration.
+fn step_ensemble_verify(state: &mut WizardState) -> anyhow::Result<()> {
+    state.ensemble_enabled = Confirm::new()
+        .with_prompt(
+            "Enable ensemble-verified plan verification? (opt-in, multiplies verify \
+             cost by member count — runs the same completeness check through N \
+             providers in parallel and merges by deterministic majority vote)",
+        )
+        .default(false)
+        .interact()?;
+
+    if !state.ensemble_enabled {
+        return Ok(());
+    }
+
+    loop {
+        let members_raw: String = Input::new()
+            .with_prompt(
+                "Ensemble member provider names (comma-separated, from \
+                 [[llm.providers]]; must be odd count and >= 3, no duplicates)",
+            )
+            .interact_text()?;
+        let members: Vec<String> = members_raw
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned)
+            .collect();
+        let unique: std::collections::HashSet<&str> = members.iter().map(String::as_str).collect();
+        if !members.len().is_multiple_of(2) && members.len() >= 3 && unique.len() == members.len() {
+            state.ensemble_members = members;
+            return Ok(());
+        }
+        println!(
+            "Invalid: need an odd count of >= 3 unique provider names, got {} \
+             (duplicates: {}). Try again.",
+            members.len(),
+            members.len() != unique.len()
+        );
+    }
 }
 
 pub(super) fn step_agents(state: &mut WizardState) -> anyhow::Result<()> {

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -117,6 +117,9 @@ pub(crate) struct WizardState {
     pub(crate) orchestration_failure_strategy: String,
     pub(crate) orchestration_planner_provider: Option<String>,
     pub(crate) orchestration_persistence_enabled: bool,
+    // Ensemble-verified plan verification (spec 073-orch-ensemble-merge, opt-in)
+    pub(crate) ensemble_enabled: bool,
+    pub(crate) ensemble_members: Vec<String>,
     // Debug settings
     pub(crate) debug_dump_enabled: bool,
     pub(crate) debug_dump_format: zeph_core::debug_dump::DumpFormat,
@@ -408,6 +411,8 @@ impl Default for WizardState {
             orchestration_failure_strategy: String::new(),
             orchestration_planner_provider: None,
             orchestration_persistence_enabled: true,
+            ensemble_enabled: false,
+            ensemble_members: Vec::new(),
             debug_dump_enabled: false,
             debug_dump_format: zeph_core::debug_dump::DumpFormat::Json,
             graph_memory_enabled: false,
@@ -1112,6 +1117,12 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
                 .unwrap_or_default(),
         ),
         persistence_enabled: state.orchestration_persistence_enabled,
+        ensemble: zeph_config::EnsembleConfig {
+            enabled: state.ensemble_enabled,
+            verify: state.ensemble_enabled,
+            members: state.ensemble_members.clone(),
+            ..zeph_config::EnsembleConfig::default()
+        },
         ..OrchestrationConfig::default()
     };
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2773,6 +2773,8 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
     } else {
         agent
     };
+    let ensemble_members = app.build_ensemble_members();
+    let agent = agent.with_ensemble_members(ensemble_members);
     let orchestrator_provider = app.build_orchestrator_provider();
     let agent = if let Some(op) = orchestrator_provider {
         agent.with_orchestrator_provider(op)


### PR DESCRIPTION
## Summary

Phase-1 implementation of ORCH-style deterministic multi-agent ensemble-merge (arXiv:2602.01797), scoped to `PlanVerifier` gap-severity verification (`crates/zeph-orchestration/src/verifier.rs`).

- Runs the same verification task through all configured ensemble members in parallel (inline `futures::future::join_all`, no new spawn site) and merges independent `complete: bool` ballots via a deterministic majority vote — `members.len()` enforced odd and >=3 at config load.
- New telemetry-only EMA tracker records per-member agreement for diagnostics; does not gate participation in this phase.
- `VerificationResult.confidence` is the mean of winning-side members' own self-reported confidence, never the ballot `agreement_ratio` — preserves the existing `scheduler_loop.rs` replan gate unchanged.
- Errored/timed-out members are excluded from the ballot. Below-quorum fan-out falls back to the existing single-primary `verify_provider` call.
- Feature is opt-in via a new `[orchestration.ensemble]` config section, default off — `verify()` behavior is byte-for-byte identical to today when disabled.
- A resolved-member-count guard (odd-and->=3) protects the majority-vote invariant even when bootstrap provider resolution shrinks the configured member list, firing `ensemble_degraded_total` + a warning on fallback.
- New `--migrate-config` step (`migrate_orchestration_ensemble`) for discoverability of the new config section.

Spec: `specs/073-orch-ensemble-merge/` (added in #6231; design went through a multi-round adversarial architect/critic loop in the spec-driven chain).

## Test plan

- [x] `merge()` unit-tested in isolation: majority vote, gap union, confidence semantics
- [x] Config load validation: odd/>=3/no-duplicate-provider-name, fail-fast `InvalidConfig`
- [x] Bootstrap wiring (`build_ensemble_members()`) tests: disabled, all-resolve, partial-resolution-failure
- [x] `scheduler_loop.rs` ensemble branch: default-off regression, full-quorum merge, quorum fallback (end-to-end via `Agent::run_scheduler_loop`)
- [x] Resolved-member-count guard exercised directly (mutation-verified) — distinguishes the bootstrap-shrinkage fallback path from the pre-existing runtime quorum-not-met path
- [x] `cargo +nightly fmt --check`, `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`, `cargo nextest run` (13532 passed), rustdoc gate, `cargo test --doc`, `gitleaks protect --staged`
- [x] `.local/testing/playbooks/orch-ensemble-merge.md` and `coverage-status.md` rows added (main repo path)

Closes #6232