### PR TITLE
fix(core): use atomic write for debug dumps, fix broken rustdoc links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `SubAgentManager::transcript_path_for()`, which is computed from config alone, so reaping
   handles on the dispatch path cannot silently degrade per-task or whole-plan verifier grounding
   (spec 009 §§ Verifier Tool-Call Grounding, Whole-Plan Grounding) to fail-open `None`.
+
+- `zeph-core`: `DebugDumper::write`/`write_sync` now use `zeph_common::fs_secure::atomic_write_private`
+  (write-to-`.tmp`-then-rename) instead of the non-atomic `write_private` (open-truncate then
+  `write_all`) (#6327). Under `write_private`, a reader polling for the dump file could open it
+  in the truncate-but-not-yet-written window and observe an empty file, which is what made the
+  `read_request_dump` test helper flaky under parallel `nextest` execution (~1 in 5-7 runs,
+  `serde_json` "EOF while parsing a value" panic). The atomic rename means the target path never
+  becomes visible until the complete content is already flushed and synced, fixing the race for
+  both production callers and tests; `read_request_dump`'s own empty-content retry guard is
+  therefore unnecessary and was left unchanged.
+
+- `zeph-core`: fixed the `rustdoc::broken_intra_doc_links` gate failure in `provider_factory.rs`
+  (#6329). `spawn_cocoon_health_checks`'s doc comment referenced `[TaskSupervisor::snapshot]`
+  without `TaskSupervisor` being in scope in this file (unlike other files that `use` it) — now
+  a fully-qualified `[zeph_common::TaskSupervisor::snapshot]` link. The same doc comment also
+  linked to two private helpers (`build_cocoon_provider`, `resolve_cocoon_client_params`) from a
+  public function's docs, triggering `private_intra_doc_links` warnings; both are now plain
+  inline code spans instead of unresolvable intra-doc links.
+
 - `--init` wizard: the orchestration `default_idle_timeout_secs` prompt silently dropped
   invalid input (non-numeric, negative, or `0`) to `None` via a bare `.parse().ok()`, with
   zero re-prompt or feedback to the operator (#6303). It now uses the same

--- a/crates/zeph-core/src/debug_dump/mod.rs
+++ b/crates/zeph-core/src/debug_dump/mod.rs
@@ -123,7 +123,7 @@ impl DebugDumper {
         // for this fix. Recorded here per the exception clause in
         // .claude/rules/continuous-improvement.md rather than left as a silent deviation.
         tokio::task::spawn_blocking(move || {
-            if let Err(e) = zeph_common::fs_secure::write_private(&path, &content) {
+            if let Err(e) = zeph_common::fs_secure::atomic_write_private(&path, &content) {
                 tracing::warn!(path = %path.display(), error = %e, "debug dump write failed");
             }
         });
@@ -134,7 +134,7 @@ impl DebugDumper {
     /// out of scope for the #6029 hot-path fix — see the issue for the tracked follow-up.
     fn write_sync(&self, filename: &str, content: &[u8]) {
         let path = self.dir.join(filename);
-        if let Err(e) = zeph_common::fs_secure::write_private(&path, content) {
+        if let Err(e) = zeph_common::fs_secure::atomic_write_private(&path, content) {
             tracing::warn!(path = %path.display(), error = %e, "debug dump write failed");
         }
     }
@@ -1050,9 +1050,9 @@ mod tests {
     }
 
     /// Polls for a plain-text dump file by name, mirroring `read_request_dump`. Requires
-    /// non-empty content (not just a successful open) to avoid a truncate-then-write race in
-    /// `write_private`: `write()` opens the file with `truncate` before `write_all` runs, so a
-    /// read landing in that window would otherwise see an empty file instead of retrying.
+    /// non-empty content (not just a successful open) as defense-in-depth; `write`/`write_sync`
+    /// now use `atomic_write_private` (write-to-`.tmp`-then-rename, #6327), so the target path
+    /// only ever becomes visible once fully written.
     async fn read_dump_file(dir: &Path, filename: &str) -> String {
         let session = std::fs::read_dir(dir)
             .unwrap()

--- a/crates/zeph-core/src/provider_factory.rs
+++ b/crates/zeph-core/src/provider_factory.rs
@@ -648,12 +648,12 @@ fn build_cocoon_provider(
 /// Spawn an advisory health-check for all Cocoon providers that have `cocoon_health_check = true`.
 ///
 /// Registers each check as a one-shot supervised task so it is observable via
-/// [`TaskSupervisor::snapshot`] and abortable on shutdown. Failures are logged at `warn` level
-/// and never propagated — the check is purely advisory. Gating logic for `access_hash`/`base_url`
-/// is shared with [`build_cocoon_provider`] via [`resolve_cocoon_client_params`]; unlike the
-/// provider-build path, a resolution error here only skips that entry's health check (logged at
-/// `warn`) rather than failing bootstrap, since this path is advisory and runs after providers
-/// have already been built successfully.
+/// [`zeph_common::TaskSupervisor::snapshot`] and abortable on shutdown. Failures are logged at
+/// `warn` level and never propagated — the check is purely advisory. Gating logic for
+/// `access_hash`/`base_url` is shared with `build_cocoon_provider` via
+/// `resolve_cocoon_client_params`; unlike the provider-build path, a resolution error here only
+/// skips that entry's health check (logged at `warn`) rather than failing bootstrap, since this
+/// path is advisory and runs after providers have already been built successfully.
 ///
 /// Call this once after [`build_provider_from_entry`] has succeeded for all providers, passing
 /// the session-level supervisor. The function is a no-op when `cocoon` feature is not enabled


### PR DESCRIPTION
## Summary

- `DebugDumper::write`/`write_sync` (`crates/zeph-core/src/debug_dump/mod.rs`) now use `zeph_common::fs_secure::atomic_write_private` (write-to-`.tmp`-then-rename) instead of the non-atomic `write_private` (open-truncate then `write_all`). The target path never becomes visible until the fully-flushed content is renamed into place, closing the window where the `read_request_dump` test helper could observe an empty file mid-write under parallel `nextest` execution (~1 in 5-7 runs).
- Fixed the `rustdoc::broken_intra_doc_links` gate failure in `provider_factory.rs`: `spawn_cocoon_health_checks`'s doc comment referenced `[TaskSupervisor::snapshot]` without `TaskSupervisor` being in scope in this file — now a fully-qualified `[zeph_common::TaskSupervisor::snapshot]` link. The same doc comment also linked to two private helpers from a public function's docs, triggering `private_intra_doc_links`; both are now plain inline code spans.

Closes #6327
Closes #6329

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13869 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p zeph-core --features "candle,classifiers,cocoon,index,metal,mock,profiling,scheduler,sqlite,sysinfo"` — clean
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — all passed
- [x] `gitleaks protect --staged --no-banner --redact` — no leaks
- [x] Reproduced the original #6327 flaky repro command 7 times in a row with zero failures (89/89 tests passed each run)