### PR TITLE
fix(orchestration): validate idle-timeout wizard input, warn on inert idle_timeout_secs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `[debug] include_raw_images` config flag (default `false`) restores the previous
   full-byte behavior for developers who explicitly need wire-payload fidelity (#6306).
 
+### Fixed
+
+- `--init` wizard: the orchestration `default_idle_timeout_secs` prompt silently dropped
+  invalid input (non-numeric, negative, or `0`) to `None` via a bare `.parse().ok()`, with
+  zero re-prompt or feedback to the operator (#6303). It now uses the same
+  `allow_empty(true)` + `validate_with(...)` re-prompt pattern already used for
+  `worktree_max_worktrees`/`worktree_disk_quota_mb`, sharing the extracted
+  `parse_optional_nonzero` helper (moved from `src/init/worktree.rs` into a new
+  `src/init/validate.rs` module, now used by three call sites). `Config::validate()` also
+  now rejects `orchestration.default_idle_timeout_secs = Some(0)`, matching the
+  `worktree.max_worktrees`/`worktree.disk_quota_mb` convention, so the wizard and the
+  config loader agree on what a valid value is.
+
+### Added
+
+- `zeph-orchestration`: `DagScheduler::new`/`resume_from` now emit a one-time
+  `tracing::warn!` when `orchestration.default_idle_timeout_secs` or any task's
+  `TimeoutPolicy.idle_timeout_secs` is set, since the field is accepted but not yet
+  enforced in this release (spec-075 FR-005) (#6302). The warning fires exactly once per
+  scheduler construction regardless of how many tasks set the field, giving operators who
+  set it directly in `config.toml` or a task graph (bypassing the `--init` wizard, which
+  already documents the reservation) a runtime signal that the value is currently inert.
+
 ## [0.22.1] - 2026-07-15
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11197,6 +11197,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-test",
  "uuid",
  "zeph-common",
  "zeph-config",

--- a/crates/zeph-config/src/loader.rs
+++ b/crates/zeph-config/src/loader.rs
@@ -432,6 +432,13 @@ impl Config {
                 "orchestration.verifier_timeout_secs must be > 0".into(),
             ));
         }
+        if self.orchestration.default_idle_timeout_secs == Some(0) {
+            return Err(ConfigError::Validation(
+                "orchestration.default_idle_timeout_secs must be > 0 or unset; 0 would mean \
+                 an instant idle timeout"
+                    .into(),
+            ));
+        }
         Ok(())
     }
 
@@ -1173,6 +1180,31 @@ weight = 0.3
             err.contains("verifier_timeout_secs"),
             "expected verifier_timeout_secs in error, got: {err}"
         );
+    }
+
+    #[test]
+    fn validate_default_idle_timeout_zero_rejected() {
+        let mut cfg = Config::default();
+        cfg.orchestration.default_idle_timeout_secs = Some(0);
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("default_idle_timeout_secs"),
+            "expected default_idle_timeout_secs in error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_default_idle_timeout_none_accepted() {
+        let mut cfg = Config::default();
+        cfg.orchestration.default_idle_timeout_secs = None;
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_default_idle_timeout_positive_accepted() {
+        let mut cfg = Config::default();
+        cfg.orchestration.default_idle_timeout_secs = Some(60);
+        assert!(cfg.validate().is_ok());
     }
 
     #[test]

--- a/crates/zeph-orchestration/Cargo.toml
+++ b/crates/zeph-orchestration/Cargo.toml
@@ -41,6 +41,7 @@ futures.workspace = true
 tempfile.workspace = true
 testcontainers = { workspace = true, features = ["watchdog"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tracing-test.workspace = true
 zeph-llm = { workspace = true, features = ["testing"] }
 zeph-memory.workspace = true
 

--- a/crates/zeph-orchestration/src/scheduler/mod.rs
+++ b/crates/zeph-orchestration/src/scheduler/mod.rs
@@ -531,6 +531,23 @@ impl DagScheduler {
 
         let (event_tx, event_rx) = mpsc::channel(64);
 
+        // Reserved-field hint (FR-005 / specs/075): idle_timeout_secs is accepted in config
+        // and per-task TimeoutPolicy but not enforced in this release — warn once per
+        // scheduler construction (covers both `new()` and `resume_from()`, never per-tick).
+        if config.default_idle_timeout_secs.is_some()
+            || graph.tasks.iter().any(|t| {
+                t.timeout
+                    .as_ref()
+                    .is_some_and(|tp| tp.idle_timeout_secs.is_some())
+            })
+        {
+            tracing::warn!(
+                "idle_timeout_secs is set but not enforced in this release (reserved for a \
+                 future progress-signal mechanism, see FR-005 / specs/075); only \
+                 run_timeout_secs is currently enforced"
+            );
+        }
+
         let task_timeout = if config.task_timeout_secs > 0 {
             Duration::from_secs(config.task_timeout_secs)
         } else {
@@ -932,5 +949,96 @@ mod tests {
             scheduler.orchestrator_provider_name().is_empty(),
             "default config must yield empty orchestrator_provider_name"
         );
+    }
+
+    // --- idle_timeout_secs reserved-field hint (#6302) ---
+
+    const IDLE_TIMEOUT_HINT: &str = "idle_timeout_secs is set but not enforced";
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn idle_timeout_hint_silent_when_unset() {
+        let graph = graph_from_nodes(vec![make_node(0, &[])]);
+        let _scheduler =
+            DagScheduler::new(graph, &make_config(), Box::new(FirstRouter), vec![], None).unwrap();
+        assert!(
+            !logs_contain(IDLE_TIMEOUT_HINT),
+            "no idle_timeout_secs is set anywhere; the hint must not fire"
+        );
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn idle_timeout_hint_warns_once_on_config_default() {
+        let graph = graph_from_nodes(vec![make_node(0, &[])]);
+        let config = zeph_config::OrchestrationConfig {
+            default_idle_timeout_secs: Some(30),
+            ..make_config()
+        };
+        let _scheduler =
+            DagScheduler::new(graph, &config, Box::new(FirstRouter), vec![], None).unwrap();
+        assert!(logs_contain(IDLE_TIMEOUT_HINT));
+        logs_assert(|lines: &[&str]| {
+            match lines
+                .iter()
+                .filter(|line| line.contains(IDLE_TIMEOUT_HINT))
+                .count()
+            {
+                1 => Ok(()),
+                n => Err(format!("expected exactly one idle_timeout hint, got {n}")),
+            }
+        });
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn idle_timeout_hint_warns_once_on_per_task_policy_even_with_multiple_tasks() {
+        let mut task_a = make_node(0, &[]);
+        task_a.timeout = Some(crate::graph::TimeoutPolicy {
+            run_timeout_secs: None,
+            idle_timeout_secs: Some(10),
+        });
+        let mut task_b = make_node(1, &[]);
+        task_b.timeout = Some(crate::graph::TimeoutPolicy {
+            run_timeout_secs: None,
+            idle_timeout_secs: Some(20),
+        });
+        let graph = graph_from_nodes(vec![task_a, task_b]);
+        let _scheduler =
+            DagScheduler::new(graph, &make_config(), Box::new(FirstRouter), vec![], None).unwrap();
+        assert!(logs_contain(IDLE_TIMEOUT_HINT));
+        logs_assert(|lines: &[&str]| {
+            match lines
+                .iter()
+                .filter(|line| line.contains(IDLE_TIMEOUT_HINT))
+                .count()
+            {
+                1 => Ok(()),
+                n => Err(format!("expected exactly one idle_timeout hint, got {n}")),
+            }
+        });
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn idle_timeout_hint_warns_once_on_resume() {
+        let graph = graph_from_nodes(vec![make_node(0, &[])]);
+        let config = zeph_config::OrchestrationConfig {
+            default_idle_timeout_secs: Some(30),
+            ..make_config()
+        };
+        let _scheduler =
+            DagScheduler::resume_from(graph, &config, Box::new(FirstRouter), vec![], None).unwrap();
+        assert!(logs_contain(IDLE_TIMEOUT_HINT));
+        logs_assert(|lines: &[&str]| {
+            match lines
+                .iter()
+                .filter(|line| line.contains(IDLE_TIMEOUT_HINT))
+                .count()
+            {
+                1 => Ok(()),
+                n => Err(format!("expected exactly one idle_timeout hint, got {n}")),
+            }
+        });
     }
 }

--- a/specs/075-orchestration-node-control-parity/spec.md
+++ b/specs/075-orchestration-node-control-parity/spec.md
@@ -303,7 +303,7 @@ performed.
 | Scenario | Expected Behavior |
 |----------|-------------------|
 | Per-task `run_timeout_secs` shorter than time already elapsed when set mid-run (e.g. hot-reloaded graph data) | Flagged as timed out on the next `check_timeouts()`/`wait_event()` evaluation — no special-cased grace period, consistent with existing `check_timeouts()` semantics |
-| `idle_timeout_secs` set (per-task or global) | Documented no-op in v1 — never fires, never treated as "always idle" by omission; `--init`/config.toml text states this explicitly (FR-005) |
+| `idle_timeout_secs` set (per-task or global) | Documented no-op in v1 — never fires, never treated as "always idle" by omission; `--init`/config.toml text states this explicitly (FR-005). Additive completion (#6302, not a spec deviation): `DagScheduler::init_common()` also emits a one-time `tracing::warn!` per scheduler construction when the field is set anywhere in config or the graph, giving FR-005's "loudly marked reserved" requirement a runtime signal in addition to the static docs/wizard text — the warning only logs, it never enforces or partially enforces the timeout |
 | `recovery.state_injection` set but effective strategy is `Skip` | `validate()` warns at graph-construction time; at runtime the task is `Skipped` via the existing `Skip` arm — recovery is never consulted (that arm does not call the recovery branch) |
 | `recovery.state_injection` set but effective strategy is `Ask` | Same as `Skip` — `validate()` warns; runtime pauses the graph via the existing `Ask` arm, recovery is never consulted |
 | `recovery.state_injection` set AND `verify_predicate` set on the same node | `validate()` rejects the graph at construction time (FR-011) — never reaches runtime |

--- a/src/init/agents.rs
+++ b/src/init/agents.rs
@@ -7,6 +7,7 @@ use dialoguer::{Confirm, Input, Select};
 use zeph_subagent::def::{MemoryScope, PermissionMode};
 
 use super::WizardState;
+use super::validate::parse_optional_nonzero;
 
 pub(super) fn step_orchestration(state: &mut WizardState) -> anyhow::Result<()> {
     println!("== Orchestration (/plan command) ==\n");
@@ -85,9 +86,13 @@ pub(super) fn step_orchestration(state: &mut WizardState) -> anyhow::Result<()> 
                  in this release; leave blank unless you want the value persisted for when \
                  it ships",
             )
-            .default(String::new())
+            .allow_empty(true)
+            .validate_with(|s: &String| -> Result<(), String> {
+                parse_optional_nonzero::<u64>(s).map(|_| ())
+            })
             .interact_text()?;
-        state.orchestration_default_idle_timeout_secs = idle_timeout_raw.trim().parse().ok();
+        state.orchestration_default_idle_timeout_secs =
+            parse_optional_nonzero(&idle_timeout_raw).map_err(|e| anyhow::anyhow!(e))?;
 
         step_ensemble_verify(state)?;
     }

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -23,6 +23,7 @@ pub(super) mod mcp;
 pub(super) mod memory;
 pub(super) mod security;
 pub(super) mod session;
+pub(super) mod validate;
 pub(super) mod worktree;
 
 use agents::{step_agents, step_learning, step_orchestration, step_router};

--- a/src/init/validate.rs
+++ b/src/init/validate.rs
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shared wizard input validators used across `init` steps.
+
+/// Parses an optional positive integer field: blank input means "unset" (`None`); a `0`
+/// is rejected (matches `Config::validate`'s rejection of `Some(0)` for `max_worktrees`/
+/// `disk_quota_mb`/`default_idle_timeout_secs` — see `crates/zeph-config/src/loader.rs`) so
+/// the wizard cannot emit a self-contradictory config.
+pub(super) fn parse_optional_nonzero<T>(input: &str) -> Result<Option<T>, String>
+where
+    T: std::str::FromStr + PartialEq + Default,
+{
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let value: T = trimmed
+        .parse()
+        .map_err(|_| format!("'{trimmed}' is not a valid positive integer"))?;
+    if value == T::default() {
+        return Err("must be > 0, or blank to leave unset".to_owned());
+    }
+    Ok(Some(value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_optional_nonzero_blank_is_none() {
+        assert_eq!(parse_optional_nonzero::<usize>(""), Ok(None));
+        assert_eq!(parse_optional_nonzero::<usize>("   "), Ok(None));
+    }
+
+    #[test]
+    fn parse_optional_nonzero_positive_value_ok() {
+        assert_eq!(parse_optional_nonzero::<usize>("5"), Ok(Some(5)));
+        assert_eq!(parse_optional_nonzero::<u64>("2048"), Ok(Some(2048)));
+    }
+
+    #[test]
+    fn parse_optional_nonzero_rejects_zero() {
+        assert!(parse_optional_nonzero::<usize>("0").is_err());
+        assert!(parse_optional_nonzero::<u64>("0").is_err());
+    }
+
+    #[test]
+    fn parse_optional_nonzero_rejects_non_numeric() {
+        assert!(parse_optional_nonzero::<usize>("abc").is_err());
+    }
+
+    #[test]
+    fn parse_optional_nonzero_rejects_negative() {
+        // Unsigned FromStr rejects a leading '-' outright, which is how negative input
+        // is rejected for the u64/usize fields this helper is actually used for.
+        assert!(parse_optional_nonzero::<u64>("-5").is_err());
+    }
+}

--- a/src/init/worktree.rs
+++ b/src/init/worktree.rs
@@ -5,6 +5,7 @@ use dialoguer::{Confirm, Input, Select};
 use zeph_config::{BgIsolation, WorktreeBaseRef};
 
 use super::WizardState;
+use super::validate::parse_optional_nonzero;
 
 /// Interactive wizard step that configures `[worktree]` in the generated config.
 ///
@@ -111,53 +112,4 @@ pub(super) fn step_worktree(state: &mut WizardState) -> anyhow::Result<()> {
 
     println!();
     Ok(())
-}
-
-/// Parses an optional positive integer field: blank input means "unset" (`None`); a `0`
-/// is rejected (matches `Config::validate`'s rejection of `Some(0)` for `max_worktrees`/
-/// `disk_quota_mb` — see `crates/zeph-config/src/loader.rs`) so the wizard cannot emit a
-/// self-contradictory config.
-fn parse_optional_nonzero<T>(input: &str) -> Result<Option<T>, String>
-where
-    T: std::str::FromStr + PartialEq + Default,
-{
-    let trimmed = input.trim();
-    if trimmed.is_empty() {
-        return Ok(None);
-    }
-    let value: T = trimmed
-        .parse()
-        .map_err(|_| format!("'{trimmed}' is not a valid positive integer"))?;
-    if value == T::default() {
-        return Err("must be > 0, or blank for unlimited/no accounting".to_owned());
-    }
-    Ok(Some(value))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parse_optional_nonzero_blank_is_none() {
-        assert_eq!(parse_optional_nonzero::<usize>(""), Ok(None));
-        assert_eq!(parse_optional_nonzero::<usize>("   "), Ok(None));
-    }
-
-    #[test]
-    fn parse_optional_nonzero_positive_value_ok() {
-        assert_eq!(parse_optional_nonzero::<usize>("5"), Ok(Some(5)));
-        assert_eq!(parse_optional_nonzero::<u64>("2048"), Ok(Some(2048)));
-    }
-
-    #[test]
-    fn parse_optional_nonzero_rejects_zero() {
-        assert!(parse_optional_nonzero::<usize>("0").is_err());
-        assert!(parse_optional_nonzero::<u64>("0").is_err());
-    }
-
-    #[test]
-    fn parse_optional_nonzero_rejects_non_numeric() {
-        assert!(parse_optional_nonzero::<usize>("abc").is_err());
-    }
 }


### PR DESCRIPTION
## Summary
- `--init` wizard no longer silently drops invalid idle-timeout input to `None`; it now reuses a shared `parse_optional_nonzero` validator (extracted from `worktree.rs`) so invalid input re-prompts, consistent with other numeric fields in the wizard.
- Config loader rejects `default_idle_timeout_secs == Some(0)` for consistency with the worktree fields.
- Scheduler emits a one-time `tracing::warn!` when `idle_timeout_secs` is set anywhere (config-level or per-task) but not enforced, since the field remains a documented no-op in this release per spec-075.

Both issues were flagged by impl-critic during review of #6243 (orchestration node control parity, spec-075) and deliberately deferred to keep that PR scoped.

Closes #6303
Closes #6302

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (13800 passed / 0 failed)
- [x] rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace ...`)
- [x] `gitleaks protect --staged` (0 leaks)
- [x] New unit tests: wizard validator boundary cases (blank/positive/zero/non-numeric/negative), loader `Some(0)` rejection, scheduler warn-once behavior for both `Scheduler::new()` and `resume_from()`
- [x] Existing tests confirmed unchanged: `zeph-config experiment::tests::orchestration_config_default_idle_timeout_secs_is_none`, `zeph-orchestration scheduler::tick::tests::test_idle_timeout_secs_is_a_no_op`
- [x] `.local/testing/playbooks/orchestration.md` and `.local/testing/coverage-status.md` updated (main repo path)
- [ ] Live agent session test for the wizard re-prompt (not yet run — noted as a remaining gap in coverage-status.md)