### PR TITLE
refactor(experiments): make ParameterKind sync points compiler-enforced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+### Changed
+
+- `zeph-experiments`: `ParameterKind::as_str`, `ParameterKind::is_integer`,
+  `ConfigSnapshot::get`, and `ConfigSnapshot::set` are now exhaustive matches over
+  every current variant instead of relying on a wildcard arm (`_ => "unknown"` /
+  `_ => 0.0` / `_ => {}`) guarded by `#[allow(unreachable_patterns)]` (#5948).
+  `ConfigSnapshot::diff` now iterates the new `ParameterKind::ALL` constant instead of
+  a second hand-maintained list of variants. Previously, adding a `ParameterKind`
+  variant without updating all four match sites and the `diff` list compiled cleanly
+  but silently made the new parameter a no-op (`get` returned `0.0`, `set` discarded
+  writes, `diff` never detected it as changed). Forgetting to update `as_str`,
+  `is_integer`, `get`, or `set` for a new variant now fails to compile. `ParameterKind::ALL`
+  itself is a plain array literal, not a match, so it is not directly compiler-checked
+  against the enum's variant count — a colocated private const fn
+  (`_all_variants_exhaustive`, evaluated at compile time) provides the same guarantee
+  in practice: it is an exhaustive match with no wildcard, so a new variant fails the
+  build there too, pointing the author back at `ALL`. The `zeph-experiments` test suite
+  additionally asserts that its own hand-enumerated fixtures stay the same length as
+  `ParameterKind::ALL`, which keeps those fixtures from silently drifting out of sync
+  with `ALL` (but does not by itself detect a variant missing from `ALL`). No behavior
+  change for any of the 9 existing variants.
+
 ### Fixed
 
 - `zeph-core`: `cached_prompt_tokens` was never recomputed after `rebuild_system_prompt`

--- a/crates/zeph-experiments/src/snapshot.rs
+++ b/crates/zeph-experiments/src/snapshot.rs
@@ -141,19 +141,8 @@ impl ConfigSnapshot {
     /// Integer parameters (`TopK`, `RetrievalTopK`) produce a [`VariationValue::Int`] variant.
     #[must_use]
     pub fn diff(&self, other: &ConfigSnapshot) -> Option<Variation> {
-        let kinds = [
-            ParameterKind::Temperature,
-            ParameterKind::TopP,
-            ParameterKind::TopK,
-            ParameterKind::FrequencyPenalty,
-            ParameterKind::PresencePenalty,
-            ParameterKind::RetrievalTopK,
-            ParameterKind::SimilarityThreshold,
-            ParameterKind::TemporalDecay,
-            ParameterKind::GroupStructured,
-        ];
         let mut result = None;
-        for kind in kinds {
+        for kind in ParameterKind::ALL {
             let a = self.get(kind);
             let b = other.get(kind);
             if (a - b).abs() > f64::EPSILON {
@@ -177,7 +166,8 @@ impl ConfigSnapshot {
 
     /// Get the current value of a parameter by kind.
     ///
-    /// Unknown kinds (from `#[non_exhaustive]` additions) return `0.0`.
+    /// The match is exhaustive over every current [`ParameterKind`] variant — adding a
+    /// new variant to the enum without a matching arm here fails to compile.
     ///
     /// # Examples
     ///
@@ -190,7 +180,6 @@ impl ConfigSnapshot {
     /// ```
     #[must_use]
     pub fn get(&self, kind: ParameterKind) -> f64 {
-        #[allow(unreachable_patterns)]
         match kind {
             ParameterKind::Temperature => self.temperature,
             ParameterKind::TopP => self.top_p,
@@ -201,13 +190,13 @@ impl ConfigSnapshot {
             ParameterKind::SimilarityThreshold => self.similarity_threshold,
             ParameterKind::TemporalDecay => self.temporal_decay,
             ParameterKind::GroupStructured => self.group_structured,
-            _ => 0.0,
         }
     }
 
     /// Set the value of a parameter by kind.
     ///
-    /// Unknown kinds (from `#[non_exhaustive]` additions) are silently ignored.
+    /// The match is exhaustive over every current [`ParameterKind`] variant — adding a
+    /// new variant to the enum without a matching arm here fails to compile.
     ///
     /// # Examples
     ///
@@ -219,7 +208,6 @@ impl ConfigSnapshot {
     /// assert!((s.temperature - 1.2).abs() < f64::EPSILON);
     /// ```
     pub fn set(&mut self, kind: ParameterKind, value: f64) {
-        #[allow(unreachable_patterns)]
         match kind {
             ParameterKind::Temperature => self.temperature = value,
             ParameterKind::TopP => self.top_p = value,
@@ -230,7 +218,6 @@ impl ConfigSnapshot {
             ParameterKind::SimilarityThreshold => self.similarity_threshold = value,
             ParameterKind::TemporalDecay => self.temporal_decay = value,
             ParameterKind::GroupStructured => self.group_structured = value,
-            _ => {}
         }
     }
 
@@ -419,7 +406,7 @@ mod tests {
     }
 
     #[test]
-    fn diff_all_nine_kinds() {
+    fn diff_all_kinds() {
         let fields: &[(ParameterKind, fn(&mut ConfigSnapshot))] = &[
             (ParameterKind::Temperature, |s| s.temperature = 1.5),
             (ParameterKind::TopP, |s| s.top_p = 0.5),
@@ -435,6 +422,13 @@ mod tests {
             (ParameterKind::TemporalDecay, |s| s.temporal_decay = 60.0),
             (ParameterKind::GroupStructured, |s| s.group_structured = 1.0),
         ];
+        // If a variant is added to `ParameterKind::ALL` without adding a fixture entry
+        // here, this catches the gap instead of silently under-covering the new kind.
+        assert_eq!(
+            fields.len(),
+            ParameterKind::ALL.len(),
+            "fixture must cover every ParameterKind variant"
+        );
         for (kind, mutate) in fields {
             let a = ConfigSnapshot::default();
             let mut b = ConfigSnapshot::default();
@@ -443,6 +437,22 @@ mod tests {
                 .diff(&b)
                 .unwrap_or_else(|| panic!("expected diff for {kind:?}"));
             assert_eq!(v.parameter, *kind);
+        }
+    }
+
+    #[test]
+    fn get_set_round_trip_all_kinds() {
+        // Derived from `ParameterKind::ALL` (not hand-enumerated) so a newly added
+        // variant is automatically exercised here.
+        let mut s = ConfigSnapshot::default();
+        for (i, kind) in ParameterKind::ALL.into_iter().enumerate() {
+            #[allow(clippy::cast_precision_loss)]
+            let value = i as f64 + 1.0;
+            s.set(kind, value);
+            assert!(
+                (s.get(kind) - value).abs() < f64::EPSILON,
+                "get/set round-trip failed for {kind:?}"
+            );
         }
     }
 

--- a/crates/zeph-experiments/src/types.rs
+++ b/crates/zeph-experiments/src/types.rs
@@ -80,6 +80,53 @@ pub enum ParameterKind {
 }
 
 impl ParameterKind {
+    /// Every variant of this enum, in declaration order.
+    ///
+    /// This is the single source of truth for code that must iterate all parameters,
+    /// e.g. [`ConfigSnapshot::diff`](crate::ConfigSnapshot::diff) and tests asserting
+    /// full-coverage behavior. `as_str`, `is_integer`, and `ConfigSnapshot::get`/`set`
+    /// are exhaustive matches and fail to compile if a new variant is left unhandled —
+    /// but this array is a plain literal, not a match, so adding a variant here is
+    /// **not** compiler-enforced. The `_all_variants_exhaustive` check directly below
+    /// forces a compile error pointing back at this array when a variant is added to
+    /// the enum, which is the practical guard against forgetting to extend `ALL`.
+    pub const ALL: [Self; 9] = [
+        Self::Temperature,
+        Self::TopP,
+        Self::TopK,
+        Self::FrequencyPenalty,
+        Self::PresencePenalty,
+        Self::RetrievalTopK,
+        Self::SimilarityThreshold,
+        Self::TemporalDecay,
+        Self::GroupStructured,
+    ];
+
+    /// Compile-time reminder to extend [`Self::ALL`] when a variant is added.
+    ///
+    /// Evaluated once at compile time via the `_ASSERT_ALL_VARIANTS_HANDLED` const below
+    /// (never called at runtime). Its only purpose is that adding a `ParameterKind`
+    /// variant without a corresponding arm here fails the build with `E0004:
+    /// non-exhaustive patterns`, pointing the author at `ALL` immediately above. It does
+    /// not verify `ALL`'s *length* or *contents* match the enum, only that every variant
+    /// has been acknowledged somewhere in this match.
+    const fn _all_variants_exhaustive(kind: Self) {
+        match kind {
+            Self::Temperature
+            | Self::TopP
+            | Self::TopK
+            | Self::FrequencyPenalty
+            | Self::PresencePenalty
+            | Self::RetrievalTopK
+            | Self::SimilarityThreshold
+            | Self::TemporalDecay
+            | Self::GroupStructured => {}
+        }
+    }
+
+    /// Forces [`Self::_all_variants_exhaustive`] to be checked at compile time.
+    const _ASSERT_ALL_VARIANTS_HANDLED: () = Self::_all_variants_exhaustive(Self::Temperature);
+
     /// Return the canonical snake_case name of this parameter.
     ///
     /// The returned string matches the key used in config files and experiment
@@ -95,7 +142,6 @@ impl ParameterKind {
     /// ```
     #[must_use]
     pub fn as_str(&self) -> &'static str {
-        #[allow(unreachable_patterns)]
         match self {
             Self::Temperature => "temperature",
             Self::TopP => "top_p",
@@ -106,7 +152,6 @@ impl ParameterKind {
             Self::SimilarityThreshold => "similarity_threshold",
             Self::TemporalDecay => "temporal_decay",
             Self::GroupStructured => "group_structured",
-            _ => "unknown",
         }
     }
 
@@ -126,7 +171,16 @@ impl ParameterKind {
     /// ```
     #[must_use]
     pub fn is_integer(&self) -> bool {
-        matches!(self, Self::TopK | Self::RetrievalTopK)
+        match self {
+            Self::TopK | Self::RetrievalTopK => true,
+            Self::Temperature
+            | Self::TopP
+            | Self::FrequencyPenalty
+            | Self::PresencePenalty
+            | Self::SimilarityThreshold
+            | Self::TemporalDecay
+            | Self::GroupStructured => false,
+        }
     }
 }
 
@@ -307,6 +361,11 @@ mod tests {
             (ParameterKind::TemporalDecay, "temporal_decay"),
             (ParameterKind::GroupStructured, "group_structured"),
         ];
+        assert_eq!(
+            cases.len(),
+            ParameterKind::ALL.len(),
+            "fixture must cover every ParameterKind variant"
+        );
         for (kind, expected) in cases {
             assert_eq!(kind.as_str(), expected);
             assert_eq!(kind.to_string(), expected);


### PR DESCRIPTION
## Summary

`ParameterKind` (crates/zeph-experiments) required updating 5 hand-synced sites for every variant, none enforced by the compiler. Adding a variant without updating all of them compiled cleanly but silently made the new parameter a no-op.

- `ParameterKind::as_str`, `ParameterKind::is_integer`, `ConfigSnapshot::get`, and `ConfigSnapshot::set` are now exhaustive matches (wildcard arms and `#[allow(unreachable_patterns)]` removed) — forgetting a variant now fails to compile.
- Added `ParameterKind::ALL` as the single source of truth for code that must iterate every variant; `ConfigSnapshot::diff` now iterates it instead of maintaining a second hand-typed list.
- A colocated private const-fn exhaustiveness guard closes the remaining gap: forgetting to extend `ALL` for a new variant now also fails to compile, alongside the 4 match sites.
- No behavior change for any of the 9 existing variants.

Closes #5948

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (13879 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] Sanity check: added a temporary 10th dummy variant — all 5 sync points (as_str, is_integer, get, set, the new const guard) failed to compile with `E0004: non-exhaustive patterns` as expected; reverted cleanly
- [x] Independently verified in review: adding match arms for a dummy variant everywhere except `ALL` compiles clean, confirming `ALL`'s own contents are documented as the one remaining non-compiler-enforced sync point (not silently overstated)