### PR TITLE
feat(orchestration): activate idle_timeout via eviction-safe progress-signal plumbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+### Added
+
+- **zeph-orchestration** / **zeph-subagent** / **zeph-core**: `idle_timeout_secs` (per-task
+  `TimeoutPolicy` and global `default_idle_timeout_secs`) is now enforced — previously it was
+  defined and config-surfaced but a documented no-op (#6245, Alt-A progress-signal plumbing
+  for spec-075's FR-005). A per-task `Arc<AtomicU64>` progress heartbeat, anchored to a new
+  process-lifetime `zeph_common::monotonic_millis()` clock, is written once per agent-loop
+  turn boundary and read by the scheduler's `check_timeouts()`; a task with no observed
+  progress for longer than its effective idle timeout is killed. Idle enforcement is opt-in
+  (unset = disabled) and applies only to the normal spawn dispatch path — `RunInline` tasks
+  are exempt (documented invariant, defense-in-depth via a `None` progress handle). When both
+  run-timeout and idle-timeout are exceeded on the same tick, run-timeout wins (it is the hard
+  wall-clock cap). `--init` wizard text, `config.toml` comments, and the `TimeoutPolicy`/
+  `default_idle_timeout_secs` doc comments now describe the enforced semantics and warn that
+  the value must be set above the longest expected single-turn duration.
+
 ### Changed
 
 - `zeph-experiments`: `ParameterKind::as_str`, `ParameterKind::is_integer`,
@@ -41,7 +57,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   after writing the rebuilt prompt into `messages[0]`, so the counter always reflects the
   actual outgoing prompt on every turn.
 
+- **zeph-orchestration**: a task killed by `run_timeout` (or the new `idle_timeout`) now
+  populates `TaskResult.output` with a human-readable cause (e.g. `"task exceeded run timeout
+  (60s)"`) before marking the task `Failed` (#6245). Previously the timeout path left
+  `result: None`, so the TUI/CLI showed no reason at all for a timeout-killed task — reuses
+  the existing `TaskGraphSnapshot` conversion (`metrics.rs`), no new widget or snapshot field.
+
 ### Testing
+
+- **zeph-orchestration** / **zeph-subagent**: closed three coverage gaps in the idle-timeout
+  progress plumbing (#6245) flagged during review: direct unit tests for `effective_idle_timeout()`'s
+  global-fallback branch (mirroring the existing `effective_run_timeout()` tests), a direct
+  unit test for the `record_progress()` atomic-store helper plus an end-to-end test proving a
+  real `run_agent_loop` turn writes into the `Arc<AtomicU64>` a `DagScheduler` later reads, and
+  a multi-task test confirming two tasks' progress heartbeats are independent (one stale task
+  is idle-killed while a sibling with its own fresh heartbeat survives).
 
 - **zeph-core**: added end-to-end coverage for `TurnSummary.tool_calls` / `TurnSummary.llm_requests`
   (#6330), closing the gap left by #6328: no prior test drove a real turn through

--- a/config/default.toml
+++ b/config/default.toml
@@ -1160,8 +1160,12 @@ verify_max_tokens = 1024
 max_replans = 2
 # Enable post-task completeness verification (best-effort, does not gate dispatch)
 verify_completeness = false
-# Global default idle/no-progress timeout in seconds. RESERVED — not yet enforced; see
-# specs/075-orchestration-node-control-parity/spec.md §4/FR-005. Unset = off.
+# Global default idle/no-progress timeout in seconds. Kills a task if it emits no progress
+# heartbeat (written once per agent-loop turn) for this long. Opt-in — unset = off. Only
+# enforced on the normal spawn dispatch path; RunInline tasks are exempt. IMPORTANT: set this
+# above the longest expected single-turn (single LLM call + its tool calls) duration, or a
+# healthy long-running task may be killed spuriously. See
+# specs/075-orchestration-node-control-parity/spec.md §4/FR-005.
 # default_idle_timeout_secs = 60
 # Timeout in seconds for aggregation LLM calls (0 rejected by validation). Default: 60.
 # aggregator_timeout_secs = 60

--- a/crates/zeph-common/src/lib.rs
+++ b/crates/zeph-common/src/lib.rs
@@ -22,6 +22,7 @@ pub mod http_middleware;
 pub mod llm_response;
 pub mod math;
 pub mod memory;
+pub mod monotonic;
 pub mod net;
 pub mod path_guard;
 pub mod patterns;
@@ -48,6 +49,7 @@ pub const OVERFLOW_NOTICE_PREFIX: &str = "[full output stored \u{2014} ID: ";
 
 pub use fidelity::{ContextFidelity, PlannedToolHint};
 pub use math::{EmbeddingVector, Normalized, Unnormalized};
+pub use monotonic::monotonic_millis;
 pub use policy::{PolicyLlmClient, PolicyMessage, PolicyRole};
 pub use sanitize::{IdentitySanitizer, OutputSanitizer};
 pub use security_event::SecurityEventCategory;

--- a/crates/zeph-common/src/monotonic.rs
+++ b/crates/zeph-common/src/monotonic.rs
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Process-lifetime monotonic millisecond clock shared across crates.
+//!
+//! Unlike a wall-clock timestamp (`SystemTime`), this origin is immune to NTP steps and
+//! manual clock adjustments — a backward time jump between a writer and a reader can never
+//! produce a spurious elapsed-time reading. Intended for in-process liveness/heartbeat
+//! signals (e.g. idle-timeout detection) where writer and reader always run in the same
+//! process and only relative deltas matter, never the absolute value.
+
+use std::sync::LazyLock;
+use std::time::Instant;
+
+static PROCESS_START: LazyLock<Instant> = LazyLock::new(Instant::now);
+
+/// Milliseconds elapsed since an arbitrary process-lifetime origin (the first call to any
+/// function in this module).
+///
+/// Monotonic and immune to wall-clock adjustments. Compare two readings with
+/// `saturating_sub` to compute an elapsed duration; the absolute value has no meaning on
+/// its own.
+///
+/// # Examples
+///
+/// ```rust
+/// let t0 = zeph_common::monotonic_millis();
+/// std::thread::sleep(std::time::Duration::from_millis(5));
+/// let t1 = zeph_common::monotonic_millis();
+/// assert!(t1 >= t0);
+/// assert!(t1.saturating_sub(t0) >= 5);
+/// ```
+#[must_use]
+pub fn monotonic_millis() -> u64 {
+    u64::try_from(PROCESS_START.elapsed().as_millis()).unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn monotonic_millis_is_non_decreasing() {
+        let a = monotonic_millis();
+        let b = monotonic_millis();
+        assert!(b >= a);
+    }
+
+    #[test]
+    fn monotonic_millis_advances_with_real_sleep() {
+        let a = monotonic_millis();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let b = monotonic_millis();
+        assert!(b.saturating_sub(a) >= 10);
+    }
+}

--- a/crates/zeph-config/src/experiment.rs
+++ b/crates/zeph-config/src/experiment.rs
@@ -534,11 +534,15 @@ pub struct OrchestrationConfig {
     pub ensemble: EnsembleConfig,
 
     /// Global default idle/no-progress timeout in seconds, used when a `TaskNode`'s own
-    /// `TimeoutPolicy.idle_timeout_secs` is unset.
+    /// `TimeoutPolicy.idle_timeout_secs` is unset. `None` (the default) disables idle
+    /// enforcement — it is opt-in, unlike `task_timeout_secs`.
     ///
-    /// **RESERVED — not yet enforced.** Defined and config-surfaced so the value can be
-    /// persisted ahead of the progress-signal plumbing (Alt A) that will consume it in a
-    /// future release. `None` = off. See
+    /// A task is killed if no progress heartbeat is observed for this many seconds — a
+    /// heartbeat is written once per agent-loop turn boundary, so **this value must be set
+    /// above the longest expected single-turn (single LLM call + its tool calls) duration**,
+    /// or a healthy task performing one long-running tool call can be killed spuriously.
+    /// Only enforced on the normal spawn dispatch path; `RunInline` tasks (no sub-agent
+    /// definitions configured) are exempt. See
     /// `specs/075-orchestration-node-control-parity/spec.md` §4/FR-005.
     #[serde(default)]
     pub default_idle_timeout_secs: Option<u64>,

--- a/crates/zeph-config/src/migrate/features.rs
+++ b/crates/zeph-config/src/migrate/features.rs
@@ -815,14 +815,13 @@ pub fn migrate_orchestration_asset_sensitivity(
 }
 
 /// Step 88 — add `default_idle_timeout_secs` advisory comment to `[orchestration]`
-/// (spec-075-orchestration-node-control-parity, #6021).
+/// (spec-075-orchestration-node-control-parity, #6021; enforcement activated by #6245).
 ///
 /// Advisory only: `#[serde(default)]` already makes existing configs load with the field
-/// unset (`None`), so this migration is purely informational — it surfaces the new
-/// reserved-not-yet-enforced option without changing behaviour. Skipped when the key is
-/// already present or `[orchestration]` is absent. Mirrors
-/// [`migrate_orchestration_asset_sensitivity`]'s shape exactly (same section, same
-/// advisory-comment idiom).
+/// unset (`None`), so this migration is purely informational — it surfaces the option
+/// without changing behaviour. Skipped when the key is already present or
+/// `[orchestration]` is absent. Mirrors [`migrate_orchestration_asset_sensitivity`]'s shape
+/// exactly (same section, same advisory-comment idiom).
 ///
 /// # Errors
 ///
@@ -845,7 +844,8 @@ pub fn migrate_orchestration_idle_timeout(toml_src: &str) -> Result<MigrationRes
     }
 
     let comment = "\n# default_idle_timeout_secs = 60  \
-        # reserved — not yet enforced (spec-075-orchestration-node-control-parity, #6021)\n";
+        # kill a task if it emits no progress for this many seconds; must be set above the \
+        # longest expected single-turn duration (spec-075-orchestration-node-control-parity, #6021)\n";
     let output = insert_after_section(toml_src, "orchestration", comment);
     // Defensive: the guards above already guarantee `[orchestration]` is present and
     // `insert_after_section` always inserts non-empty content when reached, so this is

--- a/crates/zeph-core/README.md
+++ b/crates/zeph-core/README.md
@@ -313,7 +313,7 @@ Key `OrchestrationConfig` fields (TOML section `[orchestration]`):
 | `dependency_context_budget` | usize | `16384` | Character budget injected as cross-task context |
 | `confirm_before_execute` | bool | `true` | Require `/plan confirm` before executing a new plan |
 | `aggregator_max_tokens` | u32 | `4096` | Token budget for the `LlmAggregator` synthesis call; divided equally across completed tasks |
-| `default_idle_timeout_secs` | `Option<u64>` | `None` | Graph-wide default for `TaskNode::idle_timeout_secs` (reserved, currently a documented no-op); per-task `run_timeout` enforcement applies independently to both spawned and `RunInline` dispatch, defaulting `RunInline` tasks to the graph-global 300s bound instead of running unbounded |
+| `default_idle_timeout_secs` | `Option<u64>` | `None` | Graph-wide default for `TaskNode::idle_timeout_secs`; kills a task if it emits no progress heartbeat (written once per agent-loop turn) for this many seconds. Opt-in — `None` disables idle enforcement. Only enforced on the normal spawn dispatch path; `RunInline` tasks are exempt. Must be set above the longest expected single-turn duration. Independent of `run_timeout` enforcement, which applies to both spawned and `RunInline` dispatch, defaulting `RunInline` tasks to the graph-global 300s bound instead of running unbounded |
 
 > [!NOTE]
 > A task whose verification (plan-level or per-task) judges output incomplete and for which no automatic repair resolves it now surfaces a visible signal to the user instead of only a debug/warn log line. `state_injection` recovery lets the graph continue past a failed node on terminal `Abort`/retry-exhausted failures instead of pausing unrelated work.

--- a/crates/zeph-core/config/default.toml
+++ b/crates/zeph-core/config/default.toml
@@ -720,8 +720,12 @@ confirm_before_execute = true
 aggregator_max_tokens = 4096
 # Backoff in ms before retrying deferred tasks
 deferral_backoff_ms = 250
-# Global default idle/no-progress timeout in seconds. RESERVED — not yet enforced; see
-# specs/075-orchestration-node-control-parity/spec.md §4/FR-005. Unset = off.
+# Global default idle/no-progress timeout in seconds. Kills a task if it emits no progress
+# heartbeat (written once per agent-loop turn) for this long. Opt-in — unset = off. Only
+# enforced on the normal spawn dispatch path; RunInline tasks are exempt. IMPORTANT: set this
+# above the longest expected single-turn (single LLM call + its tool calls) duration, or a
+# healthy long-running task may be killed spuriously. See
+# specs/075-orchestration-node-control-parity/spec.md §4/FR-005.
 # default_idle_timeout_secs = 60
 
 [experiments]

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
 
 use tokio_util::sync::CancellationToken;
 use zeph_llm::provider::LlmProvider;
@@ -175,6 +176,14 @@ impl<C: crate::channel::Channel> Agent<C> {
         let mut spawn_ctx = self.build_spawn_context(&cfg);
         spawn_ctx.network_denied = network_denied;
 
+        // Idle-timeout progress heartbeat (issue #6245, Alt-A): the driver owns creation of
+        // the Arc. One clone flows into the sub-agent loop via `spawn_ctx.progress_at`
+        // (`run_agent_loop` writes `monotonic_millis()` to it once per turn boundary); the
+        // original is handed to `record_spawn` below on successful spawn so the scheduler's
+        // `check_timeouts()` reads the same counter.
+        let progress_at = Arc::new(AtomicU64::new(zeph_common::monotonic_millis()));
+        spawn_ctx.progress_at = Some(Arc::clone(&progress_at));
+
         let mgr = self
             .services
             .orchestration
@@ -241,7 +250,7 @@ impl<C: crate::channel::Channel> Agent<C> {
                         "Executing task {spawn_counter}/{task_count}: {task_title}..."
                     ))
                     .await;
-                scheduler.record_spawn(task_id, handle_id, agent_def_name);
+                scheduler.record_spawn(task_id, handle_id, agent_def_name, Some(progress_at));
                 (true, false, None)
             }
             Err(e) => {
@@ -278,7 +287,17 @@ impl<C: crate::channel::Channel> Agent<C> {
             .await;
 
         let handle_id = format!("__inline_{task_id}__");
-        scheduler.record_spawn(task_id, handle_id.clone(), "__main__".to_string());
+        // Idle-timeout exemption (issue #6245, F2): `RunInline` tasks pass `None` for the
+        // progress handle — they are never idle-tracked. Primary guard: `check_timeouts`'s
+        // idle branch short-circuits on `RunningTask::last_progress_at.is_none()`, so the
+        // exemption holds unconditionally. Secondary (explanatory) reason: this action runs
+        // synchronously inside the current tick's action loop, so `check_timeouts` cannot
+        // observe it mid-run anyway, and its completion event is sent in-band (awaited,
+        // below) and drained by the next `tick()` before `check_timeouts` runs — never
+        // detach that send (e.g. via `spawn_oneshot` as the spawn path's `on_done` does) or
+        // a completed-but-still-`running` inline task could be spuriously idle-killed if the
+        // primary guard above were ever removed.
+        scheduler.record_spawn(task_id, handle_id.clone(), "__main__".to_string(), None);
 
         // Inject per-task execution environment so that ToolCalls built inside this
         // inline loop carry the right named env for ShellExecutor::resolve_context.

--- a/crates/zeph-orchestration/src/graph.rs
+++ b/crates/zeph-orchestration/src/graph.rs
@@ -375,9 +375,22 @@ pub struct TimeoutPolicy {
     /// Hard wall-clock cap on this task's execution. `None` falls back to the
     /// graph-global `task_timeout_secs` default.
     pub run_timeout_secs: Option<u64>,
-    /// Idle/no-progress cap. Defined and config-surfaced but **not enforced in v1** —
-    /// reserved for a future progress-signal mechanism. See
-    /// `specs/075-orchestration-node-control-parity/spec.md` §4/FR-005.
+    /// Idle/no-progress cap. `None` falls back to the graph-global
+    /// `default_idle_timeout_secs` default (itself `None` = idle enforcement disabled).
+    ///
+    /// The task is killed if no progress heartbeat is observed for this many seconds — a
+    /// heartbeat is written once per agent-loop turn boundary (LLM call + its tool calls),
+    /// so **this must be set above the longest expected single-turn duration**, or a
+    /// healthy task performing one long-running tool call can be killed spuriously. Only
+    /// enforced on the normal spawn dispatch path; `RunInline` tasks are exempt (see
+    /// `specs/075-orchestration-node-control-parity/spec.md` §4/FR-005).
+    ///
+    /// **`Some(0)` means "kill on the very next idle check", not "use the default"** — unlike
+    /// `run_timeout_secs`, where a caller-set `0` is not specially interpreted and simply
+    /// produces an (unrealistic) immediate-timeout duration through the same code path, this
+    /// field's `0` is not rejected by validation at the per-task level (only the global
+    /// `default_idle_timeout_secs` config field rejects `Some(0)`). Leave the field `None`
+    /// to disable idle enforcement for a task; do not use `0` expecting default behavior.
     pub idle_timeout_secs: Option<u64>,
 }
 

--- a/crates/zeph-orchestration/src/scheduler/mod.rs
+++ b/crates/zeph-orchestration/src/scheduler/mod.rs
@@ -10,6 +10,7 @@ mod tick;
 
 use std::collections::{HashMap, VecDeque};
 use std::path::PathBuf;
+use std::sync::atomic::AtomicU64;
 use std::time::{Duration, Instant};
 
 use tokio::sync::mpsc;
@@ -42,7 +43,7 @@ use zeph_config::OrchestrationConfig;
 ///         match action {
 ///             SchedulerAction::Spawn { task_id, agent_def_name, prompt } => {
 ///                 match manager.spawn_for_task(task_id, &agent_def_name, &prompt) {
-///                     Ok(handle_id) => scheduler.record_spawn(task_id, handle_id, agent_def_name),
+///                     Ok(handle_id) => scheduler.record_spawn(task_id, handle_id, agent_def_name, Some(progress_at)),
 ///                     Err(e) => {
 ///                         for a in scheduler.record_spawn_failure(task_id, &e) {
 ///                             // execute cancel action…
@@ -175,6 +176,19 @@ pub(super) struct RunningTask {
     /// `DagScheduler` skips `running` (it logs `running_count` instead).
     #[allow(dead_code)]
     pub(super) admission_permit: Option<tokio::sync::OwnedSemaphorePermit>,
+    /// Shared progress heartbeat (issue #6245), written once per turn boundary by
+    /// `zeph_subagent::agent_loop::run_agent_loop` and read by `DagScheduler::check_timeouts`
+    /// (private, in the `tick` submodule) to detect idle (no-progress) tasks.
+    ///
+    /// `None` means this task is never idle-tracked, regardless of `effective_idle_timeout`:
+    /// currently `RunInline` tasks (dispatched via `SchedulerAction::RunInline`, which shares
+    /// the scheduler's own tick loop and so cannot be observed mid-run by `check_timeouts` in
+    /// the first place — see `record_spawn` call site in `scheduler_loop.rs`) and tasks
+    /// reconstructed by [`DagScheduler::resume_from`] after a process restart (no live
+    /// heartbeat exists to reattach to). The idle branch in `check_timeouts` skips a task
+    /// entirely when this is `None`, so the exemption holds regardless of any tick-ordering
+    /// invariant elsewhere.
+    pub(super) last_progress_at: Option<Arc<AtomicU64>>,
 }
 
 /// DAG execution engine.
@@ -191,7 +205,7 @@ pub(super) struct RunningTask {
 ///         match action {
 ///             Spawn { task_id, agent_def_name, prompt } => {
 ///                 match manager.spawn_for_task(...) {
-///                     Ok(handle_id) => scheduler.record_spawn(task_id, handle_id),
+///                     Ok(handle_id) => scheduler.record_spawn(task_id, handle_id, agent_def_name, Some(progress_at)),
 ///                     Err(e) => { for a in scheduler.record_spawn_failure(task_id, &e) { /* exec */ } }
 ///                 }
 ///             }
@@ -221,6 +235,10 @@ pub struct DagScheduler {
     pub(super) event_tx: mpsc::Sender<TaskEvent>,
     /// Per-task wall-clock timeout.
     pub(super) task_timeout: Duration,
+    /// Global default idle/no-progress timeout, used when a task's own
+    /// `TimeoutPolicy.idle_timeout_secs` is unset. `None` = idle enforcement disabled by
+    /// default (idle is opt-in, unlike `task_timeout` which always has a value).
+    pub(super) default_idle_timeout: Option<Duration>,
     /// Router for agent selection.
     pub(super) router: Box<dyn AgentRouter>,
     /// Available agent definitions (cached from `SubAgentManager`).
@@ -438,6 +456,11 @@ impl DagScheduler {
                         started_at: Instant::now(),
                         // Permits are not persisted; resumed tasks start without a slot.
                         admission_permit: None,
+                        // No live subagent loop is reattached here — this entry only
+                        // guards against a stale completion event for the pre-restart
+                        // task, so there is no real heartbeat to track. run_timeout still
+                        // applies via started_at above; idle enforcement is skipped.
+                        last_progress_at: None,
                     },
                 ))
             })
@@ -531,22 +554,7 @@ impl DagScheduler {
 
         let (event_tx, event_rx) = mpsc::channel(64);
 
-        // Reserved-field hint (FR-005 / specs/075): idle_timeout_secs is accepted in config
-        // and per-task TimeoutPolicy but not enforced in this release — warn once per
-        // scheduler construction (covers both `new()` and `resume_from()`, never per-tick).
-        if config.default_idle_timeout_secs.is_some()
-            || graph.tasks.iter().any(|t| {
-                t.timeout
-                    .as_ref()
-                    .is_some_and(|tp| tp.idle_timeout_secs.is_some())
-            })
-        {
-            tracing::warn!(
-                "idle_timeout_secs is set but not enforced in this release (reserved for a \
-                 future progress-signal mechanism, see FR-005 / specs/075); only \
-                 run_timeout_secs is currently enforced"
-            );
-        }
+        let default_idle_timeout = config.default_idle_timeout_secs.map(Duration::from_secs);
 
         let task_timeout = if config.task_timeout_secs > 0 {
             Duration::from_secs(config.task_timeout_secs)
@@ -583,6 +591,7 @@ impl DagScheduler {
             event_rx,
             event_tx,
             task_timeout,
+            default_idle_timeout,
             router,
             available_agents,
             dependency_context_budget: config.dependency_context_budget,
@@ -949,96 +958,5 @@ mod tests {
             scheduler.orchestrator_provider_name().is_empty(),
             "default config must yield empty orchestrator_provider_name"
         );
-    }
-
-    // --- idle_timeout_secs reserved-field hint (#6302) ---
-
-    const IDLE_TIMEOUT_HINT: &str = "idle_timeout_secs is set but not enforced";
-
-    #[test]
-    #[tracing_test::traced_test]
-    fn idle_timeout_hint_silent_when_unset() {
-        let graph = graph_from_nodes(vec![make_node(0, &[])]);
-        let _scheduler =
-            DagScheduler::new(graph, &make_config(), Box::new(FirstRouter), vec![], None).unwrap();
-        assert!(
-            !logs_contain(IDLE_TIMEOUT_HINT),
-            "no idle_timeout_secs is set anywhere; the hint must not fire"
-        );
-    }
-
-    #[test]
-    #[tracing_test::traced_test]
-    fn idle_timeout_hint_warns_once_on_config_default() {
-        let graph = graph_from_nodes(vec![make_node(0, &[])]);
-        let config = zeph_config::OrchestrationConfig {
-            default_idle_timeout_secs: Some(30),
-            ..make_config()
-        };
-        let _scheduler =
-            DagScheduler::new(graph, &config, Box::new(FirstRouter), vec![], None).unwrap();
-        assert!(logs_contain(IDLE_TIMEOUT_HINT));
-        logs_assert(|lines: &[&str]| {
-            match lines
-                .iter()
-                .filter(|line| line.contains(IDLE_TIMEOUT_HINT))
-                .count()
-            {
-                1 => Ok(()),
-                n => Err(format!("expected exactly one idle_timeout hint, got {n}")),
-            }
-        });
-    }
-
-    #[test]
-    #[tracing_test::traced_test]
-    fn idle_timeout_hint_warns_once_on_per_task_policy_even_with_multiple_tasks() {
-        let mut task_a = make_node(0, &[]);
-        task_a.timeout = Some(crate::graph::TimeoutPolicy {
-            run_timeout_secs: None,
-            idle_timeout_secs: Some(10),
-        });
-        let mut task_b = make_node(1, &[]);
-        task_b.timeout = Some(crate::graph::TimeoutPolicy {
-            run_timeout_secs: None,
-            idle_timeout_secs: Some(20),
-        });
-        let graph = graph_from_nodes(vec![task_a, task_b]);
-        let _scheduler =
-            DagScheduler::new(graph, &make_config(), Box::new(FirstRouter), vec![], None).unwrap();
-        assert!(logs_contain(IDLE_TIMEOUT_HINT));
-        logs_assert(|lines: &[&str]| {
-            match lines
-                .iter()
-                .filter(|line| line.contains(IDLE_TIMEOUT_HINT))
-                .count()
-            {
-                1 => Ok(()),
-                n => Err(format!("expected exactly one idle_timeout hint, got {n}")),
-            }
-        });
-    }
-
-    #[test]
-    #[tracing_test::traced_test]
-    fn idle_timeout_hint_warns_once_on_resume() {
-        let graph = graph_from_nodes(vec![make_node(0, &[])]);
-        let config = zeph_config::OrchestrationConfig {
-            default_idle_timeout_secs: Some(30),
-            ..make_config()
-        };
-        let _scheduler =
-            DagScheduler::resume_from(graph, &config, Box::new(FirstRouter), vec![], None).unwrap();
-        assert!(logs_contain(IDLE_TIMEOUT_HINT));
-        logs_assert(|lines: &[&str]| {
-            match lines
-                .iter()
-                .filter(|line| line.contains(IDLE_TIMEOUT_HINT))
-                .count()
-            {
-                1 => Ok(()),
-                n => Err(format!("expected exactly one idle_timeout hint, got {n}")),
-            }
-        });
     }
 }

--- a/crates/zeph-orchestration/src/scheduler/planner.rs
+++ b/crates/zeph-orchestration/src/scheduler/planner.rs
@@ -375,6 +375,7 @@ mod tests {
                 agent_def_name: "worker".to_string(),
                 started_at: std::time::Instant::now(),
                 admission_permit: None,
+                last_progress_at: None,
             },
         );
 

--- a/crates/zeph-orchestration/src/scheduler/tick/mod.rs
+++ b/crates/zeph-orchestration/src/scheduler/tick/mod.rs
@@ -3,6 +3,8 @@
 
 //! Core tick/execution loop, event processing, and spawn record-keeping.
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use super::{DagScheduler, RunningTask, SchedulerAction, TaskEvent, TaskOutcome};
@@ -313,11 +315,18 @@ impl DagScheduler {
     /// [`DagScheduler::record_batch_backoff`]: `record_spawn` provides an immediate reset on the first
     /// success within a batch, while [`DagScheduler::record_batch_backoff`] governs the tick-granular
     /// failure counter used for exponential wait backoff.
+    ///
+    /// `last_progress_at` is the progress-heartbeat handle (issue #6245) for idle-timeout
+    /// detection: `Some(handle)` for normally-dispatched tasks (the caller must pass the same
+    /// `Arc` whose clone was threaded into the sub-agent loop via
+    /// `SpawnContext::progress_at`), or `None` for tasks that are never idle-tracked (the
+    /// `RunInline` dispatch path — see its call site for why `None` is safe there).
     pub fn record_spawn(
         &mut self,
         task_id: TaskId,
         agent_handle_id: String,
         agent_def_name: String,
+        last_progress_at: Option<Arc<AtomicU64>>,
     ) {
         self.consecutive_spawn_failures = 0;
         self.graph.tasks[task_id.index()].assigned_agent = Some(agent_handle_id.clone());
@@ -329,6 +338,7 @@ impl DagScheduler {
                 agent_def_name,
                 started_at: std::time::Instant::now(),
                 admission_permit,
+                last_progress_at,
             },
         );
     }
@@ -753,7 +763,36 @@ impl DagScheduler {
             .map_or(self.task_timeout, Duration::from_secs)
     }
 
+    /// Compute the effective idle-timeout for a task: its per-task
+    /// `TaskNode.timeout.idle_timeout_secs` override when set, else the graph-global
+    /// `self.default_idle_timeout` default. Returns `None` when neither is set — idle
+    /// enforcement is opt-in, unlike `effective_run_timeout` which always has a value.
+    fn effective_idle_timeout(&self, task_id: TaskId) -> Option<Duration> {
+        self.graph.tasks[task_id.index()]
+            .timeout
+            .as_ref()
+            .and_then(|t| t.idle_timeout_secs)
+            .map(Duration::from_secs)
+            .or(self.default_idle_timeout)
+    }
+
     /// Check all running tasks for timeout violations.
+    ///
+    /// Evaluates run-timeout before idle-timeout for each task, so a task that has
+    /// exceeded both on the same tick is reported with a single cause: run wins (it is the
+    /// hard wall-clock cap; idle is the softer no-progress liveness signal). Satisfies
+    /// NFR-OB-01 (spec-075 §"timeout-cause disambiguation") — the log line and the
+    /// synthetic `TaskResult.output` below always name exactly one mechanism.
+    ///
+    /// Idle detection reads `RunningTask::last_progress_at` with `Ordering::Relaxed`. A
+    /// stale `Relaxed` load can only observe an *older* heartbeat timestamp, which biases
+    /// toward firing *earlier* than the true idle time — never later — so this can never
+    /// mask a genuinely idle task. The false-positive risk from that bias is vanishingly
+    /// small in practice: staleness is bounded by cache-coherence propagation (sub-µs on
+    /// tier-1 hardware) versus a threshold measured in seconds-to-minutes, and every tick
+    /// re-`load`s a fresh value, so a value missed on one tick is observed well before a
+    /// second wrongful crossing on the next. `Acquire`/`Release` would remove even that
+    /// vanishing risk but is unjustified overhead for a cooperative liveness timeout.
     ///
     /// # Warning: Cooperative Cancellation
     ///
@@ -761,23 +800,63 @@ impl DagScheduler {
     /// at the time of cancellation complete before the agent loop checks the cancellation
     /// token. Partially-written artifacts may remain on disk after cancellation.
     fn check_timeouts(&mut self) -> Vec<SchedulerAction> {
-        let timed_out: Vec<(TaskId, String)> = self
+        let timed_out: Vec<(TaskId, String, TimeoutCause, Duration)> = self
             .running
             .iter()
-            .filter(|(id, r)| r.started_at.elapsed() > self.effective_run_timeout(**id))
-            .map(|(id, r)| (*id, r.agent_handle_id.clone()))
+            .filter_map(|(id, r)| {
+                let run_limit = self.effective_run_timeout(*id);
+                if r.started_at.elapsed() > run_limit {
+                    return Some((*id, r.agent_handle_id.clone(), TimeoutCause::Run, run_limit));
+                }
+
+                let idle_limit = self.effective_idle_timeout(*id)?;
+                let progress = r.last_progress_at.as_ref()?;
+                let idle_elapsed_ms = zeph_common::monotonic_millis()
+                    .saturating_sub(progress.load(Ordering::Relaxed));
+                let idle_limit_ms = u64::try_from(idle_limit.as_millis()).unwrap_or(u64::MAX);
+                (idle_elapsed_ms > idle_limit_ms).then(|| {
+                    (
+                        *id,
+                        r.agent_handle_id.clone(),
+                        TimeoutCause::Idle,
+                        idle_limit,
+                    )
+                })
+            })
             .collect();
 
         let mut actions = Vec::new();
-        for (task_id, agent_handle_id) in timed_out {
+        for (task_id, agent_handle_id, cause, limit) in timed_out {
             tracing::warn!(
                 task_id = %task_id,
-                timeout_secs = self.effective_run_timeout(task_id).as_secs(),
+                cause = ?cause,
+                timeout_secs = limit.as_secs(),
                 "task timed out"
             );
             self.graph_dirty = true;
-            self.running.remove(&task_id);
+
+            let removed = self.running.remove(&task_id);
             self.graph.tasks[task_id.index()].status = TaskStatus::Failed;
+
+            let duration_ms = removed.as_ref().map_or(0, |r| {
+                u64::try_from(r.started_at.elapsed().as_millis()).unwrap_or(u64::MAX)
+            });
+            let agent_def_name = removed.map(|r| r.agent_def_name);
+            self.graph.tasks[task_id.index()].result = Some(TaskResult {
+                output: match cause {
+                    TimeoutCause::Run => {
+                        format!("task exceeded run timeout ({}s)", limit.as_secs())
+                    }
+                    TimeoutCause::Idle => format!(
+                        "task exceeded idle timeout ({}s of no progress)",
+                        limit.as_secs()
+                    ),
+                },
+                artifacts: Vec::new(),
+                duration_ms,
+                agent_id: Some(agent_handle_id.clone()),
+                agent_def: agent_def_name,
+            });
 
             actions.push(SchedulerAction::Cancel { agent_handle_id });
 
@@ -802,6 +881,18 @@ impl DagScheduler {
 
         actions
     }
+}
+
+/// Which mechanism fired a task timeout — carried through `check_timeouts` so the log line
+/// and the synthetic `TaskResult.output` always name a single cause (NFR-OB-01).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TimeoutCause {
+    /// Hard wall-clock cap exceeded (`effective_run_timeout`). Always enforced.
+    Run,
+    /// No progress heartbeat observed within the idle window (`effective_idle_timeout`).
+    /// Opt-in: only fires when an idle limit is configured AND the task carries a live
+    /// progress handle (`RunningTask::last_progress_at.is_some()`).
+    Idle,
 }
 
 #[cfg(test)]

--- a/crates/zeph-orchestration/src/scheduler/tick/tests.rs
+++ b/crates/zeph-orchestration/src/scheduler/tick/tests.rs
@@ -86,6 +86,7 @@ fn test_completion_event_marks_deps_ready() {
             agent_def_name: "worker".to_string(),
             started_at: std::time::Instant::now(),
             admission_permit: None,
+            last_progress_at: None,
         },
     );
 
@@ -162,7 +163,12 @@ fn test_plan_with_verify_criteria_and_predicate_disabled_reaches_completed() {
             .iter()
             .any(|a| matches!(a, SchedulerAction::Spawn { task_id, .. } if *task_id == TaskId(0)))
     );
-    scheduler.record_spawn(TaskId(0), "handle-parent".to_string(), "worker".to_string());
+    scheduler.record_spawn(
+        TaskId(0),
+        "handle-parent".to_string(),
+        "worker".to_string(),
+        None,
+    );
     scheduler.buffered_events.push_back(TaskEvent {
         task_id: TaskId(0),
         agent_handle_id: "handle-parent".to_string(),
@@ -183,7 +189,12 @@ fn test_plan_with_verify_criteria_and_predicate_disabled_reaches_completed() {
             .any(|a| matches!(a, SchedulerAction::Spawn { task_id, .. } if *task_id == TaskId(1))),
         "child must be dispatched once its only dependency completes"
     );
-    scheduler.record_spawn(TaskId(1), "handle-child".to_string(), "worker".to_string());
+    scheduler.record_spawn(
+        TaskId(1),
+        "handle-child".to_string(),
+        "worker".to_string(),
+        None,
+    );
     scheduler.buffered_events.push_back(TaskEvent {
         task_id: TaskId(1),
         agent_handle_id: "handle-child".to_string(),
@@ -226,6 +237,7 @@ fn test_failure_abort_cancels_running() {
             agent_def_name: "worker".to_string(),
             started_at: std::time::Instant::now(),
             admission_permit: None,
+            last_progress_at: None,
         },
     );
     scheduler.graph.tasks[1].status = TaskStatus::Running;
@@ -236,6 +248,7 @@ fn test_failure_abort_cancels_running() {
             agent_def_name: "worker".to_string(),
             started_at: std::time::Instant::now(),
             admission_permit: None,
+            last_progress_at: None,
         },
     );
 
@@ -286,6 +299,7 @@ fn test_failure_skip_propagates() {
             agent_def_name: "worker".to_string(),
             started_at: std::time::Instant::now(),
             admission_permit: None,
+            last_progress_at: None,
         },
     );
 
@@ -321,6 +335,7 @@ fn test_failure_retry_reschedules() {
             agent_def_name: "worker".to_string(),
             started_at: std::time::Instant::now(),
             admission_permit: None,
+            last_progress_at: None,
         },
     );
 
@@ -365,6 +380,7 @@ fn test_process_event_failed_retry() {
             agent_def_name: "worker".to_string(),
             started_at: std::time::Instant::now(),
             admission_permit: None,
+            last_progress_at: None,
         },
     );
 
@@ -435,6 +451,7 @@ fn test_cascade_chain_threshold_preempts_recovery() {
                 agent_def_name: "worker".to_string(),
                 started_at: std::time::Instant::now(),
                 admission_permit: None,
+                last_progress_at: None,
             },
         );
     }
@@ -489,6 +506,7 @@ fn test_timeout_cancels_stalled() {
                 .checked_sub(Duration::from_secs(2))
                 .unwrap(), // already timed out
             admission_permit: None,
+            last_progress_at: None,
         },
     );
 
@@ -532,6 +550,7 @@ fn test_per_task_timeout_override_fires_before_global_default() {
             agent_def_name: "worker".to_string(),
             started_at: started_2s_ago,
             admission_permit: None,
+            last_progress_at: None,
         },
     );
     scheduler.running.insert(
@@ -541,6 +560,7 @@ fn test_per_task_timeout_override_fires_before_global_default() {
             agent_def_name: "worker".to_string(),
             started_at: started_2s_ago,
             admission_permit: None,
+            last_progress_at: None,
         },
     );
 
@@ -581,6 +601,7 @@ fn test_no_overrides_timing_matches_pre_feature_behavior() {
                 .checked_sub(Duration::from_secs(2))
                 .unwrap(),
             admission_permit: None,
+            last_progress_at: None,
         },
     );
 
@@ -595,22 +616,36 @@ fn test_no_overrides_timing_matches_pre_feature_behavior() {
     assert_eq!(scheduler.graph.tasks[0].status, TaskStatus::Failed);
 }
 
-/// spec-075 §6 success criterion (FR-005): `idle_timeout_secs` is defined and config-surfaced
-/// but a documented no-op in v1 — a task with a short `idle_timeout_secs` and long idle
-/// execution must never be flagged as timed out by that field. Only `run_timeout_secs` is
-/// enforced; `check_timeouts()` never reads `idle_timeout_secs` at all.
+// --- idle_timeout_secs enforcement (issue #6245, Alt-A progress-signal plumbing) ---
+
+/// A heartbeat recording the current instant, as if the sub-agent loop just wrote to it.
+///
+/// To simulate a *stale* heartbeat, record one and then let real time pass
+/// (`std::thread::sleep`) before checking — subtracting an offset from `monotonic_millis()`
+/// to fake staleness would underflow (`saturating_sub` clamps to 0) whenever the process,
+/// and therefore its `PROCESS_START` origin, is young — which it always is at the start of
+/// an isolated test binary.
+fn progress_handle_now() -> std::sync::Arc<std::sync::atomic::AtomicU64> {
+    std::sync::Arc::new(std::sync::atomic::AtomicU64::new(
+        zeph_common::monotonic_millis(),
+    ))
+}
+
+/// spec-075 §6 (FR-005, activated by #6245): a task with a short `idle_timeout_secs` and a
+/// stale progress heartbeat (no turn boundary reached within the window) must be killed
+/// with `TimeoutCause::Idle`, distinguishable via the synthetic `TaskResult.output` (F5).
 #[test]
-fn test_idle_timeout_secs_is_a_no_op() {
+fn test_idle_timeout_fires_on_stale_progress() {
     let graph = graph_from_nodes(vec![make_node(0, &[])]);
     let mut config = make_config();
-    config.task_timeout_secs = 300; // long global run_timeout default
+    config.task_timeout_secs = 300; // long global run_timeout — must not be what fires
     let defs = vec![make_def("worker")];
     let mut scheduler =
         DagScheduler::new(graph, &config, Box::new(FirstRouter), defs, None).unwrap();
 
     scheduler.graph.tasks[0].timeout = Some(crate::graph::TimeoutPolicy {
-        run_timeout_secs: None,     // falls back to the long global default above
-        idle_timeout_secs: Some(1), // short — would fire immediately if it were enforced
+        run_timeout_secs: None,
+        idle_timeout_secs: Some(1), // short — we sleep past it below
     });
     scheduler.graph.tasks[0].status = TaskStatus::Running;
     scheduler.running.insert(
@@ -618,11 +653,59 @@ fn test_idle_timeout_secs_is_a_no_op() {
         RunningTask {
             agent_handle_id: "h0".to_string(),
             agent_def_name: "worker".to_string(),
-            // Idle well past idle_timeout_secs (1s), but nowhere near run_timeout_secs (300s).
-            started_at: std::time::Instant::now()
-                .checked_sub(Duration::from_secs(5))
-                .unwrap(),
+            started_at: std::time::Instant::now(), // recent — run_timeout nowhere close
             admission_permit: None,
+            last_progress_at: Some(progress_handle_now()),
+        },
+    );
+    std::thread::sleep(Duration::from_millis(1_100)); // let the 1s idle_timeout actually elapse
+
+    let actions = scheduler.tick();
+    let has_cancel = actions
+        .iter()
+        .any(|a| matches!(a, SchedulerAction::Cancel { .. }));
+    assert!(
+        has_cancel,
+        "stale progress heartbeat must fire idle timeout"
+    );
+    assert_eq!(scheduler.graph.tasks[0].status, TaskStatus::Failed);
+    let output = scheduler.graph.tasks[0]
+        .result
+        .as_ref()
+        .expect("timeout must populate TaskResult")
+        .output
+        .clone();
+    assert!(
+        output.contains("idle timeout"),
+        "TaskResult.output must name the idle cause, got: {output}"
+    );
+}
+
+/// Mirror of the fire test: a task with the same short `idle_timeout_secs` but a heartbeat
+/// that was just refreshed must NOT be killed — idle enforcement tracks real progress, not
+/// just task age.
+#[test]
+fn test_idle_timeout_does_not_fire_while_progress_continues() {
+    let graph = graph_from_nodes(vec![make_node(0, &[])]);
+    let mut config = make_config();
+    config.task_timeout_secs = 300;
+    let defs = vec![make_def("worker")];
+    let mut scheduler =
+        DagScheduler::new(graph, &config, Box::new(FirstRouter), defs, None).unwrap();
+
+    scheduler.graph.tasks[0].timeout = Some(crate::graph::TimeoutPolicy {
+        run_timeout_secs: None,
+        idle_timeout_secs: Some(60), // generous relative to the fresh heartbeat below
+    });
+    scheduler.graph.tasks[0].status = TaskStatus::Running;
+    scheduler.running.insert(
+        TaskId(0),
+        RunningTask {
+            agent_handle_id: "h0".to_string(),
+            agent_def_name: "worker".to_string(),
+            started_at: std::time::Instant::now(),
+            admission_permit: None,
+            last_progress_at: Some(progress_handle_now()),
         },
     );
 
@@ -632,13 +715,220 @@ fn test_idle_timeout_secs_is_a_no_op() {
         .any(|a| matches!(a, SchedulerAction::Cancel { .. }));
     assert!(
         !has_cancel,
-        "idle_timeout_secs must never fire a timeout in v1 — it is a documented no-op"
+        "a task with a fresh heartbeat must not be idle-killed"
+    );
+    assert_eq!(scheduler.graph.tasks[0].status, TaskStatus::Running);
+}
+
+/// F2 regression: a task with `last_progress_at: None` (the `RunInline` exemption — see
+/// `RunningTask::last_progress_at` doc and the `record_spawn` call site in
+/// `scheduler_loop.rs::handle_run_inline_action`) must never be idle-killed, even with an
+/// idle timeout configured and a task age far past it. This is the `DagScheduler`-level half
+/// of the guarantee; the exemption holds regardless of how stale `started_at` is because the
+/// idle branch short-circuits on `last_progress_at.is_none()` before ever comparing durations.
+#[test]
+fn test_idle_timeout_exempt_without_progress_handle() {
+    let graph = graph_from_nodes(vec![make_node(0, &[])]);
+    let mut config = make_config();
+    config.task_timeout_secs = 300; // long — run_timeout must not be what's tested here
+    let defs = vec![make_def("worker")];
+    let mut scheduler =
+        DagScheduler::new(graph, &config, Box::new(FirstRouter), defs, None).unwrap();
+
+    scheduler.graph.tasks[0].timeout = Some(crate::graph::TimeoutPolicy {
+        run_timeout_secs: None,
+        idle_timeout_secs: Some(1), // short — would fire immediately if last_progress_at were Some
+    });
+    scheduler.graph.tasks[0].status = TaskStatus::Running;
+    scheduler.running.insert(
+        TaskId(0),
+        RunningTask {
+            agent_handle_id: "h0".to_string(),
+            agent_def_name: "worker".to_string(),
+            started_at: std::time::Instant::now()
+                .checked_sub(Duration::from_secs(5))
+                .unwrap(),
+            admission_permit: None,
+            last_progress_at: None, // RunInline-style exemption
+        },
+    );
+
+    let actions = scheduler.tick();
+    let has_cancel = actions
+        .iter()
+        .any(|a| matches!(a, SchedulerAction::Cancel { .. }));
+    assert!(
+        !has_cancel,
+        "a task with no progress handle must never be idle-killed, regardless of age"
+    );
+    assert_eq!(scheduler.graph.tasks[0].status, TaskStatus::Running);
+}
+
+/// Multi-task isolation: two independently-running tasks each carry their own
+/// `Arc<AtomicU64>` heartbeat. A stale heartbeat on one task must not affect the other —
+/// every idle-timeout test above uses a single-task graph, which cannot by itself rule out
+/// a bug that reads/writes the wrong task's handle (e.g. an accidental shared `Arc`, or a
+/// `check_timeouts` loop that mixes up per-task state).
+#[test]
+fn test_idle_timeout_multi_task_heartbeats_are_independent() {
+    let graph = graph_from_nodes(vec![make_node(0, &[]), make_node(1, &[])]);
+    let mut config = make_config();
+    config.task_timeout_secs = 300; // long — isolate idle-timeout behavior from run-timeout
+    let defs = vec![make_def("worker")];
+    let mut scheduler =
+        DagScheduler::new(graph, &config, Box::new(FirstRouter), defs, None).unwrap();
+
+    let short_idle = crate::graph::TimeoutPolicy {
+        run_timeout_secs: None,
+        idle_timeout_secs: Some(1),
+    };
+    scheduler.graph.tasks[0].timeout = Some(short_idle.clone());
+    scheduler.graph.tasks[1].timeout = Some(short_idle);
+    // Use Skip (not the graph default Abort) on task 0 so its idle-timeout kill doesn't
+    // cascade-abort the whole graph and collaterally cancel unrelated task 1 (mirrors
+    // test_per_task_timeout_override_fires_before_global_default's rationale) — isolates
+    // per-task heartbeat independence from unrelated Abort cascade semantics.
+    scheduler.graph.tasks[0].failure_strategy = Some(zeph_config::FailureStrategy::Skip);
+    scheduler.graph.tasks[0].status = TaskStatus::Running;
+    scheduler.graph.tasks[1].status = TaskStatus::Running;
+
+    // Task 0's heartbeat is recorded first, then we sleep past the 1s idle window, then
+    // task 1's heartbeat is recorded fresh — so task 0's Arc is genuinely stale relative to
+    // the idle window while task 1's is not, and each task holds a distinct Arc.
+    let handle0 = progress_handle_now();
+    scheduler.running.insert(
+        TaskId(0),
+        RunningTask {
+            agent_handle_id: "h0".to_string(),
+            agent_def_name: "worker".to_string(),
+            started_at: std::time::Instant::now(),
+            admission_permit: None,
+            last_progress_at: Some(handle0),
+        },
+    );
+    std::thread::sleep(Duration::from_millis(1_100));
+    let handle1 = progress_handle_now();
+    scheduler.running.insert(
+        TaskId(1),
+        RunningTask {
+            agent_handle_id: "h1".to_string(),
+            agent_def_name: "worker".to_string(),
+            started_at: std::time::Instant::now(),
+            admission_permit: None,
+            last_progress_at: Some(handle1),
+        },
+    );
+
+    let actions = scheduler.tick();
+    let canceled: Vec<&str> = actions
+        .iter()
+        .filter_map(|a| match a {
+            SchedulerAction::Cancel { agent_handle_id } => Some(agent_handle_id.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        canceled,
+        vec!["h0"],
+        "only the task with the stale heartbeat should be idle-killed"
     );
     assert_eq!(
         scheduler.graph.tasks[0].status,
-        TaskStatus::Running,
-        "the task must remain Running, unaffected by the short idle_timeout_secs value"
+        TaskStatus::Skipped,
+        "task 0 (stale heartbeat) must be killed — Skip strategy turns the timeout-Failed \
+         status into Skipped via propagate_failure, same as the existing per-task-timeout test"
     );
+    assert_eq!(
+        scheduler.graph.tasks[1].status,
+        TaskStatus::Running,
+        "task 1's own fresh heartbeat must keep it alive, unaffected by task 0's staleness"
+    );
+}
+
+/// F4: when both run-timeout and idle-timeout are exceeded on the same tick, run must win
+/// — it is the hard wall-clock cap, idle the softer liveness signal. Verified indirectly via
+/// the synthetic `TaskResult.output` cause string (the `TimeoutCause` enum itself is private).
+#[test]
+fn test_run_timeout_wins_precedence_over_idle_on_same_tick() {
+    let graph = graph_from_nodes(vec![make_node(0, &[])]);
+    let mut config = make_config();
+    config.task_timeout_secs = 1; // both run and idle will be exceeded
+    let defs = vec![make_def("worker")];
+    let mut scheduler =
+        DagScheduler::new(graph, &config, Box::new(FirstRouter), defs, None).unwrap();
+
+    scheduler.graph.tasks[0].timeout = Some(crate::graph::TimeoutPolicy {
+        run_timeout_secs: None,
+        idle_timeout_secs: Some(1),
+    });
+    scheduler.graph.tasks[0].status = TaskStatus::Running;
+    scheduler.running.insert(
+        TaskId(0),
+        RunningTask {
+            agent_handle_id: "h0".to_string(),
+            agent_def_name: "worker".to_string(),
+            started_at: std::time::Instant::now()
+                .checked_sub(Duration::from_secs(10))
+                .unwrap(),
+            admission_permit: None,
+            // Value irrelevant to this test: run-timeout is checked first and already
+            // exceeded via started_at above, so the idle branch is never reached regardless
+            // of heartbeat freshness.
+            last_progress_at: Some(progress_handle_now()),
+        },
+    );
+
+    scheduler.tick();
+    let output = scheduler.graph.tasks[0]
+        .result
+        .as_ref()
+        .expect("timeout must populate TaskResult")
+        .output
+        .clone();
+    assert!(
+        output.contains("run timeout"),
+        "run timeout must win precedence on a same-tick tie, got: {output}"
+    );
+    assert!(
+        !output.contains("idle timeout"),
+        "only one cause must be reported per NFR-OB-01, got: {output}"
+    );
+}
+
+/// F5: a run-timeout kill (no idle policy configured at all) must also populate
+/// `TaskResult.output` with a cause — this was a latent bug (timeout kills previously left
+/// `result: None`, showing no reason anywhere in the TUI/CLI).
+#[test]
+fn test_run_timeout_populates_task_result_cause() {
+    let graph = graph_from_nodes(vec![make_node(0, &[])]);
+    let mut config = make_config();
+    config.task_timeout_secs = 1;
+    let defs = vec![make_def("worker")];
+    let mut scheduler =
+        DagScheduler::new(graph, &config, Box::new(FirstRouter), defs, None).unwrap();
+
+    scheduler.graph.tasks[0].status = TaskStatus::Running;
+    scheduler.running.insert(
+        TaskId(0),
+        RunningTask {
+            agent_handle_id: "h0".to_string(),
+            agent_def_name: "worker".to_string(),
+            started_at: std::time::Instant::now()
+                .checked_sub(Duration::from_secs(2))
+                .unwrap(),
+            admission_permit: None,
+            last_progress_at: None,
+        },
+    );
+
+    scheduler.tick();
+    let result = scheduler.graph.tasks[0]
+        .result
+        .as_ref()
+        .expect("run-timeout kill must populate TaskResult (F5 fix)");
+    assert!(result.output.contains("run timeout"));
+    assert_eq!(result.agent_id.as_deref(), Some("h0"));
+    assert_eq!(result.agent_def.as_deref(), Some("worker"));
 }
 
 #[test]
@@ -675,6 +965,56 @@ fn test_effective_run_timeout_uses_per_task_override() {
 }
 
 #[test]
+fn test_effective_idle_timeout_none_when_unset_anywhere() {
+    // Unlike effective_run_timeout, idle is opt-in — with no per-task override and no
+    // global default configured, the effective value must be None (disabled), never a
+    // sentinel Duration.
+    let graph = graph_from_nodes(vec![make_node(0, &[])]);
+    let defs = vec![make_def("worker")];
+    let scheduler =
+        DagScheduler::new(graph, &make_config(), Box::new(FirstRouter), defs, None).unwrap();
+    assert_eq!(scheduler.effective_idle_timeout(TaskId(0)), None);
+}
+
+#[test]
+fn test_effective_idle_timeout_falls_back_to_global_default() {
+    let graph = graph_from_nodes(vec![make_node(0, &[])]);
+    let config = zeph_config::OrchestrationConfig {
+        default_idle_timeout_secs: Some(30),
+        ..make_config()
+    };
+    let defs = vec![make_def("worker")];
+    let scheduler = DagScheduler::new(graph, &config, Box::new(FirstRouter), defs, None).unwrap();
+
+    assert_eq!(
+        scheduler.effective_idle_timeout(TaskId(0)),
+        Some(Duration::from_secs(30))
+    );
+}
+
+#[test]
+fn test_effective_idle_timeout_uses_per_task_override_over_global_default() {
+    let graph = graph_from_nodes(vec![make_node(0, &[])]);
+    let config = zeph_config::OrchestrationConfig {
+        default_idle_timeout_secs: Some(30),
+        ..make_config()
+    };
+    let defs = vec![make_def("worker")];
+    let mut scheduler =
+        DagScheduler::new(graph, &config, Box::new(FirstRouter), defs, None).unwrap();
+    scheduler.graph.tasks[0].timeout = Some(crate::graph::TimeoutPolicy {
+        run_timeout_secs: None,
+        idle_timeout_secs: Some(5),
+    });
+
+    assert_eq!(
+        scheduler.effective_idle_timeout(TaskId(0)),
+        Some(Duration::from_secs(5)),
+        "per-task override must win over the global default (30s), not merge with it"
+    );
+}
+
+#[test]
 fn test_cancel_all() {
     let graph = graph_from_nodes(vec![make_node(0, &[]), make_node(1, &[])]);
     let mut scheduler = make_scheduler(graph);
@@ -687,6 +1027,7 @@ fn test_cancel_all() {
             agent_def_name: "worker".to_string(),
             started_at: std::time::Instant::now(),
             admission_permit: None,
+            last_progress_at: None,
         },
     );
     scheduler.graph.tasks[1].status = TaskStatus::Running;
@@ -697,6 +1038,7 @@ fn test_cancel_all() {
             agent_def_name: "worker".to_string(),
             started_at: std::time::Instant::now(),
             admission_permit: None,
+            last_progress_at: None,
         },
     );
 
@@ -791,6 +1133,7 @@ fn test_concurrency_deferral_does_not_affect_running_task() {
             agent_def_name: "worker".to_string(),
             started_at: std::time::Instant::now(),
             admission_permit: None,
+            last_progress_at: None,
         },
     );
     scheduler.graph.tasks[1].status = TaskStatus::Running;
@@ -939,6 +1282,7 @@ fn test_stale_event_rejected() {
             agent_def_name: "worker".to_string(),
             started_at: std::time::Instant::now(),
             admission_permit: None,
+            last_progress_at: None,
         },
     );
 
@@ -989,6 +1333,7 @@ fn test_duration_ms_computed_correctly() {
                 .checked_sub(Duration::from_millis(50))
                 .unwrap(),
             admission_permit: None,
+            last_progress_at: None,
         },
     );
 
@@ -1061,7 +1406,12 @@ fn test_consecutive_spawn_failures_resets_on_success() {
     scheduler.record_batch_backoff(false, true);
     assert_eq!(scheduler.consecutive_spawn_failures, 2);
 
-    scheduler.record_spawn(TaskId(0), "handle-0".to_string(), "worker".to_string());
+    scheduler.record_spawn(
+        TaskId(0),
+        "handle-0".to_string(),
+        "worker".to_string(),
+        None,
+    );
     assert_eq!(
         scheduler.consecutive_spawn_failures, 0,
         "record_spawn must reset consecutive_spawn_failures to 0"
@@ -1149,6 +1499,7 @@ async fn test_wait_event_nearest_deadline_reflects_per_task_override() {
             agent_def_name: "worker".to_string(),
             started_at: now.checked_sub(Duration::from_millis(950)).unwrap(),
             admission_permit: None,
+            last_progress_at: None,
         },
     );
     scheduler.running.insert(
@@ -1158,6 +1509,7 @@ async fn test_wait_event_nearest_deadline_reflects_per_task_override() {
             agent_def_name: "worker".to_string(),
             started_at: now,
             admission_permit: None,
+            last_progress_at: None,
         },
     );
 
@@ -1260,7 +1612,7 @@ fn test_record_spawn_resets_consecutive_failures() {
     scheduler.consecutive_spawn_failures = 3;
     let task_id = TaskId(0);
     scheduler.graph.tasks[0].status = TaskStatus::Running;
-    scheduler.record_spawn(task_id, "handle-1".into(), "worker".into());
+    scheduler.record_spawn(task_id, "handle-1".into(), "worker".into(), None);
 
     assert_eq!(scheduler.consecutive_spawn_failures, 0);
 }
@@ -1570,7 +1922,7 @@ fn admission_gate_permit_transferred_to_running() {
     );
 
     scheduler.graph.tasks[task_id.index()].status = TaskStatus::Running;
-    scheduler.record_spawn(task_id, "handle-1".into(), "worker".into());
+    scheduler.record_spawn(task_id, "handle-1".into(), "worker".into(), None);
 
     assert!(
         !scheduler.pending_permits.contains_key(&task_id),
@@ -1676,6 +2028,7 @@ fn take_graph_dirty_true_after_task_completes() {
             agent_def_name: "worker".to_string(),
             started_at: std::time::Instant::now(),
             admission_permit: None,
+            last_progress_at: None,
         },
     );
 
@@ -1715,6 +2068,7 @@ fn take_graph_dirty_true_after_task_fails() {
             agent_def_name: "worker".to_string(),
             started_at: std::time::Instant::now(),
             admission_permit: None,
+            last_progress_at: None,
         },
     );
 
@@ -1786,6 +2140,7 @@ fn take_graph_dirty_true_after_cancel_all() {
             agent_def_name: "worker".to_string(),
             started_at: std::time::Instant::now(),
             admission_permit: None,
+            last_progress_at: None,
         },
     );
 
@@ -1822,6 +2177,7 @@ fn take_graph_dirty_true_after_timeout() {
                 .checked_sub(Duration::from_secs(2))
                 .unwrap(),
             admission_permit: None,
+            last_progress_at: None,
         },
     );
 

--- a/crates/zeph-subagent/src/agent_loop.rs
+++ b/crates/zeph-subagent/src/agent_loop.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 use tokio::sync::{mpsc, watch};
@@ -70,6 +72,22 @@ pub(super) struct AgentLoopArgs {
     pub(super) content_isolation: zeph_config::ContentIsolationConfig,
     /// Maximum wall time for a single LLM call inside an agent turn.
     pub(super) llm_timeout: std::time::Duration,
+    /// Shared progress heartbeat for idle-timeout detection (issue #6245).
+    ///
+    /// `Some` when this spawn is orchestration-dispatched via `DagScheduler` — the driver
+    /// clones the `Arc` in here and keeps the original for `DagScheduler::record_spawn`'s
+    /// `last_progress_at`. `run_agent_loop` stores `monotonic_millis()` into it once per
+    /// turn boundary. `None` for spawns not tracked by an orchestration scheduler (the
+    /// standalone `/agent run`/`resume` commands), which are never idle-tracked.
+    pub(super) progress_at: Option<Arc<AtomicU64>>,
+}
+
+/// Record a progress heartbeat, if this loop has a live handle. No-op for `None` (untracked
+/// or `RunInline`-style spawns — see [`AgentLoopArgs::progress_at`]).
+fn record_progress(progress_at: Option<&Arc<AtomicU64>>) {
+    if let Some(p) = progress_at {
+        p.store(zeph_common::monotonic_millis(), Ordering::Relaxed);
+    }
 }
 
 pub(super) fn make_message(role: Role, content: String) -> Message {
@@ -733,6 +751,7 @@ pub(super) async fn run_agent_loop(
         mcp_tool_names,
         content_isolation,
         llm_timeout,
+        progress_at,
     } = args;
 
     let sanitizer = ContentSanitizer::new(&content_isolation);
@@ -761,6 +780,8 @@ pub(super) async fn run_agent_loop(
     let mut granted_secrets: HashMap<String, GrantedSecret> = HashMap::new();
 
     loop {
+        record_progress(progress_at.as_ref());
+
         if cancel.is_cancelled() {
             tracing::debug!("sub-agent cancelled, stopping loop");
             break;
@@ -799,6 +820,8 @@ pub(super) async fn run_agent_loop(
             TurnOutcome::NudgeSent | TurnOutcome::SecretHandled => {}
             TurnOutcome::Done | TurnOutcome::Cancelled => break,
         }
+
+        record_progress(progress_at.as_ref());
 
         trim_message_history(&mut messages, max_history_messages);
     }
@@ -878,6 +901,58 @@ mod trim_message_history_tests {
         trim_message_history(&mut msgs, 3);
         assert_eq!(msgs.len(), 3);
         assert_eq!(msgs[0].role, Role::System);
+    }
+}
+
+#[cfg(test)]
+mod record_progress_tests {
+    use super::*;
+
+    #[test]
+    fn none_handle_is_a_noop() {
+        // Must not panic and must not affect anything — this is the RunInline/untracked path.
+        record_progress(None);
+    }
+
+    #[test]
+    fn some_handle_stores_a_fresh_monotonic_reading() {
+        // Seed with a sentinel a real monotonic_millis() reading can never produce (0 is not
+        // safe here — an isolated test binary can be young enough that monotonic_millis()
+        // itself legitimately reads 0, which would make an unwritten handle indistinguishable
+        // from a written one). u64::MAX proves the write actually happened; the >= check
+        // proves it reflects a reading taken at-or-after this test's own pre-call timestamp.
+        let before = zeph_common::monotonic_millis();
+        let handle = Arc::new(AtomicU64::new(u64::MAX));
+
+        record_progress(Some(&handle));
+
+        let stored = handle.load(Ordering::Relaxed);
+        assert_ne!(
+            stored,
+            u64::MAX,
+            "record_progress must overwrite the initial placeholder value"
+        );
+        assert!(
+            stored >= before,
+            "stored value ({stored}) must be a monotonic reading taken at-or-after the pre-call \
+             timestamp ({before})"
+        );
+    }
+
+    #[test]
+    fn some_handle_overwrites_a_stale_previous_value() {
+        let handle = Arc::new(AtomicU64::new(0));
+        record_progress(Some(&handle));
+        let first = handle.load(Ordering::Relaxed);
+
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        record_progress(Some(&handle));
+        let second = handle.load(Ordering::Relaxed);
+
+        assert!(
+            second >= first,
+            "a second call must never move the stored heartbeat backward"
+        );
     }
 }
 

--- a/crates/zeph-subagent/src/manager/mod.rs
+++ b/crates/zeph-subagent/src/manager/mod.rs
@@ -158,6 +158,19 @@ pub struct SpawnContext {
     /// `false` (the default) imposes no restriction beyond the executor/global
     /// `allow_network` default.
     pub network_denied: bool,
+
+    /// Shared progress heartbeat for idle-timeout detection (issue #6245).
+    ///
+    /// Set by the orchestration driver (`handle_scheduler_spawn_action` in `zeph-core`'s
+    /// `scheduler_loop.rs`) alongside [`network_denied`][Self::network_denied] — same
+    /// post-construction assignment pattern, not part of `build_spawn_context`'s base
+    /// literal. The driver creates the `Arc`, clones it in here, and keeps the original for
+    /// `zeph_orchestration::DagScheduler::record_spawn`'s `last_progress_at` parameter so
+    /// both the running loop and the scheduler observe the same counter.
+    ///
+    /// `None` (the default) for spawns not tracked by a `DagScheduler` — e.g. the standalone
+    /// `/agent run` command — which are never idle-tracked.
+    pub progress_at: Option<Arc<std::sync::atomic::AtomicU64>>,
 }
 
 /// Live status snapshot of a running sub-agent.

--- a/crates/zeph-subagent/src/manager/spawn.rs
+++ b/crates/zeph-subagent/src/manager/spawn.rs
@@ -737,6 +737,7 @@ impl SubAgentManager {
             mcp_tool_names,
             content_isolation: ctx.content_isolation,
             llm_timeout: std::time::Duration::from_secs(config.llm_timeout_secs),
+            progress_at: ctx.progress_at,
         };
 
         let join_handle = self.spawn_agent_task(Arc::from(task_id.as_str()), move || async move {
@@ -1166,6 +1167,9 @@ impl SubAgentManager {
                 mcp_tool_names: resumed_mcp_tool_names,
                 content_isolation: ContentIsolationConfig::default(),
                 llm_timeout,
+                // `resume()` is the standalone `/agent resume` command path, never tracked
+                // by a `DagScheduler` — no progress handle to reattach to.
+                progress_at: None,
             })
         });
 

--- a/crates/zeph-subagent/src/manager/tests.rs
+++ b/crates/zeph-subagent/src/manager/tests.rs
@@ -2222,6 +2222,7 @@ fn make_agent_loop_args(
         content_isolation: ContentIsolationConfig::default(),
         max_history_messages: 200,
         llm_timeout: std::time::Duration::from_mins(2),
+        progress_at: None,
     }
 }
 
@@ -2329,6 +2330,57 @@ async fn run_agent_loop_passes_tools_to_provider() {
         1,
         "chat_with_tools must have been called exactly once"
     );
+}
+
+// ── idle-timeout progress heartbeat (#6245) ──────────────────────────────
+
+#[tokio::test]
+async fn run_agent_loop_writes_progress_heartbeat_on_a_real_turn() {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    // Proves the full path end-to-end: a real `run_agent_loop` turn actually stores into
+    // the `Arc<AtomicU64>` that a `DagScheduler` would later read via `RunningTask::
+    // last_progress_at` — not just that the low-level `record_progress` helper works in
+    // isolation (covered separately in `agent_loop.rs`'s `record_progress_tests`).
+    let provider = mock_provider(vec!["done"]);
+    let executor = FilteredToolExecutor::new(noop_executor(), ToolPolicy::InheritAll);
+
+    // u64::MAX as the placeholder (not 0) — a young test process can legitimately have
+    // monotonic_millis() itself read 0, which would make an unwritten handle
+    // indistinguishable from a written one.
+    let handle = Arc::new(AtomicU64::new(u64::MAX));
+    let before = zeph_common::monotonic_millis();
+    let args = AgentLoopArgs {
+        progress_at: Some(Arc::clone(&handle)),
+        ..make_agent_loop_args(provider, executor, 1)
+    };
+
+    let result = run_agent_loop(args).await;
+    assert!(result.is_ok(), "loop failed: {result:?}");
+
+    let stored = handle.load(Ordering::Relaxed);
+    assert_ne!(
+        stored,
+        u64::MAX,
+        "run_agent_loop must have written to the progress handle during the turn"
+    );
+    assert!(
+        stored >= before,
+        "stored heartbeat ({stored}) must be a monotonic reading taken during or after the \
+         turn ({before})"
+    );
+}
+
+#[tokio::test]
+async fn run_agent_loop_none_progress_handle_is_unaffected() {
+    // RunInline-style: no handle at all — the loop must run to completion without touching
+    // anything (no panic, no attempted write). Regression guard for the `Option` branch.
+    let provider = mock_provider(vec!["done"]);
+    let executor = FilteredToolExecutor::new(noop_executor(), ToolPolicy::InheritAll);
+    let args = make_agent_loop_args(provider, executor, 1); // progress_at: None by default
+
+    let result = run_agent_loop(args).await;
+    assert!(result.is_ok(), "loop failed: {result:?}");
 }
 
 #[tokio::test]

--- a/specs/075-orchestration-node-control-parity/spec.md
+++ b/specs/075-orchestration-node-control-parity/spec.md
@@ -26,6 +26,12 @@ issues:
 # Spec: Orchestration Node Control Parity — Per-Task Timeouts and Retry-Exhausted Recovery Routing (GitHub #6021)
 
 > [!info]
+> **Status update (#6245):** `idle_timeout_secs` moved from documented no-op to enforced —
+> see the Alt-A progress-signal plumbing design in `.local/handoff/2026-07-16T21-37-11-architect.md`
+> (+ amendment `2026-07-16T21-53-03-architect.md`). FR-005 below and the "documented no-op"
+> language throughout this spec describe the v1 state this spec originally shipped; treat
+> them as historical for `idle_timeout_secs` specifically — run-timeout behavior is unchanged.
+>
 > `TaskNode` gains an optional per-task `TimeoutPolicy` (hard `run_timeout_secs` override,
 > enforced; `idle_timeout_secs`, defined but a documented no-op in v1) and an optional
 > `RecoveryAction` (`state_injection` — substitute a synthetic output and continue, on terminal

--- a/src/init/agents.rs
+++ b/src/init/agents.rs
@@ -82,9 +82,10 @@ pub(super) fn step_orchestration(state: &mut WizardState) -> anyhow::Result<()> 
 
         let idle_timeout_raw: String = Input::new()
             .with_prompt(
-                "Default idle/no-progress timeout in seconds — RESERVED, not yet enforced \
-                 in this release; leave blank unless you want the value persisted for when \
-                 it ships",
+                "Default idle/no-progress timeout in seconds — kills a task if it emits no \
+                 progress for this long; leave blank to disable. IMPORTANT: set this above \
+                 the longest expected single-turn (single LLM call + its tool calls) \
+                 duration, or a healthy long-running task may be killed spuriously",
             )
             .allow_empty(true)
             .validate_with(|s: &String| -> Result<(), String> {

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -118,7 +118,8 @@ pub(crate) struct WizardState {
     pub(crate) orchestration_failure_strategy: String,
     pub(crate) orchestration_planner_provider: Option<String>,
     pub(crate) orchestration_persistence_enabled: bool,
-    /// RESERVED — not yet enforced (spec-075-orchestration-node-control-parity, #6021).
+    /// Kills a task if it emits no progress for this many seconds (opt-in; `None` disables).
+    /// Must be set above the longest expected single-turn duration (spec-075-orchestration-node-control-parity, #6021, enforced by #6245).
     pub(crate) orchestration_default_idle_timeout_secs: Option<u64>,
     // Ensemble-verified plan verification (spec 073-orch-ensemble-merge, opt-in)
     pub(crate) ensemble_enabled: bool,

--- a/tests/orchestration_integration.rs
+++ b/tests/orchestration_integration.rs
@@ -103,7 +103,7 @@ mod orchestration_integration {
                         ..
                     } => {
                         let handle_id = format!("handle-{}", task_id.index());
-                        scheduler.record_spawn(task_id, handle_id.clone(), agent_def_name);
+                        scheduler.record_spawn(task_id, handle_id.clone(), agent_def_name, None);
                         spawned.push((task_id, handle_id));
                     }
                     SchedulerAction::Done { status } => {
@@ -332,7 +332,7 @@ mod orchestration_integration {
                     } => {
                         let handle_id = format!("handle-{attempt}");
                         attempt += 1;
-                        scheduler.record_spawn(task_id, handle_id.clone(), agent_def_name);
+                        scheduler.record_spawn(task_id, handle_id.clone(), agent_def_name, None);
                         spawned.push((task_id, handle_id));
                     }
                     SchedulerAction::Done { status } => {


### PR DESCRIPTION
## Summary
- Wires the real idle-detection mechanism for `idle_timeout_secs`, previously shipped as a defined but documented no-op (zero progress-signal plumbing existed across `zeph-subagent`/`zeph-orchestration`).
- Introduces a per-task `Arc<AtomicU64>` coalescing progress timestamp (monotonic millis via a new `zeph_common::monotonic_millis()`, `Relaxed` ordering) written on each agent-loop turn boundary and read by the scheduler's `check_timeouts()`. This deliberately avoids the existing completion-event `mpsc::channel(64)`, which drops buffered events under saturation and would risk evicting a real terminal completion if progress signals were multiplexed onto it.
- `RunInline` tasks are exempt from idle-timeout enforcement via a `None` progress handle (defense-in-depth, not merely ordering-dependent) — documented no-op for v1.
- Adds a `TimeoutCause { Run, Idle }` enum with run-timeout winning on a same-tick tie, and a single-cause log line.
- Fixes a latent bug found during design review: timeout kills (both run and idle) previously surfaced no reason anywhere (`TaskResult` was left unpopulated). `TaskResult.output` now carries the cause, surfaced into the TUI's existing `task.error` field via the current `metrics.rs` conversion with no widget changes.

## Process
Full new-feature chain: architect → critic (verdict `significant`, 6 findings) → architect amendment → critic re-review (`approved`) → developer → tester/perf/security/impl-critic in parallel (impl-critic verdict `minor`, 2 small gaps) → developer closed all validator findings (rebase onto main, doc fix, 3 new test groups, footgun doc) → reviewer (`approved`, independently re-ran full check suite).

Closes #6245

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml` scoped to zeph-orchestration, zeph-subagent, zeph-common, zeph-config, zeph-core — 4030/4030 passed (17 new tests)
- [x] `cargo test --doc` — new `monotonic_millis()` doctest passes
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links"`)
- [x] `gitleaks protect --staged` — clean
- [x] New coverage: `record_progress()` unit tests + end-to-end `run_agent_loop` write-through test, `effective_idle_timeout()` global-fallback test, multi-task independent-heartbeat test, RunInline idle-exemption regression test
- [x] CHANGELOG.md, `.local/testing/playbooks/orchestration.md`, and `.local/testing/coverage-status.md` updated