### PR TITLE
fix(security): reject empty-string bearer/vault tokens across ACP and shared auth middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   Fixed by adding `AgentEvent::SetTaskSupervisor` and forwarding it alongside the existing
   `SetCancelSignal`/`SetMetricsRx` sends. Also wired the `t` keybinding to the previously
   unreachable `Action::ToggleTaskPanel` (#6276).
+- **Security (auth)**: `AuthConfig::new` (`zeph-common`'s shared bearer-auth middleware, used
+  by `zeph-gateway`, `zeph-a2a`, and `zeph serve-sessions`) hashed a configured token without
+  checking for emptiness, so a vault-resolved secret that resolved to `""` produced a valid
+  `Some(blake3::hash(b""))`. `auth_middleware` defaults a request's submitted token to `""`
+  whenever no `Authorization` header is present, so that empty-vs-empty hash comparison
+  matched — silently authenticating every unauthenticated request instead of rejecting them
+  or letting `require_auth` reject them outright. Fixed by treating an empty token the same as
+  `None` in `AuthConfig::new`, checking non-emptiness (not `is_some()`/`is_none()`) at the
+  `zeph-gateway` startup-warning and `zeph serve-sessions` bind-refusal guard call sites, and
+  skipping the `ZEPH_A2A_AUTH_TOKEN`/`ZEPH_GATEWAY_TOKEN` vault-hydration assignment in
+  `zeph-core`'s config resolver when the resolved secret is an empty string (#6268).
+- **Security (ACP auth)**: `resolve_acp_auth_clients` pushed a `[[acp.auth_clients]]` entry's
+  vault-resolved token straight into the client list with no non-emptiness check, so a vault
+  secret resolving to `""` produced an `AcpClientToken` with `token: ""`. `zeph-acp`'s bearer
+  middleware hashes tokens independently of the shared `AuthConfig` primitive, so it was not
+  covered by the `AuthConfig::new` fix above: a request with `Authorization: Bearer ` (empty
+  presented token) hashed to `blake3::hash(b"")` and matched the empty-token client. Fixed by
+  treating an empty/whitespace-only vault-resolved token the same as a missing one (warn and
+  skip) in `resolve_acp_auth_clients`, plus a defense-in-depth filter in `zeph-acp`'s
+  `BearerAuthLayer::new` that drops any client constructed with an empty or whitespace-only
+  token regardless of caller. Additionally, when *every* configured `auth_token`/
+  `auth_clients` entry fails to resolve (leaving the client set empty), `resolve_acp_auth_clients`
+  now fails startup instead of silently falling back to the empty-list state that
+  `zeph_acp::transport::router` treats as intentionally unauthenticated — a declared-but-
+  unresolvable auth configuration must never downgrade to "fully public" (#6270).
 - **Docs**: fixed 11 stale Claude model ID examples across 5 mdBook pages (`acp.md`,
   `sub-agents.md`, `experiments.md`, `wizard.md`, `configuration.md`) that still used the
   outdated `claude-sonnet-4-5`/`claude-sonnet-4-20250514` naming (incorrectly pairing the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10799,6 +10799,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
+ "tower 0.5.3",
  "tracing",
  "tree-sitter",
  "tree-sitter-bash",

--- a/crates/zeph-a2a/src/server/mod.rs
+++ b/crates/zeph-a2a/src/server/mod.rs
@@ -231,7 +231,7 @@ impl A2aServer {
     /// Returns [`A2aError::Server`] if the TCP listener fails to
     /// bind or if the axum server encounters a fatal I/O error during operation.
     pub async fn serve(self) -> Result<(), A2aError> {
-        if self.auth_cfg.token_hash.is_none() {
+        if !self.auth_cfg.is_token_configured() {
             tracing::warn!(
                 "A2A server running without bearer auth — ensure this is a trusted-network-only deployment"
             );

--- a/crates/zeph-acp/src/transport/auth.rs
+++ b/crates/zeph-acp/src/transport/auth.rs
@@ -41,7 +41,26 @@ pub(crate) struct BearerAuthLayer {
 }
 
 impl BearerAuthLayer {
+    /// Constructs the layer from `clients`, dropping any entry whose `token` is empty or
+    /// whitespace-only.
+    ///
+    /// An empty token would hash to `blake3::hash(b"")` and match a request presenting
+    /// `Authorization: Bearer ` (empty bearer value) — this is the last line of defense
+    /// against that bypass, independent of whatever validated the tokens upstream (#6270).
+    /// Trims before checking (F5) to stay consistent with `resolve_acp_auth_clients`'s
+    /// existing `!t.trim().is_empty()` check — a whitespace-only token is as weak a secret
+    /// as an empty one, even though it does not collide with the missing-header default.
     pub(crate) fn new(clients: Vec<AcpClientToken>) -> Self {
+        let clients = clients
+            .into_iter()
+            .filter(|c| {
+                let keep = !c.token.trim().is_empty();
+                if !keep {
+                    tracing::warn!(id = %c.id, "BearerAuthLayer: dropping client with empty token");
+                }
+                keep
+            })
+            .collect();
         Self {
             clients: Arc::new(clients),
         }
@@ -197,6 +216,26 @@ mod tests {
         let (status_b, body_b) = send(app, Some("Bearer token-b")).await;
         assert_eq!(status_b, StatusCode::OK);
         assert_eq!(body_b, "bob");
+    }
+
+    #[tokio::test]
+    async fn empty_configured_token_client_is_dropped_and_never_matches() {
+        // #6270: a client constructed with an empty token must not be reachable via an
+        // empty presented bearer value (`Authorization: Bearer `), which would otherwise
+        // hash-match `blake3::hash(b"")` on both sides.
+        let app = app_with_clients(vec![client("bad", ""), client("default", "my-secret")]);
+        assert_eq!(send(app, Some("Bearer ")).await.0, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn whitespace_only_configured_token_client_is_dropped() {
+        // #6270 F5: a whitespace-only token is as weak a secret as an empty one — trimmed
+        // the same way `resolve_acp_auth_clients` already trims vault-resolved tokens.
+        let app = app_with_clients(vec![client("bad", "   "), client("default", "my-secret")]);
+        assert_eq!(
+            send(app, Some("Bearer    ")).await.0,
+            StatusCode::UNAUTHORIZED
+        );
     }
 
     #[tokio::test]

--- a/crates/zeph-common/Cargo.toml
+++ b/crates/zeph-common/Cargo.toml
@@ -69,6 +69,7 @@ regex.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
+tower = { workspace = true, features = ["util"] }
 
 [lints]
 workspace = true

--- a/crates/zeph-common/src/http_middleware.rs
+++ b/crates/zeph-common/src/http_middleware.rs
@@ -64,7 +64,13 @@ pub const RATE_WINDOW: Duration = Duration::from_mins(1);
 #[derive(Clone)]
 pub struct AuthConfig {
     /// BLAKE3 hash of the configured bearer token, or `None` when no token is set.
-    pub token_hash: Option<blake3::Hash>,
+    ///
+    /// Private (not `pub`): the empty-token-normalizes-to-`None` invariant established by
+    /// [`AuthConfig::new`] (#6268) must hold for every `AuthConfig` in existence — a `pub`
+    /// field would let a future caller construct one via struct-literal syntax with
+    /// `token_hash: Some(blake3::hash(b""))`, silently reintroducing the bypass `new`
+    /// exists to prevent. Read via [`AuthConfig::is_token_configured`].
+    token_hash: Option<blake3::Hash>,
     /// When `true`, requests are rejected even if no token is configured.
     ///
     /// Useful for A2A servers that must enforce authentication at the config level.
@@ -77,9 +83,15 @@ impl AuthConfig {
     /// If `token` is `None` and `require_auth` is `false`, all requests pass through.
     /// If `token` is `None` and `require_auth` is `true`, all requests are rejected with 401.
     ///
+    /// An empty or whitespace-only `token` is treated the same as `None` (#6268): otherwise a
+    /// misconfigured or blank vault-resolved secret would hash to a fixed digest that a
+    /// request with no `Authorization` header also hashes to (`auth_middleware` defaults the
+    /// submitted token to `""`) — silently granting every unauthenticated request full access
+    /// instead of rejecting or requiring `require_auth` to gate it.
+    ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use zeph_common::http_middleware::AuthConfig;
     ///
     /// // Auth enabled with a token
@@ -87,13 +99,38 @@ impl AuthConfig {
     ///
     /// // Require auth even without a configured token (rejects all requests)
     /// let cfg_strict = AuthConfig::new(None, true);
+    ///
+    /// // An empty token is treated as unset, not as a valid "" secret
+    /// let cfg_empty = AuthConfig::new(Some(""), false);
+    /// assert!(!cfg_empty.is_token_configured());
     /// ```
     #[must_use]
     pub fn new(token: Option<&str>, require_auth: bool) -> Self {
         Self {
-            token_hash: token.map(|t| blake3::hash(t.as_bytes())),
+            token_hash: token
+                .filter(|t| !t.trim().is_empty())
+                .map(|t| blake3::hash(t.as_bytes())),
             require_auth,
         }
+    }
+
+    /// Returns `true` when a non-empty bearer token was configured.
+    ///
+    /// Useful for startup-time warnings/guards that need to know whether auth is active
+    /// without re-deriving the empty-string normalization `new` already applied.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_common::http_middleware::AuthConfig;
+    ///
+    /// assert!(AuthConfig::new(Some("secret"), false).is_token_configured());
+    /// assert!(!AuthConfig::new(Some(""), false).is_token_configured());
+    /// assert!(!AuthConfig::new(None, false).is_token_configured());
+    /// ```
+    #[must_use]
+    pub fn is_token_configured(&self) -> bool {
+        self.token_hash.is_some()
     }
 }
 
@@ -256,7 +293,7 @@ impl RateLimitState {
 
 /// Axum middleware that enforces bearer-token authentication.
 ///
-/// When [`AuthConfig::token_hash`] is `Some`, the request must carry
+/// When [`AuthConfig::is_token_configured`] is `true`, the request must carry
 /// `Authorization: Bearer <token>` whose BLAKE3 hash matches the pre-computed digest.
 /// Comparison uses [`ConstantTimeEq`] on two 32-byte arrays — constant time regardless
 /// of token content, preventing timing-oracle attacks.
@@ -473,7 +510,7 @@ mod tests {
     #[test]
     fn auth_config_new_hashes_token() {
         let cfg = AuthConfig::new(Some("secret"), false);
-        assert!(cfg.token_hash.is_some());
+        assert!(cfg.is_token_configured());
         assert!(!cfg.require_auth);
         let expected = blake3::hash(b"secret");
         assert_eq!(cfg.token_hash.unwrap(), expected);
@@ -482,8 +519,99 @@ mod tests {
     #[test]
     fn auth_config_new_none_token() {
         let cfg = AuthConfig::new(None, true);
-        assert!(cfg.token_hash.is_none());
+        assert!(!cfg.is_token_configured());
         assert!(cfg.require_auth);
+    }
+
+    #[test]
+    fn auth_config_new_empty_token_treated_as_unset() {
+        // #6268: an empty configured token must not become a valid "" secret that a
+        // request with no Authorization header (which also submits "") can match.
+        let cfg = AuthConfig::new(Some(""), false);
+        assert!(!cfg.is_token_configured());
+    }
+
+    #[test]
+    fn auth_config_new_whitespace_only_token_treated_as_unset() {
+        // #6268 F5: whitespace-only tokens must be trimmed the same way empty ones are —
+        // otherwise " " would be accepted as a "valid" weak secret instead of being
+        // normalized to unset like the rest of the empty-token handling.
+        let cfg = AuthConfig::new(Some("   "), false);
+        assert!(!cfg.is_token_configured());
+    }
+
+    /// Route handler reflects the `AuthIdentity` the middleware inserted, so tests can
+    /// distinguish "passed through because auth is off" from "passed through because it
+    /// was (wrongly) considered authenticated".
+    fn identity_app(cfg: AuthConfig) -> axum::Router {
+        axum::Router::new()
+            .route(
+                "/",
+                axum::routing::get(
+                    |axum::extract::Extension(id): axum::extract::Extension<AuthIdentity>| async move {
+                        id.authenticated.to_string()
+                    },
+                ),
+            )
+            .layer(axum::middleware::from_fn_with_state(cfg, auth_middleware))
+    }
+
+    async fn send(app: axum::Router, auth: Option<&str>) -> (StatusCode, String) {
+        use tower::ServiceExt as _;
+
+        let mut builder = axum::http::Request::builder().method("GET").uri("/");
+        if let Some(v) = auth {
+            builder = builder.header("authorization", v);
+        }
+        let req = builder.body(Body::empty()).unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let status = resp.status();
+        let body = axum::body::to_bytes(resp.into_body(), 64).await.unwrap();
+        (status, String::from_utf8_lossy(&body).into_owned())
+    }
+
+    #[tokio::test]
+    async fn empty_configured_token_with_require_auth_never_authenticates() {
+        // #6268: pre-fix, `AuthConfig::new(Some(""), _)` hashed to `blake3::hash(b"")`,
+        // which a request with no Authorization header (submitted token defaults to "")
+        // or an empty `Bearer ` also hashed to — matching and marking the request
+        // `authenticated: true` despite the caller presenting no real credential.
+        let cfg = AuthConfig::new(Some(""), false);
+        let app = identity_app(cfg.clone());
+        let (status, body) = send(app, None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body, "false",
+            "missing-header request must not read as authenticated"
+        );
+
+        let app = identity_app(cfg);
+        let (status, body) = send(app, Some("Bearer ")).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body, "false",
+            "empty bearer request must not read as authenticated"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_configured_token_with_require_auth_true_rejects_all_requests() {
+        // With require_auth=true, an empty token must behave exactly like no token at all:
+        // reject every request with 401, never silently authenticate via an empty-vs-empty
+        // hash match.
+        let cfg = AuthConfig::new(Some(""), true);
+        let app = identity_app(cfg.clone());
+        assert_eq!(send(app, None).await.0, StatusCode::UNAUTHORIZED);
+
+        let app = identity_app(cfg);
+        assert_eq!(send(app, Some("Bearer ")).await.0, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn real_token_still_rejects_missing_header() {
+        let cfg = AuthConfig::new(Some("secret"), false);
+        let app = identity_app(cfg);
+        assert_eq!(send(app, None).await.0, StatusCode::UNAUTHORIZED);
     }
 
     #[test]

--- a/crates/zeph-core/src/config.rs
+++ b/crates/zeph-core/src/config.rs
@@ -185,8 +185,17 @@ impl SecretResolver for Config {
             tg.token = Some(val);
         }
         if let Some(val) = vault.get_secret("ZEPH_A2A_AUTH_TOKEN").await? {
-            register_masked_secret(registry, "ZEPH_A2A_AUTH_TOKEN", &val);
-            self.a2a.auth_token = Some(val);
+            // #6268: an empty-string secret must be treated as "not configured", not as a
+            // valid "" bearer token that `AuthConfig`/`auth_middleware` would otherwise
+            // (pre-fix) accept from any request with no Authorization header at all.
+            if val.is_empty() {
+                tracing::warn!(
+                    "ZEPH_A2A_AUTH_TOKEN resolved to an empty string; treating as not configured"
+                );
+            } else {
+                register_masked_secret(registry, "ZEPH_A2A_AUTH_TOKEN", &val);
+                self.a2a.auth_token = Some(val);
+            }
         }
         for entry in &self.llm.providers {
             if entry.provider_type == crate::config::ProviderKind::Compatible
@@ -214,8 +223,16 @@ impl SecretResolver for Config {
             }
         }
         if let Some(val) = vault.get_secret("ZEPH_GATEWAY_TOKEN").await? {
-            register_masked_secret(registry, "ZEPH_GATEWAY_TOKEN", &val);
-            self.gateway.auth_token = Some(val);
+            // #6268: same rationale as ZEPH_A2A_AUTH_TOKEN above — an empty secret is
+            // "not configured", not a valid "" bearer token.
+            if val.is_empty() {
+                tracing::warn!(
+                    "ZEPH_GATEWAY_TOKEN resolved to an empty string; treating as not configured"
+                );
+            } else {
+                register_masked_secret(registry, "ZEPH_GATEWAY_TOKEN", &val);
+                self.gateway.auth_token = Some(val);
+            }
         }
         if let Some(val) = vault.get_secret("ZEPH_DATABASE_URL").await? {
             register_masked_secret(registry, "ZEPH_DATABASE_URL", &val);
@@ -390,5 +407,31 @@ mod tests {
             config.secrets.openai_api_key.as_ref().unwrap().expose(),
             "sk-openai-abc"
         );
+    }
+
+    #[tokio::test]
+    #[cfg(any(test, feature = "mock"))]
+    async fn resolve_secrets_empty_gateway_token_treated_as_not_configured() {
+        use crate::vault::MockVaultProvider;
+
+        // #6268: an empty-string ZEPH_GATEWAY_TOKEN must not become `Some("")` — that would
+        // let AuthConfig hash "" and accept any request with no Authorization header at all.
+        let vault = MockVaultProvider::new().with_secret("ZEPH_GATEWAY_TOKEN", "");
+        let mut config = Config::load(std::path::Path::new("/nonexistent/config.toml")).unwrap();
+        config.resolve_secrets(&vault).await.unwrap();
+
+        assert!(config.gateway.auth_token.is_none());
+    }
+
+    #[tokio::test]
+    #[cfg(any(test, feature = "mock"))]
+    async fn resolve_secrets_empty_a2a_token_treated_as_not_configured() {
+        use crate::vault::MockVaultProvider;
+
+        let vault = MockVaultProvider::new().with_secret("ZEPH_A2A_AUTH_TOKEN", "");
+        let mut config = Config::load(std::path::Path::new("/nonexistent/config.toml")).unwrap();
+        config.resolve_secrets(&vault).await.unwrap();
+
+        assert!(config.a2a.auth_token.is_none());
     }
 }

--- a/crates/zeph-gateway/src/server.rs
+++ b/crates/zeph-gateway/src/server.rs
@@ -310,7 +310,10 @@ impl GatewayServer {
             webhook_send_timeout: self.webhook_send_timeout,
         };
 
-        if self.auth_token.is_none() {
+        // Non-emptiness, not `is_none()` (#6268): a vault-resolved token that resolves to an
+        // empty string must trigger this warning the same as no token at all — `Some("")`
+        // used to silently suppress it while `AuthConfig` (correctly) rejects every request.
+        if self.auth_token.as_deref().is_none_or(str::is_empty) {
             tracing::warn!(
                 "gateway running without bearer auth — ensure firewall or upstream proxy enforces access control"
             );

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -43,7 +43,12 @@ fn resolve_runtime_path(path: &std::path::Path, cwd: &std::path::Path) -> std::p
 /// # Errors
 ///
 /// Returns an error if two configured clients (across `auth_token` and `auth_clients`,
-/// inline or vault-resolved) end up with the same resolved token.
+/// inline or vault-resolved) end up with the same resolved token. Also returns an error
+/// (rather than starting with authentication silently disabled) when `acp_config` declared
+/// `auth_token` and/or `auth_clients` but every one of them failed to resolve — a missing
+/// vault key, an empty vault secret, or a vault backend error emptying the *entire* declared
+/// set must fail startup, not silently fall back to the "no auth configured" empty-list state
+/// that `zeph_acp::transport::router` treats as intentionally public (#6270 F3).
 #[cfg(any(feature = "acp", feature = "acp-http"))]
 async fn resolve_acp_auth_clients(
     acp_config: &zeph_config::AcpConfig,
@@ -65,7 +70,14 @@ async fn resolve_acp_auth_clients(
             Some(t.clone())
         } else if let Some(ref key) = client.token_vault_key {
             match vault.get_secret(key).await {
-                Ok(Some(t)) => Some(t),
+                Ok(Some(t)) if !t.trim().is_empty() => Some(t),
+                Ok(Some(_)) => {
+                    tracing::warn!(
+                        id = %client.id, vault_key = %key,
+                        "acp.auth_clients: vault key resolved to an empty token; client disabled"
+                    );
+                    None
+                }
                 Ok(None) => {
                     tracing::warn!(
                         id = %client.id, vault_key = %key,
@@ -100,6 +112,23 @@ async fn resolve_acp_auth_clients(
             token,
         });
     }
+
+    // #6270 F3: an operator who configured `auth_token`/`auth_clients` intended
+    // authentication to be active. If every entry failed to resolve (bad vault key, empty
+    // vault secret, or backend error), the empty `Vec` this function would otherwise return
+    // is indistinguishable from "no auth was configured at all" — and
+    // `zeph_acp::transport::router` treats an empty `auth_clients` list as intentionally
+    // public, serving session-history endpoints with no auth layer at all (only a `warn!`).
+    // Fail startup instead of silently downgrading to fully public.
+    let auth_declared = acp_config.auth_token.is_some() || !acp_config.auth_clients.is_empty();
+    anyhow::ensure!(
+        !auth_declared || !clients.is_empty(),
+        "[acp] auth_token / [[acp.auth_clients]] configured authentication, but every entry \
+         failed to resolve (missing vault key, empty vault secret, or vault backend error) — \
+         refusing to start with authentication silently disabled. Fix the vault key(s), or \
+         remove the auth_token/auth_clients configuration entirely to run intentionally \
+         without authentication."
+    );
 
     Ok(clients)
 }
@@ -2963,6 +2992,77 @@ mod tests {
         let clients = resolve_acp_auth_clients(&cfg, &vault).await.unwrap();
         assert_eq!(clients.len(), 1);
         assert_eq!(clients[0].id, "bob");
+    }
+
+    #[tokio::test]
+    async fn resolve_acp_auth_clients_empty_vault_token_soft_disables_client() {
+        // #6270: a vault key resolving to "" must be treated the same as a missing key
+        // (Ok(None)), not pushed through as a live client whose token is "" — that would let
+        // `zeph-acp`'s BearerAuthLayer match a request presenting an empty bearer value.
+        let cfg = acp_config_with(
+            None,
+            vec![
+                vault_client("alice", "ZEPH_ACP_TOKEN_ALICE"),
+                inline_client("bob", "token-b"),
+            ],
+        );
+        let vault = TestVault::default().with_secret("ZEPH_ACP_TOKEN_ALICE", "");
+        let clients = resolve_acp_auth_clients(&cfg, &vault).await.unwrap();
+        assert_eq!(clients.len(), 1);
+        assert_eq!(clients[0].id, "bob");
+    }
+
+    #[tokio::test]
+    async fn resolve_acp_auth_clients_sole_empty_vault_token_fails_closed() {
+        // #6270 F3: when the ONLY configured client's vault-resolved token is empty, the
+        // resolved set would otherwise be empty — indistinguishable from "no auth
+        // configured", which `zeph_acp::transport::router` treats as intentionally public.
+        // Must fail startup instead of silently serving everything unauthenticated.
+        let cfg = acp_config_with(None, vec![vault_client("alice", "ZEPH_ACP_TOKEN_ALICE")]);
+        let vault = TestVault::default().with_secret("ZEPH_ACP_TOKEN_ALICE", "");
+        let err = resolve_acp_auth_clients(&cfg, &vault).await.unwrap_err();
+        assert!(
+            err.to_string().contains("refusing to start"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_acp_auth_clients_sole_missing_vault_key_fails_closed() {
+        // Same fail-closed guard, but for the pre-existing "vault key not found" soft-disable
+        // path — the class this PR extends rather than introduces (critic F3).
+        let cfg = acp_config_with(None, vec![vault_client("alice", "ZEPH_ACP_TOKEN_ALICE")]);
+        let err = resolve_acp_auth_clients(&cfg, &TestVault::default())
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("refusing to start"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_acp_auth_clients_sole_client_backend_error_fails_closed() {
+        let cfg = acp_config_with(None, vec![vault_client("alice", "ZEPH_ACP_TOKEN_ALICE")]);
+        let vault = TestVault::default().with_erroring_key("ZEPH_ACP_TOKEN_ALICE");
+        let err = resolve_acp_auth_clients(&cfg, &vault).await.unwrap_err();
+        assert!(
+            err.to_string().contains("refusing to start"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_acp_auth_clients_legacy_token_alone_never_empties_so_no_fail_closed_path() {
+        // Sanity check: the legacy scalar `auth_token` path has no vault resolution, so it
+        // can never trigger the fail-closed guard through normal config loading (an inline
+        // empty auth_token is already rejected by AcpConfig::validate_auth_clients at
+        // config-load time, before this function ever runs).
+        let cfg = acp_config_with(Some("legacy-secret"), vec![]);
+        let clients = resolve_acp_auth_clients(&cfg, &TestVault::default())
+            .await
+            .unwrap();
+        assert_eq!(clients.len(), 1);
     }
 
     #[tokio::test]

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -158,7 +158,14 @@ pub(crate) async fn handle_serve_sessions_command(
     ))
     .await?;
 
-    check_require_auth_guard(serve_config, http_addr, auth_token.is_some())?;
+    // Non-emptiness, not `is_some()` (#6268): a vault-resolved secret that resolves to an
+    // empty string must be treated the same as "no token configured", not as a token that
+    // satisfies the require_auth guard while `AuthConfig` (correctly) rejects every request.
+    // Trimmed for consistency with `AuthConfig::new`/`BearerAuthLayer::new`/
+    // `resolve_acp_auth_clients` — not a bypass either way (require_auth's deny-all still
+    // applies), just a clearer error message in the whitespace-only-token edge case.
+    let has_auth_token = auth_token.as_deref().is_some_and(|t| !t.trim().is_empty());
+    check_require_auth_guard(serve_config, http_addr, has_auth_token)?;
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let supervisor = TaskSupervisor::new(cancel.clone());
@@ -235,7 +242,8 @@ async fn run_serve_with_acp(
     check_acp_http_port_clash(http_addr, &acp_bind_addr)?;
 
     let auth_token = deps::resolve_auth_token(&app).await;
-    check_require_auth_guard(&serve_config, http_addr, auth_token.is_some())?;
+    let has_auth_token = auth_token.as_deref().is_some_and(|t| !t.trim().is_empty());
+    check_require_auth_guard(&serve_config, http_addr, has_auth_token)?;
     // M1-security (code review 2026-07-04): serve's own `require_auth` guard only covers
     // `http_addr`. Without an equivalent check here, `[serve] require_auth = true` gives an
     // operator false confidence that the whole combined process is authenticated, while the


### PR DESCRIPTION
## Summary

- Fixes two independent CWE-287/306 defects where an empty-string bearer or vault-resolved token silently produced a fully authenticated bypass state instead of being rejected.
- `zeph-common`'s shared `AuthConfig::new`/`auth_middleware` (used by `zeph-gateway`, `zeph-a2a`, and `zeph serve-sessions`) now normalizes an empty/whitespace-only token to `None` before hashing, closing the "no header == empty configured secret" hash collision, and the non-loopback bind guards / startup warnings now check non-emptiness instead of `Option::is_some()`.
- `zeph-acp`'s independent bearer-auth path (`resolve_acp_auth_clients` + `BearerAuthLayer`) now rejects an empty vault-resolved `[[acp.auth_clients]]` token instead of constructing a live `""`-token client, with a defense-in-depth filter at the crate boundary, and fails startup (rather than silently starting fully public) when every configured auth entry fails to resolve.
- `AuthConfig::token_hash` is now private, exposed only via `is_token_configured()`, so a future struct literal cannot reintroduce the bypass.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — full unscoped workspace suite, 13613 passed / 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo test --doc -p zeph-common --features http-middleware`
- [x] `gitleaks protect --staged --no-banner --redact`
- [x] New regression tests covering both bypass scenarios end-to-end (real `axum` `auth_middleware` round-trip for #6268; `resolve_acp_auth_clients`/`BearerAuthLayer` construction for #6270, including the sole-auth-client-resolves-empty startup-failure case)
- [x] Went through two rounds of adversarial critique (`rust-critic`) — first round found a significant fail-open gap (empty ACP client set silently treated as "intentionally public"), which was fixed and independently re-verified as resolved
- [x] Independent code review — approved

Closes #6270
Closes #6268