### PR TITLE
fix(core): wire TurnSummary.tool_calls to hook env export and notification body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-core`: `TurnSummary::tool_calls` was computed every turn but had no downstream consumer,
+  unlike its sibling `llm_requests` (issue #6335). It is now exported to `turn_complete` hooks as
+  `ZEPH_TURN_TOOL_CALLS` (mirroring `ZEPH_TURN_LLM_REQUESTS`) and included in the completion
+  notification body (`Notifier`, both macOS-native and ntfy webhook channels) whenever a turn
+  dispatches at least one tool call. `Notifier::should_fire` gating is unchanged — `tool_calls`
+  does not gate notifications, only `llm_requests` does.
 - `zeph-core`/`zeph-subagent`: orchestration-dispatched sub-agents (`SchedulerAction::Spawn` via
   `run_scheduler_loop`) are now reaped once they reach a terminal state (`Completed`/`Failed`/
   `Canceled`) — `SubAgentManager::collect()` was previously only called from the interactive

--- a/config/default.toml
+++ b/config/default.toml
@@ -1723,6 +1723,7 @@ provider_persistence = true
 #   ZEPH_TURN_STATUS        — "success" or "error"
 #   ZEPH_TURN_PREVIEW       — redacted first ≤160 chars of the assistant response
 #   ZEPH_TURN_LLM_REQUESTS  — number of completed LLM round-trips this turn
+#   ZEPH_TURN_TOOL_CALLS    — number of tool calls dispatched this turn
 #
 # Note: the built-in [notifications] section is the preferred path for desktop
 # and webhook delivery. This hook is an escape hatch for custom shell integration

--- a/crates/zeph-config/src/hooks.rs
+++ b/crates/zeph-config/src/hooks.rs
@@ -94,6 +94,7 @@ pub struct HooksConfig {
     /// - `ZEPH_TURN_STATUS`        — `"success"` or `"error"`.
     /// - `ZEPH_TURN_PREVIEW`       — redacted first ≤ 160 chars of the assistant response.
     /// - `ZEPH_TURN_LLM_REQUESTS`  — number of completed LLM round-trips this turn.
+    /// - `ZEPH_TURN_TOOL_CALLS`    — number of tool calls dispatched this turn.
     #[serde(default)]
     pub turn_complete: Vec<HookDef>,
     /// Maximum number of `PreToolUse` hook blocks allowed per turn before the turn is ended

--- a/crates/zeph-config/src/migrate/session.rs
+++ b/crates/zeph-config/src/migrate/session.rs
@@ -190,7 +190,7 @@ pub fn migrate_hooks_turn_complete_config(toml_src: &str) -> Result<MigrationRes
 
     let comment = "\n# [[hooks.turn_complete]] — hook fired after every agent turn completes (#3308).\n\
          # Available env vars: ZEPH_TURN_DURATION_MS, ZEPH_TURN_STATUS, ZEPH_TURN_PREVIEW,\n\
-         # ZEPH_TURN_LLM_REQUESTS.\n\
+         # ZEPH_TURN_LLM_REQUESTS, ZEPH_TURN_TOOL_CALLS.\n\
          # Note: ZEPH_TURN_PREVIEW is available as env var but should not be embedded\n\
          # directly in the command string to avoid shell injection. Use a wrapper script instead.\n\
          # [[hooks.turn_complete]]\n\

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -191,6 +191,36 @@ enum DispatchFlow {
     Fallthrough,
 }
 
+/// Build the `turn_complete` hook environment from a turn summary.
+///
+/// Mirrors the fields exposed on [`crate::notifications::TurnSummary`]: duration, status,
+/// redacted preview, LLM round-trip count, and tool-call count. Extracted as a pure function
+/// so the env var set can be asserted without driving a full agent turn.
+fn build_turn_hook_env(
+    summary: &crate::notifications::TurnSummary,
+    is_error: bool,
+) -> std::collections::HashMap<String, String> {
+    let mut env = std::collections::HashMap::new();
+    env.insert(
+        "ZEPH_TURN_DURATION_MS".to_owned(),
+        summary.duration_ms.to_string(),
+    );
+    env.insert(
+        "ZEPH_TURN_STATUS".to_owned(),
+        if is_error { "error" } else { "success" }.to_owned(),
+    );
+    env.insert("ZEPH_TURN_PREVIEW".to_owned(), summary.preview.clone());
+    env.insert(
+        "ZEPH_TURN_LLM_REQUESTS".to_owned(),
+        summary.llm_requests.to_string(),
+    );
+    env.insert(
+        "ZEPH_TURN_TOOL_CALLS".to_owned(),
+        summary.tool_calls.to_string(),
+    );
+    env
+}
+
 impl<C: Channel> Agent<C> {
     /// Create a new agent instance with the given LLM provider, I/O channel, and subsystems.
     ///
@@ -1423,20 +1453,7 @@ impl<C: Channel> Agent<C> {
         // borrow is created inside the future from the owned dispatch value.
         let hooks = self.services.session.hooks_config.turn_complete.clone();
         if !hooks.is_empty() && gate_ok {
-            let mut env = std::collections::HashMap::new();
-            env.insert(
-                "ZEPH_TURN_DURATION_MS".to_owned(),
-                summary.duration_ms.to_string(),
-            );
-            env.insert(
-                "ZEPH_TURN_STATUS".to_owned(),
-                if is_error { "error" } else { "success" }.to_owned(),
-            );
-            env.insert("ZEPH_TURN_PREVIEW".to_owned(), summary.preview.clone());
-            env.insert(
-                "ZEPH_TURN_LLM_REQUESTS".to_owned(),
-                summary.llm_requests.to_string(),
-            );
+            let mut env = build_turn_hook_env(&summary, is_error);
             let conv_id_str = self
                 .services
                 .memory

--- a/crates/zeph-core/src/agent/tests/turn_summary_counters_tests.rs
+++ b/crates/zeph-core/src/agent/tests/turn_summary_counters_tests.rs
@@ -13,13 +13,12 @@
 //! are exactly what a constructed `TurnSummary` for that turn would carry.
 //!
 //! This is real regression coverage for the counter logic (reset site, increment site, batch
-//! counting) — not an end-to-end proof of delivery to a downstream consumer. As of this writing
-//! `TurnSummary::llm_requests` does have a shipped consumer (`Notifier::should_fire` gates on
-//! it, and it is exported to `turn_complete` hooks as `ZEPH_TURN_LLM_REQUESTS` —
-//! `crate::notifications` / `mod.rs`'s hook-env-building code), but `TurnSummary::tool_calls` is
-//! currently write-only: no gate reads it, no notification body includes it, and no hook env var
-//! exports it. That gap is a separate, pre-existing product issue tracked outside this PR, not
-//! something these tests can or should paper over.
+//! counting) — not an end-to-end proof of delivery to a downstream consumer. Both
+//! `TurnSummary::llm_requests` and `TurnSummary::tool_calls` now have shipped consumers:
+//! `llm_requests` gates `Notifier::should_fire` and is exported to `turn_complete` hooks as
+//! `ZEPH_TURN_LLM_REQUESTS`; `tool_calls` feeds the notification body (non-zero counts only,
+//! see `crate::notifications::build_notification_message`) and is exported as
+//! `ZEPH_TURN_TOOL_CALLS` — both in `crate::notifications` / `mod.rs`'s hook-env-building code.
 
 use zeph_llm::any::AnyProvider;
 use zeph_llm::mock::MockProvider;
@@ -28,6 +27,7 @@ use zeph_tools::executor::ToolOutput;
 
 use crate::agent::Agent;
 use crate::agent::agent_tests::{MockChannel, MockToolExecutor, create_test_registry};
+use crate::notifications::{TurnExitStatus, TurnSummary};
 
 fn tool_output(name: &str, summary: &str) -> ToolOutput {
     ToolOutput {
@@ -156,4 +156,24 @@ async fn tool_call_counter_resets_between_turns_not_accumulated() {
         agent.runtime.lifecycle.turn_llm_requests, 1,
         "turn 2 made exactly one LLM round-trip; an accumulated counter would show 3 here"
     );
+}
+
+/// Regression coverage for #6335: `TurnSummary::tool_calls` must reach the `turn_complete`
+/// hook environment as `ZEPH_TURN_TOOL_CALLS`, mirroring `ZEPH_TURN_LLM_REQUESTS`.
+#[test]
+fn hook_env_includes_tool_calls_count() {
+    let summary = TurnSummary {
+        duration_ms: 1234,
+        preview: "done".to_owned(),
+        tool_calls: 3,
+        llm_requests: 2,
+        exit_status: TurnExitStatus::Success,
+    };
+
+    let env = crate::agent::build_turn_hook_env(&summary, false);
+
+    assert_eq!(env.get("ZEPH_TURN_TOOL_CALLS"), Some(&"3".to_owned()));
+    assert_eq!(env.get("ZEPH_TURN_LLM_REQUESTS"), Some(&"2".to_owned()));
+    assert_eq!(env.get("ZEPH_TURN_DURATION_MS"), Some(&"1234".to_owned()));
+    assert_eq!(env.get("ZEPH_TURN_STATUS"), Some(&"success".to_owned()));
 }

--- a/crates/zeph-core/src/notifications.rs
+++ b/crates/zeph-core/src/notifications.rs
@@ -20,6 +20,11 @@
 //! 4. Duration gate (`min_turn_duration_ms`) applies only to successful turns;
 //!    error turns always fire regardless of duration
 //!
+//! `tool_calls` does not participate in gating — a turn can legitimately dispatch
+//! zero tool calls (e.g. an LLM response with no tool use) and still fire. It only
+//! feeds the notification body and the `turn_complete` hook env (see
+//! [`TurnSummary::tool_calls`]).
+//!
 //! # Examples
 //!
 //! ```no_run
@@ -77,6 +82,10 @@ pub struct TurnSummary {
     /// First ≤ 160 chars of the assistant response, already redacted by the caller.
     pub preview: String,
     /// Number of tool calls dispatched this turn.
+    ///
+    /// Included in the notification body when non-zero, and exported to
+    /// `turn_complete` hooks as `ZEPH_TURN_TOOL_CALLS`. Does not participate in
+    /// [`Notifier::should_fire`] gating.
     pub tool_calls: u32,
     /// Number of completed LLM round-trips this turn.
     /// Zero for slash commands, cache-only turns, and security-blocked inputs.
@@ -136,6 +145,9 @@ impl Notifier {
     /// 3. If `only_on_error`: turn must have errored
     /// 4. For successful turns: `duration_ms >= min_turn_duration_ms`
     ///    (error turns bypass the duration gate)
+    ///
+    /// `summary.tool_calls` is never gated on — a turn with `tool_calls == 0` but
+    /// `llm_requests > 0` (an LLM response with no tool use) still fires.
     #[must_use]
     pub fn should_fire(&self, summary: &TurnSummary) -> bool {
         if !self.cfg.enabled {
@@ -275,17 +287,28 @@ fn build_notification_message(summary: &TurnSummary) -> String {
         "Done"
     };
 
+    let header = if summary.tool_calls > 0 {
+        let noun = if summary.tool_calls == 1 {
+            "tool call"
+        } else {
+            "tool calls"
+        };
+        format!(
+            "{status} — {dur}ms, {calls} {noun}",
+            dur = summary.duration_ms,
+            calls = summary.tool_calls,
+        )
+    } else {
+        format!("{status} — {dur}ms", dur = summary.duration_ms)
+    };
+
     // Apply scrub_content to redact any secrets that may be in the preview.
     let safe_preview = scrub_content(&summary.preview);
 
     if safe_preview.is_empty() {
-        format!("{status} — {dur}ms", dur = summary.duration_ms)
+        header
     } else {
-        format!(
-            "{status} — {dur}ms\n{preview}",
-            dur = summary.duration_ms,
-            preview = safe_preview,
-        )
+        format!("{header}\n{safe_preview}")
     }
 }
 
@@ -642,6 +665,46 @@ mod tests {
         let summary = error_summary(500, 1);
         let msg = build_notification_message(&summary);
         assert!(msg.starts_with("Error"));
+    }
+
+    #[test]
+    fn notification_message_includes_tool_calls_when_nonzero() {
+        let summary = TurnSummary {
+            duration_ms: 1234,
+            preview: "All done.".to_owned(),
+            tool_calls: 3,
+            llm_requests: 1,
+            exit_status: TurnExitStatus::Success,
+        };
+        let msg = build_notification_message(&summary);
+        assert!(
+            msg.contains("3 tool calls"),
+            "message should mention the tool-call count: {msg}"
+        );
+    }
+
+    #[test]
+    fn notification_message_singular_tool_call() {
+        let summary = TurnSummary {
+            duration_ms: 1234,
+            preview: "All done.".to_owned(),
+            tool_calls: 1,
+            llm_requests: 1,
+            exit_status: TurnExitStatus::Success,
+        };
+        let msg = build_notification_message(&summary);
+        assert!(
+            msg.contains("1 tool call") && !msg.contains("1 tool calls"),
+            "singular count should use singular noun: {msg}"
+        );
+    }
+
+    #[test]
+    fn notification_message_omits_tool_calls_when_zero() {
+        // tool_calls == 0 (e.g. slash commands, plain LLM replies) must not clutter the banner.
+        let summary = success_summary(1234, 1);
+        let msg = build_notification_message(&summary);
+        assert!(!msg.contains("tool call"), "message should be: {msg}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `TurnSummary.tool_calls` was computed every turn but had no downstream consumer, unlike its sibling `llm_requests`.
- Export it as `ZEPH_TURN_TOOL_CALLS` to `turn_complete` hooks, mirroring the existing `ZEPH_TURN_LLM_REQUESTS` export.
- Include the tool-call count in the notification body (macOS native + ntfy webhook) when non-zero, with correct singular/plural grammar.
- `should_fire` gating is intentionally left untouched — `llm_requests` remains the sole zero-activity gate, since a turn can legitimately have `tool_calls == 0` with `llm_requests > 0`.
- Added `ZEPH_TURN_TOOL_CALLS` to the three places that already document `ZEPH_TURN_LLM_REQUESTS` as a `turn_complete` hook env var: `crates/zeph-config/src/hooks.rs`, `config/default.toml`, `crates/zeph-config/src/migrate/session.rs`.

Closes #6335

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci -p zeph-core --all-targets --features scheduler -- -D warnings`
- [x] `cargo clippy --profile ci -p zeph-config --all-targets -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-core --features scheduler --lib --bins` (1999/1999 passed)
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-config --lib --bins` (849/849 passed)
- [x] `cargo test --doc -p zeph-core` (45/45 passed)
- [x] New unit tests cover notification-body inclusion/omission (incl. singular "1 tool call" boundary) and the `ZEPH_TURN_TOOL_CALLS` hook env export