### PR TITLE
fix(tui): wire TaskSupervisor into phase-2 startup, add t task-panel toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   functions the subcommand arms call — no duplicated business logic. `--in-place`/`--diff` now
   `requires = "migrate_config"`, so using them without `--migrate-config` is a clean clap error
   instead of silently falling through to the interactive agent (#6277).
+- **TUI**: the task registry panel (`/tasks` or the `t` key) always showed "supervisor not
+  available" on the default `--tui` launch path. The two-phase/early-start TUI startup
+  (`run_tui_agent` in `src/tui_bridge.rs`) forwarded the cancel signal and metrics channel
+  into the running `App` via `AgentEvent`, but never the `TaskSupervisor` handle — only the
+  legacy (dead-in-practice) startup path wired it correctly via `App::with_task_supervisor`.
+  Fixed by adding `AgentEvent::SetTaskSupervisor` and forwarding it alongside the existing
+  `SetCancelSignal`/`SetMetricsRx` sends. Also wired the `t` keybinding to the previously
+  unreachable `Action::ToggleTaskPanel` (#6276).
 - **Docs**: fixed 11 stale Claude model ID examples across 5 mdBook pages (`acp.md`,
   `sub-agents.md`, `experiments.md`, `wizard.md`, `configuration.md`) that still used the
   outdated `claude-sonnet-4-5`/`claude-sonnet-4-20250514` naming (incorrectly pairing the

--- a/crates/zeph-common/src/task_supervisor.rs
+++ b/crates/zeph-common/src/task_supervisor.rs
@@ -355,6 +355,15 @@ pub struct TaskSupervisor {
     inner: Arc<Inner>,
 }
 
+impl std::fmt::Debug for TaskSupervisor {
+    /// Prints a stable placeholder rather than task internals (factory closures
+    /// inside `TaskEntry` are not `Debug`); callers needing task details should
+    /// use [`TaskSupervisor::snapshot`] instead.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TaskSupervisor").finish_non_exhaustive()
+    }
+}
+
 impl TaskSupervisor {
     /// Create a new supervisor and start its reap driver.
     ///

--- a/crates/zeph-tui/src/app/events.rs
+++ b/crates/zeph-tui/src/app/events.rs
@@ -235,6 +235,9 @@ impl App {
             AgentEvent::SetMetricsRx(rx) => {
                 self.set_metrics_rx(rx);
             }
+            AgentEvent::SetTaskSupervisor(supervisor) => {
+                self.set_task_supervisor(supervisor);
+            }
             AgentEvent::ForegroundSubagentStarted { id, name } => {
                 self.sessions.current_mut().status_label =
                     Some(format!("Sub-agent '{name}' running..."));

--- a/crates/zeph-tui/src/app/keys.rs
+++ b/crates/zeph-tui/src/app/keys.rs
@@ -820,6 +820,7 @@ impl App {
             KeyCode::Char('D') => Some(Action::SetActivePanel(Panel::Durable)),
             KeyCode::Char('S') => Some(Action::SetActivePanel(Panel::Settings)),
             KeyCode::Char('a') => Some(Action::SetActivePanel(Panel::SubAgents)),
+            KeyCode::Char('t') => Some(Action::ToggleTaskPanel),
             KeyCode::Char('o') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 Some(Action::CopyLastAssistant)
             }
@@ -1411,6 +1412,16 @@ mod tests {
         let action = app.decode_key(plain_key('f'));
 
         assert_eq!(action, Some(Action::SetActivePanel(Panel::Fleet)));
+    }
+
+    #[test]
+    fn plain_t_in_normal_mode_toggles_task_panel() {
+        let (mut app, _user_rx, _agent_tx) = make_app();
+        app.sessions.current_mut().input_mode = InputMode::Normal;
+
+        let action = app.decode_key(plain_key('t'));
+
+        assert_eq!(action, Some(Action::ToggleTaskPanel));
     }
 
     #[test]

--- a/crates/zeph-tui/src/app/state.rs
+++ b/crates/zeph-tui/src/app/state.rs
@@ -654,6 +654,15 @@ impl App {
         self
     }
 
+    /// Wire a [`TaskSupervisor`] into a running App instance.
+    ///
+    /// Used by the two-phase TUI startup path to connect the supervisor after
+    /// early startup (Phase 2), mirroring [`App::set_cancel_signal`] and
+    /// [`App::set_metrics_rx`] so the task registry panel works on that path too.
+    pub fn set_task_supervisor(&mut self, supervisor: TaskSupervisor) {
+        self.task_supervisor = Some(supervisor);
+    }
+
     /// Refresh the cached task snapshot from the supervisor.
     ///
     /// Must be called once per render tick **before** `terminal.draw()` to avoid

--- a/crates/zeph-tui/src/app/tests.rs
+++ b/crates/zeph-tui/src/app/tests.rs
@@ -2695,6 +2695,41 @@ async fn supervisor_activity_label_multiple_tasks_shows_more() {
     cancel.cancel();
 }
 
+#[tokio::test]
+async fn set_task_supervisor_event_wires_supervisor_for_phase2_startup() {
+    // Regression for #6276: the phase-2 (early-start) TUI path forwards the
+    // TaskSupervisor via AgentEvent::SetTaskSupervisor rather than the
+    // App::with_task_supervisor builder used by the legacy path.
+    use zeph_common::task_supervisor::{RestartPolicy, TaskDescriptor, TaskSupervisor};
+
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let sup = TaskSupervisor::new(cancel.clone());
+    sup.spawn(TaskDescriptor {
+        name: "phase2-task",
+        restart: RestartPolicy::RunOnce,
+        factory: || async { std::future::pending::<()>().await },
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+    let (mut app, _rx, _tx) = make_app();
+    assert!(app.task_supervisor.is_none());
+
+    app.handle_agent_event(AgentEvent::SetTaskSupervisor(sup));
+    app.refresh_task_snapshots();
+
+    let label = app.supervisor_activity_label();
+    assert!(
+        label.is_some(),
+        "expected Some label after wiring via event"
+    );
+    assert!(
+        label.as_deref().unwrap().contains("phase2-task"),
+        "label should contain task name: {label:?}"
+    );
+
+    cancel.cancel();
+}
+
 #[test]
 fn paste_inserts_text_in_insert_mode() {
     let (mut app, _rx, _tx) = make_app();

--- a/crates/zeph-tui/src/event.rs
+++ b/crates/zeph-tui/src/event.rs
@@ -231,6 +231,10 @@ pub enum AgentEvent {
     SetCancelSignal(Arc<Notify>),
     /// Wire a metrics receiver into the TUI App after early startup (Phase 2).
     SetMetricsRx(watch::Receiver<MetricsSnapshot>),
+    /// Wire a [`zeph_common::task_supervisor::TaskSupervisor`] into the TUI App after
+    /// early startup (Phase 2), so the task registry panel reflects live task state
+    /// instead of reporting "supervisor not available".
+    SetTaskSupervisor(zeph_common::task_supervisor::TaskSupervisor),
     /// A foreground subagent has been spawned; the TUI should switch view to its transcript.
     ForegroundSubagentStarted {
         /// Stable sub-agent identifier (`task_id` from `SubAgentManager`).

--- a/src/tui_bridge.rs
+++ b/src/tui_bridge.rs
@@ -335,6 +335,11 @@ pub(crate) async fn run_tui_agent<C: Channel + 'static>(
                 .agent_tx
                 .try_send(zeph_tui::AgentEvent::SetMetricsRx(metrics_rx));
         }
+        if let Some(task_supervisor) = params.task_supervisor.take() {
+            let _ = early
+                .agent_tx
+                .try_send(zeph_tui::AgentEvent::SetTaskSupervisor(task_supervisor));
+        }
         (early.tui_done, early.agent_tx)
     } else {
         // Legacy path: TUI hasn't started yet, create App and spawn its thread now.


### PR DESCRIPTION
## Summary

- The phase-2/early-start TUI startup path in `run_tui_agent` (`src/tui_bridge.rs`) forwarded the cancel signal and metrics channel into the running `App` via `AgentEvent`, but never the `TaskSupervisor` handle — only the legacy (dead-in-practice) startup path wired it correctly via `App::with_task_supervisor`. Since `early_tui_guard` is unconditionally `Some(...)` for every real `--tui` launch, the phase-2 path is the only one that ever runs, so the task registry panel always showed "supervisor not available".
- Added `AgentEvent::SetTaskSupervisor(TaskSupervisor)` and forward it alongside the existing `SetCancelSignal`/`SetMetricsRx` sends, handled via new `App::set_task_supervisor`.
- Wired the previously-dead `t` keybinding to `Action::ToggleTaskPanel` (a reducer arm and test already existed asserting this shortcut, but no key ever dispatched it).

Closes #6276

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (13601 passed, 0 failed)
- [x] rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace ...`)
- [x] `cargo test --doc` on touched crates
- [x] Live `--tui` verification via tmux pty: confirmed the `/tasks` command palette entry now shows live task rows (e.g. `core.config_watcher`, `mcp.refresh_task`, `mem-consolidation`) instead of "supervisor not available", and the `t` keybinding correctly toggles the panel
- [x] Sanity `cargo check --features full --all-targets` after rebasing onto latest `main`