### PR TITLE
fix(mcp): bound unbounded regex cache in name_referenced_in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -595,6 +595,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   Known residual gap, intentionally not addressed here: an execution that ends via an ungraceful
   process exit (crash, OOM, `SIGKILL`) still has no reclamation path if never resumed — this needs a
   separate periodic staleness-sweep mechanism, tracked in a follow-up issue (#6251).
+- **Security (zeph-mcp)**: `name_referenced_in`'s two regex memoization caches
+  (`crates/zeph-mcp/src/sanitize.rs`) were process-lifetime `static`s keyed by lowercased MCP
+  tool name with no eviction — since tool names are attacker-influenced (untrusted MCP server
+  input), a malicious/compromised server rotating its advertised tool names on reconnect or
+  catalog refresh could grow both caches without bound, leaking memory over the lifetime of a
+  long-running daemon/gateway/serve process. Replaced both `HashMap<String, Regex>` caches with
+  `lru::LruCache<String, Regex>` capped at 256 entries, using `get_or_insert` in place of
+  `entry().or_insert_with()` — same single-lock-acquisition semantics, no new attack surface
+  (#6255).
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11106,6 +11106,7 @@ dependencies = [
  "futures",
  "glob",
  "http",
+ "lru",
  "open",
  "parking_lot",
  "qdrant-client",

--- a/crates/zeph-mcp/Cargo.toml
+++ b/crates/zeph-mcp/Cargo.toml
@@ -28,6 +28,7 @@ dashmap.workspace = true
 futures.workspace = true
 glob.workspace = true
 http.workspace = true
+lru.workspace = true
 open.workspace = true
 parking_lot.workspace = true
 rand.workspace = true

--- a/crates/zeph-mcp/src/sanitize.rs
+++ b/crates/zeph-mcp/src/sanitize.rs
@@ -43,6 +43,14 @@ const MAX_TOOL_NAME_LEN: usize = 64;
 const MAX_SCHEMA_DEPTH: usize = 10;
 const MAX_LOG_MATCH_BYTES: usize = 64;
 
+/// Cap on distinct entries in each `name_referenced_in` regex cache.
+///
+/// Tool names are attacker-influenced (untrusted MCP server input): a server that rotates
+/// its advertised names on every reconnect/catalog-refresh must not be able to grow these
+/// caches without bound. 256 comfortably covers realistic tool-name cardinality for a single
+/// process while capping worst-case memory to a small, fixed number of compiled regexes.
+const NAME_REGEX_CACHE_CAPACITY: usize = 256;
+
 /// Minimum tool name length for cross-reference matching.
 ///
 /// Short names like "get", "set", "run" produce too many false positives.
@@ -627,18 +635,21 @@ fn detect_cross_tool_references(
 /// For hyphenated names, `\b` does not work correctly because hyphen is a word boundary
 /// character. A custom boundary set is used instead: whitespace and common punctuation.
 fn name_referenced_in(text: &str, tool_name: &str) -> bool {
-    use std::collections::HashMap;
+    use std::num::NonZeroUsize;
     use std::sync::OnceLock;
+
+    use lru::LruCache;
 
     let lower_text = text.to_lowercase();
     let lower_name = tool_name.to_lowercase();
+    let capacity = || NonZeroUsize::new(NAME_REGEX_CACHE_CAPACITY).expect("capacity is non-zero");
 
     if tool_name.contains('-') {
         // Custom word boundaries for hyphenated names.
-        static CACHE: OnceLock<parking_lot::Mutex<HashMap<String, Regex>>> = OnceLock::new();
-        let cache = CACHE.get_or_init(|| parking_lot::Mutex::new(HashMap::new()));
+        static CACHE: OnceLock<parking_lot::Mutex<LruCache<String, Regex>>> = OnceLock::new();
+        let cache = CACHE.get_or_init(|| parking_lot::Mutex::new(LruCache::new(capacity())));
         let mut guard = cache.lock();
-        let re = guard.entry(lower_name.clone()).or_insert_with(|| {
+        let re = guard.get_or_insert(lower_name.clone(), || {
             let escaped = regex::escape(&lower_name);
             let pattern =
                 format!(r#"(?:^|[\s,;.()\[\]{{}}\"'`]){escaped}(?:[\s,;.()\[\]{{}}\"'`]|$)"#);
@@ -647,10 +658,10 @@ fn name_referenced_in(text: &str, tool_name: &str) -> bool {
         re.is_match(&lower_text)
     } else {
         // Plain word boundary is fine for non-hyphenated names.
-        static CACHE: OnceLock<parking_lot::Mutex<HashMap<String, Regex>>> = OnceLock::new();
-        let cache = CACHE.get_or_init(|| parking_lot::Mutex::new(HashMap::new()));
+        static CACHE: OnceLock<parking_lot::Mutex<LruCache<String, Regex>>> = OnceLock::new();
+        let cache = CACHE.get_or_init(|| parking_lot::Mutex::new(LruCache::new(capacity())));
         let mut guard = cache.lock();
-        let re = guard.entry(lower_name.clone()).or_insert_with(|| {
+        let re = guard.get_or_insert(lower_name.clone(), || {
             let escaped = regex::escape(&lower_name);
             let pattern = format!(r"\b{escaped}\b");
             Regex::new(&pattern).expect("cross-ref word boundary regex")
@@ -1749,6 +1760,46 @@ mod tests {
                 .any(|r| { r.source_tool == "list_pages" && r.target_tool == "fetch-url" }),
             "hyphenated tool name 'fetch-url' must be matched via custom boundary regex"
         );
+    }
+
+    #[test]
+    fn name_referenced_in_cache_bounded_survives_churn() {
+        // Regression guard for #6255: both `name_referenced_in` regex caches are bounded LRUs
+        // (`NAME_REGEX_CACHE_CAPACITY`). Insert well past the cap with distinct names to force
+        // repeated eviction, then confirm a long-evicted entry still matches correctly when
+        // recompiled on demand — proving eviction churn causes no panic or stale/wrong result
+        // in either the hyphenated-name or the plain-word-boundary cache.
+        let churn = NAME_REGEX_CACHE_CAPACITY * 2 + 10;
+
+        for i in 0..churn {
+            let name = format!("tool-{i}");
+            let text = format!("call the {name} tool");
+            assert!(
+                name_referenced_in(&text, &name),
+                "hyphenated name {name} must match its own text"
+            );
+        }
+        let evicted_hyphenated = "tool-0";
+        assert!(
+            name_referenced_in("call the tool-0 tool", evicted_hyphenated),
+            "evicted hyphenated entry must still match after being recompiled"
+        );
+        assert!(!name_referenced_in("no reference here", evicted_hyphenated));
+
+        for i in 0..churn {
+            let name = format!("toolname{i}");
+            let text = format!("call the {name} tool");
+            assert!(
+                name_referenced_in(&text, &name),
+                "plain name {name} must match its own text"
+            );
+        }
+        let evicted_plain = "toolname0";
+        assert!(
+            name_referenced_in("call the toolname0 tool", evicted_plain),
+            "evicted plain entry must still match after being recompiled"
+        );
+        assert!(!name_referenced_in("no reference here", evicted_plain));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `name_referenced_in` in `crates/zeph-mcp/src/sanitize.rs` memoized a compiled `Regex` per distinct lowercased MCP tool name in two process-lifetime static caches with no eviction; since tool names are attacker-influenced (untrusted MCP server input), a malicious or reconnecting server rotating its advertised tool names could grow both caches without bound, leaking memory over the lifetime of a long-running daemon/gateway/serve process.
- Replaced both `HashMap<String, Regex>` caches with `lru::LruCache<String, Regex>` capped at 256 entries (`NAME_REGEX_CACHE_CAPACITY`), using `get_or_insert` as a drop-in replacement for `entry().or_insert_with()` with the same single-lock-acquisition semantics — no new attack surface, no TOCTOU.
- `lru` was already a workspace dependency (0.18.0, used identically in `crates/zeph-memory/src/graph/ontology.rs`), so this adds `lru.workspace = true` to `crates/zeph-mcp/Cargo.toml` with no new crate/version.
- Added a regression test (`name_referenced_in_cache_bounded_survives_churn`) that churns well past the cap on both cache branches and confirms a long-evicted entry still matches correctly on recompile.

Closes #6255

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (13694 passed, 0 failed, 34 skipped)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `gitleaks protect --staged --no-banner --redact`
- [x] New regression test exercises eviction churn on both cache branches (hyphenated + plain word-boundary), confirming correctness is preserved past the LRU cap