### PR TITLE
fix(core): redact image bytes from debug dumps by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `TranscriptWriter::append` call it instead of duplicating the filter. The caller's in-memory
   `Message` is unaffected; only the persisted copy is stripped.
 
+- `zeph-core`: debug dumps (`[debug] enabled = true`) no longer write full raw base64
+  `MessagePart::Image` bytes to disk by default. Both dump formats — `json` (typed message
+  serialization) and `raw` (provider wire payload, covering Claude/OpenAI/Gemini/Ollama
+  vision request shapes) — now redact image payloads to a
+  `<redacted image: {mime_type}, {n} bytes, blake3:{prefix}>` marker. A new opt-in
+  `[debug] include_raw_images` config flag (default `false`) restores the previous
+  full-byte behavior for developers who explicitly need wire-payload fidelity (#6306).
+
 ## [0.22.1] - 2026-07-15
 ### Fixed
 

--- a/book/src/advanced/debug-dump.md
+++ b/book/src/advanced/debug-dump.md
@@ -70,6 +70,7 @@ Both the streaming and non-streaming LLM code paths are instrumented. Tool outpu
 [debug]
 enabled = false             # Enable at startup (default: false)
 output_dir = ".zeph/debug" # Base directory for dump files (default: ".zeph/debug")
+include_raw_images = false # Include full raw base64 image bytes instead of a redacted marker (default: false)
 ```
 
 The `--debug-dump` CLI flag overrides both fields: if `PATH` is provided it overrides `output_dir`; if omitted, `output_dir` is used. If neither the flag nor `enabled = true` is set, no files are written.
@@ -79,6 +80,8 @@ The `--debug-dump` CLI flag overrides both fields: if `PATH` is provided it over
 ## Security
 
 Dump files contain the full conversation context including any secrets, tokens, or sensitive data present in messages and tool output. Do not store dump directories in version-controlled or publicly accessible locations.
+
+Image content (`MessagePart::Image`, vision requests) is redacted by default: instead of the full base64 payload, dump files contain a `<redacted image: {mime_type}, {n} bytes, blake3:{prefix}>` marker — enough to identify format, size, and correlate the same image across dumps without ever writing raw image bytes to disk. Set `[debug] include_raw_images = true` only when you explicitly need full wire-payload fidelity for image-related debugging; the raw bytes are then written exactly as sent to the provider.
 
 Add `.zeph/debug/` to `.gitignore` (covered by the `.zeph/*` rule in the default `.gitignore`) to keep dumps out of your repository.
 

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -814,6 +814,7 @@ max_files = 7                 # Rotated log files to retain (default: 7)
 [debug]
 enabled = false             # Enable debug dump at startup (default: false)
 output_dir = "/absolute/path/to/debug"  # Optional override; omit to use the platform default in the user data dir (%LOCALAPPDATA%\Zeph\debug on Windows)
+include_raw_images = false  # Include full raw base64 image bytes instead of a redacted marker (default: false)
 
 # Requires `classifiers` feature.
 # ML-backed injection detection and PII detection via Candle/DeBERTa models.

--- a/config/default.toml
+++ b/config/default.toml
@@ -1011,6 +1011,10 @@ enabled = false
 #   "trace" — OpenTelemetry-compatible OTLP JSON spans written to trace.json at session end
 #             Use --dump-format trace on the CLI to override at runtime.
 format = "json"
+# Include full raw base64 image bytes (MessagePart::Image) in debug dumps instead of a
+# redacted "<redacted image: ...>" marker. Default false — leave disabled unless a developer
+# explicitly needs full wire-payload fidelity for image-related debugging (#6306).
+include_raw_images = false
 
 [debug.traces]
 # OTLP gRPC endpoint for trace export (only used when format = "trace" and otel feature enabled).

--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -1596,6 +1596,15 @@ pub struct DebugConfig {
     pub format: crate::dump_format::DumpFormat,
     /// `OTel` trace configuration (only used when `format = "trace"`).
     pub traces: TraceConfig,
+    /// Include full raw base64 `MessagePart::Image` bytes in debug dumps instead of a
+    /// redacted `<redacted image: ...>` marker (#6306).
+    ///
+    /// Default: `false`. Image payloads are redacted by default to avoid writing
+    /// potentially large or sensitive binary data to disk on an opt-in debugging feature.
+    /// Enable only when a developer explicitly needs full wire-payload fidelity for
+    /// image-related debugging.
+    #[serde(default)]
+    pub include_raw_images: bool,
 }
 
 impl Default for DebugConfig {
@@ -1604,6 +1613,7 @@ impl Default for DebugConfig {
             enabled: false,
             output_dir: super::defaults::default_debug_output_dir(),
             format: crate::dump_format::DumpFormat::default(),
+            include_raw_images: false,
             traces: TraceConfig::default(),
         }
     }

--- a/crates/zeph-core/src/debug_dump/mod.rs
+++ b/crates/zeph-core/src/debug_dump/mod.rs
@@ -26,6 +26,7 @@ pub struct DebugDumper {
     dir: PathBuf,
     counter: Arc<AtomicU32>,
     format: DumpFormat,
+    include_raw_images: bool,
 }
 
 pub struct RequestDebugDump<'a> {
@@ -57,7 +58,26 @@ impl DebugDumper {
             dir,
             counter: Arc::new(AtomicU32::new(0)),
             format,
+            include_raw_images: false,
         })
+    }
+
+    /// Sets whether `MessagePart::Image` payloads are written to debug dumps as full raw
+    /// base64 bytes instead of a redacted `<redacted image: ...>` marker.
+    ///
+    /// Default: `false` (redacted). Mirrors [`zeph_config::DebugConfig::include_raw_images`];
+    /// enable only when a developer explicitly needs full wire-payload fidelity for
+    /// image-related debugging (#6306). Logs a warning when enabled so operators have a
+    /// visible signal that this security tradeoff is active.
+    #[must_use]
+    pub fn with_include_raw_images(mut self, include: bool) -> Self {
+        if include {
+            tracing::warn!(
+                "debug dumps: include_raw_images=true — image payloads will be written to disk unredacted"
+            );
+        }
+        self.include_raw_images = include;
+        self
     }
 
     /// Return the session dump directory.
@@ -130,9 +150,9 @@ impl DebugDumper {
             return id;
         }
         let json = match self.format {
-            DumpFormat::Raw => raw_dump(request),
+            DumpFormat::Raw => raw_dump(request, self.include_raw_images),
             DumpFormat::Trace => unreachable!("handled above"),
-            _ => json_dump(request),
+            _ => json_dump(request, self.include_raw_images),
         };
         self.write(&format!("{id:04}-request.json"), json.as_bytes());
         id
@@ -395,12 +415,16 @@ impl DebugDumper {
     }
 }
 
-fn json_dump(request: &RequestDebugDump<'_>) -> String {
+fn json_dump(request: &RequestDebugDump<'_>, include_raw_images: bool) -> String {
+    let mut messages =
+        serde_json::to_value(request.messages).unwrap_or(serde_json::Value::Array(vec![]));
+    if !include_raw_images {
+        redact_image_payloads(&mut messages);
+    }
     let payload = serde_json::json!({
         "model": extract_model(&request.provider_request, request.model_name),
         "max_tokens": extract_max_tokens(&request.provider_request),
-        "messages": serde_json::to_value(request.messages)
-            .unwrap_or(serde_json::Value::Array(vec![])),
+        "messages": messages,
         "tools": extract_tools(&request.provider_request, request.tools),
         "temperature": request
             .provider_request
@@ -417,7 +441,7 @@ fn json_dump(request: &RequestDebugDump<'_>) -> String {
     serde_json::to_string_pretty(&payload).unwrap_or_else(|e| format!("serialization error: {e}"))
 }
 
-fn raw_dump(request: &RequestDebugDump<'_>) -> String {
+fn raw_dump(request: &RequestDebugDump<'_>, include_raw_images: bool) -> String {
     let mut payload = if request.provider_request.is_object() {
         request.provider_request.clone()
     } else {
@@ -460,7 +484,137 @@ fn raw_dump(request: &RequestDebugDump<'_>) -> String {
             }
         }
     }
+    if !include_raw_images {
+        redact_image_payloads(&mut payload);
+    }
     serde_json::to_string_pretty(&payload).unwrap_or_else(|e| format!("serialization error: {e}"))
+}
+
+/// Minimum base64-encoded length treated as plausible image data under an `"images"` key
+/// (Ollama's per-message image array). Guards against clobbering unrelated short strings
+/// that happen to occupy a key named `images` (e.g. a tool argument) with a redaction marker.
+const MIN_IMAGE_BASE64_LEN: usize = 64;
+
+/// Recursively redacts base64-encoded image payloads from a dumped JSON tree, replacing
+/// them with a size/format marker (see [`image_marker`]).
+///
+/// `MessagePart::Image` bytes reach the dump under different key shapes depending on the
+/// dump format and target LLM provider, so the whole tree is walked rather than assuming
+/// one shape:
+/// - This crate's internal `MessagePart` serde form (`json_dump`, `part_to_block`) and
+///   Claude/Anthropic content blocks: `{"type":"image","source":{"data":...,"media_type":...}}`
+///   or `{"kind":"image","data":...,"mime_type":...}`.
+/// - `OpenAI`: `{"image_url":{"url":"data:<mime>;base64,<data>"}}`.
+/// - Gemini: `{"inlineData":{"mimeType":...,"data":...}}`.
+/// - Ollama: `{"images":["<base64>", ...]}`.
+fn redact_image_payloads(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            let is_image_kind =
+                map.get("kind").and_then(serde_json::Value::as_str) == Some("image");
+            let is_image_type =
+                map.get("type").and_then(serde_json::Value::as_str) == Some("image");
+
+            if is_image_kind {
+                redact_base64_field(map, "data", "mime_type");
+            }
+            if is_image_type
+                && let Some(source) = map
+                    .get_mut("source")
+                    .and_then(serde_json::Value::as_object_mut)
+            {
+                redact_base64_field(source, "data", "media_type");
+            }
+            if let Some(image_url) = map
+                .get_mut("image_url")
+                .and_then(serde_json::Value::as_object_mut)
+                && let Some(marker) = image_url
+                    .get("url")
+                    .and_then(serde_json::Value::as_str)
+                    .and_then(redact_data_url)
+            {
+                image_url.insert("url".to_owned(), serde_json::Value::String(marker));
+            }
+            if let Some(inline) = map
+                .get_mut("inlineData")
+                .and_then(serde_json::Value::as_object_mut)
+            {
+                redact_base64_field(inline, "data", "mimeType");
+            }
+            if let Some(images) = map
+                .get_mut("images")
+                .and_then(serde_json::Value::as_array_mut)
+            {
+                for img in images.iter_mut() {
+                    if let Some(encoded) = img.as_str().filter(|s| s.len() >= MIN_IMAGE_BASE64_LEN)
+                    {
+                        *img =
+                            serde_json::Value::String(image_marker_from_base64("image", encoded));
+                    }
+                }
+            }
+            for v in map.values_mut() {
+                redact_image_payloads(v);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for v in arr.iter_mut() {
+                redact_image_payloads(v);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn redact_base64_field(
+    obj: &mut serde_json::Map<String, serde_json::Value>,
+    data_key: &str,
+    mime_key: &str,
+) {
+    let mime_type = obj
+        .get(mime_key)
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("unknown")
+        .to_owned();
+    if let Some(marker) = obj
+        .get(data_key)
+        .and_then(serde_json::Value::as_str)
+        .map(|encoded| image_marker_from_base64(&mime_type, encoded))
+    {
+        obj.insert(data_key.to_owned(), serde_json::Value::String(marker));
+    }
+}
+
+fn redact_data_url(url: &str) -> Option<String> {
+    let rest = url.strip_prefix("data:")?;
+    let (mime_type, encoded) = rest.split_once(";base64,")?;
+    Some(image_marker_from_base64(mime_type, encoded))
+}
+
+fn image_marker_from_base64(mime_type: &str, encoded: &str) -> String {
+    base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .map_or_else(
+            |_| {
+                format!(
+                    "<redacted image: {mime_type}, undecodable base64 ({} chars)>",
+                    encoded.len()
+                )
+            },
+            |bytes| image_marker(mime_type, &bytes),
+        )
+}
+
+/// Builds a placeholder for a redacted image, retaining enough context (MIME type, exact
+/// byte size, content fingerprint) to correlate or diff dumps without ever persisting the
+/// raw bytes to disk.
+fn image_marker(mime_type: &str, data: &[u8]) -> String {
+    let hash = blake3::hash(data).to_hex();
+    format!(
+        "<redacted image: {mime_type}, {} bytes, blake3:{}>",
+        data.len(),
+        &hash[..16]
+    )
 }
 
 fn extract_model(payload: &serde_json::Value, fallback: &str) -> serde_json::Value {
@@ -671,6 +825,31 @@ mod tests {
         }]
     }
 
+    const SAMPLE_IMAGE_BYTES: &[u8] = b"not-a-real-png-but-long-enough-to-look-like-image-bytes";
+    const SAMPLE_IMAGE_MIME: &str = "image/png";
+
+    fn sample_image_messages() -> Vec<Message> {
+        vec![
+            Message::from_legacy(Role::System, "system prompt"),
+            Message::from_parts(
+                Role::User,
+                vec![
+                    MessagePart::Text {
+                        text: "describe this".to_owned(),
+                    },
+                    MessagePart::Image(Box::new(zeph_llm::provider::ImageData {
+                        data: SAMPLE_IMAGE_BYTES.to_vec(),
+                        mime_type: SAMPLE_IMAGE_MIME.to_owned(),
+                    })),
+                ],
+            ),
+        ]
+    }
+
+    fn sample_image_base64() -> String {
+        base64::engine::general_purpose::STANDARD.encode(SAMPLE_IMAGE_BYTES)
+    }
+
     /// Polls for the dump file rather than reading it immediately: `write()` now offloads to
     /// `spawn_blocking` and is fire-and-forget (#6029), so the file may not exist yet the
     /// instant `dump_request` returns.
@@ -831,5 +1010,276 @@ mod tests {
 
         // The write still completes shortly afterward (fire-and-forget, not dropped).
         let _ = read_request_dump(dir.path()).await;
+    }
+
+    // --- Image redaction (#6306) ---
+
+    #[tokio::test]
+    async fn json_dump_redacts_image_bytes_by_default() {
+        let dir = tempdir().unwrap();
+        let dumper = DebugDumper::new(dir.path(), DumpFormat::Json).unwrap();
+        let messages = sample_image_messages();
+        let tools = sample_tools();
+
+        let _ = dumper.dump_request(&RequestDebugDump {
+            model_name: "test-model",
+            messages: &messages,
+            tools: &tools,
+            provider_request: serde_json::json!({ "model": "test-model", "max_tokens": 1024 }),
+            memcot_state: None,
+        });
+
+        let payload = read_request_dump(dir.path()).await;
+        let dumped_json = payload.to_string();
+        assert!(
+            !dumped_json.contains(&sample_image_base64()),
+            "json dump must not contain raw base64 image bytes by default"
+        );
+        let image_part = &payload["messages"][1]["parts"][1];
+        assert_eq!(image_part["mime_type"], SAMPLE_IMAGE_MIME);
+        let marker = image_part["data"].as_str().unwrap();
+        assert!(
+            marker.starts_with("<redacted image: image/png,"),
+            "unexpected marker: {marker}"
+        );
+        // Sibling text part must be untouched.
+        assert_eq!(payload["messages"][1]["parts"][0]["text"], "describe this");
+    }
+
+    #[tokio::test]
+    async fn raw_dump_redacts_image_bytes_via_fallback_content_blocks() {
+        let dir = tempdir().unwrap();
+        let dumper = DebugDumper::new(dir.path(), DumpFormat::Raw).unwrap();
+        let messages = sample_image_messages();
+        let tools = sample_tools();
+
+        // No "messages"/"system" key present, so raw_dump falls back to
+        // messages_to_api_value/part_to_block, which mirrors Claude's content-block shape.
+        let _ = dumper.dump_request(&RequestDebugDump {
+            model_name: "claude-sonnet-test",
+            messages: &messages,
+            tools: &tools,
+            provider_request: serde_json::json!({ "model": "claude-sonnet-test" }),
+            memcot_state: None,
+        });
+
+        let payload = read_request_dump(dir.path()).await;
+        let dumped_json = payload.to_string();
+        assert!(
+            !dumped_json.contains(&sample_image_base64()),
+            "raw dump fallback content blocks must not contain raw base64 image bytes by default"
+        );
+        let image_block = &payload["messages"][0]["content"][1];
+        assert_eq!(image_block["type"], "image");
+        assert_eq!(image_block["source"]["media_type"], SAMPLE_IMAGE_MIME);
+        let marker = image_block["source"]["data"].as_str().unwrap();
+        assert!(
+            marker.starts_with("<redacted image: image/png,"),
+            "unexpected marker: {marker}"
+        );
+    }
+
+    #[tokio::test]
+    async fn raw_dump_redacts_openai_style_image_url_in_provider_request() {
+        let dir = tempdir().unwrap();
+        let dumper = DebugDumper::new(dir.path(), DumpFormat::Raw).unwrap();
+        let messages = sample_messages();
+        let tools = sample_tools();
+        let data_url = format!("data:{SAMPLE_IMAGE_MIME};base64,{}", sample_image_base64());
+
+        // provider_request already carries a "messages" key (real OpenAI vision wire format),
+        // so raw_dump clones it verbatim without hitting the part_to_block fallback.
+        let _ = dumper.dump_request(&RequestDebugDump {
+            model_name: "gpt-5-mini",
+            messages: &messages,
+            tools: &tools,
+            provider_request: serde_json::json!({
+                "model": "gpt-5-mini",
+                "messages": [{
+                    "role": "user",
+                    "content": [
+                        { "type": "text", "text": "describe this" },
+                        { "type": "image_url", "image_url": { "url": data_url } },
+                    ],
+                }],
+            }),
+            memcot_state: None,
+        });
+
+        let payload = read_request_dump(dir.path()).await;
+        let dumped_json = payload.to_string();
+        assert!(
+            !dumped_json.contains(&sample_image_base64()),
+            "raw dump of a real provider_request must not contain raw base64 image bytes by default"
+        );
+        let url = payload["messages"][0]["content"][1]["image_url"]["url"]
+            .as_str()
+            .unwrap();
+        assert!(
+            url.starts_with("<redacted image: image/png,"),
+            "unexpected marker: {url}"
+        );
+    }
+
+    #[tokio::test]
+    async fn raw_dump_redacts_gemini_and_ollama_style_provider_request_shapes() {
+        let dir = tempdir().unwrap();
+        let dumper = DebugDumper::new(dir.path(), DumpFormat::Raw).unwrap();
+        let messages = sample_messages();
+        let tools = sample_tools();
+        let b64 = sample_image_base64();
+
+        let _ = dumper.dump_request(&RequestDebugDump {
+            model_name: "test-model",
+            messages: &messages,
+            tools: &tools,
+            provider_request: serde_json::json!({
+                "model": "test-model",
+                // Gemini shape.
+                "contents": [{
+                    "role": "user",
+                    "parts": [{ "inlineData": { "mimeType": SAMPLE_IMAGE_MIME, "data": b64 } }],
+                }],
+                // Ollama shape (also satisfies the "messages" key so the fallback isn't hit).
+                "messages": [{ "role": "user", "content": "hi", "images": [b64] }],
+            }),
+            memcot_state: None,
+        });
+
+        let payload = read_request_dump(dir.path()).await;
+        let dumped_json = payload.to_string();
+        assert!(
+            !dumped_json.contains(&sample_image_base64()),
+            "raw dump must redact both Gemini inlineData and Ollama images-array shapes"
+        );
+        let gemini_data = payload["contents"][0]["parts"][0]["inlineData"]["data"]
+            .as_str()
+            .unwrap();
+        assert!(gemini_data.starts_with("<redacted image:"));
+        let ollama_image = payload["messages"][0]["images"][0].as_str().unwrap();
+        assert!(ollama_image.starts_with("<redacted image:"));
+    }
+
+    #[tokio::test]
+    async fn include_raw_images_opt_in_preserves_full_bytes() {
+        for fmt in [DumpFormat::Json, DumpFormat::Raw] {
+            let dir = tempdir().unwrap();
+            let dumper = DebugDumper::new(dir.path(), fmt)
+                .unwrap()
+                .with_include_raw_images(true);
+            let messages = sample_image_messages();
+            let tools = sample_tools();
+
+            let _ = dumper.dump_request(&RequestDebugDump {
+                model_name: "test-model",
+                messages: &messages,
+                tools: &tools,
+                provider_request: serde_json::json!({ "model": "test-model" }),
+                memcot_state: None,
+            });
+
+            let payload = read_request_dump(dir.path()).await;
+            assert!(
+                payload.to_string().contains(&sample_image_base64()),
+                "with include_raw_images=true, {fmt:?} dump must contain the full base64 image bytes"
+            );
+        }
+    }
+
+    /// Cross-crate regression guard (#6306 critic finding S1): the 6 tests above all hand-author
+    /// JSON matching `redact_image_payloads`'s own assumed shapes, which only proves the
+    /// redactor redacts shapes it already knows about — a real provider renaming/restructuring
+    /// its image field (or a new provider) could silently reopen the leak with every other test
+    /// still green. This drives the *actual* `LlmProvider::debug_request_json` implementation
+    /// of each real provider — the exact code path `raw_dump`'s primary branch consumes in
+    /// production via `RequestDebugDump::provider_request` — through the real `dump_request`
+    /// write path, and asserts no raw base64 image data survives.
+    #[tokio::test]
+    async fn raw_dump_redacts_real_provider_debug_request_json_for_every_provider() {
+        use zeph_llm::provider::LlmProvider;
+
+        let messages = sample_image_messages();
+        let b64 = sample_image_base64();
+
+        let claude = zeph_llm::claude::ClaudeProvider::new(
+            "test-key".to_owned(),
+            "claude-sonnet-test".to_owned(),
+            4096,
+        );
+        let openai = zeph_llm::openai::OpenAiProvider::new(zeph_llm::openai::OpenAiConfig {
+            api_key: "test-key".to_owned(),
+            base_url: "https://api.openai.com/v1".to_owned(),
+            model: "gpt-5-mini".to_owned(),
+            max_tokens: 4096,
+            embedding_model: None,
+            reasoning_effort: None,
+            context_window: None,
+            completion_tokens_param: None,
+        });
+        let gemini = zeph_llm::gemini::GeminiProvider::new(
+            "test-key".to_owned(),
+            "gemini-2.5-flash".to_owned(),
+            4096,
+        );
+        let ollama = zeph_llm::ollama::OllamaProvider::new(
+            "http://localhost:11434",
+            "llava".to_owned(),
+            "nomic-embed-text".to_owned(),
+        );
+
+        let providers: Vec<(&str, serde_json::Value)> = vec![
+            ("claude", claude.debug_request_json(&messages, &[], false)),
+            ("openai", openai.debug_request_json(&messages, &[], false)),
+            ("gemini", gemini.debug_request_json(&messages, &[], false)),
+            ("ollama", ollama.debug_request_json(&messages, &[], false)),
+        ];
+
+        for (name, provider_request) in providers {
+            assert!(
+                provider_request.to_string().contains(&b64),
+                "test setup sanity check: {name}'s debug_request_json must actually contain \
+                 the raw base64 image bytes before redaction (otherwise this test proves \
+                 nothing)"
+            );
+
+            let dir = tempdir().unwrap();
+            let dumper = DebugDumper::new(dir.path(), DumpFormat::Raw).unwrap();
+            let _ = dumper.dump_request(&RequestDebugDump {
+                model_name: name,
+                messages: &messages,
+                tools: &[],
+                provider_request,
+                memcot_state: None,
+            });
+
+            let payload = read_request_dump(dir.path()).await;
+            assert!(
+                !payload.to_string().contains(&b64),
+                "{name}'s real debug_request_json output must not contain raw base64 image \
+                 bytes after passing through the real dump_request/raw_dump redaction path"
+            );
+        }
+    }
+
+    #[test]
+    fn redact_image_payloads_leaves_non_image_values_untouched() {
+        let mut value = serde_json::json!({
+            "model": "test-model",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    { "type": "text", "text": "hello world" },
+                    { "type": "tool_use", "id": "t1", "name": "read_file", "input": { "path": "a.rs" } },
+                    { "type": "tool_result", "tool_use_id": "t1", "content": "file contents", "is_error": false },
+                ],
+            }],
+            "temperature": 0.5,
+        });
+        let before = value.clone();
+        redact_image_payloads(&mut value);
+        assert_eq!(
+            value, before,
+            "non-image JSON must be unchanged by redaction"
+        );
     }
 }

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -2158,9 +2158,13 @@ async fn spawn_acp_agent(
         let session_dump_dir = debug_config
             .output_dir
             .join(session_ctx.session_id.to_string());
-        agent =
-            agent_setup::apply_debug_dumper(agent, session_dump_dir.as_path(), debug_config.format)
-                .0;
+        agent = agent_setup::apply_debug_dumper(
+            agent,
+            session_dump_dir.as_path(),
+            debug_config.format,
+            debug_config.include_raw_images,
+        )
+        .0;
     }
 
     if !safe_mode {

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -1306,9 +1306,11 @@ pub(crate) fn apply_debug_dumper<C: Channel>(
     agent: Agent<C>,
     dir: &Path,
     format: zeph_core::debug_dump::DumpFormat,
+    include_raw_images: bool,
 ) -> (Agent<C>, PathBuf) {
     match zeph_core::debug_dump::DebugDumper::new(dir, format) {
         Ok(dumper) => {
+            let dumper = dumper.with_include_raw_images(include_raw_images);
             let session_dir = dumper.dir().to_owned();
             (agent.with_debug_dumper(dumper), session_dir)
         }
@@ -3608,7 +3610,7 @@ mod tests {
         // that create_dir_all call fails, forcing the Err branch.
         let dir = tmp.path().to_owned();
         let (result_agent, result_dir) =
-            apply_debug_dumper(agent, &dir, zeph_core::debug_dump::DumpFormat::Raw);
+            apply_debug_dumper(agent, &dir, zeph_core::debug_dump::DumpFormat::Raw, false);
         assert_eq!(
             result_dir, dir,
             "on DebugDumper::new failure, the original dir must be returned unchanged"

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1202,6 +1202,7 @@ pub(crate) async fn run_daemon(
             agent,
             config.debug.output_dir.as_path(),
             config.debug.format,
+            config.debug.include_raw_images,
         )
         .0;
     }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -3251,8 +3251,12 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
                     .then(|| config.debug.output_dir.clone())
             });
         if let Some(ref dir) = dump_dir {
-            let (agent, session_dir) =
-                agent_setup::apply_debug_dumper(agent, dir.as_path(), effective_format);
+            let (agent, session_dir) = agent_setup::apply_debug_dumper(
+                agent,
+                dir.as_path(),
+                effective_format,
+                config.debug.include_raw_images,
+            );
             // Store trace config so runtime `/dump-format trace` can create a collector (CR-04).
             let agent = agent.with_trace_config(
                 dir.clone(),

--- a/src/serve/agent_factory.rs
+++ b/src/serve/agent_factory.rs
@@ -279,6 +279,7 @@ pub(crate) async fn build_agent_factory(
                 agent,
                 session_dump_dir.as_path(),
                 debug_config.format,
+                debug_config.include_raw_images,
             )
             .0;
         }


### PR DESCRIPTION
## Summary

- `debug_dump/mod.rs` serialized outbound LLM requests verbatim, including `MessagePart::Image` base64 payloads, in both `json` and `raw` dump formats. The `raw` format's dominant path clones the provider's native wire payload directly, so Claude/OpenAI/Gemini/Ollama vision requests all leaked full image bytes to disk whenever debug dumps were enabled (`[debug] enabled = true`, opt-in feature).
- All known image-payload shapes (internal typed form, Claude, OpenAI, Gemini, Ollama) are now redacted to a `<redacted image: {mime_type}, {n} bytes, blake3:{prefix}>` marker via a single generic recursive JSON-value redactor applied to both dump formats.
- Added an opt-in `[debug] include_raw_images` config flag (default `false`) to restore full raw byte output for wire-payload debugging; enabling it now emits a `tracing::warn!` at construction time so the tradeoff is visible in logs.

## Notes

- Scope is intentionally bounded to `MessagePart::Image` in outbound requests. Other sensitive text content in messages (PII, secrets) is unaffected by this change, and `dump_tool_output`/`dump_response` have a related but out-of-scope residual leak vector (raw tool output text, e.g. a vision tool returning base64 as text) — filing a follow-up issue for that.
- Adversarial review (impl-critic) flagged that the initial test suite was self-referential (hand-authored JSON matching the redactor's own shape assumptions, fail-open risk if a provider's wire shape drifts). Addressed with a regression test that drives the actual `ClaudeProvider`/`OpenAiProvider`/`GeminiProvider`/`OllamaProvider` serializers from `zeph-llm` with an image-bearing message and asserts no raw base64 survives the real `dump_request`/`raw_dump` path.
- OpenAI's Responses API `input_image` string shape (a known future leak vector) is not wired up anywhere in this codebase today — no dead-code test added; documented in the playbook.

Closes #6306

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13802 passed, 0 failed, 35 skipped
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] `gitleaks protect --staged --no-banner --redact` — no leaks
- [x] New regression test drives real provider serializers (Claude/OpenAI/Gemini/Ollama) and asserts redaction on actual wire-format JSON, not hand-authored fixtures
- [ ] Live-session verification against a real vision-capable provider — not yet exercised with a live API key; tracked as `Untested` in `.local/testing/coverage-status.md`