### PR TITLE
fix(durable): wire finalize(Completed/Failed) into production execution paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -355,6 +355,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   tokio::sync::Mutex<()>`, held across the full quota-check-through-registration sequence,
   making in-process admission a hard guarantee. The existing cross-process soft cap (no locking
   across separate zeph sessions sharing the same `root`) is unchanged (#6250).
+- **Durable execution**: `finalize(Completed/Failed)` was never called in production — every
+  consumer (`zeph-orchestration`'s budget journal, `zeph-scheduler`'s job fire, `zeph-core`'s
+  per-conversation `AgentTurn`) drove steps through the durable journal but never marked the
+  execution row terminal, so `durable_executions.status` stayed `'running'` forever and the
+  TTL-based retention prune sweep could never reclaim any row. Wired `finalize(Completed)` on
+  success and `finalize(Failed)` on unrecoverable step failure into all three production execution
+  models, plus `finalize(Aborted)` on the hard step-cap (`DurableError::StepCapExceeded`), matching
+  the already-documented retention contract (`specs/064-durable-execution/spec.md`). Made
+  `finalize` idempotent against a race with the internal replay-divergence `Aborted` transition, and
+  made reopening a finalized execution (e.g. a resumed conversation, a same-slot scheduler retry)
+  automatically un-finalize it back to `running` so the retention sweep can never prune a row that's
+  actively being reused — closed a TOCTOU window between the prune sweep's candidate selection and
+  a concurrent reopen by moving the selection inside the same write transaction as the deletes.
+  Known residual gap, intentionally not addressed here: an execution that ends via an ungraceful
+  process exit (crash, OOM, `SIGKILL`) still has no reclamation path if never resumed — this needs a
+  separate periodic staleness-sweep mechanism, tracked in a follow-up issue (#6251).
 
 ### Added
 

--- a/crates/zeph-core/src/agent/durable_bootstrap.rs
+++ b/crates/zeph-core/src/agent/durable_bootstrap.rs
@@ -206,15 +206,17 @@ impl<C: Channel> Agent<C> {
     /// `durable_ctx_init_attempted` so it never re-derives the execution again. Without this
     /// reset, every turn after a conversation switch would keep journaling under the *old*
     /// conversation's execution — silently mixing two conversations' turn state and defeating the
-    /// per-conversation crash-resume the keying is meant to provide. Flushes and aborts the old
-    /// writer (best-effort, same 2s deadline as `flush_durable_writer` on shutdown) before
-    /// clearing the session's durable fields — including `durable_execution_lock` (INV-15,
+    /// per-conversation crash-resume the keying is meant to provide. Flushes the old writer,
+    /// finalizes the old execution as `Completed` (best-effort — this session is done with it, but
+    /// per #6251 a later `/conv resume` back to it reopens and un-finalizes the row, so nothing is
+    /// lost), then aborts the writer task (same 2s deadline as `flush_durable_writer` on shutdown)
+    /// before clearing the session's durable fields — including `durable_execution_lock` (INV-15,
     /// #6122), releasing the old execution's advisory lock so another process (or a later switch
     /// back in this same process) may open it — so the next durable-gated call re-derives a fresh
     /// execution for the new `conversation_id`.
     pub(in crate::agent) async fn reset_durable_ctx_for_conversation_switch(&mut self) {
+        let flush_deadline = std::time::Duration::from_secs(2);
         if let Some(ref writer) = self.services.session.durable_writer {
-            let flush_deadline = std::time::Duration::from_secs(2);
             match tokio::time::timeout(flush_deadline, writer.flush()).await {
                 Ok(Ok(())) => {}
                 Ok(Err(e)) => {
@@ -226,6 +228,27 @@ impl<C: Channel> Agent<C> {
                 Err(_) => tracing::warn!(
                     "durable agent_turns writer: flush timed out on conversation switch"
                 ),
+            }
+        }
+        if let Some(ref ctx) = self.services.session.durable_ctx {
+            match tokio::time::timeout(
+                flush_deadline,
+                ctx.finalize(zeph_durable::ExecutionStatus::Completed),
+            )
+            .await
+            {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    tracing::warn!(
+                        error = %e,
+                        "durable agent_turns: failed to finalize execution on conversation switch"
+                    );
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        "durable agent_turns: finalize timed out on conversation switch"
+                    );
+                }
             }
         }
         if let Some(h) = self.services.session.durable_writer_task.take() {
@@ -376,6 +399,50 @@ mod tests {
         assert_ne!(
             first_exec_id, second_exec_id,
             "a conversation switch must rebind the P1 execution to the new conversation_id"
+        );
+    }
+
+    #[tokio::test]
+    async fn conversation_switch_finalizes_the_old_execution_as_completed() {
+        // #6251: a conversation switch must finalize the *old* conversation's P1 execution as
+        // `Completed`, otherwise it stays `running` forever and the retention sweep can never
+        // reclaim it. `:memory:` can't be re-opened from a second connection to verify this, so
+        // this test uses a real file-backed sqlite db instead (same pattern as
+        // `legacy_shared_durable_db_upgrade_path_does_not_collide` below).
+        let dir = tempfile::tempdir().unwrap();
+        let db_url = dir.path().join("durable.db").to_string_lossy().into_owned();
+
+        let mut agent = agent_with_conversation();
+        agent.services.session.durable_agent_turns_config = Some(zeph_config::DurableConfig {
+            enabled: true,
+            agent_turns: true,
+            ..zeph_config::DurableConfig::default()
+        });
+        agent.services.session.durable_agent_turns_db_url = Some(db_url.clone());
+
+        agent.ensure_session_durable_ctx().await;
+        let old_exec_id = agent
+            .services
+            .session
+            .durable_ctx
+            .as_ref()
+            .expect("durable_ctx should be populated")
+            .execution_id();
+
+        agent.reset_durable_ctx_for_conversation_switch().await;
+
+        let backend = zeph_durable::LocalBackend::open(&db_url, 1_048_576)
+            .await
+            .unwrap();
+        let summaries = backend.list_executions(None, None, 10).await.unwrap();
+        let old = summaries
+            .iter()
+            .find(|s| s.execution_id == old_exec_id)
+            .expect("the old execution's row must still exist");
+        assert_eq!(
+            old.status,
+            zeph_durable::ExecutionStatus::Completed,
+            "the old conversation's execution must finalize as Completed on switch"
         );
     }
 

--- a/crates/zeph-core/src/agent/shutdown.rs
+++ b/crates/zeph-core/src/agent/shutdown.rs
@@ -433,8 +433,9 @@ impl<C: Channel> Agent<C> {
         tracing::info!("agent shutdown complete");
     }
 
-    /// Flush buffered durable journal entries then abort the writer task, for both the P2
-    /// (orchestration) and P1 (agent-turn, #5452) durable adapters.
+    /// Flush buffered durable journal entries, finalize the P1 agent-turn execution, then abort
+    /// the writer tasks, for both the P2 (orchestration) and P1 (agent-turn, #5452) durable
+    /// adapters.
     ///
     /// `flush()` has a built-in ack timeout; the outer 2 s cap ensures shutdown never
     /// hangs beyond that. Errors are logged as warnings — shutdown must not fail.
@@ -461,8 +462,181 @@ impl<C: Channel> Agent<C> {
                 Err(_) => tracing::warn!("durable agent_turns writer: flush timed out on shutdown"),
             }
         }
+        // Finalize the P1 execution as Completed now that its last turn's steps are flushed. The
+        // execution spans the whole conversation (keyed on ConversationId, #5452), not a single
+        // turn, so this is not "the conversation is over" — it just makes the row eligible for
+        // the TTL prune sweep if the conversation is never resumed. A later resume of the *same*
+        // conversation reopens this row and automatically un-finalizes it back to `running`
+        // (`LocalBackend::open_execution`, #6251), so nothing is lost if the user comes back.
+        // Bounded by the same 2 s deadline as the flush calls above, so this doc comment's "never
+        // hangs beyond that" claim stays accurate.
+        if let Some(ref ctx) = self.services.session.durable_ctx {
+            match tokio::time::timeout(
+                flush_deadline,
+                ctx.finalize(zeph_durable::ExecutionStatus::Completed),
+            )
+            .await
+            {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    tracing::warn!(
+                        error = %e,
+                        "durable agent_turns: failed to finalize execution on shutdown"
+                    );
+                }
+                Err(_) => tracing::warn!("durable agent_turns: finalize timed out on shutdown"),
+            }
+        }
         if let Some(h) = self.services.session.durable_writer_task.take() {
             h.abort();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::agent::agent_tests::*;
+
+    fn agent_with_conversation() -> crate::agent::Agent<MockChannel> {
+        let provider = mock_provider(vec!["ok".into()]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+        agent.services.memory.persistence.conversation_id = Some(zeph_memory::ConversationId(1));
+        agent
+    }
+
+    #[tokio::test]
+    async fn flush_durable_writer_finalizes_the_p1_execution_as_completed() {
+        // #6251: graceful shutdown must finalize the P1 agent-turn execution as `Completed`,
+        // otherwise it stays `running` forever and the retention sweep can never reclaim it.
+        // `:memory:` can't be re-opened from a second connection to verify this, so this test uses
+        // a real file-backed sqlite db (same pattern as
+        // `durable_bootstrap::tests::conversation_switch_finalizes_the_old_execution_as_completed`).
+        let dir = tempfile::tempdir().unwrap();
+        let db_url = dir.path().join("durable.db").to_string_lossy().into_owned();
+
+        let mut agent = agent_with_conversation();
+        agent.services.session.durable_agent_turns_config = Some(zeph_config::DurableConfig {
+            enabled: true,
+            agent_turns: true,
+            ..zeph_config::DurableConfig::default()
+        });
+        agent.services.session.durable_agent_turns_db_url = Some(db_url.clone());
+
+        agent.ensure_session_durable_ctx().await;
+        let exec_id = agent
+            .services
+            .session
+            .durable_ctx
+            .as_ref()
+            .expect("durable_ctx should be populated")
+            .execution_id();
+
+        agent.flush_durable_writer().await;
+
+        let backend = zeph_durable::LocalBackend::open(&db_url, 1_048_576)
+            .await
+            .unwrap();
+        let summaries = backend.list_executions(None, None, 10).await.unwrap();
+        let row = summaries
+            .iter()
+            .find(|s| s.execution_id == exec_id)
+            .expect("the execution's row must still exist");
+        assert_eq!(
+            row.status,
+            zeph_durable::ExecutionStatus::Completed,
+            "the P1 execution must finalize as Completed on graceful shutdown"
+        );
+    }
+
+    #[tokio::test]
+    async fn flush_durable_writer_finalize_is_bounded_by_the_2s_timeout() {
+        // #6251 critic M1: the shutdown finalize call must not hang indefinitely (or for the full
+        // 5s sqlite `busy_timeout`, zeph-db/src/pool.rs) when it can't immediately acquire the
+        // write lock. Holds a write transaction open on a second connection to the same
+        // file-backed db (BEGIN IMMEDIATE takes the write lock upfront, per
+        // `zeph_db::begin_write`'s doc comment) so `ctx.finalize`'s own `begin_write` blocks, then
+        // asserts `flush_durable_writer` still returns well within the 2s bound rather than
+        // waiting out the 5s busy_timeout or hanging forever.
+        let dir = tempfile::tempdir().unwrap();
+        let db_url = dir.path().join("durable.db").to_string_lossy().into_owned();
+
+        let mut agent = agent_with_conversation();
+        agent.services.session.durable_agent_turns_config = Some(zeph_config::DurableConfig {
+            enabled: true,
+            agent_turns: true,
+            ..zeph_config::DurableConfig::default()
+        });
+        agent.services.session.durable_agent_turns_db_url = Some(db_url.clone());
+
+        agent.ensure_session_durable_ctx().await;
+        let exec_id = agent
+            .services
+            .session
+            .durable_ctx
+            .as_ref()
+            .expect("durable_ctx should be populated")
+            .execution_id();
+
+        // A second, independent connection to the same file holds the write lock throughout the
+        // finalize attempt below, without ever committing or rolling back until after the timing
+        // assertion.
+        let lock_holder = zeph_durable::LocalBackend::open(&db_url, 1_048_576)
+            .await
+            .unwrap();
+        let blocking_tx = zeph_db::begin_write(lock_holder.pool()).await.unwrap();
+
+        let start = std::time::Instant::now();
+        agent.flush_durable_writer().await;
+        let elapsed = start.elapsed();
+
+        drop(blocking_tx); // release the write lock
+
+        assert!(
+            elapsed < std::time::Duration::from_secs(4),
+            "flush_durable_writer must return well within its 2s finalize timeout \
+             (plus the writer.flush() call's own bound), not the 5s sqlite busy_timeout; took \
+             {elapsed:?}"
+        );
+
+        let backend = zeph_durable::LocalBackend::open(&db_url, 1_048_576)
+            .await
+            .unwrap();
+        let summaries = backend.list_executions(None, None, 10).await.unwrap();
+        let row = summaries
+            .iter()
+            .find(|s| s.execution_id == exec_id)
+            .expect("the execution's row must still exist");
+        assert_eq!(
+            row.status,
+            zeph_durable::ExecutionStatus::Running,
+            "finalize must not have committed while the write lock was held elsewhere"
+        );
+
+        // Sanity check: with the lock released, a direct finalize succeeds normally — proving the
+        // earlier non-completion was purely lock contention, not a latent bug. (Not calling
+        // `flush_durable_writer` again: its first call already aborted `durable_writer_task`, so a
+        // second `writer.flush()` would just time out waiting for a reply from a dead task.)
+        agent
+            .services
+            .session
+            .durable_ctx
+            .as_ref()
+            .unwrap()
+            .finalize(zeph_durable::ExecutionStatus::Completed)
+            .await
+            .unwrap();
+        let summaries = backend.list_executions(None, None, 10).await.unwrap();
+        let row = summaries
+            .iter()
+            .find(|s| s.execution_id == exec_id)
+            .expect("the execution's row must still exist");
+        assert_eq!(
+            row.status,
+            zeph_durable::ExecutionStatus::Completed,
+            "finalize succeeds once the write lock is free"
+        );
     }
 }

--- a/crates/zeph-durable/src/backend/local.rs
+++ b/crates/zeph-durable/src/backend/local.rs
@@ -357,11 +357,29 @@ impl LocalBackend {
     /// row for a resumed one (returning `true`). The journal's foreign key requires this row before
     /// any entry is appended, so callers open the execution first.
     ///
+    /// Reopening a row previously [`finalize`](Journal::finalize)d as `completed` or `failed`
+    /// un-finalizes it: status resets to `running` and `finalized_at` clears. A caller reopening an
+    /// execution is, by definition, still using it, so the retention sweep (gated on
+    /// `finalized_at`) must not consider it prunable while it does — without this, a long-lived
+    /// execution finalized at one process's graceful shutdown and legitimately resumed by a later
+    /// process (e.g. a per-conversation `AgentTurn` execution) would keep a stale `finalized_at`
+    /// and could be pruned out from under its still-active journal. `aborted` rows are left
+    /// untouched: divergence recovery reopens the same row on purpose and starts a fresh replay
+    /// cursor without needing the status reset.
+    ///
+    /// The un-finalize is attempted as a single guarded `UPDATE` (no preceding `SELECT`) so there
+    /// is no read-then-write window against a concurrent prune sweep (#6251 critic S1): if the row
+    /// was deleted by `prune` between an earlier observation and this call, the `UPDATE` simply
+    /// matches zero rows rather than silently resurrecting a half-deleted row. A zero-row `UPDATE`
+    /// falls back to checking whether the row exists at all (already `running`/`aborted`, or
+    /// genuinely gone) before deciding between reporting a resume or inserting a fresh execution —
+    /// so this never reports `is_resume = true` for a row that turned out not to exist.
+    ///
     /// Span: `durable.backend.open`.
     ///
     /// # Errors
     ///
-    /// Returns [`DurableError::Storage`] if the lookup or insert fails.
+    /// Returns [`DurableError::Storage`] if the lookup, reset, or insert fails.
     pub async fn open_execution(
         &self,
         id: ExecutionId,
@@ -375,6 +393,28 @@ impl LocalBackend {
         );
         async move {
             let exec = id.as_uuid().to_string();
+
+            // Attempt the un-finalize directly, with no preceding SELECT: this is the only write
+            // this call needs to make for an existing terminal row, so there is no window between
+            // "observe completed/failed" and "reset to running" for a concurrent prune to act in.
+            let reopened = zeph_db::query(sql!(
+                "UPDATE durable_executions SET status = 'running', updated_at = ?, finalized_at = NULL
+                 WHERE execution_id = ? AND status IN ('completed', 'failed')"
+            ))
+            .bind(now_unix_millis())
+            .bind(&exec)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| DurableError::storage("open", e))?;
+            if reopened.rows_affected() > 0 {
+                tracing::Span::current().record("is_resume", true);
+                return Ok(true);
+            }
+
+            // Zero rows: either the row doesn't exist, or it exists but wasn't terminal (already
+            // `running`/`aborted`, no reset needed). Distinguish the two — if a concurrent prune
+            // deleted a terminal row between any earlier observation and this check, this SELECT
+            // sees the authoritative post-delete state instead of a stale belief that it's there.
             let existing: Option<(String,)> = zeph_db::query_as(sql!(
                 "SELECT status FROM durable_executions WHERE execution_id = ?"
             ))
@@ -1041,11 +1081,46 @@ impl LocalBackend {
     /// and execution rows in a single transaction (children first, to respect the foreign keys).
     /// Returns the number of executions removed; the retention loop stops once a batch returns fewer
     /// than `batch`.
+    ///
+    /// The candidate-selection `SELECT` runs *inside* the same `begin_write` transaction as the
+    /// deletes (not on the autocommit pool beforehand), closing the race where a concurrent
+    /// `open_execution` reopen (un-finalize, #6251) lands between "select prunable ids" and
+    /// "delete them" — without this, a legitimately-resumed execution could be deleted out from
+    /// under its own reopen. `SQLite`'s `BEGIN IMMEDIATE` (via `begin_write`) already serializes
+    /// writers at the file level, so the `SELECT` alone is enough there; `PostgreSQL` needs an
+    /// explicit `SELECT ... FOR UPDATE` first to take row locks on the same candidates before
+    /// they're read, since a plain `BEGIN` does not otherwise block a concurrent `UPDATE` on those
+    /// rows (mirrors the `BEGIN IMMEDIATE` / `SELECT FOR UPDATE` split in `goal/store.rs`).
     async fn delete_prune_batch(
         &self,
         cutoffs: crate::retention::PruneCutoffs,
         batch: u64,
     ) -> Result<u64, DurableError> {
+        let mut tx = zeph_db::begin_write(&self.pool)
+            .await
+            .map_err(|e| DurableError::storage("prune", e))?;
+
+        // Postgres only: lock the same candidate rows before reading them, so a concurrent
+        // `open_execution` reopen UPDATE on one of these rows blocks until this transaction
+        // commits (and then no longer matches, since the SELECT below re-reads post-commit) or
+        // this transaction rolls back. Bounded by the same ORDER BY/LIMIT as the real read below
+        // so the lock's blast radius matches the batch, not the whole prunable backlog.
+        #[cfg(feature = "postgres")]
+        zeph_db::query(sql!(
+            "SELECT execution_id FROM durable_executions
+             WHERE finalized_at IS NOT NULL
+               AND ( (status = 'completed' AND finalized_at <= ?)
+                  OR (status IN ('failed', 'aborted') AND finalized_at <= ?) )
+             ORDER BY finalized_at LIMIT ?
+             FOR UPDATE"
+        ))
+        .bind(cutoffs.completed_before_ms)
+        .bind(cutoffs.failed_before_ms)
+        .bind(i64::try_from(batch).unwrap_or(i64::MAX))
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| DurableError::storage("prune", e))?;
+
         let ids: Vec<(String,)> = zeph_db::query_as(sql!(
             "SELECT execution_id FROM durable_executions
              WHERE finalized_at IS NOT NULL
@@ -1056,32 +1131,49 @@ impl LocalBackend {
         .bind(cutoffs.completed_before_ms)
         .bind(cutoffs.failed_before_ms)
         .bind(i64::try_from(batch).unwrap_or(i64::MAX))
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *tx)
         .await
         .map_err(|e| DurableError::storage("prune", e))?;
         if ids.is_empty() {
+            tx.commit()
+                .await
+                .map_err(|e| DurableError::storage("prune", e))?;
             return Ok(0);
         }
         let journal = sql!("DELETE FROM durable_journal WHERE execution_id = ?");
         let promises = sql!("DELETE FROM durable_promises WHERE execution_id = ?");
         let timers = sql!("DELETE FROM durable_timers WHERE execution_id = ?");
-        let executions = sql!("DELETE FROM durable_executions WHERE execution_id = ?");
-        let mut tx = zeph_db::begin_write(&self.pool)
-            .await
-            .map_err(|e| DurableError::storage("prune", e))?;
+        // Re-guarded by the same status/finalized_at predicate as the SELECT above (not just
+        // `execution_id = ?`) — belt and suspenders alongside the transactional read above.
+        let executions = sql!(
+            "DELETE FROM durable_executions
+             WHERE execution_id = ?
+               AND finalized_at IS NOT NULL
+               AND ( (status = 'completed' AND finalized_at <= ?)
+                  OR (status IN ('failed', 'aborted') AND finalized_at <= ?) )"
+        );
+        let mut removed = 0u64;
         for (id,) in &ids {
-            for stmt in [journal, promises, timers, executions] {
+            for stmt in [journal, promises, timers] {
                 zeph_db::query(stmt)
                     .bind(id)
                     .execute(&mut *tx)
                     .await
                     .map_err(|e| DurableError::storage("prune", e))?;
             }
+            let result = zeph_db::query(executions)
+                .bind(id)
+                .bind(cutoffs.completed_before_ms)
+                .bind(cutoffs.failed_before_ms)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| DurableError::storage("prune", e))?;
+            removed += result.rows_affected();
         }
         tx.commit()
             .await
             .map_err(|e| DurableError::storage("prune", e))?;
-        Ok(ids.len() as u64)
+        Ok(removed)
     }
 
     /// Seal a plaintext payload, or pass it through verbatim when no cipher is configured.
@@ -1508,9 +1600,13 @@ impl Journal for LocalBackend {
             let mut tx = zeph_db::begin_write(&self.pool)
                 .await
                 .map_err(|e| DurableError::storage("finalize", e))?;
+            // `AND status = 'running'` makes this a one-shot transition: whichever of a concurrent
+            // divergence-triggered `Aborted` or a caller's `Completed`/`Failed` commits first wins,
+            // and the loser's UPDATE affects zero rows instead of clobbering the winner's terminal
+            // status (finalize is otherwise safe to call more than once per execution).
             zeph_db::query(sql!(
                 "UPDATE durable_executions SET status = ?, updated_at = ?, finalized_at = ?
-                 WHERE execution_id = ?"
+                 WHERE execution_id = ? AND status = 'running'"
             ))
             .bind(status.as_str())
             .bind(now)
@@ -2170,6 +2266,354 @@ mod tests {
         .unwrap();
         assert_eq!(status, "completed");
         assert!(finalized.is_some(), "a terminal status stamps finalized_at");
+    }
+
+    #[tokio::test]
+    async fn finalize_is_a_noop_once_already_terminal() {
+        // #6251: finalize must be safe to call more than once (e.g. a caller's own `Completed`
+        // racing the divergence guard's `Aborted`) — whichever status lands first wins.
+        let backend = mem_backend(1_048_576).await;
+        let exec = ExecutionId::new();
+        backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        backend
+            .finalize(exec, ExecutionStatus::Completed)
+            .await
+            .unwrap();
+
+        // A later call with a different terminal status must not overwrite the first.
+        backend
+            .finalize(exec, ExecutionStatus::Failed)
+            .await
+            .unwrap();
+
+        let (status,): (String,) = zeph_db::query_as(sql!(
+            "SELECT status FROM durable_executions WHERE execution_id = ?"
+        ))
+        .bind(exec.as_uuid().to_string())
+        .fetch_one(backend.pool())
+        .await
+        .unwrap();
+        assert_eq!(
+            status, "completed",
+            "the first terminal status must stick; a later finalize call is a no-op"
+        );
+    }
+
+    #[tokio::test]
+    async fn finalize_after_abort_is_a_noop() {
+        // #6251: the reverse direction of the divergence race — the internal `Aborted` transition
+        // (replay-divergence guard) commits first, so a consumer's later own `Completed`/`Failed`
+        // call must be a no-op rather than resurrecting the row out of its aborted state.
+        let backend = mem_backend(1_048_576).await;
+        let exec = ExecutionId::new();
+        backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        backend
+            .finalize(exec, ExecutionStatus::Aborted)
+            .await
+            .unwrap();
+
+        backend
+            .finalize(exec, ExecutionStatus::Completed)
+            .await
+            .unwrap();
+
+        let (status,): (String,) = zeph_db::query_as(sql!(
+            "SELECT status FROM durable_executions WHERE execution_id = ?"
+        ))
+        .bind(exec.as_uuid().to_string())
+        .fetch_one(backend.pool())
+        .await
+        .unwrap();
+        assert_eq!(
+            status, "aborted",
+            "an aborted execution must not be overwritten by a later Completed/Failed call"
+        );
+    }
+
+    #[tokio::test]
+    async fn reopening_a_finalized_execution_resets_it_to_running() {
+        // #6251: a finalized execution that is legitimately reopened (e.g. a resumed conversation)
+        // must not keep a stale `finalized_at` — otherwise the retention sweep could prune a row
+        // that is still receiving new journal writes.
+        let backend = mem_backend(1_048_576).await;
+        let exec = ExecutionId::new();
+        backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        backend
+            .finalize(exec, ExecutionStatus::Completed)
+            .await
+            .unwrap();
+
+        let is_resume = backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        assert!(is_resume, "the row already existed, so this is a resume");
+
+        let (status, finalized): (String, Option<i64>) = zeph_db::query_as(sql!(
+            "SELECT status, finalized_at FROM durable_executions WHERE execution_id = ?"
+        ))
+        .bind(exec.as_uuid().to_string())
+        .fetch_one(backend.pool())
+        .await
+        .unwrap();
+        assert_eq!(
+            status, "running",
+            "reopening a completed execution must un-finalize it"
+        );
+        assert!(
+            finalized.is_none(),
+            "reopening must clear the stale finalized_at"
+        );
+    }
+
+    #[tokio::test]
+    async fn reopening_a_failed_execution_resets_it_to_running() {
+        // #6251: same guarantee as `reopening_a_finalized_execution_resets_it_to_running`, but for
+        // the `Failed` terminal status — e.g. a scheduler retry of the same (job_name, slot_ms)
+        // after the previous fire failed must not orphan a `Failed` row.
+        let backend = mem_backend(1_048_576).await;
+        let exec = ExecutionId::new();
+        backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        backend
+            .finalize(exec, ExecutionStatus::Failed)
+            .await
+            .unwrap();
+
+        let is_resume = backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        assert!(is_resume, "the row already existed, so this is a resume");
+
+        let (status, finalized): (String, Option<i64>) = zeph_db::query_as(sql!(
+            "SELECT status, finalized_at FROM durable_executions WHERE execution_id = ?"
+        ))
+        .bind(exec.as_uuid().to_string())
+        .fetch_one(backend.pool())
+        .await
+        .unwrap();
+        assert_eq!(
+            status, "running",
+            "reopening a failed execution must un-finalize it"
+        );
+        assert!(
+            finalized.is_none(),
+            "reopening must clear the stale finalized_at"
+        );
+    }
+
+    #[tokio::test]
+    async fn reopening_an_aborted_execution_leaves_it_untouched() {
+        // Divergence recovery reopens the same row on purpose (a fresh replay cursor, not a status
+        // reset) — only `completed`/`failed` rows are un-finalized on reopen, `aborted` is not.
+        let backend = mem_backend(1_048_576).await;
+        let exec = ExecutionId::new();
+        backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        backend
+            .finalize(exec, ExecutionStatus::Aborted)
+            .await
+            .unwrap();
+
+        backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+
+        let (status,): (String,) = zeph_db::query_as(sql!(
+            "SELECT status FROM durable_executions WHERE execution_id = ?"
+        ))
+        .bind(exec.as_uuid().to_string())
+        .fetch_one(backend.pool())
+        .await
+        .unwrap();
+        assert_eq!(
+            status, "aborted",
+            "reopening must not un-finalize an aborted execution"
+        );
+    }
+
+    #[tokio::test]
+    async fn reopen_of_a_row_deleted_out_from_under_it_starts_fresh() {
+        // #6251 critic S1: simulates the tail of the prune-vs-reopen race — a concurrent prune
+        // sweep deletes the row entirely before the reopen's guarded UPDATE runs. The guarded
+        // UPDATE must match zero rows (not resurrect a half-deleted row), and the existence
+        // fallback must see the row is genuinely gone and start a fresh execution rather than
+        // falsely reporting `is_resume = true` for a row that no longer exists.
+        let backend = mem_backend(1_048_576).await;
+        let exec = ExecutionId::new();
+        backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        backend
+            .finalize(exec, ExecutionStatus::Completed)
+            .await
+            .unwrap();
+
+        // Simulate the prune sweep's delete completing before the reopen runs.
+        zeph_db::query(sql!(
+            "DELETE FROM durable_executions WHERE execution_id = ?"
+        ))
+        .bind(exec.as_uuid().to_string())
+        .execute(backend.pool())
+        .await
+        .unwrap();
+
+        let is_resume = backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        assert!(
+            !is_resume,
+            "a row deleted by a concurrent prune must be reported as a fresh execution, not a resume"
+        );
+
+        let (status,): (String,) = zeph_db::query_as(sql!(
+            "SELECT status FROM durable_executions WHERE execution_id = ?"
+        ))
+        .bind(exec.as_uuid().to_string())
+        .fetch_one(backend.pool())
+        .await
+        .unwrap();
+        assert_eq!(status, "running", "the fresh row starts running");
+    }
+
+    #[tokio::test]
+    async fn prune_does_not_delete_a_row_reopened_since_it_was_finalized() {
+        // #6251 critic S1: a row finalized, then legitimately reopened (un-finalized back to
+        // running) before prune runs, must not be deleted even though prune's cutoff would have
+        // matched its now-stale-if-it-were-still-finalized state.
+        let backend = mem_backend(1_048_576).await;
+        let exec = ExecutionId::new();
+        backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        backend.append(step_result(exec, 0, b"x")).await.unwrap();
+        zeph_db::query(sql!(
+            "UPDATE durable_executions SET status = 'completed', finalized_at = 1000 WHERE execution_id = ?"
+        ))
+        .bind(exec.as_uuid().to_string())
+        .execute(backend.pool())
+        .await
+        .unwrap();
+
+        // A legitimate resume reopens and un-finalizes it before the prune sweep runs.
+        let is_resume = backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        assert!(is_resume);
+
+        let policy = RetentionPolicy {
+            ttl_completed_secs: 1,
+            prune_batch_size: 10,
+            ..RetentionPolicy::default()
+        };
+        let deleted = backend.prune(&policy).await.unwrap();
+        assert_eq!(
+            deleted, 0,
+            "a reopened (un-finalized) execution must not be pruned"
+        );
+        assert_eq!(
+            backend.read_execution(exec).await.unwrap().len(),
+            1,
+            "the execution's journal must survive"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_prune_and_reopen_never_lose_or_corrupt_the_row() {
+        // #6251 critic S1: the deterministic tests above exercise each ordering of the prune-vs-
+        // reopen race one step at a time; this test drives the two operations as genuinely
+        // concurrent tasks against a real multi-connection pool (file-backed — `:memory:` forces
+        // a single connection, per `zeph-db/src/pool.rs`'s `connect_sqlite`, which would serialize
+        // the two calls trivially and prove nothing about the locking fix). Runs many trials with
+        // fresh executions so the two tasks' actual scheduling order varies across iterations,
+        // covering both "prune's tx starts first" and "reopen's UPDATE starts first" without
+        // needing artificial delay injection into the DB layer.
+        //
+        // Invariant checked every trial, regardless of which task wins: neither operation errors,
+        // and the row is never lost — it either stays `running` (reopen won, or ran after prune's
+        // read already excluded it) or is deleted and then reinserted fresh by reopen's
+        // does-not-exist fallback (prune won). It must never end up half-deleted (FK violation on
+        // a later journal append) or stuck `completed` with a live journal.
+        let dir = tempfile::tempdir().unwrap();
+        let db_url = dir.path().join("durable.db").to_string_lossy().into_owned();
+        let backend = Arc::new(LocalBackend::open(&db_url, 1_048_576).await.unwrap());
+        backend.init().await.unwrap();
+
+        let policy = RetentionPolicy {
+            ttl_completed_secs: 1,
+            prune_batch_size: 10,
+            ..RetentionPolicy::default()
+        };
+
+        for _ in 0..20 {
+            let exec = ExecutionId::new();
+            backend
+                .open_execution(exec, ExecutionKind::AgentTurn)
+                .await
+                .unwrap();
+            backend.append(step_result(exec, 0, b"x")).await.unwrap();
+            // Backdate finalized_at so this row is immediately prune-eligible.
+            zeph_db::query(sql!(
+                "UPDATE durable_executions SET status = 'completed', finalized_at = 1000 WHERE execution_id = ?"
+            ))
+            .bind(exec.as_uuid().to_string())
+            .execute(backend.pool())
+            .await
+            .unwrap();
+
+            let reopen_backend = backend.clone();
+            let reopen = tokio::spawn(async move {
+                reopen_backend
+                    .open_execution(exec, ExecutionKind::AgentTurn)
+                    .await
+            });
+            let prune_backend = backend.clone();
+            let policy_for_task = policy.clone();
+            let prune = tokio::spawn(async move { prune_backend.prune(&policy_for_task).await });
+
+            let (reopen_result, prune_result) = tokio::join!(reopen, prune);
+            reopen_result
+                .expect("reopen task must not panic")
+                .expect("reopen must not error under concurrent prune");
+            prune_result
+                .expect("prune task must not panic")
+                .expect("prune must not error under a concurrent reopen");
+
+            let (status,): (String,) = zeph_db::query_as(sql!(
+                "SELECT status FROM durable_executions WHERE execution_id = ?"
+            ))
+            .bind(exec.as_uuid().to_string())
+            .fetch_one(backend.pool())
+            .await
+            .expect(
+                "the row must exist under either race outcome — reopened-running, or \
+                 deleted-then-reinserted-fresh-running by reopen's fallback",
+            );
+            assert_eq!(
+                status, "running",
+                "whichever task wins, the row must end up running — never left completed \
+                 (orphaned from a live journal) or absent"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/zeph-durable/src/handle.rs
+++ b/crates/zeph-durable/src/handle.rs
@@ -248,7 +248,7 @@ impl DurableContext {
         fields(execution_id = %self.execution_id.as_uuid())
     )]
     pub async fn promise<T>(&self) -> Result<DurablePromise<T>, DurableError> {
-        let step_id = self.checked_step_id()?;
+        let step_id = self.checked_step_id().await?;
         let promise_id = PromiseId::derive(self.execution_id, step_id);
 
         // Replay/resume: a row at this position means the promise was already created in a prior run.
@@ -378,7 +378,7 @@ impl DurableContext {
         fields(execution_id = %self.execution_id.as_uuid())
     )]
     pub async fn sleep_until(&self, due: SystemTime) -> Result<(), DurableError> {
-        let step_id = self.checked_step_id()?;
+        let step_id = self.checked_step_id().await?;
         let timer_id = TimerId::derive(self.execution_id, step_id);
         let due_ms = system_time_to_millis(due);
 
@@ -451,6 +451,43 @@ impl DurableContext {
         crate::promise::DurableHandle::new(self.backend.clone())
     }
 
+    /// Transition this execution to a terminal status (FR-DE / retention section).
+    ///
+    /// Consumers call this on the two production terminal transitions the journal itself never
+    /// observes: `Completed` when the unit of work this execution represents finishes
+    /// successfully, and `Failed` on an unrecoverable (non-retryable) error. `Aborted` is reserved
+    /// for the replay-divergence guard ([`DurableError::ReplayDivergence`]) and is set internally,
+    /// not by consumers.
+    ///
+    /// Idempotent: calling this more than once, or racing it against an internal `Aborted`
+    /// transition, is safe — only the first call to observe the execution as `running` applies
+    /// (see [`crate::journal::Journal::finalize`]). The retention sweep only reclaims a finalized execution after
+    /// its configured TTL, so a finalized-then-reopened execution (e.g. a resumed conversation)
+    /// automatically un-finalizes back to `running` on the next [`DurableContext::new`] with
+    /// `is_resume = true`, protecting it from a stale `finalized_at`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a storage error if the transition cannot be committed.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # async fn run(ctx: &zeph_durable::DurableContext) -> Result<(), zeph_durable::DurableError> {
+    /// use zeph_durable::ExecutionStatus;
+    ///
+    /// ctx.finalize(ExecutionStatus::Completed).await?;
+    /// # Ok(()) }
+    /// ```
+    #[tracing::instrument(
+        name = "durable.context.finalize",
+        skip(self),
+        fields(execution_id = %self.execution_id.as_uuid(), status = status.as_str())
+    )]
+    pub async fn finalize(&self, status: ExecutionStatus) -> Result<(), DurableError> {
+        self.backend.finalize(self.execution_id, status).await
+    }
+
     /// Await any in-flight background checkpoint folds — a turn-boundary / test barrier.
     ///
     /// The soft step-cap fold runs on a spawned task so it never blocks step dispatch; call this at
@@ -473,15 +510,30 @@ impl DurableContext {
     }
 
     /// Assign the next step id, rejecting it if it exceeds the per-execution step cap.
-    fn checked_step_id(&self) -> Result<StepId, DurableError> {
+    async fn checked_step_id(&self) -> Result<StepId, DurableError> {
         let step_id = self.assign_step_id();
-        self.enforce_step_cap(step_id)?;
+        self.enforce_step_cap(step_id).await?;
         Ok(step_id)
     }
 
     /// Reject `step_id` if it exceeds the per-execution step cap (`0` means uncapped).
-    fn enforce_step_cap(&self, step_id: StepId) -> Result<(), DurableError> {
+    ///
+    /// A hard-cap rejection finalizes the execution as `Aborted` (best-effort, its own failure
+    /// only logs) — the retention spec describes the hard cap as aborting the execution, so this
+    /// is the one terminal transition the durable crate fully owns and can finalize internally,
+    /// rather than leaving the execution `running` forever with no reclamation path (#6251 critic
+    /// S2). Idempotent per [`Journal::finalize`]'s `running`-only guard, so a caller that keeps
+    /// calling `step`/`promise`/`sleep_until` after the cap trips (each hitting this same path)
+    /// only finalizes once.
+    async fn enforce_step_cap(&self, step_id: StepId) -> Result<(), DurableError> {
         if self.max_steps_per_execution != 0 && step_id.value() >= self.max_steps_per_execution {
+            if let Err(error) = self
+                .backend
+                .finalize(self.execution_id, ExecutionStatus::Aborted)
+                .await
+            {
+                tracing::warn!(%error, "failed to mark step-cap-exceeded execution aborted");
+            }
             return Err(DurableError::StepCapExceeded {
                 cap: self.max_steps_per_execution,
             });
@@ -542,7 +594,7 @@ impl DurableContext {
         F: FnOnce(StepHandle) -> Fut + Send,
         Fut: Future<Output = Result<T, StepError>> + Send,
     {
-        self.enforce_step_cap(step_id)?;
+        self.enforce_step_cap(step_id).await?;
         // Soft cap (90%): fold a checkpoint on a background task, once per execution.
         self.maybe_checkpoint(step_id);
         let effect = desc.effect();
@@ -1279,6 +1331,28 @@ mod tests {
         h.shutdown().await;
     }
 
+    #[tokio::test]
+    async fn finalize_transitions_the_execution_to_the_given_status() {
+        // #6251: DurableContext::finalize is the ergonomic entry point production consumers use to
+        // reach the terminal transition the journal itself never observes.
+        let exec = ExecutionId::new();
+        let h = Harness::open(exec, false).await;
+        h.ctx
+            .finalize(ExecutionStatus::Completed)
+            .await
+            .expect("finalize succeeds");
+
+        let (status,): (String,) = zeph_db::query_as(zeph_db::sql!(
+            "SELECT status FROM durable_executions WHERE execution_id = ?"
+        ))
+        .bind(exec.as_uuid().to_string())
+        .fetch_one(h.backend.pool())
+        .await
+        .unwrap();
+        assert_eq!(status, "completed");
+        h.shutdown().await;
+    }
+
     /// Build a fresh context over a shared in-memory backend with a custom config (e.g. a small cap).
     fn context_with(
         local: &Arc<LocalBackend>,
@@ -1578,6 +1652,27 @@ mod tests {
             .await
             .unwrap_err();
         assert_matches!(err, DurableError::StepCapExceeded { cap: 1 });
+
+        // #6251 critic S2: the hard cap is the one terminal transition the durable crate fully
+        // owns — it must finalize the execution as Aborted itself rather than leaving it
+        // `running` forever with no reclamation path.
+        let (status, finalized_at): (String, Option<i64>) = zeph_db::query_as(zeph_db::sql!(
+            "SELECT status, finalized_at FROM durable_executions WHERE execution_id = ?"
+        ))
+        .bind(exec.as_uuid().to_string())
+        .fetch_one(local.pool())
+        .await
+        .unwrap();
+        assert_eq!(
+            status, "aborted",
+            "a step-cap-exceeded execution must finalize as aborted"
+        );
+        assert!(
+            finalized_at.is_some(),
+            "finalize must stamp finalized_at too, not just flip status — otherwise the \
+             retention sweep (gated on finalized_at, not status alone) still can't reclaim it"
+        );
+
         drop(ctx);
         drop(handle);
         task.await.unwrap();

--- a/crates/zeph-durable/src/journal.rs
+++ b/crates/zeph-durable/src/journal.rs
@@ -273,6 +273,11 @@ pub trait Journal: Send + Sync {
 
     /// Transition an execution to a terminal status.
     ///
+    /// Idempotent and safe to race: the transition only applies while the execution is still
+    /// `running`, so calling this more than once for the same execution (e.g. a divergence-driven
+    /// `Aborted` racing a caller's own `Completed`/`Failed`) is a no-op after the first call commits
+    /// — whichever status lands first wins and is never overwritten by a later one.
+    ///
     /// # Errors
     ///
     /// Returns [`DurableError::JournalUnavailable`] if the transition cannot be committed.

--- a/crates/zeph-orchestration/src/durable.rs
+++ b/crates/zeph-orchestration/src/durable.rs
@@ -183,6 +183,13 @@ fn build_budget_ctx(
 /// being wrapped into a `DurableBackendEnum`.  When encryption is disabled, pass a backend
 /// without a cipher; the journal will store plaintext payloads (development mode only).
 ///
+/// A budget execution is a one-shot write: it opens fresh, writes its single step, and is never
+/// revisited (the next pause derives a new `ExecutionId` from the incremented generation), so the
+/// execution is finalized immediately after the step settles — `Completed` on success, `Failed` on
+/// a step-write error (the error is still propagated to the caller; finalizing is best-effort and
+/// its own failure is only logged, per [`DurableContext::finalize`]). Without this the retention
+/// sweep could never reclaim these rows (#6251): `finalized_at` would stay `NULL` forever.
+///
 /// # Errors
 ///
 /// Returns [`DurableError`] if the backend cannot be opened or the step write fails.
@@ -220,12 +227,27 @@ pub async fn journal_budget(
     let ctx = build_budget_ctx(exec_id, false, backend, writer, config);
 
     let desc = StepDescriptor::idempotent(BUDGET_STEP_NAME, BUDGET_STEP_FP.to_vec());
-    ctx.step(desc, move |_handle| async move {
-        Ok::<ReplanBudgetSnapshot, zeph_durable::step::StepError>(snapshot)
-    })
-    .await?;
+    let result = ctx
+        .step(desc, move |_handle| async move {
+            Ok::<ReplanBudgetSnapshot, zeph_durable::step::StepError>(snapshot)
+        })
+        .await;
 
-    Ok(())
+    let terminal_status = if result.is_ok() {
+        zeph_durable::ExecutionStatus::Completed
+    } else {
+        zeph_durable::ExecutionStatus::Failed
+    };
+    if let Err(finalize_err) = ctx.finalize(terminal_status).await {
+        tracing::warn!(
+            error = %finalize_err,
+            graph_id = %graph_id,
+            generation,
+            "orch.durable.budget_journal: failed to finalize budget execution"
+        );
+    }
+
+    result.map(|_| ())
 }
 
 /// Restore the replan budget for a graph that is being resumed.
@@ -381,13 +403,35 @@ mod tests {
         }
 
         async fn make_backend() -> (Arc<DurableBackendEnum>, JournalWriterHandle) {
+            let (_local, backend, handle) = make_backend_with_local().await;
+            (backend, handle)
+        }
+
+        /// Like `make_backend`, but also returns the raw `LocalBackend` so tests can read
+        /// `durable_executions` directly.
+        async fn make_backend_with_local() -> (
+            Arc<LocalBackend>,
+            Arc<DurableBackendEnum>,
+            JournalWriterHandle,
+        ) {
             let local = LocalBackend::open(":memory:", 1_048_576).await.unwrap();
             local.init().await.unwrap();
             let local = Arc::new(local);
             let backend = Arc::new(DurableBackendEnum::Local(local.clone()));
-            let (writer, handle) = JournalWriter::new(local, &test_config());
+            let (writer, handle) = JournalWriter::new(local.clone(), &test_config());
             tokio::spawn(async move { writer.run().await }); // EXEMPT: test-only helper
-            (backend, handle)
+            (local, backend, handle)
+        }
+
+        async fn execution_status(local: &LocalBackend, exec: ExecutionId) -> String {
+            let (status,): (String,) = zeph_db::query_as(zeph_db::sql!(
+                "SELECT status FROM durable_executions WHERE execution_id = ?"
+            ))
+            .bind(exec.as_uuid().to_string())
+            .fetch_one(local.pool())
+            .await
+            .unwrap();
+            status
         }
 
         #[tokio::test]
@@ -482,6 +526,63 @@ mod tests {
                 restored.global_replan_count, 2,
                 "restore should pick the latest generation"
             );
+        }
+
+        #[tokio::test]
+        async fn journal_budget_finalizes_the_execution_as_completed() {
+            // #6251: journal_budget must finalize its one-shot execution on success, otherwise the
+            // retention sweep can never reclaim it (`finalized_at` stays NULL forever).
+            let (local, backend, writer) = make_backend_with_local().await;
+            let config = test_config();
+            let graph_id = GraphId::new();
+            let generation: u32 = 0;
+
+            journal_budget(
+                &graph_id,
+                generation,
+                backend,
+                writer.clone(),
+                &config,
+                ReplanBudgetSnapshot::default(),
+            )
+            .await
+            .unwrap();
+            writer.flush().await.unwrap();
+
+            let exec = budget_exec_id(&graph_id, generation);
+            assert_eq!(execution_status(&local, exec).await, "completed");
+        }
+
+        #[tokio::test]
+        async fn journal_budget_finalizes_the_execution_as_failed_on_step_error() {
+            // #6251: when the step write itself fails (e.g. the encoded snapshot exceeds
+            // `max_payload_bytes`), the execution must finalize as `Failed` rather than being left
+            // `running` forever, while the original error is still propagated to the caller.
+            let (local, backend, writer) = make_backend_with_local().await;
+            let config = DurableConfig {
+                max_payload_bytes: 1,
+                ..test_config()
+            };
+            let graph_id = GraphId::new();
+            let generation: u32 = 0;
+
+            let err = journal_budget(
+                &graph_id,
+                generation,
+                backend,
+                writer.clone(),
+                &config,
+                ReplanBudgetSnapshot::default(),
+            )
+            .await
+            .expect_err("a 1-byte payload cap must reject the encoded snapshot");
+            assert!(
+                matches!(err, DurableError::PayloadTooLarge { .. }),
+                "unexpected error: {err:?}"
+            );
+
+            let exec = budget_exec_id(&graph_id, generation);
+            assert_eq!(execution_status(&local, exec).await, "failed");
         }
     }
 }

--- a/crates/zeph-scheduler/src/durable.rs
+++ b/crates/zeph-scheduler/src/durable.rs
@@ -27,7 +27,7 @@ use tracing::Instrument as _;
 use zeph_config::DurableConfig;
 use zeph_durable::{
     DurableBackendEnum, DurableContext, EffectIntentSubClass, ExecutionId, ExecutionKind,
-    JournalWriterHandle, LocalBackend, StepDescriptor, StepError,
+    ExecutionStatus, JournalWriterHandle, LocalBackend, StepDescriptor, StepError,
 };
 
 use crate::error::SchedulerError;
@@ -98,8 +98,12 @@ impl SchedulerDurableAdapter {
 /// crashed after `EffectIntent` was committed but before `StepResult`, `OnAmbiguous::Skip`
 /// documents the skip in the audit log without re-firing.
 ///
-/// When `fire` succeeds its `()` result is journaled. On error no `StepResult` is committed, so a
-/// future restart retries the fire.
+/// When `fire` succeeds its `()` result is journaled and the execution finalizes as `Completed`.
+/// On error no `StepResult` is committed and the execution finalizes as `Failed` — but if the
+/// caller's scheduler loop retries the same `(job_name, slot_ms)` on a later tick (`next_run` was
+/// never advanced), reopening the execution automatically un-finalizes it back to `running`
+/// ([`LocalBackend::open_execution`](zeph_durable::LocalBackend::open_execution)), so the retry is
+/// journaled onto the same row rather than orphaning a `Failed` one.
 ///
 /// # Errors
 ///
@@ -170,11 +174,31 @@ where
         )
         .map_err(|e| SchedulerError::TaskFailed(format!("durable descriptor error: {e}")))?;
 
-        ctx.step(desc, |_handle| async move {
-            fire().await.map_err(|e| StepError::new(e.to_string()))
-        })
-        .await
-        .map_err(|e| SchedulerError::TaskFailed(format!("durable step failed: {e}")))
+        let step_result = ctx
+            .step(desc, |_handle| async move {
+                fire().await.map_err(|e| StepError::new(e.to_string()))
+            })
+            .await;
+
+        // One execution per fire (keyed on job+slot, never revisited once the slot has passed),
+        // so it is finalized right after the step settles — otherwise the retention sweep could
+        // never reclaim these rows (#6251): `finalized_at` would stay NULL forever. Finalizing is
+        // best-effort: its own failure only logs and does not shadow the step's own error.
+        let terminal_status = if step_result.is_ok() {
+            ExecutionStatus::Completed
+        } else {
+            ExecutionStatus::Failed
+        };
+        if let Err(finalize_err) = ctx.finalize(terminal_status).await {
+            tracing::warn!(
+                error = %finalize_err,
+                job = job_name,
+                slot_ms,
+                "sched.durable.fire: failed to finalize scheduled-job execution"
+            );
+        }
+
+        step_result.map_err(|e| SchedulerError::TaskFailed(format!("durable step failed: {e}")))
     }
     .instrument(span)
     .await
@@ -264,13 +288,42 @@ mod tests {
         }
 
         async fn make_adapter() -> (SchedulerDurableAdapter, tokio::task::JoinHandle<()>) {
+            let (_local, adapter, task) = make_adapter_with_local(fast_config()).await;
+            (adapter, task)
+        }
+
+        /// Like `make_adapter`, but also returns the raw `LocalBackend` (so a test can read
+        /// `durable_executions` directly) and accepts a config, so a test can force a step to fail
+        /// by capping `max_payload_bytes` below the encoded step-result size.
+        async fn make_adapter_with_local(
+            config: DurableConfig,
+        ) -> (
+            Arc<LocalBackend>,
+            SchedulerDurableAdapter,
+            tokio::task::JoinHandle<()>,
+        ) {
             let local = Arc::new(LocalBackend::open(":memory:", 1_048_576).await.unwrap());
             local.init().await.unwrap();
             let backend = Arc::new(DurableBackendEnum::Local(local.clone()));
-            let cfg = Arc::new(fast_config());
-            let (writer, handle) = JournalWriter::new(local, &cfg);
+            let cfg = Arc::new(config);
+            let (writer, handle) = JournalWriter::new(local.clone(), &cfg);
             let task = tokio::spawn(writer.run()); // EXEMPT: test-only helper
-            (SchedulerDurableAdapter::new(backend, handle, cfg), task)
+            (
+                local,
+                SchedulerDurableAdapter::new(backend, handle, cfg),
+                task,
+            )
+        }
+
+        async fn execution_status(local: &LocalBackend, exec: ExecutionId) -> String {
+            let (status,): (String,) = zeph_db::query_as(zeph_db::sql!(
+                "SELECT status FROM durable_executions WHERE execution_id = ?"
+            ))
+            .bind(exec.as_uuid().to_string())
+            .fetch_one(local.pool())
+            .await
+            .unwrap();
+            status
         }
 
         /// First fire executes the closure and journals the result.
@@ -332,6 +385,43 @@ mod tests {
                 2,
                 "different slot_ms must produce a separate execution and run"
             );
+        }
+
+        #[tokio::test]
+        async fn fire_with_durable_finalizes_the_execution_as_completed() {
+            // #6251: fire_with_durable must finalize its one-shot execution on success, otherwise
+            // the retention sweep can never reclaim it (`finalized_at` stays NULL forever).
+            let (local, adapter, _task) = make_adapter_with_local(fast_config()).await;
+
+            fire_with_durable(&adapter, "test-job", 1_000, || async { Ok(()) })
+                .await
+                .unwrap();
+
+            let exec = derive_execution_id("test-job", 1_000);
+            assert_eq!(execution_status(&local, exec).await, "completed");
+        }
+
+        #[tokio::test]
+        async fn fire_with_durable_finalizes_the_execution_as_failed_on_fire_error() {
+            // #6251: when the caller's fire body itself fails, the execution must finalize as
+            // `Failed` rather than being left `running` forever, while the original error is still
+            // propagated to the caller.
+            let (local, adapter, _task) = make_adapter_with_local(fast_config()).await;
+
+            let err = fire_with_durable(&adapter, "test-job", 1_000, || async {
+                Err(SchedulerError::TaskFailed("boom".to_string()))
+            })
+            .await
+            .expect_err("the fire body's error must propagate");
+            // The step-failure message is metadata-only by design (INV-5) — the closure's own
+            // error detail is attached as the `source`, not inlined into `Display`.
+            assert!(
+                matches!(&err, SchedulerError::TaskFailed(_)),
+                "unexpected error: {err:?}"
+            );
+
+            let exec = derive_execution_id("test-job", 1_000);
+            assert_eq!(execution_status(&local, exec).await, "failed");
         }
     }
 }

--- a/crates/zeph-scheduler/src/error.rs
+++ b/crates/zeph-scheduler/src/error.rs
@@ -36,7 +36,7 @@ pub enum SchedulerError {
     /// Another `zeph serve` instance is already running with the given PID.
     ///
     /// Returned by [`crate::PidFile::acquire`] when the pid file is locked by another process.
-    #[cfg(unix)]
+    #[cfg(all(unix, feature = "daemon"))]
     #[error(
         "daemon pid file is locked: another zeph serve instance appears to be running (pid {pid})"
     )]


### PR DESCRIPTION
## Summary

`zeph-durable`'s retention/TTL prune sweep is gated on `durable_executions.status IN
('completed','failed','aborted') AND finalized_at <= cutoff`, but in production `finalize()` was
only ever called with `ExecutionStatus::Aborted` (on replay divergence). No consumer ever called
`finalize(Completed)` on success or `finalize(Failed)` on unrecoverable failure, so
`durable_executions.status` stayed `'running'` forever and the prune sweep could never reclaim any
row.

This PR wires `finalize` into every production execution-scoping model:

- **zeph-orchestration** (`journal_budget`) and **zeph-scheduler** (`fire_with_durable`): both are
  one-shot executions finalized `Completed`/`Failed` right after their single step settles.
- **zeph-core** (`AgentTurn`, per-conversation execution, #5452): finalized `Completed` at its two
  natural detach points, graceful shutdown and conversation switch (`/new`, `/conv resume`,
  `/conv fork`). A later resume of the same conversation reopens and un-finalizes the row
  automatically, so nothing is lost.
- **zeph-subagent**: no change needed, subagents journal into the parent AgentTurn's execution and
  have no execution of their own (verified: every `open_execution`/`DurableContext::new` call in
  that crate is test-only).

To make this safe, `zeph-durable` itself gained:

- An idempotency guard on `finalize` (`AND status = 'running'`), so a caller's own
  `Completed`/`Failed` racing the internal divergence-triggered `Aborted` transition can't clobber
  whichever commits first.
- Reopening a `completed`/`failed` row (e.g. a resumed conversation, a same-slot scheduler retry)
  now un-finalizes it back to `running`, clearing `finalized_at`, so the retention sweep can't prune
  a row that's actively being reused. This reopen is a single guarded `UPDATE` (no preceding read),
  and `delete_prune_batch`'s candidate-selection now runs inside the same write transaction as its
  deletes (plus a `SELECT ... FOR UPDATE` on Postgres), closing a TOCTOU window between "select
  prunable rows" and "delete them" that could otherwise race a legitimate reopen.
- `DurableError::StepCapExceeded` (the hard step-cap) now finalizes the execution `Aborted`
  in-crate — this was already the documented contract (`specs/064-durable-execution/spec.md`,
  "the execution is aborted with `DurableError::StepCapExceeded`") but nothing previously enacted
  it.
- The shutdown and conversation-switch finalize calls are bounded by the same 2s timeout as the
  sibling journal-writer flush calls, so shutdown's documented latency bound stays accurate.

## Known residual gap (NOT fixed by this PR)

An execution that ends via an **ungraceful process exit** (SIGKILL, panic, OOM, power loss) still
has no path to `finalize()` — if the conversation/job it belongs to is never resumed, its row stays
`running` forever. This is a genuinely separate feature (a periodic staleness sweep of abandoned
`running` executions past some inactivity threshold), not a wiring gap, and is intentionally out of
scope here. A follow-up issue will be filed to track it.

## Unrelated change bundled into this branch

`crates/zeph-scheduler/src/error.rs`: `SchedulerError::AlreadyRunning`'s `#[cfg(unix)]` was widened
to `#[cfg(all(unix, feature = "daemon"))]`. This is a pre-existing, unrelated bug — the variant's
doc comment references `crate::PidFile::acquire`, but `PidFile` and its re-export are gated on
`unix + feature = "daemon"` at the module level, while the variant itself was only gated on `unix`.
Without `daemon`, the doc link is broken and fails the rustdoc gate. One-line fix, opportunistically
folded in while fixing the rustdoc gate for this PR's own changes.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo clippy --profile ci -p zeph-durable --all-targets --no-default-features --features postgres -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13598 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo test --doc -p zeph-durable --features sqlite` — 35 passed
- [x] `cargo check -p zeph-durable --no-default-features --features postgres`
- [x] 10 new regression tests, including a genuine concurrent two-task race test (prune vs. reopen) and a real timeout-bound test under write-lock contention

Closes #6251