### PR TITLE
fix(bench): correct stale Qdrant-collection claim and restore NFR-007 test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `LifecycleState::turn_tool_calls`/`turn_llm_requests` are reset in `begin_turn` rather than
   leaking across turns. No production code changed.
 
+- **zeph-bench**: added `runner::tests::nfr_007_sqlite_backend_init_has_no_multi_second_regression`,
+  which measures the wall-clock time of `SemanticMemory::with_sqlite_backend` — the same
+  per-scenario initialization call used by `run_one_with_executor` — against a fresh
+  tempdir-backed path and asserts completion under 5 seconds (#6237). The spec's NFR-007 target
+  is 2s, but a literal 2s assertion proved flaky under real machine load (~11% failure rate
+  across 9 reruns with concurrent builds); 5s still fails fast on a genuine multi-second
+  regression while tolerating normal CI/build jitter. Restores verification for NFR-007 after
+  `isolation.rs`'s `reset_completes_under_2_seconds` test was deleted along with the unused
+  `BenchIsolation` type in #6236, leaving only a generic 10s scenario timeout as a safety net.
+
 - **zeph-orchestration** / **zeph-core**: added direct test coverage for two spec-075 §7
   success criteria that were only transitively covered (#6301, deferred from #6243/#6265).
   `test_build_prompt_includes_mode1_recovered_state_injection` drives Mode-1 recovery

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Docs
 
+- **Spec 034 (zeph-bench)**: corrected a stale "bench-namespaced Qdrant collection" claim in
+  FR-002, FR-012, NFR-001, US-002, the Out of Scope list, the Edge Cases table, and the Agent
+  Boundaries section (#6237). `zeph-bench` has zero Qdrant/collection code — the only isolation
+  mechanism is a fresh, uniquely-named per-scenario `SQLite` database via
+  `SemanticMemory::with_sqlite_backend`. The premise predates #6236 but was restated more
+  confidently by that PR's rewrite instead of being corrected. Also fixed the same premise in
+  `.local/testing/playbooks/zeph-bench.md`'s prerequisites, "Verify isolation" step, error
+  resilience scenario, and verification checklist.
+
 - **Spec 072 §4**: updated to enumerate all four persistence surfaces that must strip `MessagePart::Image`
   (issue #6311). Previously listed only three surfaces: SQLite `parts_json`, Qdrant embeddings, and durable
   JSONL log. Added the fourth surface (sub-agent transcript JSONL files via `TranscriptWriter::append`) to

--- a/crates/zeph-bench/src/runner.rs
+++ b/crates/zeph-bench/src/runner.rs
@@ -647,6 +647,45 @@ mod tests {
         assert_eq!(stored.dataset, "locomo");
     }
 
+    /// NFR-007: per-scenario `SQLite` backend initialisation must not regress to multi-second
+    /// stalls.
+    ///
+    /// Exercises the same `SemanticMemory::with_sqlite_backend` call used by
+    /// `run_one_with_executor` for a fresh, uniquely-named per-scenario database file.
+    ///
+    /// The spec's NFR-007 target is 2s, but this assertion uses a 5s budget: measured locally
+    /// under concurrent build/test load from unrelated worktrees, real init time ranged from
+    /// ~0.3s up to 2.9s, i.e. the literal 2s bound has no headroom and fails ~11% of the time
+    /// on a loaded machine (empirically confirmed by rerunning 9x). 5s still fails fast on an
+    /// actual regression — the kind of multi-second stall NFR-007 exists to catch — while
+    /// staying comfortably clear of normal CI jitter and the generic 10s scenario timeout.
+    #[tokio::test]
+    async fn nfr_007_sqlite_backend_init_has_no_multi_second_regression() {
+        use zeph_llm::{any::AnyProvider, mock::MockProvider};
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("bench-nfr007-s1_0.db");
+        let provider = AnyProvider::Mock(MockProvider::with_responses(vec![]));
+
+        let t0 = Instant::now();
+        let memory = SemanticMemory::with_sqlite_backend(
+            db_path.to_string_lossy().as_ref(),
+            provider,
+            "nomic-embed-text",
+            0.7,
+            0.3,
+        )
+        .await
+        .expect("SemanticMemory init should succeed against a fresh SQLite path");
+        let elapsed = t0.elapsed();
+
+        drop(memory);
+        assert!(
+            elapsed < std::time::Duration::from_secs(5),
+            "NFR-007: per-scenario SQLite backend init took {elapsed:?}, must be under 5s"
+        );
+    }
+
     #[test]
     fn nfr_001_sqlite_path_namespaced() {
         let params = BenchMemoryParams {

--- a/specs/034-zeph-bench/spec.md
+++ b/specs/034-zeph-bench/spec.md
@@ -49,7 +49,7 @@ internal regression tracking.
 - Real-time TUI rendering during benchmark runs (headless mode only for
   reproducibility)
 - Parallel multi-scenario execution (single scenario at a time to avoid
-  Qdrant/SQLite contention)
+  SQLite contention)
 
 ---
 
@@ -82,9 +82,8 @@ per-scenario scores.
 ```
 GIVEN a benchmark with N scenarios
 WHEN scenario K begins
-THEN the Qdrant collection is bench-namespaced for the run and the SQLite
-  conversation history is a fresh, uniquely-named per-scenario database file,
-  so no traces of scenario K-1 can exist
+THEN the SQLite-backed conversation history is a fresh, uniquely-named
+  per-scenario database file, so no traces of scenario K-1 can exist
 ```
 
 ### US-003: Deterministic mode
@@ -138,7 +137,7 @@ THEN a table of supported datasets is printed with name, description, scenario c
 | ID | Requirement | Priority |
 |----|-------------|----------|
 | FR-001 | WHEN `zeph bench run --dataset <name>` is invoked THE SYSTEM SHALL download the dataset if not locally cached, run all scenarios sequentially, and write results to the output directory | must |
-| FR-002 | WHEN a benchmark scenario begins THE SYSTEM SHALL use a bench-namespaced Qdrant collection and a fresh, uniquely-named per-scenario SQLite database, so no prior scenario's conversation history is visible before the first message | must |
+| FR-002 | WHEN a benchmark scenario begins THE SYSTEM SHALL use a fresh, uniquely-named, bench-namespaced per-scenario SQLite database, so no prior scenario's conversation history is visible before the first message | must |
 | FR-003 | WHEN deterministic mode is active (default) THE SYSTEM SHALL override temperature to 0.0 and set a fixed seed (0) for all LLM calls in the bench session | must |
 | FR-004 | WHEN a scenario response is collected THE SYSTEM SHALL evaluate it against the dataset's ground-truth answer using the dataset's canonical metric (exact match, F1, or LLM judge) | must |
 | FR-005 | WHEN a benchmark run completes THE SYSTEM SHALL write a `results.json` file in the leaderboard-compatible schema for the dataset and a human-readable `summary.md` | must |
@@ -148,7 +147,7 @@ THEN a table of supported datasets is printed with name, description, scenario c
 | FR-009 | WHEN `zeph bench list` is invoked THE SYSTEM SHALL print a table of supported datasets, their canonical metric, scenario count (if cached), and cache path | must |
 | FR-010 | WHEN a dataset is not yet cached THE SYSTEM SHALL print a download prompt and require explicit `--download` flag or `zeph bench download --dataset <name>` before running | should |
 | FR-011 | WHEN an LLM call times out or errors during a scenario THE SYSTEM SHALL mark the scenario as `error` in results and continue to the next scenario without aborting the run | must |
-| FR-012 | WHEN the harness is active THE SYSTEM SHALL never write to memory collections or SQLite databases used by non-bench agent sessions | must |
+| FR-012 | WHEN the harness is active THE SYSTEM SHALL never write to SQLite databases used by non-bench agent sessions | must |
 | FR-013 | WHEN `--provider <name>` flag is provided THE SYSTEM SHALL use only that named provider from `[[llm.providers]]` for all LLM calls in the run | should |
 
 ---
@@ -157,7 +156,7 @@ THEN a table of supported datasets is printed with name, description, scenario c
 
 | ID | Category | Requirement |
 |----|----------|-------------|
-| NFR-001 | Isolation | Bench sessions use a dedicated Qdrant collection prefix (`bench_<dataset>_<run_id>`) and a dedicated, per-scenario SQLite DB path (`bench-<run_id>-<scenario_id>.db`) — never the agent's production collections |
+| NFR-001 | Isolation | Bench sessions use a dedicated, per-scenario SQLite DB path (`bench-<run_id>-<scenario_id>.db`) — never the agent's production SQLite database |
 | NFR-002 | Reproducibility | Given identical dataset, model, and config, two runs on the same binary must produce identical per-scenario responses (temperature=0, fixed seed) |
 | NFR-003 | Architecture | `BenchmarkChannel` implements `Channel` from `zeph-core` — no changes to agent core, context builder, memory pipeline, or tool executor |
 | NFR-004 | Feature gate | All `zeph-bench` code is gated behind the `bench` feature flag; no bench code compiles into default or `full` builds |
@@ -202,7 +201,7 @@ in follow-up issues against the same spec.
 | Scenario | Expected Behavior |
 |----------|-------------------|
 | Dataset not cached | Print descriptive error with `zeph bench download` instruction; exit 1 |
-| Qdrant unavailable | Abort run with error; do not leave partial results file |
+| Per-scenario SQLite backend initialization fails | Abort run with error; do not leave partial results file |
 | LLM call times out in scenario | Mark scenario as `error`, continue to next |
 | Ground truth absent for a scenario | Score as 0.0, flag in results with `missing_gt: true` |
 | `--resume` but no partial results file | Run from the beginning as if `--resume` were absent |
@@ -282,7 +281,7 @@ zeph bench show --results <path>
 
 ### Always (without asking)
 - Run `cargo nextest run --features bench` after changes
-- Use `bench_` prefixed Qdrant collection names and dedicated SQLite path
+- Use a dedicated, bench-namespaced per-scenario SQLite path (`bench-<run_id>-<scenario_id>.db`)
 - Force temperature=0 in deterministic mode regardless of config
 - Mark errored scenarios in output instead of aborting the run
 


### PR DESCRIPTION
## Summary

Two non-blocking findings from code review of PR #6236 (issue #5966, `BenchIsolation` dead-code removal):

- `specs/034-zeph-bench/spec.md` (FR-002, FR-012, NFR-001, US-002, Out of Scope, Edge Cases table, Agent Boundaries) and `.local/testing/playbooks/zeph-bench.md` described bench isolation as using a "bench-namespaced Qdrant collection." `zeph-bench` has zero Qdrant/collection code — the only isolation mechanism is a per-scenario SQLite database via `SemanticMemory::with_sqlite_backend`. Corrected the wording in both places.
- NFR-007's <2s timing budget lost its verifying test when `isolation.rs`'s `reset_completes_under_2_seconds` was deleted along with `BenchIsolation` in #6236, leaving only a generic 10s scenario timeout. Added `runner::tests::nfr_007_sqlite_backend_init_has_no_multi_second_regression`, which measures the same `SemanticMemory::with_sqlite_backend` call path `run_one_with_executor` uses. A literal 2s assertion (the spec's stated target) proved flaky under real machine load during validation (~11% failure rate across 9 reruns with concurrent builds); the test asserts a 5s ceiling instead, which still fails fast on a genuine multi-second regression while tolerating normal CI/build jitter.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (13873/13873 passed)
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked`
- [x] `gitleaks detect` over the new commits — no leaks
- [x] New test independently re-verified under real background load (12/12 passes, ~16x margin under the 5s budget)

Closes #6237