### PR TITLE
fix(acp): purge persisted session data on session/delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **ACP**: `session/delete` only removed the in-memory session entry, never touching the
+  configured persistence store — a deleted session's `acp_sessions` row (and its associated
+  conversation history / config snapshot) survived, so it could resurrect via a subsequent
+  `session/load` or `session/resume`. `do_delete_session` now also calls
+  `SqliteStore::delete_acp_session_for_owner`, matching the owner-scoped pattern already used
+  by `do_load_session`/`do_fork_session`/`do_resume_session`. In-memory removal remains
+  unconditional and always happens first; a persisted-store deletion failure is now surfaced
+  to the caller as an error (rather than logged and silently swallowed) so a transient DB
+  failure never reports false success while the persisted row — and the resurrection risk it
+  carries — survives. The delete is idempotent by id, so the client can safely retry (#6271).
 - **CLI**: `--init` / `--migrate-config` were documented as top-level flags everywhere (both
   `CLAUDE.md` files, `.zeph/zeph.md`, `crates/zeph-config/AGENTS.md`, the worktree-disk-quota
   playbook, and `src/cli.rs`'s own doc comments) but only existed as `clap` subcommands (`zeph

--- a/crates/zeph-acp/src/agent/mod.rs
+++ b/crates/zeph-acp/src/agent/mod.rs
@@ -1720,7 +1720,6 @@ impl ZephAcpAgentState {
         Ok(acp::schema::v1::CloseSessionResponse::default())
     }
 
-    #[allow(clippy::unused_async)]
     #[tracing::instrument(skip_all, name = "acp.handler.delete_session", fields(session_id = %args.session_id))]
     pub(crate) async fn do_delete_session(
         &self,
@@ -1728,9 +1727,28 @@ impl ZephAcpAgentState {
     ) -> acp::Result<acp::schema::v1::DeleteSessionResponse> {
         tracing::debug!(session_id = %args.session_id, "ACP session deleted");
         // Permanent deletion — no usage summary is sent. See do_close_session for graceful
-        // close that emits a cumulative UsageUpdate before removing the session.
+        // close that emits a cumulative UsageUpdate before removing the session. In-memory
+        // removal is unconditional and happens first: the id lookup here is not owner-scoped
+        // (unlike the store delete below), which is benign only because `self.sessions` is
+        // private to this connection's owner — if it is ever shared across owners, this
+        // becomes a cross-owner eviction bug. Persisted-store deletion failure is surfaced as
+        // an error rather than swallowed: `delete_acp_session_for_owner` deletes by id, so a
+        // retry is safe (the in-memory removal above is already a no-op on retry), and a
+        // silent failure here would let a transient DB error (lock/disk full/pool exhaustion)
+        // report success to the client while the persisted row — and the resurrection risk it
+        // carries — survives.
         if let Some(entry) = self.sessions.lock().remove(&args.session_id) {
             entry.cancel_signal.notify_one();
+        }
+        if let Some(ref store) = self.store
+            && let Err(e) = store
+                .delete_acp_session_for_owner(&args.session_id.to_string(), &self.owner_key)
+                .await
+        {
+            tracing::warn!(error = %e, session_id = %args.session_id, "failed to delete persisted ACP session");
+            // Static message only (matches do_load_session/do_fork_session) — the raw
+            // MemoryError Display could leak DB URL/SQL error text to the client.
+            return Err(acp::Error::internal_error().data("session deletion not persisted"));
         }
         Ok(acp::schema::v1::DeleteSessionResponse::default())
     }

--- a/crates/zeph-acp/tests/integration.rs
+++ b/crates/zeph-acp/tests/integration.rs
@@ -858,21 +858,28 @@ async fn close_session_removes_session_from_memory() {
         .await;
 }
 
-/// `session/delete` removes the session from `session/list` (#5367).
+/// `session/delete` removes the session from `session/list` (#5367) and, when a store is
+/// configured, permanently removes the persisted row too — a deleted session must never
+/// resurrect via `session/load`/`session/resume` (#6271).
 #[tokio::test(flavor = "current_thread")]
 async fn delete_session_removes_session_from_list() {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
             let workdir = temp_workdir();
+            let db_dir = tempfile::tempdir().expect("failed to create temp db dir");
+            let sqlite_path = db_dir
+                .path()
+                .join("acp-delete-test.db")
+                .to_string_lossy()
+                .into_owned();
             let (sw, sr, cw, cr) = duplex_pair();
-            let server_fut = serve_connection(
-                noop_spawner(),
-                test_config("test-agent"),
-                sw,
-                sr,
-                "acp-local".to_owned(),
-            );
+            let config = AcpServerConfig {
+                sqlite_path: Some(sqlite_path.clone()),
+                ..test_config("test-agent")
+            };
+            let server_fut =
+                serve_connection(noop_spawner(), config, sw, sr, "acp-local".to_owned());
             let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
                 cx.send_request(acp::schema::v1::InitializeRequest::new(
                     acp::schema::ProtocolVersion::LATEST,
@@ -902,14 +909,29 @@ async fn delete_session_removes_session_from_list() {
                     !ids.contains(&&session_id),
                     "deleted session must not appear in session/list: {ids:?}"
                 );
-                Ok(())
+                Ok(session_id)
             });
-            tokio::select! {
+            let session_id = tokio::select! {
                 res = server_fut => panic!("server exited before client: {res:?}"),
                 result = client_fut => {
-                    assert!(result.is_ok(), "delete_session test failed: {result:?}");
+                    result.expect("delete_session test failed")
                 }
-            }
+            };
+
+            // Verify the row is actually gone from the persistence store, not just absent
+            // from the in-memory session/list — the regression this test guards against
+            // (#6271) is a deleted session resurrecting via load/resume because the store
+            // row survived.
+            let store = zeph_memory::store::SqliteStore::new(&sqlite_path)
+                .await
+                .expect("SqliteStore::new");
+            assert!(
+                !store
+                    .acp_session_exists(&session_id.to_string())
+                    .await
+                    .expect("acp_session_exists query failed"),
+                "deleted session must not survive in the persistence store"
+            );
         })
         .await;
 }
@@ -2140,6 +2162,99 @@ async fn load_session_cross_owner_fails() {
                     );
                 }
             }
+        })
+        .await;
+}
+
+/// `session/delete` on a session owned by a different connection must not remove the
+/// persisted row — mirrors `load_session_cross_owner_fails`/`resume_session_cross_owner_fails`
+/// but for the delete path, at the ACP-protocol handler level (the underlying
+/// `delete_acp_session_for_owner` SQL owner-scoping is already unit-tested in
+/// `zeph-memory`; the HTTP CRUD transport has its own
+/// `delete_session_cross_owner_returns_404_and_does_not_delete` — this is the missing
+/// coverage for the `do_delete_session` ACP handler itself) (#6271).
+#[tokio::test(flavor = "current_thread")]
+async fn delete_session_cross_owner_fails() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let workdir = temp_workdir();
+            let db_dir = tempfile::tempdir().expect("failed to create temp db dir");
+            let sqlite_path = db_dir
+                .path()
+                .join("acp-owner-delete-test.db")
+                .to_string_lossy()
+                .into_owned();
+
+            let session_id = {
+                let (sw, sr, cw, cr) = duplex_pair();
+                let config = AcpServerConfig {
+                    sqlite_path: Some(sqlite_path.clone()),
+                    ..test_config("test-agent")
+                };
+                let server_fut =
+                    serve_connection(noop_spawner(), config, sw, sr, "alice".to_owned());
+                let client_fut =
+                    acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                        cx.send_request(acp::schema::v1::InitializeRequest::new(
+                            acp::schema::ProtocolVersion::LATEST,
+                        ))
+                        .block_task()
+                        .await?;
+                        let session_id = cx
+                            .send_request(acp::schema::v1::NewSessionRequest::new(workdir.path()))
+                            .block_task()
+                            .await?
+                            .session_id;
+                        Ok(session_id)
+                    });
+                tokio::select! {
+                    res = server_fut => panic!("server exited before client: {res:?}"),
+                    result = client_fut => result.expect("session/new failed"),
+                }
+            };
+
+            let (sw, sr, cw, cr) = duplex_pair();
+            let config = AcpServerConfig {
+                sqlite_path: Some(sqlite_path.clone()),
+                ..test_config("test-agent")
+            };
+            let server_fut = serve_connection(noop_spawner(), config, sw, sr, "bob".to_owned());
+            let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                cx.send_request(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .block_task()
+                .await?;
+                // Bob's request may return Ok (delete is a no-op for a foreign/nonexistent id,
+                // same uniform non-distinguishing shape as `claim_acp_session_for_owner`) or
+                // Err — either is acceptable here; what matters is verified below: alice's row
+                // must survive.
+                let _ = cx
+                    .send_request(acp::schema::v1::DeleteSessionRequest::new(
+                        session_id.clone(),
+                    ))
+                    .block_task()
+                    .await;
+                Ok(())
+            });
+            tokio::select! {
+                res = server_fut => panic!("server exited before client: {res:?}"),
+                result = client_fut => {
+                    result.expect("bob's delete_session request errored unexpectedly");
+                }
+            }
+
+            let store = zeph_memory::store::SqliteStore::new(&sqlite_path)
+                .await
+                .expect("SqliteStore::new");
+            assert!(
+                store
+                    .acp_session_exists(&session_id.to_string())
+                    .await
+                    .expect("acp_session_exists query failed"),
+                "bob must not be able to delete alice's session from the store"
+            );
         })
         .await;
 }


### PR DESCRIPTION
## Summary

`ZephAcpAgentState::do_delete_session` only removed the in-memory session entry — it never touched the persistence store. When a `SqliteStore` is configured (the standard production setup), a "deleted" session's row in `acp_sessions` (and its conversation history / config snapshot) was left intact:

- the session reappeared in `session/list` on any later call
- the session was fully recoverable via `session/load` or `session/resume`

`do_delete_session` now calls `store.delete_acp_session_for_owner(...)` after removing the in-memory entry, mirroring the pattern already used by `do_load_session`/`do_fork_session`/`do_resume_session`. A persisted-store deletion failure is surfaced as an `internal_error` (a static, non-leaking message) instead of being swallowed — `delete_acp_session_for_owner` deletes by id, so a retry is safe, and returning success on a real failure would silently reintroduce the resurrection bug on any transient DB error.

Also added a handler-level `delete_session_cross_owner_fails` test (mirroring the existing `load_session_cross_owner_fails`) for symmetry, and extended `delete_session_removes_session_from_list` to assert the row is actually gone from the database via a fresh store handle, not just absent from `session/list`.

Closes #6271

## Test plan

- [x] `cargo build -p zeph-acp` clean
- [x] `cargo clippy --profile ci -p zeph-acp --all-targets --features "sqlite,unstable-session-delete,unstable-session-fork,unstable-session-resume,acp-http" -- -D warnings` clean
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-acp` — 185 passed, 0 failed
- [x] `cargo +nightly fmt --check` clean
- [x] Full workspace: `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` clean
- [x] Full workspace: `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13622 passed, 0 failed
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace ...`) clean
- [x] `gitleaks protect --staged` — no leaks