### PR TITLE
fix(deps): bump yanked spin 0.9.8/0.10.0 to 0.9.9/0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+### Security
+
+- Bumped the transitively-pinned `spin` crate off two yanked versions in `Cargo.lock`:
+  `0.9.8 -> 0.9.9` (via `flume 0.12.0` -> `sqlx-sqlite 0.9.0` -> `sqlx 0.9.0`) and
+  `0.10.0 -> 0.10.1` (via `pprof 0.15.0`, `bench` feature). Both were flagged as yanked
+  by `cargo audit` / `cargo deny check advisories`; the patch-level bumps carry no API
+  changes and required no `Cargo.toml` edits (#6249).
+
 ### Added
 
 - **TUI**: added a read-only settings view (`S` key or the `settings` command-palette

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2765,7 +2765,7 @@ checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -5720,7 +5720,7 @@ dependencies = [
  "prost-derive 0.12.6",
  "sha2 0.10.9",
  "smallvec",
- "spin 0.10.0",
+ "spin 0.10.1",
  "symbolic-demangle",
  "tempfile",
  "thiserror 2.0.18",
@@ -7662,18 +7662,18 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 dependencies = [
  "lock_api",
 ]


### PR DESCRIPTION
## Summary
- `cargo audit` / `cargo deny check advisories` flagged the transitively-pinned `spin` crate as yanked at two versions in `Cargo.lock`: `0.9.8` (via `flume 0.12.0` -> `sqlx-sqlite 0.9.0` -> `sqlx 0.9.0`) and `0.10.0` (via `pprof 0.15.0`, `bench` feature).
- Both have non-yanked patch releases already within the existing semver ranges (`0.9.9` and `0.10.1`), so this is a `Cargo.lock`-only bump via `cargo update -p spin@X --precise Y` — no `Cargo.toml` changes.

Closes #6249

## Test plan
- [x] `cargo deny check --config .github/deny.toml advisories` -> `advisories ok`, yanked warning gone
- [x] `cargo audit` -> 0 vulnerabilities, no spin/yanked matches
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` -> 13692 passed, 0 failed
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` -> 0 failed
- [x] `cargo check --workspace --all-targets --features bench` -> clean (bench feature is the only path to `spin 0.10.x` via `pprof`)
- [x] `cargo +nightly fmt --check`, `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`, rustdoc gate -> all clean
- [x] `git diff` scoped to exactly the two `spin` package blocks + dependents' inline pin refs, plus a CHANGELOG.md entry; no `Cargo.toml` touched