### PR TITLE
test(core): add e2e coverage for TurnSummary tool_calls/llm_requests counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 ### Testing
 
+- **zeph-core**: added end-to-end coverage for `TurnSummary.tool_calls` / `TurnSummary.llm_requests`
+  (#6330), closing the gap left by #6328: no prior test drove a real turn through
+  `check_and_update_quota` and asserted the resulting counters reflected actual per-turn
+  dispatch counts rather than a stale or hardcoded value. `text_only_turn_reports_zero_tool_calls_and_one_llm_request`
+  covers the zero-tool-call baseline; `single_turn_with_multiple_tool_calls_counts_full_batch`
+  dispatches 3 tool calls in a single batch to catch batch-counting/off-by-one bugs; and
+  `tool_call_counter_resets_between_turns_not_accumulated` runs two consecutive turns to prove
+  `LifecycleState::turn_tool_calls`/`turn_llm_requests` are reset in `begin_turn` rather than
+  leaking across turns. No production code changed.
+
 - **zeph-orchestration** / **zeph-core**: added direct test coverage for two spec-075 §7
   success criteria that were only transitively covered (#6301, deferred from #6243/#6265).
   `test_build_prompt_includes_mode1_recovered_state_injection` drives Mode-1 recovery

--- a/crates/zeph-core/src/agent/tests/mod.rs
+++ b/crates/zeph-core/src/agent/tests/mod.rs
@@ -37,5 +37,7 @@ mod shutdown_summary_tests;
 mod small_misc_tests;
 #[cfg(test)]
 mod trim_parent_messages_tests;
+#[cfg(test)]
+mod turn_summary_counters_tests;
 #[cfg(all(test, feature = "scheduler"))]
 mod whole_plan_verify_signal_tests;

--- a/crates/zeph-core/src/agent/tests/turn_summary_counters_tests.rs
+++ b/crates/zeph-core/src/agent/tests/turn_summary_counters_tests.rs
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Regression coverage for #6330: no test previously exercised a real turn that dispatches
+//! tool calls and asserts `LifecycleState::turn_tool_calls` / `turn_llm_requests` reflect the
+//! actual per-turn counts, rather than the pre-#6328 hardcoded `0`.
+//!
+//! These tests assert on the `LifecycleState` fields directly rather than on a constructed
+//! `TurnSummary`. `Agent::maybe_fire_completion_notification` (see `crate::agent::mod`, the
+//! single construction site at line ~1396) builds `TurnSummary` as a direct, untransformed copy
+//! of `LifecycleState::turn_tool_calls` / `turn_llm_requests`, and `Agent::end_turn` never
+//! touches either counter — only `Agent::begin_turn` resets them — so the values asserted here
+//! are exactly what a constructed `TurnSummary` for that turn would carry.
+//!
+//! This is real regression coverage for the counter logic (reset site, increment site, batch
+//! counting) — not an end-to-end proof of delivery to a downstream consumer. As of this writing
+//! `TurnSummary::llm_requests` does have a shipped consumer (`Notifier::should_fire` gates on
+//! it, and it is exported to `turn_complete` hooks as `ZEPH_TURN_LLM_REQUESTS` —
+//! `crate::notifications` / `mod.rs`'s hook-env-building code), but `TurnSummary::tool_calls` is
+//! currently write-only: no gate reads it, no notification body includes it, and no hook env var
+//! exports it. That gap is a separate, pre-existing product issue tracked outside this PR, not
+//! something these tests can or should paper over.
+
+use zeph_llm::any::AnyProvider;
+use zeph_llm::mock::MockProvider;
+use zeph_llm::provider::{ChatResponse, ToolUseRequest};
+use zeph_tools::executor::ToolOutput;
+
+use crate::agent::Agent;
+use crate::agent::agent_tests::{MockChannel, MockToolExecutor, create_test_registry};
+
+fn tool_output(name: &str, summary: &str) -> ToolOutput {
+    ToolOutput {
+        tool_name: name.into(),
+        summary: summary.to_owned(),
+        blocks_executed: 1,
+        filter_stats: None,
+        diff: None,
+        streamed: false,
+        terminal_id: None,
+        locations: None,
+        raw_response: None,
+        claim_source: None,
+        ..Default::default()
+    }
+}
+
+/// A single-batch `ChatResponse::ToolUse` carrying `n` distinct tool calls, mirroring how the
+/// LLM can request several tool invocations in one round-trip. `check_and_update_quota`
+/// (`crate::agent::tool_execution::tier_loop`) counts the whole batch in a single call, so this
+/// is the shape needed to catch off-by-one/batch-counting bugs.
+fn tool_use_batch(n: usize) -> ChatResponse {
+    ChatResponse::ToolUse {
+        text: None,
+        tool_calls: (0..n)
+            .map(|i| ToolUseRequest {
+                id: format!("call-{i}"),
+                name: format!("tool_{i}").into(),
+                input: serde_json::json!({"arg": i}),
+            })
+            .collect(),
+        thinking_blocks: vec![],
+    }
+}
+
+/// Baseline (AC #1): a turn with zero tool calls must report `turn_tool_calls == 0` and exactly
+/// one LLM round-trip, not a stale or hardcoded value.
+#[tokio::test]
+async fn text_only_turn_reports_zero_tool_calls_and_one_llm_request() {
+    let (mock, _counter) =
+        MockProvider::default().with_tool_use(vec![ChatResponse::Text("hello".into())]);
+    let provider = AnyProvider::Mock(mock);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+    agent
+        .process_user_message("no tools needed".to_owned(), vec![])
+        .await
+        .unwrap();
+
+    assert_eq!(agent.runtime.lifecycle.turn_tool_calls, 0);
+    assert_eq!(agent.runtime.lifecycle.turn_llm_requests, 1);
+}
+
+/// AC #2 (multiple tool calls in a single turn): a `ToolUse` response with 3 tool calls
+/// dispatched in one batch, followed by the final text, must land `turn_tool_calls == 3` — not
+/// `1` (would indicate the batch is miscounted as a single call) and not `0` (would indicate the
+/// pre-#6328 hardcoded-zero regression). `turn_llm_requests` must be `2`: the `ToolUse`
+/// round-trip plus the final `Text` round-trip.
+#[tokio::test]
+async fn single_turn_with_multiple_tool_calls_counts_full_batch() {
+    let (mock, _counter) = MockProvider::default().with_tool_use(vec![
+        tool_use_batch(3),
+        ChatResponse::Text("all done".into()),
+    ]);
+    let provider = AnyProvider::Mock(mock);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::new(vec![
+        Ok(Some(tool_output("tool_0", "result-0"))),
+        Ok(Some(tool_output("tool_1", "result-1"))),
+        Ok(Some(tool_output("tool_2", "result-2"))),
+    ]);
+
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+    agent
+        .process_user_message("run three tools".to_owned(), vec![])
+        .await
+        .unwrap();
+
+    assert_eq!(agent.runtime.lifecycle.turn_tool_calls, 3);
+    assert_eq!(agent.runtime.lifecycle.turn_llm_requests, 2);
+}
+
+/// AC #3 (reset-timing regression guard): a turn that dispatches tool calls must not leak its
+/// counts into the *next* turn. This directly exercises the single reset site,
+/// `Agent::begin_turn` (`self.runtime.lifecycle.turn_tool_calls = 0` /
+/// `self.runtime.lifecycle.turn_llm_requests = 0`) — a bug there (e.g. reset removed, or moved
+/// to fire before the previous turn's `TurnSummary` is built) would surface as turn 2 observing
+/// turn 1's accumulated counts instead of its own.
+#[tokio::test]
+async fn tool_call_counter_resets_between_turns_not_accumulated() {
+    let (mock, _counter) = MockProvider::default().with_tool_use(vec![
+        tool_use_batch(2),
+        ChatResponse::Text("first turn done".into()),
+        ChatResponse::Text("second turn done".into()),
+    ]);
+    let provider = AnyProvider::Mock(mock);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::new(vec![
+        Ok(Some(tool_output("tool_0", "r0"))),
+        Ok(Some(tool_output("tool_1", "r1"))),
+    ]);
+
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+    agent
+        .process_user_message("first: run two tools".to_owned(), vec![])
+        .await
+        .unwrap();
+    assert_eq!(agent.runtime.lifecycle.turn_tool_calls, 2);
+    assert_eq!(agent.runtime.lifecycle.turn_llm_requests, 2);
+
+    agent
+        .process_user_message("second: no tools".to_owned(), vec![])
+        .await
+        .unwrap();
+    assert_eq!(
+        agent.runtime.lifecycle.turn_tool_calls, 0,
+        "turn 2 dispatched no tools; a leaked/accumulated counter would show 2 here"
+    );
+    assert_eq!(
+        agent.runtime.lifecycle.turn_llm_requests, 1,
+        "turn 2 made exactly one LLM round-trip; an accumulated counter would show 3 here"
+    );
+}


### PR DESCRIPTION
## Summary
- Adds integration-style tests that drive a real `Agent::process_user_message` turn and assert `TurnSummary.tool_calls` / `TurnSummary.llm_requests` reflect actual per-turn counts, closing the coverage gap left by #6328 (previously verified only via static code trace).
- Reuses existing `MockProvider`/`MockToolExecutor`/`MockChannel` test doubles — no new mocking infrastructure.
- Test-only change; no production code modified.

Closes #6330

## Tests
- `text_only_turn_reports_zero_tool_calls_and_one_llm_request` — zero-tool-call baseline
- `single_turn_with_multiple_tool_calls_counts_full_batch` — 3 tool calls in one batch, distinguishes `+= len()` from `+= 1` batch counting
- `tool_call_counter_resets_between_turns_not_accumulated` — two sequential turns, exercises the `begin_turn` reset site

## Notes
- Reviewed by the team-develop chain (developer → tester + impl-critic → reviewer). impl-critic flagged that `TurnSummary.tool_calls` currently has no live downstream consumer (not read by `should_fire`, not in the notification body, no `ZEPH_TURN_TOOL_CALLS` hook export) — the test module doc was reworded to avoid overstating this as end-to-end delivery proof. The write-only-field gap itself is out of scope for this PR; will be filed as a separate follow-up issue.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13872 passed, 35 skipped
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`