### PR TITLE
fix(runtime): warn when --bare skips worktree subsystem bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Worktree**: `--bare` silently skipped the entire worktree subsystem bootstrap
+  (`WorktreeManager` construction, `probe_capabilities`) with no warning when
+  `worktree.enabled = true` in the active config — the 6th confirmed instance of the `--bare`
+  mode silently skipping a whole subsystem class with no operator-visible signal. A sub-agent
+  definition with `permissions.worktree = true` running under `--bare` lost its worktree
+  isolation guarantee (INV-1/INV-3, `specs/063-worktree-subsystem/spec.md`) with nothing in the
+  logs at default verbosity. `src/runner.rs`'s worktree bootstrap gate now emits a
+  `tracing::warn!` for the `worktree.enabled = true` + `--bare` combination explaining that
+  isolation is being skipped; `WorktreeManager` is still never constructed under `--bare` by
+  design (`--bare` remains a fast, dependency-light path). `Agent::with_bare_mode`'s doc comment
+  now lists the worktree subsystem among those `--bare` skips (#6256).
 - **ACP**: `session/delete` only removed the in-memory session entry, never touching the
   configured persistence store — a deleted session's `acp_sessions` row (and its associated
   conversation history / config snapshot) survived, so it could resurrect via a subsequent

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -840,8 +840,11 @@ impl<C: Channel> Agent<C> {
 
     /// Set whether the agent is running in `--bare` mode (#5551).
     ///
-    /// Bare mode skips skill loading, memory init, MCP connections, scheduler startup, and
-    /// filesystem watchers at startup. This flag additionally gates all four shutdown-path
+    /// Bare mode skips skill loading, memory init, MCP connections, scheduler startup,
+    /// filesystem watchers, and the worktree subsystem (`WorktreeManager` construction and
+    /// capability probing, #6256) at startup — a sub-agent with `permissions.worktree = true`
+    /// runs directly against the working copy with no isolation when `--bare` is set, even if
+    /// `worktree.enabled = true` in config. This flag additionally gates all four shutdown-path
     /// subsystems that can fire LLM calls after the run loop exits — autoDream consolidation
     /// (`maybe_autodream`), skill trace-extraction (`maybe_extract_skills_from_trace`), the
     /// shutdown summary (`maybe_store_shutdown_summary`), and the session digest

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -3104,6 +3104,12 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
                 Some(&agent_status_tx),
             )
             .await;
+        } else if agents_config.worktree.enabled && exec_mode.bare {
+            tracing::warn!(
+                "worktree.enabled = true but --bare skips the worktree subsystem; \
+                 background sub-agents with permissions.worktree = true will run \
+                 directly against the working copy with no isolation"
+            );
         }
 
         let agent = agent.with_orchestration(config.orchestration.clone(), agents_config, mgr);
@@ -5000,6 +5006,35 @@ mod tests {
         // Guard: `if exec_mode.bare { agent } else { bootstrap_scheduler(...) }`
         let scheduler_would_run = !mode.bare;
         assert!(!scheduler_would_run, "scheduler must not run in bare mode");
+    }
+
+    /// `--bare` combined with `worktree.enabled = true` must skip `WorktreeManager`
+    /// construction (INV-1/INV-3 in `specs/063-worktree-subsystem/spec.md`) and hit the
+    /// warning branch instead of silently dropping isolation guarantees (#6256).
+    #[test]
+    fn bare_flag_skips_worktree_guard() {
+        let cli = Cli::parse_from(["zeph", "--bare"]);
+        let mode =
+            crate::execution_mode::ExecutionMode::from_cli_and_config(&cli, &Config::default());
+        let agents_config = zeph_config::SubAgentConfig {
+            worktree: zeph_config::WorktreeConfig {
+                enabled: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        // Guard: `if agents_config.worktree.enabled && !exec_mode.bare { bootstrap } else if
+        // agents_config.worktree.enabled && exec_mode.bare { warn }`
+        let worktree_would_bootstrap = agents_config.worktree.enabled && !mode.bare;
+        let worktree_hits_warn_branch = agents_config.worktree.enabled && mode.bare;
+        assert!(
+            !worktree_would_bootstrap,
+            "worktree subsystem must not bootstrap in bare mode"
+        );
+        assert!(
+            worktree_hits_warn_branch,
+            "bare mode with worktree.enabled=true must hit the warning branch"
+        );
     }
 
     /// Without `--bare`, all three subsystems are allowed to start (guards evaluate to true).


### PR DESCRIPTION
## Summary

- `src/runner.rs`'s worktree subsystem bootstrap gate (`agents_config.worktree.enabled && !exec_mode.bare`) had no `else` branch for the `enabled && bare` combination — `WorktreeManager` was never constructed and no warning was logged either, so a config with `worktree.enabled = true` was silently ignored under `--bare`.
- This is the 6th confirmed instance of the `--bare`-mode-silently-skips-a-subsystem defect class (prior instance: #6127 for MagicDocs).
- Practical impact: a sub-agent with `permissions.worktree = true` running under `--bare` lost its worktree isolation guarantee (INV-1/INV-3, `specs/063-worktree-subsystem/spec.md`) with nothing surfaced to the operator — notable because `--bare` is the documented/recommended flag for CI/scripted sessions, exactly where this matters.

## Changes

- `src/runner.rs`: added an `else if agents_config.worktree.enabled && exec_mode.bare` branch emitting a `tracing::warn!` describing the skipped isolation guarantee. `WorktreeManager` is still never constructed under `--bare` by design — that would defeat the point of `--bare` as a fast, dependency-light path for CI/scripting.
- `src/runner.rs`: added `bare_flag_skips_worktree_guard` unit test alongside the existing sibling guard tests (`bare_flag_skips_{code_indexer,scheduler,mcp_connect,gateway_spawn}_guard`).
- `crates/zeph-core/src/agent/builder.rs`: updated `Agent::with_bare_mode`'s doc comment to list the worktree subsystem among those `--bare` skips.
- `CHANGELOG.md`: added a `Fixed` entry under `[Unreleased]`.
- `.local/testing/playbooks/worktree.md` (main repo): added Scenario 17 with reproduction steps and a negative control.
- `.local/testing/coverage-status.md` (main repo): added a row for this behavior (status `Untested`, pending live-session confirmation).

## Review notes

Went through the reduced bug-fix chain (root cause and fix were already scoped on the issue via a prior CI recommendation, so the debugger step was skipped):
- Adversarial critique (impl-critic): approved, no blocking findings. Verified the warning's factual claim against `crates/zeph-subagent/src/manager/spawn.rs` (subagents do run unisolated under `--bare` exactly as the message states).
- Test coverage validation (tester): 9/9 `bare_flag` tests pass independently, no regressions. Two advisory (non-blocking) gaps noted — pre-existing test debt unrelated to this change, and an optional negative-control test — both left as follow-up suggestions, not blockers.
- Code review: approved, no changes requested.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph --bins -E 'test(bare_flag)'` — 9/9 passed, including the new `bare_flag_skips_worktree_guard`
- [ ] Live-session confirmation of the warning firing (playbook Scenario 17) — tracked as `Untested` in coverage-status.md pending the next CI cycle

Closes #6256