### PR TITLE
fix(subagent): scope worktree admission quota and classify setup failures correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -640,6 +640,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   validate containment against the nearest existing ancestor before calling
   `create_dir_all`, so a configured root that resolves outside the repository is
   rejected without mutating the filesystem first.
+- **Sub-agents**: `WorktreeManager::reconcile()`'s admission-quota count included every
+  git worktree registered to the repository (`git worktree list --porcelain`), not just
+  ones the subagent worktree subsystem itself created — so worktrees created by
+  unrelated tooling (including this project's own `EnterWorktree` workflow) counted
+  against `max_worktrees` and could silently trip `QuotaExceeded` on a background
+  `/agent bg` spawn. Three compounding gaps then turned that single failure into a
+  permanently stuck task: the error was never logged, `TaskSupervisor::spawn_oneshot`
+  classified a failed inner `Result` as a normal completion, and the task's status
+  channel was never updated past its initial `Submitted` state, so `poll_subagents()`
+  could never collect it — leaking one `max_concurrent` slot per occurrence (#6257).
+  Fixed by: scoping `reconcile()`'s counted entries to the subsystem's own worktree
+  root; logging `WorktreeError` at `warn` in `create()`; adding
+  `CompletionKind::Failed` and a generic `TaskSupervisor::spawn_oneshot_classified`
+  that inspects the inner `Result` (subagent spawns now classify via `Result::is_ok`;
+  the existing `spawn_oneshot` and its ~20 call sites are unaffected); and sending a
+  terminal `Failed` status from all three fallible pre-loop setup points in
+  `spawn()`'s task closure (`wm.create()`, `CwdRestoreGuard::new()`,
+  `CwdRestoreGuard::acquire()`) so a setup failure is now visible via `/agent
+  list`/`/agent status`, its concurrency slot is released, and the real error is
+  retrievable via `collect()`.
 
 ### Testing
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10801,6 +10801,7 @@ dependencies = [
  "tokio-util",
  "tower 0.5.3",
  "tracing",
+ "tracing-test",
  "tree-sitter",
  "tree-sitter-bash",
  "tree-sitter-go",
@@ -11487,6 +11488,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-test",
  "walkdir",
  "zeph-config",
 ]

--- a/crates/zeph-common/Cargo.toml
+++ b/crates/zeph-common/Cargo.toml
@@ -70,6 +70,7 @@ serde_json.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 tower = { workspace = true, features = ["util"] }
+tracing-test.workspace = true
 
 [lints]
 workspace = true

--- a/crates/zeph-common/src/task_supervisor.rs
+++ b/crates/zeph-common/src/task_supervisor.rs
@@ -286,6 +286,11 @@ struct TaskEntry {
 enum CompletionKind {
     /// Future returned normally.
     Normal,
+    /// Future returned a value that the caller-supplied classifier (see
+    /// [`TaskSupervisor::spawn_oneshot_classified`]) identified as an inner failure —
+    /// distinct from `Normal` even though the outer `JoinHandle` itself resolved
+    /// successfully (no panic, no cancellation).
+    Failed,
     /// Future panicked.
     Panicked,
     /// Future was cancelled via the cancellation token or abort handle.
@@ -630,6 +635,51 @@ impl TaskSupervisor {
         Fut: Future<Output = R> + Send + 'static,
         R: Send + 'static,
     {
+        self.spawn_oneshot_classified(name, factory, |_| true)
+    }
+
+    /// Spawn an async task like [`spawn_oneshot`][Self::spawn_oneshot], but additionally
+    /// classify the produced value's own success/failure via `is_success` instead of only
+    /// the outer `JoinHandle` outcome (normal exit vs. panic vs. cancellation).
+    ///
+    /// This matters whenever `Fut::Output` itself encodes failure (typically
+    /// `Result<T, E>`): without a classifier, a task that runs to completion but produces
+    /// `Err(..)` is classified and logged identically to one that produced `Ok(..)` —
+    /// `spawn_oneshot` alone only observes whether the *outer* future resolved, never what
+    /// value it resolved to. `is_success` is called once, by reference, before the value is
+    /// sent to the returned [`BlockingHandle`]'s receiver — it never consumes or blocks on
+    /// the value, and the value itself is delivered to the caller unchanged either way.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use std::sync::Arc;
+    /// use tokio_util::sync::CancellationToken;
+    /// use zeph_common::task_supervisor::TaskSupervisor;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let sup = TaskSupervisor::new(CancellationToken::new());
+    /// let handle = sup.spawn_oneshot_classified(
+    ///     Arc::from("fallible-task"),
+    ///     || async { Result::<u32, String>::Err("boom".to_string()) },
+    ///     Result::is_ok,
+    /// );
+    /// let result = handle.join().await.unwrap();
+    /// assert!(result.is_err());
+    /// # }
+    /// ```
+    pub fn spawn_oneshot_classified<F, Fut, R>(
+        &self,
+        name: Arc<str>,
+        factory: F,
+        is_success: impl Fn(&R) -> bool + Send + 'static,
+    ) -> BlockingHandle<R>
+    where
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: Future<Output = R> + Send + 'static,
+        R: Send + 'static,
+    {
         let (tx, rx) = oneshot::channel::<Result<R, BlockingError>>();
         let cancel = self.inner.cancel.clone();
         let span = tracing::info_span!("supervised_task", task.name = %name);
@@ -668,8 +718,13 @@ impl TaskSupervisor {
         tokio::spawn(async move {
             let kind = match join_handle.await {
                 Ok(Some(val)) => {
+                    let kind = if is_success(&val) {
+                        CompletionKind::Normal
+                    } else {
+                        CompletionKind::Failed
+                    };
                     let _ = tx.send(Ok(val));
-                    CompletionKind::Normal
+                    kind
                 }
                 Err(e) if e.is_panic() => {
                     let _ = tx.send(Err(BlockingError::Panicked));
@@ -971,6 +1026,12 @@ impl TaskSupervisor {
             CompletionKind::Panicked => {
                 tracing::warn!(task.name = %completion.name, "supervised task panicked");
             }
+            CompletionKind::Failed => {
+                tracing::warn!(
+                    task.name = %completion.name,
+                    "supervised task completed with an inner failure"
+                );
+            }
             CompletionKind::Normal => {
                 tracing::info!(task.name = %completion.name, "supervised task completed");
             }
@@ -981,7 +1042,13 @@ impl TaskSupervisor {
 
         match entry.restart_policy {
             RestartPolicy::RunOnce => {
-                entry.status = TaskStatus::Completed;
+                entry.status = if completion.kind == CompletionKind::Failed {
+                    TaskStatus::Failed {
+                        reason: "task completed with an inner failure".to_string(),
+                    }
+                } else {
+                    TaskStatus::Completed
+                };
                 state.tasks.remove(&completion.name);
                 None
             }
@@ -1510,6 +1577,110 @@ mod tests {
         );
 
         cancel.cancel();
+    }
+
+    /// `spawn_oneshot_classified` must deliver the factory's actual return value to the
+    /// caller unchanged, regardless of how `is_success` classifies it — the classifier only
+    /// affects internal registry/log bookkeeping, never the value received via `join()`.
+    #[tokio::test]
+    async fn test_oneshot_classified_delivers_actual_value_on_success_and_failure() {
+        let (sup, _cancel) = make_supervisor();
+
+        let ok_handle = sup.spawn_oneshot_classified(
+            Arc::from("classified-ok"),
+            || async { Result::<u32, String>::Ok(7) },
+            Result::is_ok,
+        );
+        assert_eq!(ok_handle.join().await.unwrap(), Ok(7));
+
+        let err_handle = sup.spawn_oneshot_classified(
+            Arc::from("classified-err"),
+            || async { Result::<u32, String>::Err("boom".to_string()) },
+            Result::is_ok,
+        );
+        assert_eq!(
+            err_handle.join().await.unwrap(),
+            Err("boom".to_string()),
+            "the real Err value must reach the caller unchanged even though it is \
+             classified as CompletionKind::Failed internally"
+        );
+    }
+
+    /// Regression test for #6257: an `Err`-returning factory must be classified as
+    /// `CompletionKind::Failed` (logged at `warn` as "completed with an inner failure"),
+    /// not `CompletionKind::Normal` (logged at `info` as a plain completion). This is the
+    /// distinction `spawn_agent_task` (zeph-subagent) relies on so a subagent task that
+    /// returns `Err` after a genuine completion (e.g. a worktree-setup failure) is reported
+    /// as a supervisor-level failure instead of a normal completion. The classification
+    /// only surfaces via the reap driver's log lines — for `RunOnce` the registry entry's
+    /// `Failed`/`Completed` status assignment and its removal happen in the same locked
+    /// critical section (see `classify_completion`), so there is no window in which
+    /// `snapshot()` could observe the transient status; the log line is the only externally
+    /// observable signal of which branch was taken.
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_oneshot_classified_logs_failed_for_inner_err() {
+        let (sup, _cancel) = make_supervisor();
+
+        let handle = sup.spawn_oneshot_classified(
+            Arc::from("classified-inner-err"),
+            || async { Result::<u32, String>::Err("boom".to_string()) },
+            Result::is_ok,
+        );
+        handle.join().await.unwrap().unwrap_err();
+
+        // Give the reap driver a moment to process the completion event.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        assert!(
+            logs_contain("completed with an inner failure"),
+            "an Err value must be classified as CompletionKind::Failed, not Normal"
+        );
+    }
+
+    /// Counterpart to the above: an `Ok`-returning factory must be classified as
+    /// `CompletionKind::Normal` (logged at `info`), never as an inner failure — confirms
+    /// the classifier doesn't over-fire on the success path.
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_oneshot_classified_logs_normal_for_inner_ok() {
+        let (sup, _cancel) = make_supervisor();
+
+        let handle = sup.spawn_oneshot_classified(
+            Arc::from("classified-inner-ok"),
+            || async { Result::<u32, String>::Ok(1) },
+            Result::is_ok,
+        );
+        handle.join().await.unwrap().unwrap();
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        assert!(
+            !logs_contain("completed with an inner failure"),
+            "an Ok value must not be classified as CompletionKind::Failed"
+        );
+    }
+
+    /// Regression guard for #6257: `spawn_oneshot`'s ~20 existing call sites across the
+    /// workspace must remain unaffected by the addition of `spawn_oneshot_classified` —
+    /// `spawn_oneshot` delegates with an always-true classifier (`|_| true`), so a plain
+    /// (non-`Result`) factory value must still always be classified `Normal`/logged as a
+    /// plain completion, never as an inner failure.
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_oneshot_backward_compat_never_logs_inner_failure() {
+        let (sup, _cancel) = make_supervisor();
+
+        let handle: BlockingHandle<u32> =
+            sup.spawn_oneshot(Arc::from("plain-oneshot"), || async { 42_u32 });
+        assert_eq!(handle.join().await.unwrap(), 42);
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        assert!(
+            !logs_contain("completed with an inner failure"),
+            "spawn_oneshot's default always-true classifier must never report an inner failure"
+        );
     }
 
     #[tokio::test]

--- a/crates/zeph-subagent/src/manager/mod.rs
+++ b/crates/zeph-subagent/src/manager/mod.rs
@@ -456,21 +456,29 @@ impl SubAgentManager {
     /// Falls back to a transient local supervisor when no session supervisor has been wired via
     /// [`SubAgentManager::set_task_supervisor`] — the task runs but is not tracked globally.
     /// The returned [`BlockingHandle`] type is identical in both cases so call sites are uniform.
-    pub(crate) fn spawn_agent_task<F, Fut, R>(
+    ///
+    /// Every agent loop task's future resolves to a `Result<T, E>` (in practice always
+    /// `Result<String, SubAgentError>`), so this classifies via
+    /// [`TaskSupervisor::spawn_oneshot_classified`] rather than plain `spawn_oneshot` — an
+    /// `Err` produced by a genuinely completed task (e.g. a worktree-quota or cwd-guard setup
+    /// failure returned before the agent loop ever starts) is thus classified and logged as a
+    /// supervisor-level failure instead of a normal completion (#6257).
+    pub(crate) fn spawn_agent_task<F, Fut, T, E>(
         &self,
         name: Arc<str>,
         factory: F,
-    ) -> BlockingHandle<R>
+    ) -> BlockingHandle<Result<T, E>>
     where
         F: FnOnce() -> Fut + Send + 'static,
-        Fut: std::future::Future<Output = R> + Send + 'static,
-        R: Send + 'static,
+        Fut: std::future::Future<Output = Result<T, E>> + Send + 'static,
+        T: Send + 'static,
+        E: Send + 'static,
     {
         if let Some(ref sup) = self.task_supervisor {
-            sup.spawn_oneshot(name, factory)
+            sup.spawn_oneshot_classified(name, factory, Result::is_ok)
         } else {
             let local = TaskSupervisor::new(CancellationToken::new());
-            local.spawn_oneshot(name, factory)
+            local.spawn_oneshot_classified(name, factory, Result::is_ok)
         }
     }
 

--- a/crates/zeph-subagent/src/manager/spawn.rs
+++ b/crates/zeph-subagent/src/manager/spawn.rs
@@ -529,6 +529,27 @@ pub(crate) fn build_context_summary(parent_messages: &[Message], max_chars: usiz
     joined[..end].to_owned()
 }
 
+/// Publishes a terminal `Failed` status before an early return from the cwd-lock/worktree
+/// setup block in [`SubAgentManager::spawn`]'s task closure.
+///
+/// Without this, a setup failure (worktree quota exceeded, cwd-guard construction failure)
+/// returns before [`run_agent_loop`]'s `init_loop_state` ever sends the first status update,
+/// so `status_rx` stays frozen at its initial `Submitted` value forever — `poll_subagents()`
+/// only calls `collect()` for `Completed`/`Failed`/`Canceled` tasks, so the task is never
+/// collected, permanently occupying a `max_concurrent` slot (#6257).
+fn send_setup_failure_status(
+    status_tx: &watch::Sender<SubAgentStatus>,
+    started_at: Instant,
+    error: &SubAgentError,
+) {
+    let _ = status_tx.send(SubAgentStatus {
+        state: SubAgentState::Failed,
+        last_message: Some(error.to_string()),
+        turns_used: 0,
+        started_at,
+    });
+}
+
 // ── SubAgentManager impl ──────────────────────────────────────────────────────
 
 impl SubAgentManager {
@@ -729,13 +750,27 @@ impl SubAgentManager {
                         let handle = wm
                             .create(&task_id_for_worktree)
                             .await
-                            .map_err(|e| SubAgentError::WorktreeSetup(e.to_string()))?;
+                            .map_err(|e| SubAgentError::WorktreeSetup(e.to_string()))
+                            .inspect_err(|err| {
+                                send_setup_failure_status(
+                                    &agent_loop_args.status_tx,
+                                    agent_loop_args.started_at,
+                                    err,
+                                );
+                            })?;
                         tracing::info!(
                             path = %handle.path.display(),
                             "worktree created for sub-agent"
                         );
                         let guard = CwdRestoreGuard::new(&handle.path, owned_guard)
-                            .map_err(|e| SubAgentError::WorktreeSetup(e.to_string()))?;
+                            .map_err(|e| SubAgentError::WorktreeSetup(e.to_string()))
+                            .inspect_err(|err| {
+                                send_setup_failure_status(
+                                    &agent_loop_args.status_tx,
+                                    agent_loop_args.started_at,
+                                    err,
+                                );
+                            })?;
                         let _cleanup = WorktreeCleanupGuard {
                             wm: Arc::clone(wm),
                             handle: handle.clone(),
@@ -755,7 +790,14 @@ impl SubAgentManager {
                     }
 
                     let guard = CwdRestoreGuard::acquire(owned_guard)
-                        .map_err(|e| SubAgentError::WorktreeSetup(e.to_string()))?;
+                        .map_err(|e| SubAgentError::WorktreeSetup(e.to_string()))
+                        .inspect_err(|err| {
+                            send_setup_failure_status(
+                                &agent_loop_args.status_tx,
+                                agent_loop_args.started_at,
+                                err,
+                            );
+                        })?;
                     Some(guard)
                 } else {
                     None

--- a/crates/zeph-subagent/src/manager/tests.rs
+++ b/crates/zeph-subagent/src/manager/tests.rs
@@ -3961,6 +3961,154 @@ mod worktree_cleanup_guard_tests {
     }
 }
 
+/// End-to-end regression tests for #6257: a worktree-setup failure inside `spawn()`'s task
+/// closure must publish a terminal `Failed` status via `send_setup_failure_status` so
+/// `poll_subagents()`-style filtering (`Completed | Failed | Canceled`, see
+/// `crates/zeph-core/src/agent/subagent_commands.rs`) picks the task up and `collect()`
+/// returns the real error — instead of leaving `status_rx` frozen at `Submitted` forever,
+/// permanently occupying a `max_concurrent` slot (the original zombie-spawn bug).
+#[cfg(test)]
+mod worktree_setup_failure_tests {
+    use std::process::Command;
+    use std::sync::Arc;
+
+    use tempfile::TempDir;
+    use zeph_config::WorktreeConfig;
+    use zeph_worktree::{DefaultGitRunner, DefaultWorktreeManager};
+
+    use super::*;
+    use crate::state::SubAgentState;
+
+    fn git(args: &[&str], cwd: &std::path::Path) -> std::process::Output {
+        Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .output()
+            .expect("git must be on PATH for this test")
+    }
+
+    /// Real (not faked) git repo — `wm.create()`'s quota check runs a real `git worktree
+    /// list --porcelain` before comparing against `max_worktrees`, so a fake `.git`
+    /// directory (as used by `worktree_cleanup_guard_tests::make_dummy_wm`) would fail with
+    /// `GitCommand`, not the `QuotaExceeded` this test needs to trigger deterministically.
+    fn init_repo() -> TempDir {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path();
+        assert!(git(&["init", "-q"], path).status.success());
+        git(&["config", "user.email", "test@example.com"], path);
+        git(&["config", "user.name", "Test"], path);
+        std::fs::write(path.join("README.md"), "test\n").unwrap();
+        git(&["add", "."], path);
+        assert!(git(&["commit", "-q", "-m", "init"], path).status.success());
+        dir
+    }
+
+    fn worktree_def() -> SubAgentDef {
+        SubAgentDef::parse(
+            "---\nname: wt-bot\ndescription: A worktree bot\npermissions:\n  worktree: true\n---\n\nDo things.\n",
+        )
+        .unwrap()
+    }
+
+    /// `wm.create()` fails with `QuotaExceeded` (deterministic via `max_worktrees: Some(0)`
+    /// against a freshly-inited, empty repo — `reconcile()` finds 0 registered secondary
+    /// worktrees, so `0 >= 0` trips immediately). This must surface as a `Failed` status —
+    /// not leave the task frozen at `Submitted` — and `collect()` must return the real
+    /// `SubAgentError::WorktreeSetup` error while releasing the concurrency slot.
+    #[tokio::test]
+    async fn worktree_quota_failure_transitions_to_failed_and_is_collectible() {
+        let dir = init_repo();
+        let wm_config = WorktreeConfig {
+            enabled: true,
+            root: "worktrees".to_string(),
+            max_worktrees: Some(0),
+            ..WorktreeConfig::default()
+        };
+        let wm = Arc::new(
+            DefaultWorktreeManager::new(
+                dir.path().to_path_buf(),
+                wm_config,
+                DefaultGitRunner::new(),
+            )
+            .await
+            .unwrap(),
+        );
+
+        let mut mgr = make_manager();
+        mgr.set_worktree_manager(wm);
+        mgr.definitions.push(worktree_def());
+
+        let active_before = mgr
+            .agents
+            .values()
+            .filter(|h| matches!(h.state, SubAgentState::Working | SubAgentState::Submitted))
+            .count();
+
+        let task_id = mgr
+            .spawn(
+                "wt-bot",
+                "do the thing",
+                mock_provider(vec!["done"]),
+                noop_executor(),
+                None,
+                &SubAgentConfig::default(),
+                SpawnContext::default(),
+            )
+            .await
+            .unwrap();
+
+        // Poll until the background task publishes its terminal status — bounded so a
+        // regression back to the #6257 bug (status frozen at Submitted forever) fails this
+        // test with a clear timeout message instead of hanging indefinitely.
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            let state = mgr.agents[&task_id].status_rx.borrow().state;
+            if state != SubAgentState::Submitted {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "status_rx stuck at Submitted — #6257 zombie-spawn regression"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        // `poll_subagents()` derives its `collect()` candidates from `statuses()`, filtering
+        // on `Completed | Failed | Canceled` — assert the exact same predicate here.
+        let statuses = mgr.statuses();
+        let (_, status) = statuses
+            .iter()
+            .find(|(id, _)| id == &task_id)
+            .expect("task must still be present pending collect()");
+        assert_eq!(
+            status.state,
+            SubAgentState::Failed,
+            "a worktree-quota setup failure must publish Failed so poll_subagents()'s \
+             `Completed | Failed | Canceled` filter picks it up"
+        );
+
+        let result = mgr.collect(&task_id).await;
+        assert!(
+            result.is_err(),
+            "collect() must surface the real WorktreeSetup error: {result:?}"
+        );
+        assert!(
+            !mgr.agents.contains_key(&task_id),
+            "collect() must remove the handle, releasing the max_concurrent slot"
+        );
+
+        let active_after = mgr
+            .agents
+            .values()
+            .filter(|h| matches!(h.state, SubAgentState::Working | SubAgentState::Submitted))
+            .count();
+        assert_eq!(
+            active_after, active_before,
+            "the concurrency slot must be released after collect(), not leaked"
+        );
+    }
+}
+
 // ── TaskSupervisor integration tests ─────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/zeph-worktree/Cargo.toml
+++ b/crates/zeph-worktree/Cargo.toml
@@ -27,6 +27,7 @@ zeph-config.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
+tracing-test.workspace = true
 
 [lints]
 workspace = true

--- a/crates/zeph-worktree/src/manager.rs
+++ b/crates/zeph-worktree/src/manager.rs
@@ -166,13 +166,16 @@ impl<R: GitRunner> WorktreeManager<R> {
     /// [`WorktreeError::QuotaExceeded`] if that count is already `>= max`. The
     /// count includes worktrees created by *other*, concurrently running zeph
     /// sessions over the same `root`, since they consume the same disk budget
-    /// `max_worktrees` is meant to bound. This is a best-effort **soft** cap
-    /// across *processes*: the count-then-`git worktree add` sequence is not
-    /// atomic across separate zeph sessions, so two concurrent `create()`
-    /// calls in different processes can both pass the check and briefly push
-    /// the total above `max`. No cross-process locking is used to close that
-    /// gap — it is out of scope for the size of this feature. Within a single
-    /// process, admission is a **hard** guarantee — see `# Concurrency` below.
+    /// `max_worktrees` is meant to bound — but, per [`reconcile`][Self::reconcile]'s
+    /// "Scope" section, excludes worktrees created by unrelated tooling elsewhere in the
+    /// repository (e.g. `EnterWorktree`, a manual `git worktree add` outside `root`), which
+    /// do not consume this budget and must not count against it (#6257). This is a
+    /// best-effort **soft** cap across *processes*: the count-then-`git worktree add`
+    /// sequence is not atomic across separate zeph sessions, so two concurrent `create()`
+    /// calls in different processes can both pass the check and briefly push the total
+    /// above `max`. No cross-process locking is used to close that gap — it is out of
+    /// scope for the size of this feature. Within a single process, admission is a
+    /// **hard** guarantee — see `# Concurrency` below.
     ///
     /// ## Concurrency
     ///
@@ -213,7 +216,15 @@ impl<R: GitRunner> WorktreeManager<R> {
     /// # Ok(())
     /// # }
     /// ```
-    #[instrument(name = "worktree.create", skip(self), fields(subagent_id = %subagent_id))]
+    // `err(level = WARN)` logs every `Err` return (including `QuotaExceeded`, whose
+    // `Display` already carries `current`/`max`) at `warn` with the `subagent_id` span
+    // field attached — previously this failed silently with zero log evidence (#6257).
+    #[instrument(
+        name = "worktree.create",
+        skip(self),
+        fields(subagent_id = %subagent_id),
+        err(level = tracing::Level::WARN)
+    )]
     pub async fn create(&self, subagent_id: &str) -> Result<WorktreeHandle, WorktreeError> {
         validate_branch_component(subagent_id)?;
 
@@ -386,6 +397,20 @@ impl<R: GitRunner> WorktreeManager<R> {
     /// belong to another, concurrently running session and MUST NOT be
     /// force-removed without an explicit operator override (#6055).
     ///
+    /// ## Scope
+    ///
+    /// Only entries whose path falls under this manager's canonicalised
+    /// `worktree_root` (`config.root`, resolved at construction) are returned. `git
+    /// worktree list --porcelain` reports *every* worktree registered against the
+    /// repository, including ones created by unrelated tooling — e.g. the `EnterWorktree`
+    /// developer tool, or a manual `git worktree add` — under a completely different
+    /// directory. Those are not managed by this subsystem: `zeph worktree clean` must
+    /// never remove them, and [`create`][Self::create]'s `max_worktrees` admission count
+    /// must not be inflated by them (#6257). A worktree created by *another*,
+    /// concurrently running zeph session that shares the same `config.root` still counts
+    /// — it is under `worktree_root` and is legitimately this subsystem's responsibility,
+    /// even though it is untracked by *this* process's in-memory handle list.
+    ///
     /// # Errors
     ///
     /// Returns [`WorktreeError::GitCommand`] if `git worktree list` fails.
@@ -425,6 +450,8 @@ impl<R: GitRunner> WorktreeManager<R> {
             .filter(|e| !session_paths.contains(&e.path))
             // Skip the main worktree (repo_root itself).
             .filter(|e| e.path != self.repo_root)
+            // Skip worktrees not managed by this subsystem (see "Scope" above, #6257).
+            .filter(|e| e.path.starts_with(&self.worktree_root))
             .map(|e| {
                 let branch_name = match (e.branch, e.is_bare) {
                     (Some(branch), _) => branch,
@@ -1147,6 +1174,14 @@ mod tests {
         dir
     }
 
+    /// Canonicalises `dir`'s path the same way `WorktreeManager::new` canonicalises
+    /// `worktree_root`. Required so synthetic `git worktree list --porcelain` fixtures
+    /// match `reconcile()`'s `worktree_root`-scoped filter (#6257) — `TempDir::path()` is
+    /// not canonical on macOS (`/var` is a symlink to `/private/var`).
+    fn canon_repo(dir: &tempfile::TempDir) -> PathBuf {
+        dir.path().canonicalize().unwrap()
+    }
+
     async fn make_manager(
         dir: &tempfile::TempDir,
         runner: FakeGitRunner,
@@ -1490,7 +1525,7 @@ mod tests {
         let runner = FakeGitRunner::new();
         let porcelain = format!(
             "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\nworktree {0}/worktrees/agent-1\nHEAD def456\nbranch refs/heads/agent/agent-1\n\n",
-            dir.path().display()
+            canon_repo(&dir).display()
         );
         runner.push_ok(porcelain.into_bytes());
 
@@ -1509,7 +1544,7 @@ mod tests {
         let runner = FakeGitRunner::new();
         let porcelain = format!(
             "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\nworktree {0}/worktrees/detached-1\nHEAD def456\ndetached\n\n",
-            dir.path().display()
+            canon_repo(&dir).display()
         );
         runner.push_ok(porcelain.into_bytes());
 
@@ -1519,7 +1554,7 @@ mod tests {
         assert_eq!(stale[0].handle.branch_name, DETACHED_BRANCH_SENTINEL);
         assert_eq!(
             stale[0].handle.path,
-            dir.path().join("worktrees/detached-1")
+            canon_repo(&dir).join("worktrees/detached-1")
         );
     }
 
@@ -1563,7 +1598,7 @@ mod tests {
         let runner = FakeGitRunner::new();
         let porcelain = format!(
             "worktree {0}\nHEAD abc123\ndetached\n\nworktree {0}/worktrees/detached-2\nHEAD def456\ndetached\n\n",
-            dir.path().display()
+            canon_repo(&dir).display()
         );
         runner.push_ok(porcelain.into_bytes());
 
@@ -1573,7 +1608,7 @@ mod tests {
         assert_eq!(stale[0].handle.branch_name, DETACHED_BRANCH_SENTINEL);
         assert_eq!(
             stale[0].handle.path,
-            dir.path().join("worktrees/detached-2")
+            canon_repo(&dir).join("worktrees/detached-2")
         );
     }
 
@@ -1609,7 +1644,7 @@ mod tests {
         let runner = FakeGitRunner::new();
         let porcelain = format!(
             "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\nworktree {0}/worktrees/bare-1\nbare\n\nworktree {0}/worktrees/detached-1\nHEAD def456\ndetached\n\n",
-            dir.path().display()
+            canon_repo(&dir).display()
         );
         runner.push_ok(porcelain.into_bytes());
 
@@ -1636,7 +1671,7 @@ mod tests {
         let runner = FakeGitRunner::new();
         let porcelain = format!(
             "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\nworktree {0}/worktrees/agent-1\nHEAD def456\nbranch refs/heads/agent/agent-1\n\n",
-            dir.path().display()
+            canon_repo(&dir).display()
         );
         runner.push_ok(porcelain.into_bytes());
 
@@ -1657,7 +1692,7 @@ mod tests {
         let runner = FakeGitRunner::new();
         let porcelain = format!(
             "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\nworktree {0}/worktrees/gone\nHEAD def456\nbranch refs/heads/agent/gone\nprunable gitdir file points to non-existent location\n\n",
-            dir.path().display()
+            canon_repo(&dir).display()
         );
         runner.push_ok(porcelain.into_bytes());
 
@@ -1669,6 +1704,41 @@ mod tests {
             Some("gitdir file points to non-existent location".to_string())
         );
         assert!(stale[0].is_safe_to_force_remove());
+    }
+
+    /// Regression test for #6257: `reconcile()` must exclude a git-registered worktree
+    /// whose path falls outside this subsystem's canonicalised `worktree_root` — e.g. one
+    /// created by the `EnterWorktree` developer tool or a manual `git worktree add`
+    /// elsewhere in the repository. Only the managed worktree under `worktree_root` may
+    /// appear in the stale list.
+    #[tokio::test]
+    async fn reconcile_excludes_worktree_outside_worktree_root() {
+        let dir = make_repo();
+        let foreign = tempfile::tempdir().unwrap();
+        let foreign_path = foreign.path().canonicalize().unwrap();
+        let runner = FakeGitRunner::new();
+        let porcelain = format!(
+            "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\n\
+             worktree {0}/worktrees/agent-1\nHEAD def456\nbranch refs/heads/agent/agent-1\n\n\
+             worktree {1}\nHEAD ghi789\nbranch refs/heads/enter-worktree/fix-123\n\n",
+            canon_repo(&dir).display(),
+            foreign_path.display()
+        );
+        runner.push_ok(porcelain.into_bytes());
+
+        let mgr = make_manager(&dir, runner).await;
+        let stale = mgr.reconcile().await.unwrap();
+
+        assert_eq!(
+            stale.len(),
+            1,
+            "the foreign worktree outside worktree_root must be excluded: {stale:?}"
+        );
+        assert_eq!(stale[0].handle.branch_name, "agent/agent-1");
+        assert_eq!(
+            stale[0].handle.path,
+            canon_repo(&dir).join("worktrees/agent-1")
+        );
     }
 
     // --- prune ---
@@ -1722,7 +1792,7 @@ mod tests {
              worktree {0}/worktrees/prunable-1\nHEAD def456\nbranch refs/heads/agent/prunable-1\n\
              prunable gitdir file points to non-existent location\n\n\
              worktree {0}/worktrees/in-use-1\nHEAD ghi789\nbranch refs/heads/agent/in-use-1\n\n",
-            dir.path().display()
+            canon_repo(&dir).display()
         );
         runner.push_ok(porcelain.into_bytes()); // reconcile: worktree list --porcelain
         runner.push_ok(b"" as &[u8]); // remove prunable-1: worktree remove --force
@@ -1753,7 +1823,7 @@ mod tests {
         let porcelain = format!(
             "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\n\
              worktree {0}/worktrees/in-use-1\nHEAD ghi789\nbranch refs/heads/agent/in-use-1\n\n",
-            dir.path().display()
+            canon_repo(&dir).display()
         );
         runner.push_ok(porcelain.into_bytes());
         runner.push_ok(b"" as &[u8]); // remove in-use-1 (force bypasses the skip-gate)
@@ -1778,7 +1848,7 @@ mod tests {
             "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\n\
              worktree {0}/worktrees/locked-1\nHEAD def456\nbranch refs/heads/agent/locked-1\n\
              prunable gitdir file points to non-existent location\n\n",
-            dir.path().display()
+            canon_repo(&dir).display()
         );
         runner.push_ok(porcelain.into_bytes());
         runner.push_err(b"error: unable to remove worktree: it is locked\n" as &[u8]);
@@ -1805,7 +1875,7 @@ mod tests {
             "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\n\
              worktree {0}/worktrees/prunable-1\nHEAD def456\nbranch refs/heads/agent/prunable-1\n\
              prunable gitdir file points to non-existent location\n\n",
-            dir.path().display()
+            canon_repo(&dir).display()
         );
         runner.push_ok(porcelain.into_bytes());
         runner.push_ok(b"" as &[u8]); // remove succeeds
@@ -1986,6 +2056,82 @@ mod tests {
         assert_matches!(err, WorktreeError::QuotaExceeded { current: 1, max: 1 });
     }
 
+    /// Regression test for #6257: `create()`'s admission quota must not count a
+    /// git-registered worktree that lives outside this subsystem's `worktree_root` (e.g.
+    /// a sibling directory created by the `EnterWorktree` developer tool). With
+    /// `max_worktrees: Some(1)` and only a foreign worktree registered (no managed
+    /// worktree yet), `create()` must still be admitted — before the fix, the foreign
+    /// entry would have inflated the count and spuriously tripped `QuotaExceeded`.
+    #[tokio::test]
+    async fn create_admission_ignores_worktree_outside_worktree_root() {
+        let dir = make_repo();
+        let foreign = tempfile::tempdir().unwrap();
+        let foreign_path = foreign.path().canonicalize().unwrap();
+        let runner = FakeGitRunner::new();
+        let porcelain = format!(
+            "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\n\
+             worktree {1}\nHEAD ghi789\nbranch refs/heads/enter-worktree/fix-123\n\n",
+            canon_repo(&dir).display(),
+            foreign_path.display()
+        );
+        // reconcile (quota check) — only the foreign worktree is registered.
+        runner.push_ok(porcelain.into_bytes());
+        // status --porcelain (dirty check)
+        runner.push_ok(b"" as &[u8]);
+        // worktree add
+        runner.push_ok(b"" as &[u8]);
+
+        let config = WorktreeConfig {
+            max_worktrees: Some(1),
+            ..test_config()
+        };
+        let mgr = WorktreeManager::new(dir.path().to_path_buf(), config, runner)
+            .await
+            .unwrap();
+
+        let result = mgr.create("agent-a").await;
+        assert!(
+            result.is_ok(),
+            "admission must not be blocked by a foreign worktree outside worktree_root: {result:?}"
+        );
+    }
+
+    /// Regression test for #6257: `create()` must log a `WARN`-level event when it fails
+    /// (via `#[instrument(err(level = WARN))]`) — previously a `QuotaExceeded` failure had
+    /// zero log evidence, which is how the failure turned into a silent zombie task with no
+    /// diagnostic trail.
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn create_logs_warn_on_quota_exceeded() {
+        let dir = make_repo();
+        let runner = FakeGitRunner::new();
+        let porcelain = format!(
+            "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\n",
+            dir.path().display()
+        );
+        runner.push_ok(porcelain.into_bytes());
+
+        let config = WorktreeConfig {
+            max_worktrees: Some(0),
+            ..test_config()
+        };
+        let mgr = WorktreeManager::new(dir.path().to_path_buf(), config, runner)
+            .await
+            .unwrap();
+
+        let err = mgr.create("agent-a").await.unwrap_err();
+        assert_matches!(err, WorktreeError::QuotaExceeded { current: 0, max: 0 });
+
+        assert!(
+            logs_contain("worktree.create"),
+            "expected the worktree.create span to be logged"
+        );
+        assert!(
+            logs_contain("worktree limit reached"),
+            "expected the QuotaExceeded error text to be logged at WARN via err(level = WARN)"
+        );
+    }
+
     /// Test-only [`GitRunner`] wrapper that sleeps before delegating a
     /// `worktree list --porcelain` call (the git call `reconcile` issues as
     /// part of `create`'s quota check). This widens the check-then-act window
@@ -2158,7 +2304,7 @@ mod tests {
             "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\n\
              worktree {0}/worktrees/prunable-1\nHEAD def456\nbranch refs/heads/agent/prunable-1\n\
              prunable gitdir file points to non-existent location\n\n",
-            dir.path().display()
+            canon_repo(&dir).display()
         );
         // sweep()'s single reconcile() call, shared by the clean and count steps.
         runner.push_ok(porcelain_with_prunable.into_bytes());
@@ -2235,7 +2381,7 @@ mod tests {
             "worktree {0}\nHEAD abc123\nbranch refs/heads/main\n\n\
              worktree {0}/worktrees/agent-1\nHEAD def456\nbranch refs/heads/agent/agent-1\n\n\
              worktree {0}/worktrees/agent-2\nHEAD ghi789\nbranch refs/heads/agent/agent-2\n\n",
-            dir.path().display()
+            canon_repo(&dir).display()
         );
         // sweep()'s single reconcile() call (no prunable entries — both skipped, nothing removed).
         runner.push_ok(porcelain.into_bytes());
@@ -2331,7 +2477,7 @@ mod tests {
              worktree {0}/worktrees/skipped-1\nHEAD ghi789\nbranch refs/heads/agent/skipped-1\n\n\
              worktree {0}/worktrees/errored-1\nHEAD jkl012\nbranch refs/heads/agent/errored-1\n\
              prunable gitdir file points to non-existent location\n\n",
-            dir.path().display()
+            canon_repo(&dir).display()
         );
         // sweep()'s single reconcile() call, covering all 3 stale entries.
         runner.push_ok(porcelain.into_bytes());


### PR DESCRIPTION
## Summary

- `WorktreeManager::reconcile()` counted any git worktree registered to the repo, not just ones created by the subagent worktree subsystem, so a worktree created by unrelated tooling (e.g. `EnterWorktree`, manual `git worktree add`) could silently exhaust `max_worktrees` and trip `QuotaExceeded` on a background `/agent bg` spawn.
- Three compounding gaps then turned that failure into a permanent zombie task: the error was never logged, `TaskSupervisor::spawn_oneshot` classified a failed inner `Result` as a normal completion, and the task's status channel never left its initial `Submitted` state — so `poll_subagents()` could never collect it, leaking one `max_concurrent` slot per occurrence.
- Fix: scope `reconcile()`'s counted entries to the subsystem's own worktree root, log `WorktreeError` at `warn` in `create()`, add `CompletionKind::Failed` plus a generic `TaskSupervisor::spawn_oneshot_classified` that inspects the inner `Result` (existing `spawn_oneshot` call sites are unaffected), and send a terminal `Failed` status from all three fallible pre-loop setup points in `spawn()`'s task closure (`wm.create()`, `CwdRestoreGuard::new()`, `CwdRestoreGuard::acquire()`) so a setup failure is now visible via `/agent list`/`/agent status` and its concurrency slot is released.

Closes #6257

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13607/13607 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `gitleaks protect --staged --no-banner --redact`
- [x] 8 new regression tests added across `zeph-worktree`, `zeph-common`, `zeph-subagent`, including an end-to-end test forcing `QuotaExceeded` inside `spawn()` and asserting the task reaches `Failed` and is collected
- [x] Adversarial critique (verdict: approved) and code review (verdict: approved) completed