### PR TITLE
fix(subagent): reap orchestration-dispatched sub-agent handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-core`/`zeph-subagent`: orchestration-dispatched sub-agents (`SchedulerAction::Spawn` via
+  `run_scheduler_loop`) are now reaped once they reach a terminal state (`Completed`/`Failed`/
+  `Canceled`) — `SubAgentManager::collect()` was previously only called from the interactive
+  `/agent` polling path, so every plan-executed sub-agent leaked its handle and never wrote a
+  final `TranscriptMeta` sidecar (issue #6288). Grounding trace reads
+  (`build_tool_trace_for_task`, `resolve_whole_plan_trace_paths`) no longer depend on the handle
+  remaining resident in `SubAgentManager` — both now resolve the transcript path via the new
+  `SubAgentManager::transcript_path_for()`, which is computed from config alone, so reaping
+  handles on the dispatch path cannot silently degrade per-task or whole-plan verifier grounding
+  (spec 009 §§ Verifier Tool-Call Grounding, Whole-Plan Grounding) to fail-open `None`.
 - `--init` wizard: the orchestration `default_idle_timeout_secs` prompt silently dropped
   invalid input (non-numeric, negative, or `0`) to `None` via a bare `.parse().ok()`, with
   zero re-prompt or feedback to the operator (#6303). It now uses the same

--- a/crates/zeph-core/src/agent/plan.rs
+++ b/crates/zeph-core/src/agent/plan.rs
@@ -631,13 +631,13 @@ impl<C: crate::channel::Channel> Agent<C> {
     /// Takes a plain `&TaskGraph` (not `&DagScheduler`) so it is testable without spinning up
     /// full scheduler machinery — the caller passes `scheduler.graph()`.
     ///
-    /// Pure in-memory work (`agent_transcript_dir` is a `HashMap` lookup, no I/O) — deliberately
-    /// kept synchronous and `&self`-borrowing so it never needs to cross an `.await` point,
-    /// which would otherwise require `Agent<C>: Sync` to keep the caller's future `Send` (spec
-    /// 009 § Whole-Plan Grounding, issue #6287). Returns `None` the moment any one task's path
-    /// cannot be resolved (missing `agent_id` — e.g. a `RunInline` task, whose in-loop trace is
-    /// never persisted — or no `SubAgentManager`/transcript dir), matching the all-or-nothing
-    /// availability contract.
+    /// Pure in-memory work (`transcript_path_for` is computed from `config` alone, no I/O and no
+    /// dependence on handle residency in `SubAgentManager` — see issue #6288) — deliberately kept
+    /// synchronous and `&self`-borrowing so it never needs to cross an `.await` point, which
+    /// would otherwise require `Agent<C>: Sync` to keep the caller's future `Send` (spec 009 §
+    /// Whole-Plan Grounding, issue #6287). Returns `None` the moment any one task's path cannot
+    /// be resolved (missing `agent_id` — e.g. a `RunInline` task, whose in-loop trace is never
+    /// persisted — or no `SubAgentManager`), matching the all-or-nothing availability contract.
     fn resolve_whole_plan_trace_paths(
         &self,
         graph: &zeph_orchestration::TaskGraph,
@@ -667,16 +667,8 @@ impl<C: crate::channel::Channel> Agent<C> {
                 );
                 return None;
             };
-            let Some(dir) = mgr.agent_transcript_dir(agent_id) else {
-                tracing::debug!(
-                    task_id = %task.id,
-                    agent_id = %agent_id,
-                    "whole-plan tool-trace union: transcript dir unresolvable, aggregate \
-                     unavailable"
-                );
-                return None;
-            };
-            paths.push(dir.join(format!("{agent_id}.jsonl")));
+            let cfg = &self.services.orchestration.subagent_config;
+            paths.push(mgr.transcript_path_for(cfg, agent_id));
         }
         Some(paths)
     }
@@ -1786,6 +1778,79 @@ mod tests {
                 .iter()
                 .any(|t| t.tool == "bash" && t.args_summary.as_deref() == Some("cargo test")),
             "union must include the tool call recorded on task 0's transcript: {union:?}"
+        );
+    }
+
+    /// Regression test for issue #6288 (hazard found during implementation, not part of the
+    /// original debugger sketch): `run_whole_plan_verify` runs strictly after `run_scheduler_loop`
+    /// returns, i.e. after every per-tick `collect_finished_subagents()` call has already reaped
+    /// completed spawn-dispatched handles. Before `resolve_whole_plan_trace_paths` was re-plumbed
+    /// to use `transcript_path_for` (residency-independent) instead of `agent_transcript_dir`
+    /// (requires the handle still resident in `mgr.agents`), wiring `collect()` into the
+    /// dispatch path would have silently and permanently degraded whole-plan grounding to `None`
+    /// for every plan run — this proves the union still resolves after both handles are
+    /// collected, not just while they remain resident (as
+    /// `whole_plan_trace_union_combines_multiple_tasks` above already covers).
+    #[tokio::test]
+    async fn whole_plan_trace_union_resolves_after_handles_are_collected() {
+        use crate::agent::agent_tests::*;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let provider = mock_provider(vec![
+            "task completed successfully".into(),
+            "task completed successfully".into(),
+        ]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+
+        let id1 = spawn_worker_and_wait_completed_shared(&mut agent, tmp.path()).await;
+        let id2 = spawn_worker_and_wait_completed_shared(&mut agent, tmp.path()).await;
+
+        let dir = agent
+            .services
+            .orchestration
+            .subagent_manager
+            .as_ref()
+            .unwrap()
+            .agent_transcript_dir(&id1)
+            .unwrap()
+            .to_path_buf();
+        append_tool_round(&dir.join(format!("{id1}.jsonl"))).await;
+
+        let mgr = agent
+            .services
+            .orchestration
+            .subagent_manager
+            .as_mut()
+            .unwrap();
+        mgr.collect(&id1).await.expect("collect must succeed");
+        mgr.collect(&id2).await.expect("collect must succeed");
+        assert!(
+            mgr.statuses().is_empty(),
+            "both handles must be gone before resolving trace paths, to prove residency \
+             independence"
+        );
+
+        let mut graph = zeph_orchestration::TaskGraph::new("goal");
+        graph.tasks = vec![
+            completed_task_with_agent(0, &id1),
+            completed_task_with_agent(1, &id2),
+        ];
+
+        let paths = agent.resolve_whole_plan_trace_paths(&graph).expect(
+            "trace paths must still resolve after collect() — must not degrade to None \
+                 merely because the handles are no longer resident",
+        );
+        let union = Agent::<MockChannel>::build_whole_plan_tool_trace(paths)
+            .await
+            .expect("post-collection transcripts must still be readable");
+        assert!(
+            union
+                .iter()
+                .any(|t| t.tool == "bash" && t.args_summary.as_deref() == Some("cargo test")),
+            "post-collection union must still include the recorded tool call: {union:?}"
         );
     }
 

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -434,8 +434,15 @@ impl<C: crate::channel::Channel> Agent<C> {
 
             let mut any_spawn_success = false;
             let mut any_concurrency_failure = false;
+            // Set by the `Spawn` (forced-Done-on-failure) and `Done` arms below. Deferring the
+            // `'tick` break until after `collect_finished_subagents()` (below the `for` loop)
+            // ensures a task whose completion coincides with graph completion in the same tick —
+            // the common case for the last task of a plan — still has its handle reaped instead
+            // of leaking (issue #6288: an unconditional `break 'tick` here would bypass the
+            // per-tick reap entirely on the terminating tick).
+            let mut done_status: Option<zeph_orchestration::GraphStatus> = None;
 
-            for action in actions {
+            'actions: for action in actions {
                 match action {
                     SchedulerAction::Spawn {
                         task_id,
@@ -455,7 +462,8 @@ impl<C: crate::channel::Channel> Agent<C> {
                         any_spawn_success |= success;
                         any_concurrency_failure |= fail;
                         if let Some(s) = done {
-                            break 'tick s;
+                            done_status = Some(s);
+                            break 'actions;
                         }
                     }
                     SchedulerAction::Cancel { agent_handle_id } => {
@@ -478,7 +486,8 @@ impl<C: crate::channel::Channel> Agent<C> {
                         .await;
                     }
                     SchedulerAction::Done { status } => {
-                        break 'tick status;
+                        done_status = Some(status);
+                        break 'actions;
                     }
                     SchedulerAction::VerifyPredicate {
                         task_id,
@@ -798,6 +807,12 @@ impl<C: crate::channel::Channel> Agent<C> {
                 }
             }
 
+            self.collect_finished_subagents().await;
+
+            if let Some(status) = done_status {
+                break 'tick status;
+            }
+
             scheduler.record_batch_backoff(any_spawn_success, any_concurrency_failure);
 
             self.process_pending_secret_requests(&mut denied_secrets)
@@ -1054,8 +1069,7 @@ impl<C: crate::channel::Channel> Agent<C> {
     ) -> Option<Vec<zeph_orchestration::ToolCallSummary>> {
         let agent_id = task.result.as_ref().and_then(|r| r.agent_id.as_deref())?;
         let mgr = self.services.orchestration.subagent_manager.as_ref()?;
-        let dir = mgr.agent_transcript_dir(agent_id)?;
-        let path = dir.join(format!("{agent_id}.jsonl"));
+        let path = mgr.transcript_path_for(&self.services.orchestration.subagent_config, agent_id);
         match zeph_subagent::TranscriptReader::load_strict(&path) {
             Ok(messages) => Some(tool_trace_from_messages(&messages)),
             Err(e) => {
@@ -1066,6 +1080,38 @@ impl<C: crate::channel::Channel> Agent<C> {
                     "tool-trace transcript read failed or partial — grounding fails open for this task"
                 );
                 None
+            }
+        }
+    }
+
+    /// Reap sub-agent handles that have reached a terminal state, writing their final
+    /// `TranscriptMeta` sidecar and removing them from [`zeph_subagent::SubAgentManager`].
+    ///
+    /// Safe to call at any point in the tick loop: [`Self::build_tool_trace_for_task`] no longer
+    /// depends on handle residency, so ordering relative to `SchedulerAction::Verify` is not
+    /// load-bearing here (spec 009 § Verifier Tool-Call Grounding, issue #6288). Errors are
+    /// logged, not propagated — a collection failure for one task must not abort the tick loop
+    /// for the rest of the plan.
+    pub(super) async fn collect_finished_subagents(&mut self) {
+        let Some(mgr) = &mut self.services.orchestration.subagent_manager else {
+            return;
+        };
+        let finished: Vec<String> = mgr
+            .statuses()
+            .into_iter()
+            .filter_map(|(id, status)| {
+                matches!(
+                    status.state,
+                    zeph_subagent::SubAgentState::Completed
+                        | zeph_subagent::SubAgentState::Failed
+                        | zeph_subagent::SubAgentState::Canceled
+                )
+                .then_some(id)
+            })
+            .collect();
+        for task_id in finished {
+            if let Err(e) = mgr.collect(&task_id).await {
+                tracing::warn!(task_id, error = %e, "failed to collect finished orchestration sub-agent");
             }
         }
     }
@@ -1434,6 +1480,226 @@ mod tests {
             trace_after_tear.is_none(),
             "a torn/malformed transcript line must fail closed to None, not Some(partial): \
              {trace_after_tear:?}"
+        );
+    }
+
+    /// Regression test for issue #6288: `build_tool_trace_for_task` must still resolve the real
+    /// trace after the sub-agent's handle has already been reaped via
+    /// `SubAgentManager::collect()` — this is the exact scenario the spec's residency note used
+    /// to warn against (a naive `collect()` call site degrading grounding to fail-open `None`).
+    /// `transcript_path_for` (unlike `agent_transcript_dir`) is computed from `config` alone, so
+    /// it must not depend on the handle still being resident in `mgr.agents`.
+    #[tokio::test]
+    async fn build_tool_trace_for_task_recovers_after_handle_is_collected() {
+        use crate::agent::agent_tests::*;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let provider = mock_provider(vec!["task completed successfully".into()]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+
+        let full_id = spawn_worker_and_wait_completed(&mut agent, tmp.path()).await;
+
+        let mut task = zeph_orchestration::TaskNode::new(0, "t", "d");
+        task.result = Some(zeph_orchestration::TaskResult {
+            output: String::new(),
+            artifacts: vec![],
+            duration_ms: 0,
+            agent_id: Some(full_id.clone()),
+            agent_def: None,
+        });
+
+        let dir = agent
+            .services
+            .orchestration
+            .subagent_manager
+            .as_ref()
+            .unwrap()
+            .agent_transcript_dir(&full_id)
+            .expect("transcript dir must be resolvable for a just-spawned agent")
+            .to_path_buf();
+        let jsonl_path = dir.join(format!("{full_id}.jsonl"));
+        append_tool_round(&jsonl_path).await;
+
+        agent
+            .services
+            .orchestration
+            .subagent_manager
+            .as_mut()
+            .unwrap()
+            .collect(&full_id)
+            .await
+            .expect("collect must succeed for a completed handle");
+
+        let trace = agent
+            .build_tool_trace_for_task(&task)
+            .expect("trace must still resolve to Some after the handle has been collected");
+        assert!(
+            trace
+                .iter()
+                .any(|t| t.tool == "bash" && t.args_summary.as_deref() == Some("cargo test")),
+            "post-collection trace must still reconstruct the real bash/cargo-test call: {trace:?}"
+        );
+    }
+
+    /// Regression test for issue #6288: every `Spawn`-dispatched task's sub-agent handle must be
+    /// reaped from `SubAgentManager` once it reaches a terminal state — the orchestration
+    /// dispatch path previously never called `collect()`, leaking a handle (and never writing
+    /// the final `TranscriptMeta` sidecar) for every plan-executed task.
+    #[tokio::test]
+    async fn run_scheduler_loop_reaps_completed_spawn_dispatched_subagent() {
+        use crate::agent::agent_tests::*;
+        use zeph_orchestration::{DagScheduler, GraphStatus, RuleBasedRouter, TaskGraph, TaskNode};
+        use zeph_subagent::{SubAgentDef, SubAgentManager};
+
+        let mut graph = TaskGraph::new("goal");
+        graph.tasks.push(TaskNode::new(0, "t", "do a task"));
+
+        let def =
+            SubAgentDef::parse("---\nname: worker\ndescription: A worker\n---\n\nDo things.\n")
+                .unwrap();
+
+        let config = zeph_config::OrchestrationConfig::default();
+        let mut scheduler = DagScheduler::new(
+            graph,
+            &config,
+            Box::new(RuleBasedRouter),
+            vec![def.clone()],
+            None,
+        )
+        .unwrap();
+
+        let provider = mock_provider(vec!["task completed successfully".into()]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+        agent.services.orchestration.orchestration_config = config;
+
+        let mut mgr = SubAgentManager::new(4);
+        mgr.definitions_mut().push(def);
+        agent.services.orchestration.subagent_manager = Some(mgr);
+
+        let token = tokio_util::sync::CancellationToken::new();
+        let status = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            agent.run_scheduler_loop(&mut scheduler, 1, token),
+        )
+        .await
+        .expect("run_scheduler_loop must not hang")
+        .unwrap();
+
+        assert_eq!(status, GraphStatus::Completed);
+        assert!(
+            agent
+                .services
+                .orchestration
+                .subagent_manager
+                .as_ref()
+                .unwrap()
+                .statuses()
+                .is_empty(),
+            "completed spawn-dispatched sub-agent handle must be reaped, not leaked"
+        );
+    }
+
+    /// Regression test for issue #6288: `collect_finished_subagents()` must be a no-op (not
+    /// panic) when orchestration is not spawning any sub-agents this session, i.e.
+    /// `subagent_manager` is `None`. `run_scheduler_loop` calls it unconditionally every tick
+    /// regardless of whether the plan uses `Spawn` at all.
+    #[tokio::test]
+    async fn collect_finished_subagents_is_noop_when_subagent_manager_is_none() {
+        use crate::agent::agent_tests::*;
+
+        let provider = mock_provider(vec!["unused".into()]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+        assert!(agent.services.orchestration.subagent_manager.is_none());
+
+        agent.collect_finished_subagents().await;
+    }
+
+    /// Regression test for issue #6288: a sub-agent handle canceled mid-plan (e.g. via `/plan
+    /// cancel` triggering `cancel_agents_from_actions`) must also be reaped by
+    /// `collect_finished_subagents()` — the reap filter matches `Completed | Failed | Canceled`,
+    /// not just `Completed`, since a Verify-arm-only or Completed-only hook would permanently
+    /// leak canceled handles.
+    #[tokio::test]
+    async fn collect_finished_subagents_reaps_canceled_handle() {
+        use crate::agent::agent_tests::*;
+        use zeph_subagent::def::{SkillFilter, SubAgentPermissions, ToolPolicy};
+        use zeph_subagent::hooks::SubagentHooks;
+        use zeph_subagent::{SpawnContext, SubAgentDef, SubAgentManager};
+
+        let provider = mock_provider(vec!["unused".into()]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+
+        let def = SubAgentDef {
+            name: "worker".into(),
+            description: "A worker bot".into(),
+            model: None,
+            tools: ToolPolicy::InheritAll,
+            disallowed_tools: vec![],
+            permissions: SubAgentPermissions::default(),
+            skills: SkillFilter::default(),
+            system_prompt: "You are a worker.".into(),
+            hooks: SubagentHooks::default(),
+            memory: None,
+            source: None,
+            file_path: None,
+        };
+
+        let mut mgr = SubAgentManager::new(4);
+        mgr.definitions_mut().push(def);
+        let task_id = mgr
+            .spawn(
+                "worker",
+                "do a long task",
+                mock_provider(vec!["should not matter, canceled first".into()]),
+                std::sync::Arc::new(MockToolExecutor::no_tools()),
+                None,
+                &zeph_config::SubAgentConfig::default(),
+                SpawnContext::default(),
+            )
+            .await
+            .unwrap();
+        mgr.cancel(&task_id).unwrap();
+        agent.services.orchestration.subagent_manager = Some(mgr);
+
+        assert_eq!(
+            agent
+                .services
+                .orchestration
+                .subagent_manager
+                .as_ref()
+                .unwrap()
+                .statuses()
+                .iter()
+                .find(|(id, _)| id == &task_id)
+                .map(|(_, s)| s.state),
+            Some(zeph_subagent::SubAgentState::Canceled),
+            "precondition: handle must report Canceled before reaping"
+        );
+
+        agent.collect_finished_subagents().await;
+
+        assert!(
+            agent
+                .services
+                .orchestration
+                .subagent_manager
+                .as_ref()
+                .unwrap()
+                .statuses()
+                .is_empty(),
+            "canceled sub-agent handle must be reaped, not leaked"
         );
     }
 }

--- a/crates/zeph-subagent/src/manager/collect.rs
+++ b/crates/zeph-subagent/src/manager/collect.rs
@@ -164,6 +164,32 @@ impl SubAgentManager {
             .and_then(|h| h.transcript_dir.as_deref())
     }
 
+    /// Resolve the transcript file path for `agent_id` from `config`, independent of whether the
+    /// agent's handle is still resident in this manager.
+    ///
+    /// Unlike [`Self::agent_transcript_dir`] (which only returns a path for agents still tracked
+    /// in `self.agents`), this is safe to call after [`Self::collect`] has already removed the
+    /// handle — the path is fully determined by `config` and `agent_id`, matching exactly what
+    /// `handle.transcript_dir` held at spawn time (see the `handle_transcript_dir` construction
+    /// in `manager/spawn.rs`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_config::SubAgentConfig;
+    /// use zeph_subagent::SubAgentManager;
+    ///
+    /// let mgr = SubAgentManager::new(4);
+    /// let config = SubAgentConfig::default();
+    /// let path = mgr.transcript_path_for(&config, "task-123");
+    /// assert!(path.ends_with("task-123.jsonl"));
+    /// ```
+    #[must_use]
+    pub fn transcript_path_for(&self, config: &SubAgentConfig, agent_id: &str) -> PathBuf {
+        self.effective_transcript_dir(config)
+            .join(format!("{agent_id}.jsonl"))
+    }
+
     /// Create a transcript writer if transcripts are enabled.
     ///
     /// All three blocking FS operations (sweep, file open, meta write) are offloaded via

--- a/crates/zeph-subagent/src/manager/tests.rs
+++ b/crates/zeph-subagent/src/manager/tests.rs
@@ -205,6 +205,67 @@ async fn collect_unknown_task_id_returns_not_found() {
     assert_matches!(err, SubAgentError::NotFound(_));
 }
 
+/// Regression test for issue #6288: `transcript_path_for` must resolve the identical path
+/// whether or not the agent's handle is still resident in `mgr.agents`, and a transcript
+/// read against that path must succeed after `collect()` has removed the handle — proving
+/// grounding reads (`build_tool_trace_for_task` in `zeph-core`) do not silently degrade to
+/// `None` merely because the orchestration dispatch path has already reaped the handle.
+#[tokio::test]
+async fn transcript_path_for_stable_across_collect_and_readable_after() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config = SubAgentConfig {
+        transcript_dir: Some(tmp.path().to_path_buf()),
+        transcript_enabled: true,
+        ..SubAgentConfig::default()
+    };
+
+    let mut mgr = make_manager();
+    mgr.definitions.push(sample_def());
+
+    let task_id = mgr
+        .spawn(
+            "bot",
+            "do stuff",
+            mock_provider(vec!["done"]),
+            noop_executor(),
+            None,
+            &config,
+            SpawnContext::default(),
+        )
+        .await
+        .unwrap();
+
+    let path_before = mgr.transcript_path_for(&config, &task_id);
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        let completed = mgr
+            .statuses()
+            .into_iter()
+            .any(|(id, status)| id == task_id && status.state == SubAgentState::Completed);
+        if completed {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() <= deadline,
+            "sub-agent did not complete within timeout"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+
+    mgr.collect(&task_id).await.unwrap();
+
+    let path_after = mgr.transcript_path_for(&config, &task_id);
+    assert_eq!(
+        path_before, path_after,
+        "transcript_path_for must return the identical path before and after collect()"
+    );
+    assert!(!mgr.agents.contains_key(&task_id));
+
+    crate::transcript::TranscriptReader::load_strict(&path_after)
+        .expect("transcript must still be readable after the handle has been collected");
+}
+
 #[tokio::test]
 async fn approve_secret_grants_access() {
     let mut mgr = make_manager();

--- a/specs/009-orchestration/spec.md
+++ b/specs/009-orchestration/spec.md
@@ -479,11 +479,15 @@ line-skipping reader that silently drops a `ToolUse` entry on a partial read wou
 false-positive an honest claim. This is a code-level precondition at the read site, not spec
 prose alone.
 
-**Residency note (spawn path).** The spawn-path trace is reconstructed from the sub-agent
-transcript, which today is guaranteed resident only because `SubAgentManager::collect()` is
-never called on the orchestration dispatch path. If `collect()` is ever wired into dispatch,
-the grounding read MUST move ahead of it; until then, the read MUST fail-closed to `None` on
-any lookup miss rather than assume residency.
+**Residency note (spawn path) — resolved (issue #6288).** The spawn-path trace read no longer
+depends on the sub-agent's handle remaining resident in `SubAgentManager`.
+`SubAgentManager::collect()` **is** wired into the orchestration dispatch path (`Agent::
+collect_finished_subagents()`, called once per scheduler tick in `run_scheduler_loop`), and the
+grounding read is unaffected by its timing: `SubAgentManager::transcript_path_for()` resolves the
+transcript path purely from `SubAgentConfig` and `agent_id`, with no dependency on
+`self.agents` — unlike the residency-coupled `agent_transcript_dir()` accessor it replaced. The
+read still MUST fail-closed to `None` on any lookup miss (missing `agent_id`, missing
+`SubAgentManager`, or a transcript read error), independent of collection timing.
 
 ### Implementation Surface
 
@@ -491,8 +495,8 @@ any lookup miss rather than assume residency.
 dispatch path sources it differently, since only one of the two has a transcript file:
 
 - **Spawn path.** Sourced from the sub-agent transcript: `TaskResult.agent_id` →
-  `SubAgentManager::agent_transcript_dir()` → `TranscriptReader::load`. The read happens at the
-  `SchedulerAction::Verify` handler in `scheduler_loop.rs`, subject to the fail-closed-to-`None`
+  `SubAgentManager::transcript_path_for()` → `TranscriptReader::load_strict`. The read happens at
+  the `SchedulerAction::Verify` handler in `scheduler_loop.rs`, subject to the fail-closed-to-`None`
   contract above.
 - **RunInline path.** There is no transcript file for this path, so the trace is collected
   directly inside `run_inline_tool_loop`'s tool-call loop and threaded through a new field on
@@ -597,7 +601,7 @@ laundering a hallucinated claim that only surfaces once outputs are aggregated a
 **Aggregation is transcript-derived, not per-task-verify-derived.** At `run_whole_plan_verify`
 time the DAG-wide trace is rebuilt from source, per completed-with-result task, by reimplementing
 the same resolution logic `build_tool_trace_for_task` uses for the per-task path (`TaskResult.agent_id`
-→ `SubAgentManager::agent_transcript_dir()` → `TranscriptReader::load_strict`) — split across
+→ `SubAgentManager::transcript_path_for()` → `TranscriptReader::load_strict`) — split across
 `resolve_whole_plan_trace_paths` (synchronous path resolution) and `build_whole_plan_tool_trace`
 (the actual reads, offloaded to `spawn_blocking`). `build_tool_trace_for_task` itself is
 module-private to `scheduler_loop.rs` and is not called directly from the whole-plan path (a
@@ -607,6 +611,14 @@ from the transcript — rather than reusing a value cached during per-task `Veri
 it makes whole-plan grounding correct *even when per-task `Verify` was skipped* for some task,
 which is exactly the future gap this closes. The reads are already-persisted transcripts; no
 per-task LLM claim-extraction is re-run.
+
+**Residency note (whole-plan path) — resolved (issue #6288).** `run_whole_plan_verify` runs
+strictly after `run_scheduler_loop` returns (`plan.rs`), i.e. after every per-tick
+`collect_finished_subagents()` call for the just-completed plan has already run — every
+spawn-dispatched completed task's handle is reaped from `SubAgentManager` by the time this path
+resolves transcript paths. Like the per-task path above, `resolve_whole_plan_trace_paths` uses
+`transcript_path_for()` (not `agent_transcript_dir()`), so it does not depend on handle residency
+and is unaffected by that ordering.
 
 **Trace availability is all-or-nothing, lifted to the DAG level.** The aggregate is
 `Some(union)` only if **every** completed-with-result task resolves to `Some(trace)`; if **any**


### PR DESCRIPTION
## Summary

`SubAgentManager::collect()` was only ever invoked from the interactive `/agent`
polling path (`poll_subagents()`), never from the orchestration dispatch loop
(`run_scheduler_loop`). Every plan-executed sub-agent leaked its handle and never
wrote a final `TranscriptMeta` sidecar.

A naive ordering fix (call `collect()` right after the verifier reads the trace)
is not sufficient: `status_tx` flips to `Completed` before the corresponding
`TaskEvent` is even enqueued, and `SchedulerAction::Verify` is never emitted for
`Failed` outcomes or when `verify_completeness` is disabled, so a Verify-only reap
would still leak most terminal tasks.

Instead, grounding trace reads are decoupled from handle residency:
- `SubAgentManager::transcript_path_for()` resolves the transcript path from
  config alone, independent of whether the handle is still tracked.
- `build_tool_trace_for_task` and `resolve_whole_plan_trace_paths` (whole-plan
  grounding, a related residency hazard found during implementation) both now
  use it, so reaping can no longer silently degrade verifier grounding to
  fail-open `None`.
- `Agent::collect_finished_subagents()` reaps every `Completed`/`Failed`/`Canceled`
  handle once per scheduler tick.

`specs/009-orchestration/spec.md` updated to reflect that grounding no longer
depends on handle residency.

Closes #6288

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13808 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] `cargo test --doc -p zeph-subagent` — clean, including new `transcript_path_for` doctest
- [x] 6 new/extended regression tests added, covering: the leak fix itself, grounding survives collection (per-task and whole-plan), `None`-manager no-op, `Canceled`-state reap
- [x] `gitleaks protect --staged` — clean