### PR TITLE
fix(core): resolve scheduler-feature build gap and semaphore-acquire fail-open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **core**: `apply_tier_results`'s Phase 2 hook-firing future (`RuntimeLayer::after_tool` +
+  `PostToolUse`) discarded the `Result` from `sem.acquire()`, silently proceeding as if a
+  permit were held if the local semaphore were ever closed. It now matches the sibling
+  `make_exec_future` pattern: on a closed semaphore it logs via `tracing::warn!` and returns
+  the original tool result unchanged, skipping hook firing for that index instead of running
+  unbounded (#6258).
+- **core**: `crates/zeph-core/src/agent/tests/ensemble_scheduler_loop_tests.rs` declared its
+  helper functions and `zeph_orchestration` imports at module scope with no feature gate,
+  while its four test functions were individually gated `#[cfg(feature = "scheduler")]`. Since
+  `zeph-core`'s default features don't include `scheduler`, a plain `cargo nextest run -p
+  zeph-core` compiled the now-unused helpers/imports as dead code, which the workspace's
+  `build.warnings = "deny"` turned into a hard build failure. The module declaration in
+  `agent/tests/mod.rs` is now gated `#[cfg(all(test, feature = "scheduler"))]` so the whole
+  file compiles only when the feature enabling its content is enabled (#6274).
 - **ACP**: `session/delete` only removed the in-memory session entry, never touching the
   configured persistence store — a deleted session's `acp_sessions` row (and its associated
   conversation history / config snapshot) survived, so it could resurrect via a subsequent

--- a/crates/zeph-core/src/agent/tests/mod.rs
+++ b/crates/zeph-core/src/agent/tests/mod.rs
@@ -11,7 +11,7 @@ mod commands_rs_drift_tests;
 mod compaction_e2e;
 #[cfg(test)]
 mod confirmation_propagation_tests;
-#[cfg(test)]
+#[cfg(all(test, feature = "scheduler"))]
 mod ensemble_scheduler_loop_tests;
 #[cfg(test)]
 mod flush_orphaned_tests;

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -2315,7 +2315,14 @@ impl<C: Channel> Agent<C> {
             let matched: Vec<&zeph_config::HookDef> =
                 zeph_subagent::matching_hooks(&post_hooks, tc.name.as_str());
             async move {
-                let _permit = sem.acquire().await;
+                let Ok(_permit) = sem.acquire().await else {
+                    tracing::warn!(
+                        tool = %tc.name,
+                        "semaphore closed during post-tool hook firing, skipping \
+                         RuntimeLayer::after_tool/PostToolUse hooks for this result"
+                    );
+                    return (idx, result);
+                };
                 let mut result = result;
 
                 // RuntimeLayer after_tool hooks.


### PR DESCRIPTION
## Summary
- Gate `ensemble_scheduler_loop_tests.rs` behind `#[cfg(all(test, feature = "scheduler"))]` at the module-declaration level so `cargo nextest run -p zeph-core` (default features) builds again — previously its file-scope helpers/imports were unconditionally compiled while every test using them was individually `scheduler`-gated, producing dead-code warnings promoted to hard errors by `build.warnings = "deny"`.
- Stop discarding the `Result` from `sem.acquire()` in `apply_tier_results`'s Phase 2 hook-firing future (`tier_loop.rs`); on a closed semaphore it now logs via `tracing::warn!` and returns the original tool result early (skipping hook firing for that index only), matching the sibling `make_exec_future` pattern instead of silently proceeding as if a permit were held.

Closes #6274
Closes #6258

## Test plan
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-core` (default features) — 1851/1851 passed (previously a hard build failure)
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-core --features scheduler` — 1914/1914 passed, including the 4 ensemble scheduler tests and both #6128 `apply_tier_results_tests::*`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13630/13630 passed, 0 failed
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] Rustdoc gate (`RUSTFLAGS=-D warnings RUSTDOCFLAGS=--deny rustdoc::broken_intra_doc_links cargo doc --no-deps --workspace ...`)
- [x] `gitleaks protect --staged`
- [x] Independent adversarial critique and code review both approved with no findings