### PR TITLE
fix(durable): spawn DurableRetentionService background prune sweep in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -278,6 +278,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   closed the moment any transcript line is skipped) instead of the lenient `load`, so a
   torn/malformed line from a canceled sub-agent can no longer masquerade a partial trace as a
   complete one and false-positive an honest claim.
+- **Durable execution**: `zeph_durable::retention::DurableRetentionService` (the periodic
+  background prune sweep documented in spec-064 "Retention & Compaction") was never
+  instantiated outside its own doctest — the only production prune path was the manual
+  `zeph durable prune` one-shot CLI subcommand, so a running deployment's `durable.db`
+  journal grew unbounded regardless of `[durable.retention]` TTLs. Now spawned via
+  `TaskSupervisor::spawn` (task name `durable.retention_sweep`, `RestartPolicy::Restart`
+  with exponential backoff) alongside the `JournalWriter` actor, at every production
+  call site that already opens a durable backend: the shared `open_durable_backend` helper
+  (`crates/zeph-core/src/agent/durable_bootstrap.rs`, covering both the P1 agent-turn and
+  P2 orchestration adapters) and the P3 scheduler daemon's `build_durable_adapter`
+  (`src/commands/scheduler_daemon.rs`). Gated by the same per-adapter conditions that already
+  guard backend construction at each call site — `durable.enabled && (durable.agent_turns ||
+  durable.orchestration)` for P1/P2 (each adapter checks its own flag before invoking the
+  shared helper), `durable.enabled && durable.scheduler` for P3 — no new config surface was
+  added (#6264).
 - **Docs**: fixed 11 stale Claude model ID examples across 5 mdBook pages (`acp.md`,
   `sub-agents.md`, `experiments.md`, `wizard.md`, `configuration.md`) that still used the
   outdated `claude-sonnet-4-5`/`claude-sonnet-4-20250514` naming (incorrectly pairing the

--- a/crates/zeph-core/src/agent/durable_bootstrap.rs
+++ b/crates/zeph-core/src/agent/durable_bootstrap.rs
@@ -6,21 +6,33 @@
 //! adapter that reads the shared `[durable]` config section (#5452).
 //!
 //! This module owns only the mechanical "open backend, init schema, attach cipher, spawn
-//! writer" sequence. Each adapter keeps its own cache slot (`services.orchestration.durable_*`
-//! for P2, `services.session.durable_*` for P1) and its own [`zeph_durable::ExecutionId`]
-//! derivation — those decisions are adapter-specific and stay in `plan.rs` / `durable_bootstrap.rs`
-//! respectively.
+//! writer, spawn retention sweep" sequence. Each adapter keeps its own cache slot
+//! (`services.orchestration.durable_*` for P2, `services.session.durable_*` for P1) and its
+//! own [`zeph_durable::ExecutionId`] derivation — those decisions are adapter-specific and stay
+//! in `plan.rs` / `durable_bootstrap.rs` respectively.
 
 use std::sync::Arc;
+use std::time::Duration;
 
-use zeph_durable::{DurableBackendEnum, JournalWriterHandle, LocalBackend, PayloadCipher};
+use zeph_durable::{
+    DurableBackendEnum, DurableRetentionService, JournalWriterHandle, LocalBackend, PayloadCipher,
+};
 
 use crate::agent::Agent;
 use crate::channel::Channel;
 
+/// Supervised task name for the background retention sweep (#6264).
+///
+/// Both the P1 and P2 adapters share one `TaskSupervisor` (`runtime.lifecycle.task_supervisor`)
+/// and, in the common case, the same on-disk `durable.db`. Using one fixed name lets
+/// `TaskSupervisor::spawn`'s "same name aborts the prior instance" rule collapse a second
+/// adapter's spawn into a plain restart of the first adapter's sweep, instead of running two
+/// redundant sweeps against the same journal.
+const RETENTION_TASK_NAME: &str = "durable.retention_sweep";
+
 /// Open a [`LocalBackend`] at `db_url`, initialise its schema, attach `cipher` and `hmac_key` if
-/// present, and spawn its [`JournalWriter`](zeph_durable::JournalWriter) actor via
-/// `task_supervisor`.
+/// present, spawn its [`JournalWriter`](zeph_durable::JournalWriter) actor, and spawn the
+/// background [`DurableRetentionService`] prune sweep — all via `task_supervisor`.
 ///
 /// `hmac_key` is `None` for a single-user local, non-shared database (INV-8) — the documented
 /// stance where control entries carry no HMAC.
@@ -67,6 +79,21 @@ pub(crate) async fn open_durable_backend(
         task_supervisor.spawn_oneshot(Arc::from(writer_task_name), move || async move {
             writer_actor.run().await;
         });
+
+    let retention_backend = Arc::clone(&backend);
+    let retention_policy = cfg.retention.clone();
+    task_supervisor.spawn(zeph_common::TaskDescriptor {
+        name: RETENTION_TASK_NAME,
+        restart: zeph_common::RestartPolicy::Restart {
+            max: 5,
+            base_delay: Duration::from_secs(5),
+        },
+        factory: move || {
+            DurableRetentionService::new(Arc::clone(&retention_backend), retention_policy.clone())
+                .run()
+        },
+    });
+
     Some((backend, handle, task_handle))
 }
 
@@ -263,6 +290,7 @@ impl<C: Channel> Agent<C> {
 
 #[cfg(test)]
 mod tests {
+    use super::RETENTION_TASK_NAME;
     use crate::agent::agent_tests::*;
 
     fn agent_with_conversation() -> crate::agent::Agent<MockChannel> {
@@ -290,6 +318,35 @@ mod tests {
         assert!(agent.services.session.durable_ctx.is_some());
         assert!(agent.services.session.durable_writer.is_some());
         assert!(agent.services.session.durable_ctx_init_attempted);
+    }
+
+    #[tokio::test]
+    async fn spawns_retention_sweep_reachable_via_task_supervisor_snapshot() {
+        // #6264: `DurableRetentionService::run()` must actually be reachable from production
+        // startup, not just constructible. Assert the supervised task shows up in
+        // `TaskSupervisor::snapshot()` — the same registry the TUI task panel (#6281) reads.
+        let mut agent = agent_with_conversation();
+        agent.services.session.durable_agent_turns_config = Some(zeph_config::DurableConfig {
+            enabled: true,
+            agent_turns: true,
+            ..zeph_config::DurableConfig::default()
+        });
+        agent.services.session.durable_agent_turns_db_url = Some(":memory:".to_owned());
+
+        agent.ensure_session_durable_ctx().await;
+
+        let names: Vec<String> = agent
+            .runtime
+            .lifecycle
+            .task_supervisor
+            .snapshot()
+            .iter()
+            .map(|s| s.name.to_string())
+            .collect();
+        assert!(
+            names.contains(&RETENTION_TASK_NAME.to_owned()),
+            "expected {RETENTION_TASK_NAME:?} among supervised tasks, got {names:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/commands/scheduler_daemon.rs
+++ b/src/commands/scheduler_daemon.rs
@@ -237,6 +237,24 @@ async fn build_durable_adapter(
             },
         });
     }
+    {
+        let retention_backend = std::sync::Arc::clone(&backend);
+        let retention_policy = durable_cfg.retention.clone();
+        sched_supervisor.spawn(zeph_common::TaskDescriptor {
+            name: "durable.retention_sweep",
+            restart: zeph_common::RestartPolicy::Restart {
+                max: 5,
+                base_delay: std::time::Duration::from_secs(5),
+            },
+            factory: move || {
+                zeph_durable::DurableRetentionService::new(
+                    std::sync::Arc::clone(&retention_backend),
+                    retention_policy.clone(),
+                )
+                .run()
+            },
+        });
+    }
     Ok(Some(zeph_scheduler::durable::SchedulerDurableAdapter::new(
         backend,
         writer_handle,
@@ -273,5 +291,71 @@ fn print_status_human(status: &zeph_scheduler::DaemonStatus) {
                 run.name, last_run, run.next_run
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #6264: `build_durable_adapter` must spawn the retention sweep (not just the journal
+    /// writer) onto `sched_supervisor`, mirroring the P1/P2 coverage in
+    /// `crates/zeph-core/src/agent/durable_bootstrap.rs`. `encrypt_payload = false` avoids a
+    /// real vault dependency in this test, same pattern as
+    /// `open_backend_reveal_succeeds_without_key_when_encrypt_payload_disabled` in
+    /// `src/commands/durable.rs`.
+    #[tokio::test]
+    async fn spawns_retention_sweep_alongside_journal_writer() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = zeph_core::config::Config::default();
+        config.memory.sqlite_path = dir.path().join("zeph.db").to_string_lossy().into_owned();
+        config.durable.enabled = true;
+        config.durable.scheduler = true;
+        config.durable.encrypt_payload = false;
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let sched_supervisor = zeph_common::TaskSupervisor::new(cancel);
+
+        let adapter = build_durable_adapter(&config, &sched_supervisor)
+            .await
+            .expect("build_durable_adapter must succeed with a local, unencrypted backend");
+        assert!(
+            adapter.is_some(),
+            "durable.enabled && durable.scheduler must produce an adapter"
+        );
+
+        let names: Vec<String> = sched_supervisor
+            .snapshot()
+            .iter()
+            .map(|s| s.name.to_string())
+            .collect();
+        assert!(
+            names.contains(&"journal_writer".to_owned()),
+            "expected journal_writer among supervised tasks, got {names:?}"
+        );
+        assert!(
+            names.contains(&"durable.retention_sweep".to_owned()),
+            "expected durable.retention_sweep among supervised tasks, got {names:?}"
+        );
+    }
+
+    /// The retention sweep must not spawn at all when the P3 adapter itself is disabled — it
+    /// rides the same `durable.enabled && durable.scheduler` gate as backend construction.
+    #[tokio::test]
+    async fn does_not_spawn_when_scheduler_adapter_disabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = zeph_core::config::Config::default();
+        config.memory.sqlite_path = dir.path().join("zeph.db").to_string_lossy().into_owned();
+        config.durable.enabled = true;
+        config.durable.scheduler = false;
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let sched_supervisor = zeph_common::TaskSupervisor::new(cancel);
+
+        let adapter = build_durable_adapter(&config, &sched_supervisor)
+            .await
+            .expect("build_durable_adapter must succeed (returns None, not an error)");
+        assert!(adapter.is_none());
+        assert!(sched_supervisor.snapshot().is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- `zeph_durable::retention::DurableRetentionService::run()` implemented the periodic prune sweep documented in `specs/064-durable-execution/spec.md` ("Retention & Compaction"), but was never instantiated anywhere in production — only the crate's own doctest and the manual one-shot `zeph durable prune` CLI subcommand ever called into the durable-execution prune path.
- Every production call site that opens a durable backend now also spawns the retention sweep via `TaskSupervisor::spawn` (task name `durable.retention_sweep`, `RestartPolicy::Restart { max: 5, base_delay: 5s }`), alongside the existing `JournalWriter` actor spawn:
  - The shared `open_durable_backend()` helper (`crates/zeph-core/src/agent/durable_bootstrap.rs`), covering both the P1 agent-turn and P2 orchestration adapters.
  - The P3 scheduler daemon's `build_durable_adapter()` (`src/commands/scheduler_daemon.rs`), a separate process.
- Gated by the same per-adapter conditions that already guard backend construction — no new config surface added.
- P1/P2 deliberately share one fixed task name so a second adapter's spawn collapses into a supervised restart of the same sweep (`TaskSupervisor`'s documented same-name-aborts-prior-instance behavior) rather than running duplicate sweeps against the same `durable.db`.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13611 passed, 34 skipped
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `gitleaks protect --staged --no-banner --redact` — no leaks found
- [x] New unit test `spawns_retention_sweep_reachable_via_task_supervisor_snapshot` (P1/P2 path)
- [x] New unit tests `spawns_retention_sweep_alongside_journal_writer` + `does_not_spawn_when_scheduler_adapter_disabled` (P3 scheduler-daemon path)
- [x] CHANGELOG.md updated under `[Unreleased]`
- [x] `.local/testing/playbooks/durable.md` updated with a full `#6264 (fixed)` section

Closes #6264