### PR TITLE
fix(security): enable PII filter/secret masking by default and stop leaking gateway auth token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `build.warnings = "deny"` turned into a hard build failure. The module declaration in
   `agent/tests/mod.rs` is now gated `#[cfg(all(test, feature = "scheduler"))]` so the whole
   file compiles only when the feature enabling its content is enabled (#6274).
+- **Security (config)**: `PiiFilterConfig` and `SecretMaskingConfig` (the PAAC secret
+  placeholder masking registry) both shipped `enabled = false` by default even though both
+  controls are cheap synchronous substitutions (regex scrub / placeholder swap, no LLM call)
+  whose entire purpose is keeping vault-resolved secrets and PII out of LLM payloads, SQLite
+  message history, and debug dumps — an operator accepting `--init` defaults ended up with
+  neither protection active. Flipped both fields' effective default to `true`: the `enabled`
+  field itself now uses `#[serde(default = "default_true")]` (not a bare `#[serde(default)]`,
+  which only resolves via `bool::default()` and would have stayed `false` for any config where
+  the section is present but the key was never written — matching the existing
+  `query_bias_correction` field convention), so both a missing section and a present-but-key-
+  omitted section now correctly resolve to enabled. `PiiFilterConfig::default()` and
+  `SecretMaskingConfig::default()` updated to match. `--init` prompts now default to `true`
+  with a "(recommended)" suffix. An operator's explicit `enabled = false` in an existing
+  `config.toml` is always respected — this is a serde default-value change, not a migration
+  that rewrites live config. Also updated the shipped `config/default.toml` and
+  `crates/zeph-core/config/default.toml` reference files (both previously wrote an explicit
+  `enabled = false`, which would otherwise have silently overridden the new safe default) and
+  the `--migrate-config` step-73 advisory comment for `[security.content_isolation.secret_masking]`
+  (#6263).
+- **Security (config)**: `GatewayConfig.auth_token` is hydrated in place from the vault
+  (`ZEPH_GATEWAY_TOKEN`) at startup but derived `Serialize` only had `#[serde(default)]`, no
+  `#[serde(skip_serializing)]` — the same latent-leak class already fixed for
+  `TelegramConfig.token`/`DiscordConfig.token`/`SlackConfig.bot_token`/`SlackConfig.signing_secret`
+  in #6173. Unlike `A2aServerConfig.auth_token`, `--init` has no wizard path that persists
+  `gateway.auth_token` to `config.toml`, so redacting it in `Serialize` carries no round-trip
+  risk. Added `#[serde(skip_serializing)]`; `Deserialize` is untouched so an inline token in a
+  hand-edited `config.toml` still loads (#6248).
 - **ACP**: `session/delete` only removed the in-memory session entry, never touching the
   configured persistence store — a deleted session's `acp_sessions` row (and its associated
   conversation history / config snapshot) survived, so it could resurrect via a subsequent

--- a/book/src/getting-started/wizard.md
+++ b/book/src/getting-started/wizard.md
@@ -177,7 +177,7 @@ Debug dump is intended for context debugging — use it when you need to inspect
 
 Configure security features:
 
-- **PII filter** — scrub emails, phone numbers, SSNs, and credit card numbers from tool outputs before they reach the LLM context and debug dumps (default: disabled)
+- **PII filter** — scrub emails, phone numbers, SSNs, and credit card numbers from tool outputs before they reach the LLM context and debug dumps (default: enabled)
 - **Tool rate limiter** — sliding-window per-category limits (shell 30/min, web 20/min, memory 60/min) to prevent runaway tool calls (default: disabled)
 - **Skill scan on load** — scan skill content for injection patterns when skills are loaded; logs warnings but does not block execution (default: enabled)
 - **Pre-execution verification** — block destructive commands (e.g. `rm -rf /`) and injection patterns before every tool call (default: enabled)

--- a/config/default.toml
+++ b/config/default.toml
@@ -925,8 +925,8 @@ max_content_len = 2048
 # PAAC secret placeholder masking: substitutes vault-resolved secrets (API keys, tokens,
 # database URLs, etc.) with opaque per-session placeholders before any outbound LLM call,
 # preventing plaintext secret disclosure to third-party providers. Placeholders are resolved
-# back to real values only at tool-execution time (shell env, HTTP headers) (default: false)
-enabled = false
+# back to real values only at tool-execution time (shell env, HTTP headers) (default: true)
+enabled = true
 # Minimum secret byte length eligible for masking — shorter values are skipped to avoid
 # false-positive substitutions on common short strings (default: 8)
 min_secret_len = 8

--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -912,7 +912,16 @@ pub struct GatewayConfig {
     pub port: u16,
     /// Bearer token for request authentication. When set, all requests must include
     /// `Authorization: Bearer <token>`. Default: `None` (no auth).
-    #[serde(default)]
+    ///
+    /// # Security
+    ///
+    /// Never serialized: `--init` has no wizard path that persists this field (the real
+    /// token is resolved from the vault via `ZEPH_GATEWAY_TOKEN`), but runtime config
+    /// resolution hydrates the real value into this field in memory.
+    /// `#[serde(skip_serializing)]` keeps any future diagnostic `Serialize` of a live
+    /// `Config` from leaking it; `Deserialize` is untouched so an inline token in a
+    /// hand-edited `config.toml` still loads.
+    #[serde(default, skip_serializing)]
     pub auth_token: Option<String>,
     /// Maximum requests per minute. Must be `> 0`. Default: `120`.
     #[serde(default = "default_gateway_rate_limit")]
@@ -1358,6 +1367,26 @@ mod tests {
         let dbg = format!("{cfg:?}");
         assert!(!dbg.contains("[REDACTED]"));
         assert!(dbg.contains("auth_token: None"));
+    }
+
+    #[test]
+    fn gateway_config_serialize_omits_auth_token() {
+        let cfg = GatewayConfig {
+            auth_token: Some("real-secret-value".into()),
+            ..GatewayConfig::default()
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        assert!(!json.contains("real-secret-value"));
+        assert!(!json.contains("\"auth_token\""));
+    }
+
+    #[test]
+    fn gateway_config_deserialize_missing_auth_token_as_none() {
+        // `#[serde(skip_serializing)]` only affects the output side; this pins that
+        // `skip_serializing` cannot break loading a config that never had the key (e.g. one
+        // written before this fix, or hand-edited without it).
+        let cfg: GatewayConfig = toml::from_str("").unwrap();
+        assert!(cfg.auth_token.is_none());
     }
 
     #[test]

--- a/crates/zeph-config/src/migrate/infra.rs
+++ b/crates/zeph-config/src/migrate/infra.rs
@@ -820,7 +820,10 @@ pub fn migrate_nli_config(toml_src: &str) -> Result<MigrationResult, MigrateErro
 /// Adds a commented-out `[security.content_isolation.secret_masking]` section to configs that
 /// predate the PAAC secret placeholder masking registry (#5437). Idempotent: no-op when the
 /// real or commented `[security.content_isolation.secret_masking]` header is already present.
-/// Existing configs gain the section as comments (no behavior change — `enabled = false`).
+/// Existing configs gain the section as comments only — this migration writes no active TOML
+/// key, so it does not itself change behavior. The section is absent from `toml_src` here, so
+/// the actual effective value already comes from `SecretMaskingConfig::default()`, which is
+/// `enabled = true` as of #6263.
 ///
 /// # Errors
 ///
@@ -842,9 +845,9 @@ pub fn migrate_secret_masking_config(toml_src: &str) -> Result<MigrationResult, 
     let _doc = toml_src.parse::<DocumentMut>()?;
 
     let block = "\n# PAAC secret placeholder masking: substitutes vault-resolved secrets with opaque\n\
-         # per-session placeholders before outbound LLM calls (#5437). Opt-in, default-off.\n\
+         # per-session placeholders before outbound LLM calls (#5437). Enabled by default.\n\
          # [security.content_isolation.secret_masking]\n\
-         # enabled = false\n\
+         # enabled = true\n\
          # min_secret_len = 8\n";
     let output = format!("{}{}", toml_src.trim_end(), block);
     Ok(MigrationResult {

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -3649,7 +3649,7 @@ fn step_73_adds_secret_masking_block_when_absent() {
             .output
             .contains("# [security.content_isolation.secret_masking]")
     );
-    assert!(result.output.contains("# enabled = false"));
+    assert!(result.output.contains("# enabled = true"));
     assert_eq!(
         result.sections_changed,
         vec!["security.content_isolation.secret_masking".to_owned()]

--- a/crates/zeph-config/src/sanitizer.rs
+++ b/crates/zeph-config/src/sanitizer.rs
@@ -199,11 +199,13 @@ impl Default for NliConfig {
 /// Configuration for PAAC secret placeholder masking, nested under
 /// `[security.content_isolation.secret_masking]` in the agent config file.
 ///
-/// When `enabled = false` (the default), vault secrets are not masked.
+/// Enabled by default: substitution is a cheap synchronous placeholder swap with no LLM
+/// call, and keeps vault-resolved secrets out of LLM payloads, `SQLite` history, and debug
+/// dumps (#6263).
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct SecretMaskingConfig {
-    /// Enable secret placeholder masking (default: false — opt-in).
-    #[serde(default)]
+    /// Enable secret placeholder masking (default: true).
+    #[serde(default = "default_true")]
     pub enabled: bool,
 
     /// Minimum secret byte length to be eligible for masking (default: 8).
@@ -221,7 +223,7 @@ fn default_min_secret_len() -> usize {
 impl Default for SecretMaskingConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
+            enabled: true,
             min_secret_len: default_min_secret_len(),
         }
     }
@@ -402,12 +404,13 @@ fn default_custom_replacement() -> String {
 
 /// Configuration for the PII filter, nested under `[security.pii_filter]` in the config file.
 ///
-/// Disabled by default — opt-in to avoid unexpected data loss.
+/// Enabled by default: filtering is a cheap synchronous regex substitution with no LLM
+/// call, and keeps PII out of LLM payloads, `SQLite` history, and debug dumps (#6263).
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[allow(clippy::struct_excessive_bools)] // config struct — boolean flags are idiomatic for TOML-deserialized configuration
 pub struct PiiFilterConfig {
-    /// Master switch. When `false`, the filter is a no-op.
-    #[serde(default)]
+    /// Master switch. When `false`, the filter is a no-op. Default: `true`.
+    #[serde(default = "default_true")]
     pub enabled: bool,
     /// Scrub email addresses.
     #[serde(default = "default_true")]
@@ -439,7 +442,7 @@ pub struct PiiFilterConfig {
 impl Default for PiiFilterConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
+            enabled: true,
             filter_email: true,
             filter_phone: true,
             filter_ssn: true,
@@ -594,6 +597,59 @@ mod tests {
     fn content_isolation_deserialize_absent_defaults_true() {
         let cfg: ContentIsolationConfig = toml::from_str("").unwrap();
         assert!(cfg.mcp_to_acp_boundary);
+    }
+
+    // ── PiiFilterConfig / SecretMaskingConfig safe-default posture (#6263) ──────────────
+
+    #[test]
+    fn pii_filter_default_is_enabled() {
+        assert!(PiiFilterConfig::default().enabled);
+    }
+
+    #[test]
+    fn pii_filter_deserialize_absent_defaults_enabled_true() {
+        // The whole [security.pii_filter] table is absent — falls back to struct Default.
+        let cfg: PiiFilterConfig = toml::from_str("").unwrap();
+        assert!(cfg.enabled);
+    }
+
+    #[test]
+    fn pii_filter_deserialize_section_present_without_enabled_key_defaults_true() {
+        // The section exists (e.g. only `filter_email` was set) but omits `enabled` — must
+        // resolve via the field-level `default_true`, not `bool::default()`.
+        let cfg: PiiFilterConfig = toml::from_str("filter_email = false").unwrap();
+        assert!(cfg.enabled);
+        assert!(!cfg.filter_email);
+    }
+
+    #[test]
+    fn pii_filter_deserialize_explicit_false_is_respected() {
+        let cfg: PiiFilterConfig = toml::from_str("enabled = false").unwrap();
+        assert!(!cfg.enabled);
+    }
+
+    #[test]
+    fn secret_masking_default_is_enabled() {
+        assert!(SecretMaskingConfig::default().enabled);
+    }
+
+    #[test]
+    fn secret_masking_deserialize_absent_defaults_enabled_true() {
+        let cfg: SecretMaskingConfig = toml::from_str("").unwrap();
+        assert!(cfg.enabled);
+    }
+
+    #[test]
+    fn secret_masking_deserialize_section_present_without_enabled_key_defaults_true() {
+        let cfg: SecretMaskingConfig = toml::from_str("min_secret_len = 12").unwrap();
+        assert!(cfg.enabled);
+        assert_eq!(cfg.min_secret_len, 12);
+    }
+
+    #[test]
+    fn secret_masking_deserialize_explicit_false_is_respected() {
+        let cfg: SecretMaskingConfig = toml::from_str("enabled = false").unwrap();
+        assert!(!cfg.enabled);
     }
 
     fn de_guard(toml: &str) -> Result<EmbeddingGuardConfig, toml::de::Error> {

--- a/crates/zeph-config/src/security.rs
+++ b/crates/zeph-config/src/security.rs
@@ -531,7 +531,7 @@ pub struct SecurityConfig {
     /// Memory write validation (enabled by default).
     #[serde(default)]
     pub memory_validation: MemoryWriteValidationConfig,
-    /// PII filter for tool outputs and debug dumps (opt-in, disabled by default).
+    /// PII filter for tool outputs and debug dumps (enabled by default).
     #[serde(default)]
     pub pii_filter: PiiFilterConfig,
     /// Tool action rate limiter (opt-in, disabled by default).

--- a/crates/zeph-core/config/default.toml
+++ b/crates/zeph-core/config/default.toml
@@ -538,8 +538,8 @@ sources = ["web_scrape", "a2a_message"]
 model = "claude"
 
 [security.pii_filter]
-# Scrub PII from tool outputs before they enter LLM context and debug dumps (default: false)
-enabled = false
+# Scrub PII from tool outputs before they enter LLM context and debug dumps (default: true)
+enabled = true
 # Scrub email addresses (default: true)
 filter_email = true
 # Scrub US phone numbers (default: true)

--- a/crates/zeph-sanitizer/src/pii.rs
+++ b/crates/zeph-sanitizer/src/pii.rs
@@ -549,7 +549,12 @@ mod tests {
     }
 
     fn filter_disabled() -> PiiFilter {
-        PiiFilter::new(PiiFilterConfig::default())
+        // `enabled` now defaults to true (#6263) — construct an explicitly-disabled config to
+        // exercise the no-op fast path, rather than relying on `PiiFilterConfig::default()`.
+        PiiFilter::new(PiiFilterConfig {
+            enabled: false,
+            ..PiiFilterConfig::default()
+        })
     }
 
     // --- disabled fast-path ---
@@ -915,7 +920,7 @@ mod tests {
 
     #[test]
     fn detect_spans_disabled_returns_empty() {
-        let f = PiiFilter::new(PiiFilterConfig::default());
+        let f = filter_disabled();
         assert!(f.detect_spans("user@example.com").is_empty());
     }
 

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -440,7 +440,7 @@ impl Default for WizardState {
             experiments_eval_provider: String::new(),
             experiments_schedule_enabled: false,
             experiments_schedule_cron: String::new(),
-            pii_filter_enabled: false,
+            pii_filter_enabled: true,
             rate_limit_enabled: false,
             skill_scan_on_load: true,
             skill_require_integrity_check_on_promote: true,
@@ -461,7 +461,7 @@ impl Default for WizardState {
             guardrail_timeout_ms: 500,
             nli_enabled: false,
             nli_provider: String::new(),
-            secret_masking_enabled: false,
+            secret_masking_enabled: true,
             #[cfg(feature = "classifiers")]
             classifiers_enabled: false,
             #[cfg(feature = "classifiers")]

--- a/src/init/security.rs
+++ b/src/init/security.rs
@@ -204,9 +204,9 @@ pub(super) fn step_security(state: &mut WizardState) -> anyhow::Result<()> {
     );
     state.pii_filter_enabled = Confirm::new()
         .with_prompt(
-            "Enable PII filter? (scrubs emails, phone numbers, SSNs, and credit card numbers from tool outputs before LLM context and debug dumps)",
+            "Enable PII filter? (scrubs emails, phone numbers, SSNs, and credit card numbers from tool outputs before LLM context and debug dumps; recommended)",
         )
-        .default(false)
+        .default(true)
         .interact()?;
     state.rate_limit_enabled = Confirm::new()
         .with_prompt(
@@ -379,9 +379,9 @@ pub(super) fn step_security(state: &mut WizardState) -> anyhow::Result<()> {
     {
         state.secret_masking_enabled = Confirm::new()
             .with_prompt(
-                "Enable secret placeholder masking? (substitutes vault-resolved secrets — API keys, tokens, DB URLs — with opaque per-session placeholders before outbound LLM calls; resolved back only at tool execution)",
+                "Enable secret placeholder masking? (substitutes vault-resolved secrets — API keys, tokens, DB URLs — with opaque per-session placeholders before outbound LLM calls; resolved back only at tool execution; recommended)",
             )
-            .default(false)
+            .default(true)
             .interact()?;
     }
 


### PR DESCRIPTION
## Summary

- `PiiFilterConfig` and `SecretMaskingConfig` shipped `enabled: false` by default, and the `--init` wizard defaulted both prompts to disabled, so an operator accepting defaults ended up with neither protection active — despite both existing specifically to keep vault-resolved secrets and PII out of LLM payloads, SQLite message history, and debug dumps. Flipped both to enabled by default via field-level `#[serde(default = "default_true")]` (a bare `#[serde(default)]` only covers the whole-section-absent case, not section-present-key-omitted), and fixed the two shipped reference configs (`config/default.toml`, `crates/zeph-core/config/default.toml`) that still wrote an explicit `enabled = false`, which would have silently overridden the new default.
- `GatewayConfig.auth_token` is vault-hydrated in place at startup but only had `#[serde(default)]`, not `#[serde(skip_serializing)]`, unlike its already-fixed Telegram/Discord/Slack siblings (PR #6173). Added `#[serde(skip_serializing)]`, verified no load-mutate-save path can drop a hand-edited inline token.

## Details

- `crates/zeph-config/src/sanitizer.rs` — `PiiFilterConfig`/`SecretMaskingConfig`: field-level serde default flipped to `default_true` (matches the existing `MemoryRetrievalConfig::query_bias_correction` precedent), both `Default` impls updated, 10 new unit tests covering absent-section / present-section-key-omitted / explicit-false-respected cases.
- `crates/zeph-config/src/security.rs` — doc comment update.
- `crates/zeph-config/src/features.rs` — `GatewayConfig.auth_token` gained `#[serde(skip_serializing)]` + `# Security` doc block, mirroring PR #6173; 2 new unit tests.
- `crates/zeph-config/src/migrate/infra.rs` + `migrate/tests.rs` — step-73 advisory-comment template updated to match the new default (comment-only, no active override — same pattern as the `query_bias_correction` migration).
- `crates/zeph-sanitizer/src/pii.rs` — 2 pre-existing tests updated for the new enabled-by-default posture.
- `src/init/security.rs` + `src/init/mod.rs` — both `--init` prompts default to `true` ("(recommended)"), wizard state sentinel updated for consistency.
- `config/default.toml` + `crates/zeph-core/config/default.toml` — shipped reference configs corrected (each carries only one of the two sections; the other relies on the now-safe serde default).
- `book/src/getting-started/wizard.md` — stale "(default: disabled)" line updated to match the new default.
- `CHANGELOG.md` — `[Unreleased]` entries for both fixes.

No migration code needed for the default flip itself — `#[serde(default = "default_true")]` already gives correct safe-upgrade semantics (missing key → `true`; explicit `enabled = false` in an existing config is respected, never overridden).

## Review

- Adversarial critic pass: verdict `significant` — one real gap (stale doc line in `wizard.md`), fixed before review; all six adversarial probes (serde-default precedent validity, existing-config upgrade safety, migration advisory-text correctness, gateway serialize/deserialize safety incl. load-mutate-save regression risk, default-flip behavioral risk, test quality) came back verified sound.
- Code review: `approved`, with independent re-verification (not just re-reading handoffs) of the serde-default fix, the gateway skip_serializing safety claim, repo-wide grep for any missed stale `enabled = false`, and the doc fix — plus a scoped clippy/nextest/rustdoc re-run on the touched crates.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13676 passed, 0 failed
- [x] Rustdoc gate (`RUSTFLAGS=-D warnings RUSTDOCFLAGS=--deny rustdoc::broken_intra_doc_links`)
- [x] 17 new/updated unit tests covering both fixes, independently re-verified in isolation
- [x] `.local/testing/playbooks/security-sanitization.md` — new section 7 (9 scenarios)
- [x] `.local/testing/coverage-status.md` — new row (status: Untested, pending next CI live-testing cycle)

Closes #6263
Closes #6248