### PR TITLE
fix(core): correct turn-latency metrics and idle-window bg status visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -271,6 +271,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   unnormalized `public_url` (trailing slash, stray path, explicit default port, mixed-case
   scheme/host) would otherwise silently 403 every request even from a correctly-behaving client,
   reintroducing S1's bug class on the server side (review finding M6).
+- **TUI/metrics**: the turn-latency panel (`latency ctx:… llm:… tool:… save:…`) showed
+  `llm:0ms` for tool-enabled turns even when the real LLM call took 25+ seconds. Root cause:
+  `MetricsBridge::WATCHED_SPANS` watched the bare `llm.chat` span, but every tool-enabled turn
+  (i.e. essentially every turn) dispatches through `chat_with_tools()` (`llm.chat_with_tools`)
+  instead — a span name `WATCHED_SPANS` never matched. The bare `llm.chat` span still fires from
+  several *auxiliary* call sites within the same turn (MARCH self-check, compaction probe, magic
+  docs, background learning, session digest, heuristic promotion), so whichever of those closed
+  last silently overwrote the correct manually-timed `chat_with_tools` duration with its own,
+  typically much smaller one. Fixed by watching `llm.chat_with_tools` instead of `llm.chat`
+  (mirroring the existing `persist_message_ms` exclusion rationale from #6111) and accumulating
+  (rather than overwriting) its duration across the multiple `chat_with_tools` calls a single
+  multi-round tool-loop turn can make. `llm.chat_with_tools` also fires from concurrent
+  in-process sub-agents and the scheduler's `RunInline` inline tool loop, neither of which
+  wraps the call in the main turn's `llm.turn_call` span — the bridge now scopes the `LlmChat`
+  field strictly to spans nested under `llm.turn_call`, so a sub-agent's or scheduler task's
+  own `chat_with_tools` timing can no longer inflate or corrupt the main turn's `llm_chat_ms`
+  (#6275, review follow-up).
+- **TUI/observability**: the `bg: N enrich, M telem` background-task status segment only
+  refreshed at the top of the next turn, so it stayed stale/invisible for the entire idle window
+  after a turn's response was sent — exactly when background enrichment/telemetry extraction
+  (spawned from `persist_message`) is actually running. Added a periodic `bg_metrics_tick`
+  (`LoopEvent::BgMetricsTick`, 2s interval) to the existing `Agent::next_event` `tokio::select!`
+  loop that reuses `reap_background_tasks_and_update_metrics` between turns, so the TUI now
+  reflects real in-flight background work continuously. No new `tokio::spawn`: the tick rides
+  the agent's own already-supervised event loop and is lazily constructed on first use since
+  `tokio::time::interval` requires an active Tokio runtime that plain-`#[test]`-constructed
+  agents do not have. Uses `tokio::time::interval_at` to defer the first tick by a full interval
+  rather than firing it immediately at construction — a plain `interval(..)` would have raced
+  the pre-existing channel-closed/shutdown `select!` arms on every agent startup, occasionally
+  forcing one spurious extra loop iteration before a closed channel was observed (#6279).
 - **CLI**: `--init` / `--migrate-config` were documented as top-level flags everywhere (both
   `CLAUDE.md` files, `.zeph/zeph.md`, `crates/zeph-config/AGENTS.md`, the worktree-disk-quota
   playbook, and `src/cli.rs`'s own doc comments) but only existed as `clap` subcommands (`zeph

--- a/crates/zeph-core/src/agent/loop_event.rs
+++ b/crates/zeph-core/src/agent/loop_event.rs
@@ -49,4 +49,9 @@ pub(crate) enum LoopEvent {
 
     /// The autonomous goal driver tick fired; the agent should execute one autonomous turn.
     AutonomousTick,
+
+    /// Periodic background-metrics tick fired; refresh `bg_enrichment_inflight` /
+    /// `bg_telemetry_inflight` (and reap completed tasks) so the TUI status segment stays live
+    /// during idle time between turns, not only at the start of the next one (#6279).
+    BgMetricsTick,
 }

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -473,6 +473,10 @@ impl<C: Channel> Agent<C> {
                         }
                         continue;
                     }
+                    Some(LoopEvent::BgMetricsTick) => {
+                        self.reap_background_tasks_and_update_metrics();
+                        continue;
+                    }
                     Some(LoopEvent::Message(msg)) => {
                         self.services.session.is_guest_context = msg.is_guest_context;
                         self.drain_channel();
@@ -796,6 +800,33 @@ impl<C: Channel> Agent<C> {
             () = self.services.autonomous.next_tick(),
                 if self.services.autonomous.should_tick() => {
                 LoopEvent::AutonomousTick
+            }
+            // Periodic background-metrics refresh: keeps the TUI's bg status segment live
+            // during idle time between turns (#6279). Lazily constructed here (not in
+            // `LifecycleState::new()`) because `tokio::time::interval` requires an active Tokio
+            // runtime, which plain `#[test]`-constructed agents do not have.
+            //
+            // `interval_at(now + INTERVAL, ...)` defers the *first* tick by a full interval.
+            // Plain `tokio::time::interval()` fires its first tick immediately on construction,
+            // which — since this is lazily built on the very first `next_event()` poll — raced
+            // the pre-existing `self.channel.recv()`/shutdown branches on every agent startup:
+            // both were simultaneously ready and `tokio::select!` (unbiased here) could pick
+            // `BgMetricsTick`, forcing one spurious extra loop iteration before an
+            // already-closed/closing channel was observed (tester-found race).
+            _ = self
+                .runtime
+                .lifecycle
+                .bg_metrics_tick
+                .get_or_insert_with(|| {
+                    let mut iv = tokio::time::interval_at(
+                        tokio::time::Instant::now() + state::BG_METRICS_TICK_INTERVAL,
+                        state::BG_METRICS_TICK_INTERVAL,
+                    );
+                    iv.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                    iv
+                })
+                .tick() => {
+                LoopEvent::BgMetricsTick
             }
         };
         Ok(Some(event))
@@ -1274,7 +1305,10 @@ impl<C: Channel> Agent<C> {
 
     /// Reap completed background tasks, apply summarization signal, and update supervisor metrics.
     ///
-    /// Called at the top of each turn, before any user message processing.
+    /// Called at the top of each turn, before any user message processing, and — since #6279 —
+    /// also on every `LoopEvent::BgMetricsTick` (a periodic idle-time tick), so the TUI's
+    /// background-work status segment reflects real in-flight enrichment/telemetry tasks
+    /// continuously, not only at turn boundaries.
     fn reap_background_tasks_and_update_metrics(&mut self) {
         let bg_signal = self.runtime.lifecycle.supervisor.reap();
         if bg_signal.did_summarize {

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -32,7 +32,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use tokio::sync::{Notify, mpsc, watch};
 use tokio::time::Interval;
@@ -537,6 +537,16 @@ pub(crate) struct LifecycleState {
     /// Supervised background task manager. Owned by the agent; call `reap()` between turns
     /// and `abort_all()` on shutdown.
     pub(crate) supervisor: super::agent_supervisor::BackgroundSupervisor,
+    /// Ticks periodically so `Agent::next_event` refreshes `bg_enrichment_inflight` /
+    /// `bg_telemetry_inflight` (and reaps completed tasks) during idle time between turns, not
+    /// only at the top of the next turn. Background enrichment/telemetry tasks run *after* a
+    /// turn's response is sent (spawned from `persist_message`), so without this the TUI status
+    /// segment showing in-flight background work was invisible for the entire idle window (#6279).
+    ///
+    /// `None` until the first `Agent::next_event` call lazily constructs it: `tokio::time::interval`
+    /// requires an active Tokio runtime, but `LifecycleState::new()` is also called from plain
+    /// (non-`#[tokio::test]`) unit tests that construct an `Agent` outside any runtime.
+    pub(crate) bg_metrics_tick: Option<Interval>,
     /// Per-turn completion notifier. `None` when `notifications.enabled = false`.
     pub(crate) notifier: Option<crate::notifications::Notifier>,
     /// Per-turn LLM request counter. Incremented by `process_response`; reset at turn start.
@@ -1398,6 +1408,12 @@ impl SkillState {
     }
 }
 
+/// Interval between periodic `bg_metrics_tick` refreshes (#6279).
+///
+/// Short enough that the TUI's background-work status segment feels live during idle time
+/// between turns, long enough to be a negligible fraction of `BackgroundSupervisor::reap`'s cost.
+pub(crate) const BG_METRICS_TICK_INTERVAL: Duration = Duration::from_secs(2);
+
 impl LifecycleState {
     pub(crate) fn new() -> Self {
         let (_tx, rx) = watch::channel(false);
@@ -1423,6 +1439,7 @@ impl LifecycleState {
                 &crate::config::TaskSupervisorConfig::default(),
                 None,
             ),
+            bg_metrics_tick: None,
             notifier: None,
             turn_llm_requests: 0,
             last_no_providers_at: None,

--- a/crates/zeph-core/src/agent/state/tests.rs
+++ b/crates/zeph-core/src/agent/state/tests.rs
@@ -244,6 +244,25 @@ fn lifecycle_state_last_no_providers_at_starts_none() {
     );
 }
 
+// ------------------------------------------------------------------
+// LifecycleState — bg_metrics_tick lazy construction (#6279)
+// ------------------------------------------------------------------
+
+/// `LifecycleState::new()` is a plain synchronous constructor called from many `#[test]`
+/// functions with no Tokio runtime active. `bg_metrics_tick` must stay `None` here and only be
+/// constructed lazily inside `Agent::next_event` (which always runs inside a runtime) — eagerly
+/// building the `tokio::time::Interval` in `new()` panics with "there is no reactor running"
+/// under a plain `#[test]`.
+#[test]
+fn lifecycle_state_bg_metrics_tick_starts_none() {
+    use crate::agent::state::LifecycleState;
+    let state = LifecycleState::new();
+    assert!(
+        state.bg_metrics_tick.is_none(),
+        "bg_metrics_tick must be None until lazily constructed by Agent::next_event (#6279)"
+    );
+}
+
 #[test]
 #[allow(clippy::unchecked_time_subtraction, clippy::nonminimal_bool)]
 fn lifecycle_state_last_no_providers_at_elapsed_check() {

--- a/crates/zeph-core/src/agent/tests/agent_tests/common.rs
+++ b/crates/zeph-core/src/agent/tests/agent_tests/common.rs
@@ -256,6 +256,33 @@ impl Channel for MockChannel {
     }
 }
 
+/// A [`Channel`] whose `recv()` never resolves.
+///
+/// Unlike `MockChannel` — whose `recv()` on an empty message queue resolves *immediately* to
+/// `Ok(None)` (i.e. "closed") — this channel keeps `next_event()`'s `channel.recv()` branch of
+/// `tokio::select!` permanently pending. Tests that need to observe a specific non-channel
+/// `tokio::select!` arm (e.g. a periodic tick) in isolation, without racing against the
+/// immediately-ready channel-closed branch, should use this instead of an empty `MockChannel`.
+pub(crate) struct PendingChannel;
+
+impl Channel for PendingChannel {
+    async fn recv(&mut self) -> Result<Option<ChannelMessage>, crate::channel::ChannelError> {
+        std::future::pending().await
+    }
+
+    async fn send(&mut self, _text: &str) -> Result<(), crate::channel::ChannelError> {
+        Ok(())
+    }
+
+    async fn send_chunk(&mut self, _chunk: &str) -> Result<(), crate::channel::ChannelError> {
+        Ok(())
+    }
+
+    async fn flush_chunks(&mut self) -> Result<(), crate::channel::ChannelError> {
+        Ok(())
+    }
+}
+
 pub(crate) struct MockToolExecutor {
     outputs: Arc<Mutex<Vec<ToolOutputResult>>>,
     pub(crate) captured_env: Arc<Mutex<Vec<EnvSnapshot>>>,

--- a/crates/zeph-core/src/agent/tests/agent_tests/lifecycle_tests.rs
+++ b/crates/zeph-core/src/agent/tests/agent_tests/lifecycle_tests.rs
@@ -1034,3 +1034,77 @@ async fn heuristic_promotion_handle_not_set_when_disabled() {
         "no handle should be spawned when heuristic_promotion_enabled = false"
     );
 }
+
+/// Regression coverage for #6279 (updated for the review follow-up fix): a plain
+/// `tokio::time::interval(..)` fires its *first* tick immediately (standard `tokio` semantics),
+/// which — since `bg_metrics_tick` was lazily constructed on the very first `next_event()`
+/// call — raced the pre-existing channel-closed `select!` branch on every agent startup,
+/// empirically winning ~90% of the time (271/300 in a local run against a `MockChannel`) and
+/// forcing one spurious extra loop iteration before `Agent::run()` observed a closed channel.
+/// Fixed by constructing `bg_metrics_tick` via `tokio::time::interval_at(now +
+/// BG_METRICS_TICK_INTERVAL, ..)` instead, deferring the first fire by a full interval — see
+/// `crates/zeph-core/src/agent/tests/bg_metrics_tick_race_tests.rs` for a deterministic,
+/// paused-time proof of that specific mechanism (verified to fail if the constructor is
+/// reverted to plain `interval(..)`).
+///
+/// This test uses `PendingChannel` (a channel that never yields a message, unlike
+/// `MockChannel`'s empty-queue `recv()`, which resolves immediately to `Ok(None)` i.e.
+/// "closed") to isolate `bg_metrics_tick` from any other ready branch: with nothing else ever
+/// ready, `next_event()` still resolves via `BgMetricsTick` once virtual time auto-advances to
+/// the deferred deadline (`start_paused = true` makes tokio's test time driver jump forward to
+/// the next scheduled timer when there is no other progress to make) — confirming the tick
+/// still fires as a plain periodic signal post-fix, just no longer competing for the very first
+/// poll.
+#[tokio::test(start_paused = true)]
+async fn next_event_first_call_fires_bg_metrics_tick_once_deferred_tick_elapses() {
+    use crate::agent::loop_event::LoopEvent;
+
+    let provider = mock_provider(vec![]);
+    let channel = PendingChannel;
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+    // No explicit time advance in this test body: with no other branch ever ready, tokio's
+    // paused-time auto-advance jumps straight to the deferred tick's deadline.
+    let event = agent.next_event().await.unwrap();
+    assert!(
+        matches!(event, Some(LoopEvent::BgMetricsTick)),
+        "expected the first next_event() call to eventually fire BgMetricsTick \
+         (the only possible event on a PendingChannel), once its deferred first tick elapses"
+    );
+}
+
+/// Regression coverage for #6279: after the (now-deferred) first tick, subsequent ticks are
+/// still properly spaced `BG_METRICS_TICK_INTERVAL` apart — confirming the tick remains
+/// periodic post-fix, not a one-shot.
+#[tokio::test(start_paused = true)]
+async fn next_event_bg_metrics_tick_refires_after_interval() {
+    use crate::agent::loop_event::LoopEvent;
+    use crate::agent::state::BG_METRICS_TICK_INTERVAL;
+
+    let provider = mock_provider(vec![]);
+    let channel = PendingChannel;
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+    // Consume the (deferred) first tick.
+    let first = agent.next_event().await.unwrap();
+    assert!(matches!(first, Some(LoopEvent::BgMetricsTick)));
+
+    // Before the interval elapses, a bounded wait for the next tick must time out —
+    // the second tick is not yet due.
+    let too_early = tokio::time::timeout(BG_METRICS_TICK_INTERVAL / 2, agent.next_event()).await;
+    assert!(
+        too_early.is_err(),
+        "BgMetricsTick must not refire before BG_METRICS_TICK_INTERVAL has elapsed"
+    );
+
+    tokio::time::advance(BG_METRICS_TICK_INTERVAL).await;
+    let second = agent.next_event().await.unwrap();
+    assert!(
+        matches!(second, Some(LoopEvent::BgMetricsTick)),
+        "expected BgMetricsTick to refire after BG_METRICS_TICK_INTERVAL"
+    );
+}

--- a/crates/zeph-core/src/agent/tests/bg_metrics_tick_race_tests.rs
+++ b/crates/zeph-core/src/agent/tests/bg_metrics_tick_race_tests.rs
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Regression test for the `BgMetricsTick` vs. channel-closed race (#6279 follow-up).
+//!
+//! `Agent::next_event`'s `tokio::select!` lazily constructs `bg_metrics_tick` on its first
+//! poll. A plain `tokio::time::interval(..)` fires its first tick *immediately* at construction
+//! time (this is documented `tokio` behavior, not a bug in `tokio` itself) — since this interval
+//! is lazily built on the very first `next_event()` poll, that immediate first tick raced the
+//! also-immediately-ready `self.channel.recv()` / shutdown-detection arms: `tokio::select!` is
+//! unbiased here, so on any given poll it could pick `BgMetricsTick` over the channel-closed
+//! signal, forcing one spurious extra loop iteration before `Agent::run()` observed a
+//! closed/closing channel and exited (tester-found race, empirically ~90% `BgMetricsTick` won
+//! in a live session). Fixed by deferring the first tick via
+//! `tokio::time::interval_at(now + BG_METRICS_TICK_INTERVAL, BG_METRICS_TICK_INTERVAL)`, so the
+//! tick genuinely is not ready at all on the first poll — eliminating the race by construction
+//! rather than reducing its odds.
+//!
+//! `tokio::select!`'s tie-break among simultaneously-ready branches is not reliably reproducible
+//! in a plain real-time unit test (empirically, in this harness, the channel-closed arm — being
+//! first in the `select!` block — won every time regardless of whether the tick was immediate or
+//! deferred, so a test built around racing them directly would pass either way and prove
+//! nothing). Testing the interval's own readiness with `tokio::time::pause()` instead verifies
+//! the actual fix mechanism deterministically: with the fix, the tick must not be ready until
+//! virtual time advances by a full `BG_METRICS_TICK_INTERVAL`.
+
+use std::time::Duration;
+
+use crate::agent::agent_tests::{
+    MockChannel, MockToolExecutor, create_test_registry, mock_provider,
+};
+use crate::agent::state::BG_METRICS_TICK_INTERVAL;
+
+fn base_agent() -> crate::agent::Agent<MockChannel> {
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    crate::agent::Agent::new(provider, channel, registry, None, 5, executor)
+}
+
+/// Deterministic (paused-time) proof of the actual fix mechanism: `interval_at(now + INTERVAL,
+/// INTERVAL)` must NOT resolve `.tick()` until virtual time has advanced by a full `INTERVAL`.
+/// A plain `tokio::time::interval(INTERVAL)` (the pre-fix construction) resolves its first
+/// `.tick()` immediately instead — this test would fail against that construction (verified by
+/// temporarily swapping the constructor back to `interval(..)` while writing this test).
+#[tokio::test(start_paused = true)]
+async fn deferred_first_tick_is_not_ready_until_interval_elapses() {
+    let mut iv = tokio::time::interval_at(
+        tokio::time::Instant::now() + BG_METRICS_TICK_INTERVAL,
+        BG_METRICS_TICK_INTERVAL,
+    );
+
+    // Immediately after construction (virtual time unchanged), the first tick must not be
+    // ready — a zero-duration timeout only fires if the wrapped future is not already ready.
+    assert!(
+        tokio::time::timeout(Duration::ZERO, iv.tick())
+            .await
+            .is_err(),
+        "the deferred interval's first tick must not be ready at construction time"
+    );
+
+    // Advancing to just before the deadline: still not ready.
+    tokio::time::advance(BG_METRICS_TICK_INTERVAL.saturating_sub(Duration::from_millis(1))).await;
+    assert!(
+        tokio::time::timeout(Duration::ZERO, iv.tick())
+            .await
+            .is_err(),
+        "the deferred interval's first tick must not be ready just before the deadline"
+    );
+
+    // Advancing past the deadline: now ready.
+    tokio::time::advance(Duration::from_millis(2)).await;
+    assert!(
+        tokio::time::timeout(Duration::ZERO, iv.tick())
+            .await
+            .is_ok(),
+        "the deferred interval's first tick must become ready once the interval has elapsed"
+    );
+}
+
+/// Companion negative case, spelled out explicitly: a plain `tokio::time::interval(..)` (the
+/// pre-fix construction) resolves its first `.tick()` immediately, with no time advancement at
+/// all — this is exactly the documented `tokio` behavior that raced the channel-closed arm.
+#[tokio::test(start_paused = true)]
+async fn plain_interval_first_tick_is_immediate_this_is_the_bug_interval_at_fixes() {
+    let mut iv = tokio::time::interval(BG_METRICS_TICK_INTERVAL);
+    assert!(
+        tokio::time::timeout(Duration::ZERO, iv.tick())
+            .await
+            .is_ok(),
+        "plain tokio::time::interval fires its first tick immediately (documented tokio \
+         behavior) — this is precisely why next_event() must use interval_at instead"
+    );
+}
+
+/// Integration-level sanity check: `next_event()` on an agent with an already-empty (closed)
+/// channel must still report the channel as closed (`Ok(None)`), not error or hang, even though
+/// `bg_metrics_tick` is lazily constructed during this exact call.
+#[tokio::test]
+async fn next_event_reports_closed_channel_without_erroring() {
+    let mut agent = base_agent();
+    let event = agent.next_event().await.expect("next_event must not error");
+    assert!(
+        event.is_none(),
+        "an already-empty channel must be observed as closed by next_event()"
+    );
+}

--- a/crates/zeph-core/src/agent/tests/mod.rs
+++ b/crates/zeph-core/src/agent/tests/mod.rs
@@ -6,6 +6,8 @@ pub mod agent_tests; // path-preserving — DO NOT rename (used by 24+ modules v
 #[cfg(test)]
 mod bare_mode_shutdown_tests;
 #[cfg(test)]
+mod bg_metrics_tick_race_tests;
+#[cfg(test)]
 mod commands_rs_drift_tests;
 #[cfg(test)]
 mod compaction_e2e;

--- a/crates/zeph-core/src/agent/utils.rs
+++ b/crates/zeph-core/src/agent/utils.rs
@@ -201,6 +201,11 @@ impl<C: Channel> Agent<C> {
             // 7+ times per turn, not once, so `timings.persist_message_ms` always keeps the
             // manual `Instant::now()` value computed in `agent/mod.rs`.
             m.bridge_timings_written = 0;
+            // `MetricsBridge::on_close` accumulates `llm_chat_ms` across every `chat_with_tools`
+            // span closed this turn (#6275). Reset it to 0 here, now that it has been read into
+            // `timings` above, so the next turn's accumulation starts fresh instead of adding
+            // onto this turn's total.
+            m.last_turn_timings.llm_chat_ms = 0;
         });
 
         if self.runtime.metrics.timing_window.len() >= 10 {
@@ -990,6 +995,41 @@ mod tests {
         assert_eq!(
             snap.bridge_timings_written, 0,
             "bitmask must be cleared after flush"
+        );
+    }
+
+    // #6275: `MetricsBridge::on_close` accumulates `last_turn_timings.llm_chat_ms` via
+    // `saturating_add` across every `chat_with_tools` span closed in a turn. Without resetting
+    // that field back to 0 once `flush_turn_timings` has read it, the next turn's accumulation
+    // would start on top of the previous turn's total instead of from zero — a slow, silent
+    // leak across turns rather than a one-turn glitch.
+    #[cfg(feature = "profiling")]
+    #[test]
+    fn flush_turn_timings_resets_bridge_llm_chat_ms_across_turns() {
+        let (mut agent, rx) = agent_with_metrics_watch();
+
+        // Turn 1: bridge reports a real chat_with_tools-derived duration.
+        if let Some(tx) = agent.runtime.metrics.metrics_tx.as_ref() {
+            tx.send_modify(|m| {
+                m.last_turn_timings.llm_chat_ms = 500;
+                m.bridge_timings_written = crate::metrics_bridge::TimingField::LlmChat.bridge_bit();
+            });
+        }
+        agent.runtime.metrics.pending_timings = make_timings(0, 0, 0, 0);
+        agent.flush_turn_timings();
+        assert_eq!(rx.borrow().last_turn_timings.llm_chat_ms, 500);
+
+        // Turn 2: no chat_with_tools span closes this turn (bridge does not mark the bit).
+        // `last_turn_timings.llm_chat_ms` must have been reset to 0 by turn 1's flush, so
+        // `MetricsBridge::on_close`'s `saturating_add` (if it fired again) would start fresh —
+        // and here, since it never fires, the field must simply read 0, not the stale 500.
+        agent.runtime.metrics.pending_timings = make_timings(0, 0, 0, 0);
+        agent.flush_turn_timings();
+
+        assert_eq!(
+            rx.borrow().last_turn_timings.llm_chat_ms,
+            0,
+            "llm_chat_ms must not leak turn 1's bridge value into turn 2 (#6275)"
         );
     }
 }

--- a/crates/zeph-core/src/metrics_bridge.rs
+++ b/crates/zeph-core/src/metrics_bridge.rs
@@ -38,11 +38,49 @@ use crate::metrics::MetricsCollector;
 /// make the bridge overwrite that value with whichever persist call happens to close last, which
 /// is wrong. So `persist_message` is intentionally left out of `WATCHED_SPANS` — that field stays
 /// manually-timed only (#6111).
+///
+/// `llm.chat` (the bare, non-tool `chat()` provider method) is intentionally **not** watched,
+/// for the same reason as `persist_message`: it is not exclusive to the primary turn-level LLM
+/// call. Every tool-enabled turn (i.e. essentially every turn, since tools are always registered)
+/// dispatches through `chat_with_tools()` instead, but a bare `llm.chat` span still fires from
+/// several *auxiliary* call sites within the same turn — the MARCH self-check hook
+/// (`quality/parser.rs`), compaction/probe, magic-docs updates, background learning, session
+/// digest, heuristic promotion, and more. Any one of those closing after the real
+/// `chat_with_tools` call would silently overwrite the correct span-derived duration with its
+/// own (typically much smaller) one, which is exactly what caused turn-latency panels to show
+/// `llm:0ms` while the real call took 25+ seconds (#6275). `chat_with_tools` is watched instead,
+/// since it is the span the primary tool-loop dispatch actually creates.
+///
+/// `llm.chat_with_tools` is **not exclusive to the main interactive turn either**: in-process
+/// sub-agents (`zeph-subagent/src/agent_loop.rs`, running concurrently on their own tokio tasks)
+/// and the scheduler's `RunInline` inline-tool-loop (`agent/scheduler_loop.rs::run_inline_tool_loop`,
+/// running sequentially on the same `Agent` but outside the normal turn cycle) both call
+/// `provider.chat_with_tools()` directly, with no wrapping span of their own — sharing the same
+/// process-wide `tracing` dispatcher, their spans are indistinguishable from the main turn's by
+/// name alone and would otherwise inflate/corrupt `llm_chat_ms` for whichever real turn's
+/// `flush_turn_timings` happens to read it next. `on_close` scopes `LlmChat` to spans nested
+/// under [`MAIN_TURN_SPAN`] (`llm.turn_call`, created once per dispatch in
+/// `agent/tool_execution/llm_dispatch.rs` around every `chat_with_tools` call the main turn
+/// itself makes) and silently ignores any `llm.chat_with_tools` span that isn't (#6275 follow-up).
+/// One deliberate exception: `llm_dispatch.rs`'s speculative-stream-failure fallback passes
+/// `tracing::Span::none()` instead of reusing `llm_span`, so that fallback call's
+/// `chat_with_tools` span has no `MAIN_TURN_SPAN` ancestor and is silently dropped by the bridge
+/// too — harmless, since the manual `Instant::now()` timing still covers it.
 const WATCHED_SPANS: &[(&str, TimingField)] = &[
     ("core.context.prepare_context", TimingField::PrepareContext),
-    ("llm.chat", TimingField::LlmChat),
+    ("llm.chat_with_tools", TimingField::LlmChat),
     ("core.tool.native_loop", TimingField::ToolExec),
 ];
+
+/// Name of the span that wraps nearly every `chat_with_tools` call the *main interactive turn*
+/// makes (`agent/tool_execution/llm_dispatch.rs`), with one exception: the speculative-stream-
+/// failure fallback path deliberately uses `Span::none()` instead, so its real LLM latency isn't
+/// bridge-tracked here — the manual `pending_timings` value covers it instead (see the
+/// `WATCHED_SPANS` doc comment for the full explanation). Used to scope the `LlmChat`
+/// `WATCHED_SPANS` entry away from concurrent in-process sub-agents and the scheduler's inline
+/// tool loop, neither of which creates this wrapping span — see the `WATCHED_SPANS` doc comment
+/// (#6275 follow-up).
+const MAIN_TURN_SPAN: &str = "llm.turn_call";
 
 /// Identifies which [`crate::metrics::TurnTimings`] field a watched span maps to.
 ///
@@ -176,19 +214,37 @@ where
 
     fn on_close(&self, id: tracing::span::Id, ctx: Context<'_, S>) {
         if let Some(span) = ctx.span(&id) {
-            let exts = span.extensions();
-            if let Some(timing) = exts.get::<SpanTiming>() {
-                let duration_ms = timing.0;
-                let name = span.name();
-                if let Some((_, field)) = WATCHED_SPANS.iter().find(|(n, _)| *n == name) {
-                    let field = *field;
+            let name = span.name();
+            if let Some((_, field)) = WATCHED_SPANS.iter().find(|(n, _)| *n == name) {
+                let field = *field;
+                // #6275 follow-up: `llm.chat_with_tools` also fires from concurrent in-process
+                // sub-agents and the scheduler's inline tool loop, neither of which wraps the
+                // call in the main turn's `MAIN_TURN_SPAN`. Drop those before they ever reach
+                // the collector, so they can't inflate/corrupt the main turn's `llm_chat_ms`.
+                if matches!(field, TimingField::LlmChat)
+                    && !span
+                        .scope()
+                        .any(|ancestor| ancestor.name() == MAIN_TURN_SPAN)
+                {
+                    return;
+                }
+                let exts = span.extensions();
+                if let Some(timing) = exts.get::<SpanTiming>() {
+                    let duration_ms = timing.0;
                     self.collector.update(|m| {
                         match field {
                             TimingField::PrepareContext => {
                                 m.last_turn_timings.prepare_context_ms = duration_ms;
                             }
                             TimingField::LlmChat => {
-                                m.last_turn_timings.llm_chat_ms = duration_ms;
+                                // `chat_with_tools` may close more than once per turn (one per
+                                // tool-loop round trip), so accumulate rather than overwrite —
+                                // matching the manual `pending_timings.llm_chat_ms` semantics in
+                                // `agent/tool_execution/llm_dispatch.rs`. `flush_turn_timings`
+                                // resets this back to 0 once it has been read for the turn
+                                // (#6275), so accumulation never leaks across turns.
+                                m.last_turn_timings.llm_chat_ms =
+                                    m.last_turn_timings.llm_chat_ms.saturating_add(duration_ms);
                             }
                             TimingField::ToolExec => {
                                 m.last_turn_timings.tool_exec_ms = duration_ms;
@@ -223,13 +279,19 @@ mod tests {
     }
 
     /// `on_close` writes the correct `TurnTimings` field for each watched span.
+    ///
+    /// `llm.chat_with_tools` must be nested under `MAIN_TURN_SPAN` (`llm.turn_call`) to be
+    /// counted at all (#6275 follow-up) — see `llm_chat_with_tools_outside_main_turn_span_is_ignored`
+    /// for the negative case.
     #[test]
     fn watched_span_updates_correct_field() {
         let (bridge, _collector, rx) = make_bridge();
         let subscriber = Registry::default().with(bridge);
 
         tracing::subscriber::with_default(subscriber, || {
-            let span = tracing::span!(tracing::Level::INFO, "llm.chat");
+            let turn_span = tracing::span!(tracing::Level::INFO, "llm.turn_call");
+            let _turn_guard = turn_span.enter();
+            let span = tracing::span!(tracing::Level::INFO, "llm.chat_with_tools");
             let guard = span.enter();
             drop(guard);
             // span closes on Drop of the Span object.
@@ -245,6 +307,124 @@ mod tests {
         // llm_chat_ms may be 0 in very fast test runs (sub-millisecond); that is
         // acceptable — what matters is the field was written and others were not.
         let _ = snapshot.last_turn_timings.llm_chat_ms;
+    }
+
+    /// Regression guard for #6275: a bare `llm.chat` span (fired by auxiliary call sites like
+    /// the MARCH self-check hook, compaction probe, or magic docs — never the primary
+    /// tool-enabled turn call) must NOT be watched, since it is not exclusive to the turn's
+    /// real LLM latency and would silently overwrite the correct `chat_with_tools`-derived
+    /// duration.
+    #[test]
+    fn bare_llm_chat_span_is_not_watched() {
+        let (bridge, _collector, rx) = make_bridge();
+        let subscriber = Registry::default().with(bridge);
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::span!(tracing::Level::INFO, "llm.chat");
+            let guard = span.enter();
+            drop(guard);
+        });
+
+        let snapshot = rx.borrow().clone();
+        assert_eq!(snapshot.last_turn_timings.llm_chat_ms, 0);
+        assert_eq!(snapshot.bridge_timings_written, 0);
+    }
+
+    /// `chat_with_tools` may close more than once per turn (one per tool-loop round trip);
+    /// `on_close` must accumulate rather than overwrite so the total reflects the sum (#6275).
+    ///
+    /// Each span sleeps for a measurable duration so the test can distinguish accumulation from
+    /// overwrite numerically: under overwrite semantics the final value would be roughly the
+    /// *last* span's duration alone (~10ms); under accumulation it must be roughly the sum of
+    /// all three (~30ms+).
+    #[test]
+    fn llm_chat_with_tools_span_accumulates_across_multiple_closes() {
+        let (bridge, _collector, rx) = make_bridge();
+        let subscriber = Registry::default().with(bridge);
+
+        tracing::subscriber::with_default(subscriber, || {
+            let turn_span = tracing::span!(tracing::Level::INFO, "llm.turn_call");
+            let _turn_guard = turn_span.enter();
+            for _ in 0..3 {
+                let span = tracing::span!(tracing::Level::INFO, "llm.chat_with_tools");
+                let guard = span.enter();
+                std::thread::sleep(std::time::Duration::from_millis(10));
+                drop(guard);
+            }
+        });
+
+        let snapshot = rx.borrow().clone();
+        assert!(
+            snapshot.last_turn_timings.llm_chat_ms >= 25,
+            "expected accumulated duration across 3 closes (~30ms+), got {}ms — \
+             on_close may be overwriting instead of accumulating",
+            snapshot.last_turn_timings.llm_chat_ms
+        );
+    }
+
+    /// Regression guard (F1, #6275 follow-up): an `llm.chat_with_tools` span that is not nested
+    /// under `MAIN_TURN_SPAN` (`llm.turn_call`) must be ignored entirely, not counted into
+    /// `llm_chat_ms` or flagged via `bridge_timings_written`. This simulates in-process
+    /// sub-agents (`zeph-subagent/src/agent_loop.rs`) and the scheduler's `RunInline` inline
+    /// tool loop (`agent/scheduler_loop.rs::run_inline_tool_loop`), both of which call
+    /// `provider.chat_with_tools()` directly with no such wrapping span — sharing the same
+    /// process-wide `tracing` dispatcher as the main turn, their spans must not inflate or
+    /// corrupt whichever real turn's `flush_turn_timings` reads the field next.
+    #[test]
+    fn llm_chat_with_tools_outside_main_turn_span_is_ignored() {
+        let (bridge, _collector, rx) = make_bridge();
+        let subscriber = Registry::default().with(bridge);
+
+        tracing::subscriber::with_default(subscriber, || {
+            // No `llm.turn_call` ancestor — e.g. a sub-agent's or scheduler inline task's
+            // direct `chat_with_tools()` call.
+            let span = tracing::span!(tracing::Level::INFO, "llm.chat_with_tools");
+            let guard = span.enter();
+            std::thread::sleep(std::time::Duration::from_millis(10));
+            drop(guard);
+        });
+
+        let snapshot = rx.borrow().clone();
+        assert_eq!(
+            snapshot.last_turn_timings.llm_chat_ms, 0,
+            "an llm.chat_with_tools span with no llm.turn_call ancestor must not be counted"
+        );
+        assert_eq!(
+            snapshot.bridge_timings_written, 0,
+            "an out-of-scope llm.chat_with_tools span must not set the LlmChat bridge bit"
+        );
+    }
+
+    /// A real turn's `llm.chat_with_tools` call (nested under `llm.turn_call`) must still be
+    /// counted even when an unrelated, out-of-scope `llm.chat_with_tools` span (simulating a
+    /// concurrent sub-agent) closes around the same time — the scoping check must not
+    /// accidentally suppress legitimate main-turn spans (#6275 follow-up).
+    #[test]
+    fn llm_chat_with_tools_inside_main_turn_span_counted_despite_concurrent_out_of_scope_span() {
+        let (bridge, _collector, rx) = make_bridge();
+        let subscriber = Registry::default().with(bridge);
+
+        tracing::subscriber::with_default(subscriber, || {
+            // Out-of-scope span first (simulated concurrent sub-agent).
+            let outside = tracing::span!(tracing::Level::INFO, "llm.chat_with_tools");
+            let outside_guard = outside.enter();
+            drop(outside_guard);
+
+            // Real main-turn span, correctly nested.
+            let turn_span = tracing::span!(tracing::Level::INFO, "llm.turn_call");
+            let _turn_guard = turn_span.enter();
+            let inside = tracing::span!(tracing::Level::INFO, "llm.chat_with_tools");
+            let inside_guard = inside.enter();
+            std::thread::sleep(std::time::Duration::from_millis(10));
+            drop(inside_guard);
+        });
+
+        let snapshot = rx.borrow().clone();
+        assert!(
+            snapshot.last_turn_timings.llm_chat_ms >= 5,
+            "the in-scope span must still be counted, got {}ms",
+            snapshot.last_turn_timings.llm_chat_ms
+        );
     }
 
     /// Non-watched spans must not trigger any `collector.update()` call.
@@ -272,7 +452,7 @@ mod tests {
     fn all_watched_span_names_registered() {
         let expected = [
             "core.context.prepare_context",
-            "llm.chat",
+            "llm.chat_with_tools",
             "core.tool.native_loop",
         ];
 
@@ -291,8 +471,8 @@ mod tests {
 
     /// Regression guard for #6111: `WATCHED_SPANS` entries whose span is defined in this crate
     /// must match a real `#[tracing::instrument(name = "...")]` name, not a name that looks
-    /// plausible but was never wired up. `llm.chat` lives in `zeph-llm` and is exercised by
-    /// that crate's own span-name literals instead.
+    /// plausible but was never wired up. `llm.chat_with_tools` lives in `zeph-llm` and is
+    /// exercised by that crate's own span-name literals instead.
     #[test]
     fn watched_spans_match_real_instrument_names_in_this_crate() {
         let assembly_src = include_str!(concat!(


### PR DESCRIPTION
## Summary

- `MetricsBridge::WATCHED_SPANS` watched the bare `llm.chat` span instead of `llm.chat_with_tools`, the span every tool-enabled turn (essentially all of them) actually dispatches through — the turn-latency panel showed `llm:0ms` even when the real LLM call took 25+ seconds. Auxiliary bare `llm.chat` calls in the same turn (self-check, compaction probe, etc.) were also silently overwriting the correct manually-tracked duration.
- Fixed by watching `llm.chat_with_tools`, accumulating across a turn's multi-round tool loop (instead of overwriting), and scoping accumulation to spans nested under the main turn's `llm.turn_call` span so concurrent in-process sub-agent and scheduler `chat_with_tools` calls can't inflate or corrupt the main turn's `llm_chat_ms` (found during review).
- The `bg: N enrich, M telem` TUI status segment only refreshed at the start of the next turn, so it stayed stale/invisible during the entire idle window after a response — exactly when background enrichment/telemetry extraction is actually running. Added a periodic `BgMetricsTick` to the existing `Agent::next_event` `tokio::select!` loop (no new `tokio::spawn`), using `interval_at` to defer the first tick and avoid racing the pre-existing channel-closed shutdown path (found during testing).

Closes #6275
Closes #6279

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo clippy --profile ci -p zeph-core --all-targets --features "profiling,scheduler" -- -D warnings` (metrics_bridge.rs is profiling-gated, not covered by the CI feature matrix)
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (13636 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] New/updated regression tests in `metrics_bridge.rs`, `agent/utils.rs`, `agent/tests/bg_metrics_tick_race_tests.rs`, `agent/tests/agent_tests/lifecycle_tests.rs`
- [ ] Live `--tui` session confirmation per updated playbooks (`metrics-bridge-watched-spans.md` Scenario 2/2b/2c, `bg-supervisor-phase2.md` S9) — deferred to next live-testing cycle, `coverage-status.md` rows left `Partial`