### PR TITLE
feat(mcp): add config/CLI/TUI/migration surface for image passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 ### Added
 
+- **MCP image passthrough — config/CLI/TUI surface** (spec-072 P3, #6241): completes the
+  opt-in MCP image passthrough feature (#6331) with the remaining integration points.
+  - `--init`: the MCP remote-server wizard now asks "Enable image passthrough for this
+    server?" (default No) for each added server; Sandboxed-trust servers skip the prompt
+    since passthrough is always hard-blocked for them regardless of the flag.
+  - `--migrate-config`: new step 89 adds `media_passthrough = false` to existing
+    `[[mcp.servers]]` entries and a commented `[mcp.media]` advisory block with the pinned
+    defaults, for configs written before this feature existed.
+  - TUI/CLI status indicators: a `"Decoding MCP image…"` status during
+    `MediaSanitizer::sanitize_image`'s `spawn_blocking` decode, and a source-labeled
+    `"Image attached from mcp:<server> (<n>)"` status when validated images are attached
+    to the outgoing LLM request (`CLAUDE.md` TUI Rules).
+  - `--no-mcp-media`: a global CLI kill-switch that forces MCP image passthrough off for
+    the session regardless of config, for quick incident response.
 - **zeph-orchestration** / **zeph-subagent** / **zeph-core**: `idle_timeout_secs` (per-task
   `TimeoutPolicy` and global `default_idle_timeout_secs`) is now enforced — previously it was
   defined and config-surfaced but a documented no-op (#6245, Alt-A progress-signal plumbing

--- a/book/src/guides/mcp.md
+++ b/book/src/guides/mcp.md
@@ -69,6 +69,48 @@ max_dynamic_servers = 10
 
 Environment variables containing secrets (API keys, tokens, credentials — 21 variables plus `BASH_FUNC_*` patterns) are automatically stripped from MCP child process environments. See [MCP Security](../reference/security/mcp.md) for the full blocklist.
 
+### Image Passthrough
+
+MCP servers can return images (e.g. a screenshot tool, a chart renderer) as part of a tool
+result. By default these are dropped, leaving only the text placeholder. Set
+`media_passthrough = true` on a server to decode and attach its images as native
+`MessagePart::Image` siblings for vision-capable providers:
+
+```toml
+[[mcp.servers]]
+id = "screenshot-tool"
+command = "screenshot-mcp"
+trust_level = "trusted"
+media_passthrough = true
+```
+
+`media_passthrough` is independent of `trust_level`, but always hard-blocked when
+`trust_level = "sandboxed"`, regardless of this flag. Images are only attached when the
+turn's selected provider is vision-capable — otherwise they are dropped with a warning and
+the text placeholder remains.
+
+Global caps for every server with `media_passthrough = true` are configured under
+`[mcp.media]`:
+
+```toml
+[mcp.media]
+max_image_bytes = 5242880       # 5 MiB
+max_dimension_px = 8192
+max_pixels = 64000000           # ~64 MP, decompression-bomb defense
+max_images_per_result = 4
+max_images_per_turn = 8
+allowed_formats = ["jpeg", "png", "gif", "webp"]
+```
+
+Every image is validated by `MediaSanitizer` before it ever reaches an LLM request: a
+magic-byte sniff against the declared MIME type, a format allowlist check, the byte-size
+cap, and the dimension/pixel caps (checked both from the image header and after a full
+decode) — rejecting a mismatched, disallowed, oversized, or decompression-bomb image
+instead of decoding it. The `--init` wizard asks whether to enable image passthrough per
+remote server (default No); `--migrate-config` adds `media_passthrough = false` and a
+commented `[mcp.media]` block to configs written before this feature existed. Use
+`--no-mcp-media` to force passthrough off for a session regardless of config.
+
 ## Dynamic Management
 
 Add and remove MCP servers at runtime via chat commands:

--- a/book/src/reference/cli.md
+++ b/book/src/reference/cli.md
@@ -771,6 +771,7 @@ channels.
 | `--extended-context` | Enable Claude 1M extended context window. Tokens above 200K use long-context pricing. Requires a Claude provider. Overrides `llm.cloud.enable_extended_context` |
 | `--scan-skills-on-load` | Scan skill content for prompt injection patterns on load. Advisory only — logs warnings; does not block tool calls |
 | `--no-pre-execution-verify` | Disable pre-execution verifiers for tool calls. Use in trusted environments when verifiers produce false positives |
+| `--no-mcp-media` | Force MCP image passthrough off for this session, regardless of per-server `media_passthrough` or `[mcp.media]` config. Quick incident-response kill-switch — MCP tool calls and text results are unaffected |
 | `--policy-file <PATH>` | Path to external policy rules TOML file. Overrides `tools.policy.policy_file` |
 | `--dump-format <FORMAT>` | Override debug dump format: `json`, `raw`, or `trace` (OTel OTLP spans) |
 | `--scheduler-tick <SECS>` | Override scheduler tick interval in seconds (requires `scheduler` feature) |

--- a/crates/zeph-config/src/cli.rs
+++ b/crates/zeph-config/src/cli.rs
@@ -21,6 +21,11 @@ pub struct CliConfig {
     /// troubleshooting-flag precedent but gating a disjoint set of subsystems.
     #[serde(skip)]
     pub safe_mode: bool,
+    /// Force MCP image passthrough (spec-072) off for this session (`--no-mcp-media`),
+    /// regardless of per-server `media_passthrough` or `[mcp.media]` config. Session-scoped
+    /// only — never persisted to `config.toml` (`#[serde(skip)]`), mirroring `safe_mode`.
+    #[serde(skip)]
+    pub no_mcp_media: bool,
     /// Emit structured JSON events (JSONL) to stdout. Forces logs to stderr.
     pub json: bool,
     /// Auto-approve trust-gate prompts (`-y` / `--auto`).

--- a/crates/zeph-config/src/migrate/mcp.rs
+++ b/crates/zeph-config/src/migrate/mcp.rs
@@ -227,3 +227,65 @@ pub fn migrate_mcp_retry_and_tool_timeout(toml_src: &str) -> Result<MigrationRes
         })
     }
 }
+
+/// Add `media_passthrough = false` to every existing `[[mcp.servers]]` entry that lacks it,
+/// and a commented-out `[mcp.media]` advisory block with pinned defaults, for configs that
+/// predate the MCP image passthrough feature (spec-072, #6241).
+///
+/// Neither addition changes behavior: `media_passthrough` already defaults to `false` via
+/// `#[serde(default)]`, and `[mcp.media]`'s caps only take effect for servers that opt in.
+/// Both are surfaced for discoverability, mirroring [`migrate_mcp_trust_levels`]'s
+/// array-of-tables write for the per-server flag and the standalone commented-block append
+/// used by [`super::migrate_nli_config`] for the new section.
+///
+/// # Errors
+///
+/// Returns `MigrateError::Parse` if the TOML cannot be parsed.
+pub fn migrate_mcp_media_config(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    let mut doc = toml_src.parse::<toml_edit::DocumentMut>()?;
+    let mut changed_count = 0usize;
+    let mut sections_changed: Vec<String> = Vec::new();
+
+    if let Some(servers) = doc
+        .get_mut("mcp")
+        .and_then(toml_edit::Item::as_table_mut)
+        .and_then(|mcp| mcp.get_mut("servers"))
+        .and_then(toml_edit::Item::as_array_of_tables_mut)
+    {
+        let mut added = 0usize;
+        for entry in servers.iter_mut() {
+            if !entry.contains_key("media_passthrough") {
+                entry.insert("media_passthrough", toml_edit::value(false));
+                added += 1;
+            }
+        }
+        if added > 0 {
+            changed_count += added;
+            sections_changed.push("mcp.servers.media_passthrough".to_owned());
+        }
+    }
+
+    let mut output = doc.to_string();
+
+    let media_commented_present = output.lines().any(|l| l.trim() == "# [mcp.media]");
+    if !section_header_present(&output, "mcp.media") && !media_commented_present {
+        let block = "\n# Global caps for MCP image passthrough (spec-072). Applies to every\n\
+             # server with media_passthrough = true.\n\
+             # [mcp.media]\n\
+             # max_image_bytes = 5242880       # 5 MiB\n\
+             # max_dimension_px = 8192\n\
+             # max_pixels = 64000000           # ~64 MP (decompression-bomb defense)\n\
+             # max_images_per_result = 4\n\
+             # max_images_per_turn = 8\n\
+             # allowed_formats = [\"jpeg\", \"png\", \"gif\", \"webp\"]\n";
+        output = format!("{}{}", output.trim_end(), block);
+        changed_count += 1;
+        sections_changed.push("mcp.media".to_owned());
+    }
+
+    Ok(MigrationResult {
+        output,
+        changed_count,
+        sections_changed,
+    })
+}

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -608,28 +608,29 @@ use steps::{
     MigrateFocusAutoConsolidateMinWindow, MigrateForgettingConfig, MigrateGoalsConfig,
     MigrateGonkagateToGonka, MigrateHooksPermissionDeniedConfig, MigrateHooksTurnComplete,
     MigrateKnowledgeConfig, MigrateLlmStreamLimits, MigrateMagicDocsConfig,
-    MigrateMcpElicitationConfig, MigrateMcpMaxConnectAttempts, MigrateMcpRetryAndToolTimeout,
-    MigrateMcpTrustLevels, MigrateMemoryGraph, MigrateMemoryGraphRecallIncludeImported,
-    MigrateMemoryHebbian, MigrateMemoryHebbianConsolidation, MigrateMemoryHebbianSpread,
-    MigrateMemoryPersonaConfig, MigrateMemoryReasoning, MigrateMemoryReasoningJudge,
-    MigrateMemoryRetrieval, MigrateMemoryRetrievalQueryBias, MigrateMemoryTypeAwareCompose,
-    MigrateMicrocompactConfig, MigrateNliConfig, MigrateOrchestrationAssetSensitivity,
-    MigrateOrchestrationEnsemble, MigrateOrchestrationIdleTimeout, MigrateOrchestrationPersistence,
-    MigrateOrchestratorProvider, MigrateOtelFilter, MigratePiiFilterNames,
-    MigratePlannerModelToProvider, MigratePolicyProviderAndUtilityWindow,
-    MigrateProviderMaxConcurrent, MigrateQdrantApiKey, MigrateQdrantTimeoutSecs,
-    MigrateQualityConfig, MigrateSandboxConfig, MigrateSandboxEgressFilter, MigrateSchedulerDaemon,
-    MigrateSecretMaskingConfig, MigrateServeConfig, MigrateSessionPersistProviderOverrides,
-    MigrateSessionPersistenceConfig, MigrateSessionProviderPersistence, MigrateSessionRecapConfig,
-    MigrateShadowSentinelConfig, MigrateShellCheckpointsConfig, MigrateShellTransactional,
-    MigrateSkillTrustRequireCheck, MigrateSkillsRegistry, MigrateSttToProvider,
-    MigrateSupervisorConfig, MigrateTelemetryConfig, MigrateToolsCompressionConfig,
-    MigrateTraceMetadata, MigrateTuiDelights, MigrateTuiMouse, MigrateTuiThemeConfig,
-    MigrateTuiThemeDefaults, MigrateUtilityHighGainTools, MigrateVigilConfig,
-    MigrateWorktreeConfig, MigrateWorktreeGitTimeout, MigrateWorktreeQuotaFields,
+    MigrateMcpElicitationConfig, MigrateMcpMaxConnectAttempts, MigrateMcpMediaConfig,
+    MigrateMcpRetryAndToolTimeout, MigrateMcpTrustLevels, MigrateMemoryGraph,
+    MigrateMemoryGraphRecallIncludeImported, MigrateMemoryHebbian,
+    MigrateMemoryHebbianConsolidation, MigrateMemoryHebbianSpread, MigrateMemoryPersonaConfig,
+    MigrateMemoryReasoning, MigrateMemoryReasoningJudge, MigrateMemoryRetrieval,
+    MigrateMemoryRetrievalQueryBias, MigrateMemoryTypeAwareCompose, MigrateMicrocompactConfig,
+    MigrateNliConfig, MigrateOrchestrationAssetSensitivity, MigrateOrchestrationEnsemble,
+    MigrateOrchestrationIdleTimeout, MigrateOrchestrationPersistence, MigrateOrchestratorProvider,
+    MigrateOtelFilter, MigratePiiFilterNames, MigratePlannerModelToProvider,
+    MigratePolicyProviderAndUtilityWindow, MigrateProviderMaxConcurrent, MigrateQdrantApiKey,
+    MigrateQdrantTimeoutSecs, MigrateQualityConfig, MigrateSandboxConfig,
+    MigrateSandboxEgressFilter, MigrateSchedulerDaemon, MigrateSecretMaskingConfig,
+    MigrateServeConfig, MigrateSessionPersistProviderOverrides, MigrateSessionPersistenceConfig,
+    MigrateSessionProviderPersistence, MigrateSessionRecapConfig, MigrateShadowSentinelConfig,
+    MigrateShellCheckpointsConfig, MigrateShellTransactional, MigrateSkillTrustRequireCheck,
+    MigrateSkillsRegistry, MigrateSttToProvider, MigrateSupervisorConfig, MigrateTelemetryConfig,
+    MigrateToolsCompressionConfig, MigrateTraceMetadata, MigrateTuiDelights, MigrateTuiMouse,
+    MigrateTuiThemeConfig, MigrateTuiThemeDefaults, MigrateUtilityHighGainTools,
+    MigrateVigilConfig, MigrateWorktreeConfig, MigrateWorktreeGitTimeout,
+    MigrateWorktreeQuotaFields,
 };
 
-/// Ordered registry of all sequential migration steps (steps 1–88).
+/// Ordered registry of all sequential migration steps (steps 1–89).
 ///
 /// Each entry wraps the corresponding free function and is evaluated lazily at first access.
 /// The ordering is chronological; the dispatch loop in `src/commands/migrate.rs` iterates
@@ -797,6 +798,9 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             // Step 88 — add default_idle_timeout_secs advisory comment under [orchestration]
             // (spec-075-orchestration-node-control-parity, #6021)
             Box::new(MigrateOrchestrationIdleTimeout),
+            // Step 89 — add media_passthrough = false to existing [[mcp.servers]] entries and
+            // a commented [mcp.media] advisory block (spec-072, #6241)
+            Box::new(MigrateMcpMediaConfig),
         ]
     });
 

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -57,7 +57,9 @@
 //! step 87 adds a commented `stale_running_after_secs = 3600` advisory to an existing active
 //! `[durable.retention]` table for the crash-orphan sweep (spec-064, #6254);
 //! step 88 adds a `default_idle_timeout_secs` advisory comment under `[orchestration]`
-//! (spec-075-orchestration-node-control-parity, #6021).
+//! (spec-075-orchestration-node-control-parity, #6021);
+//! step 89 adds `media_passthrough = false` to existing `[[mcp.servers]]` entries and a
+//! commented `[mcp.media]` advisory block (spec-072, #6241).
 //!
 //! Each struct is a zero-size type that delegates to the corresponding free function in
 //! `super`. They exist solely to satisfy the object-safe [`super::Migration`] trait so the
@@ -75,7 +77,7 @@ use super::{
     migrate_focus_auto_consolidate_min_window, migrate_forgetting_config, migrate_goals_config,
     migrate_hooks_permission_denied_config, migrate_hooks_turn_complete_config,
     migrate_knowledge_config, migrate_llm_stream_limits, migrate_magic_docs_config,
-    migrate_mcp_elicitation_config, migrate_mcp_max_connect_attempts,
+    migrate_mcp_elicitation_config, migrate_mcp_max_connect_attempts, migrate_mcp_media_config,
     migrate_mcp_retry_and_tool_timeout, migrate_mcp_trust_levels, migrate_memory_graph_config,
     migrate_memory_graph_recall_include_imported, migrate_memory_hebbian_config,
     migrate_memory_hebbian_consolidation_config, migrate_memory_hebbian_spread_config,
@@ -1102,5 +1104,19 @@ impl Migration for MigrateOrchestrationIdleTimeout {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_orchestration_idle_timeout(toml_src)
+    }
+}
+
+/// Step 89 — adds `media_passthrough = false` to existing `[[mcp.servers]]` entries and a
+/// commented `[mcp.media]` advisory block, for configs that predate MCP image passthrough
+/// (spec-072, #6241).
+pub(super) struct MigrateMcpMediaConfig;
+impl Migration for MigrateMcpMediaConfig {
+    fn name(&self) -> &'static str {
+        "migrate_mcp_media_config"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_mcp_media_config(toml_src)
     }
 }

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -9,8 +9,8 @@ use super::*;
 fn migrations_registry_has_all_steps() {
     assert_eq!(
         MIGRATIONS.len(),
-        88,
-        "MIGRATIONS registry must contain all 88 sequential steps"
+        89,
+        "MIGRATIONS registry must contain all 89 sequential steps"
     );
     for m in MIGRATIONS.iter() {
         assert!(
@@ -1860,7 +1860,7 @@ fn migrate_focus_auto_consolidate_noop_when_only_commented_section() {
 
 #[test]
 fn registry_has_fifty_entries() {
-    assert_eq!(MIGRATIONS.len(), 88);
+    assert_eq!(MIGRATIONS.len(), 89);
 }
 
 #[test]
@@ -1988,6 +1988,7 @@ fn registry_preserves_order_matches_dispatch() {
         "migrate_orchestration_ensemble",
         "migrate_durable_stale_running_after_secs",
         "migrate_orchestration_idle_timeout",
+        "migrate_mcp_media_config",
     ];
     let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
     assert_eq!(actual, expected);
@@ -4573,6 +4574,76 @@ fn step_84_is_idempotent() {
     let first = migrate_a2a_server_remove_inert_fields(src).expect("first migrate");
     assert_eq!(first.changed_count, 2);
     let second = migrate_a2a_server_remove_inert_fields(&first.output).expect("second migrate");
+    assert_eq!(second.changed_count, 0, "second run must be a no-op");
+    assert_eq!(
+        second.output, first.output,
+        "output unchanged on second run"
+    );
+}
+
+// ── Step 89 — migrate_mcp_media_config (spec-072, #6241) ─────────────────
+
+#[test]
+fn step_89_adds_media_passthrough_to_existing_servers() {
+    let src = "[mcp]\n\n[[mcp.servers]]\nid = \"foo\"\ncommand = \"foo\"\n\n[[mcp.servers]]\nid = \"bar\"\ncommand = \"bar\"\n";
+    let result = migrate_mcp_media_config(src).expect("migrate");
+    assert_eq!(result.changed_count, 3, "2 servers + 1 [mcp.media] block");
+    assert_eq!(
+        result.output.matches("media_passthrough = false").count(),
+        2
+    );
+    assert!(result.output.contains("# [mcp.media]"));
+    assert!(
+        result
+            .sections_changed
+            .contains(&"mcp.servers.media_passthrough".to_owned())
+    );
+    assert!(result.sections_changed.contains(&"mcp.media".to_owned()));
+}
+
+#[test]
+fn step_89_skips_servers_that_already_have_the_key() {
+    let src = "[mcp]\n\n[[mcp.servers]]\nid = \"foo\"\nmedia_passthrough = true\n";
+    let result = migrate_mcp_media_config(src).expect("migrate");
+    // Only the [mcp.media] block is added; the existing server entry is untouched.
+    assert_eq!(result.changed_count, 1);
+    assert!(result.output.contains("media_passthrough = true"));
+    assert!(!result.output.contains("media_passthrough = false"));
+}
+
+#[test]
+fn step_89_noop_when_no_mcp_section() {
+    let src = "[agent]\nname = \"zeph\"\n";
+    let result = migrate_mcp_media_config(src).expect("migrate");
+    assert_eq!(
+        result.changed_count, 1,
+        "only the [mcp.media] block is added"
+    );
+    assert!(result.output.contains("# [mcp.media]"));
+}
+
+#[test]
+fn step_89_noop_when_mcp_media_already_present() {
+    let src = "[mcp]\n\n[mcp.media]\nmax_image_bytes = 1048576\n";
+    let result = migrate_mcp_media_config(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn step_89_noop_when_mcp_media_only_commented() {
+    let src = "[mcp]\n# [mcp.media]\n# max_image_bytes = 1048576\n";
+    let result = migrate_mcp_media_config(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn step_89_is_idempotent() {
+    let src = "[mcp]\n\n[[mcp.servers]]\nid = \"foo\"\ncommand = \"foo\"\n";
+    let first = migrate_mcp_media_config(src).expect("first migrate");
+    assert_eq!(first.changed_count, 2, "1 server + 1 [mcp.media] block");
+    let second = migrate_mcp_media_config(&first.output).expect("second migrate");
     assert_eq!(second.changed_count, 0, "second run must be a no-op");
     assert_eq!(
         second.output, first.output,

--- a/crates/zeph-core/src/agent/tool_execution/tests/boundary_and_classifier_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/boundary_and_classifier_tests.rs
@@ -1919,6 +1919,63 @@ mod reasoning_amplification_call_site {
     }
 
     #[tokio::test]
+    async fn process_one_tool_result_emits_source_labeled_status_when_media_attached() {
+        // Mandatory TUI status indicator (CLAUDE.md "TUI Rules") — the channel must see a
+        // status update naming the MCP server that contributed the attached image, followed
+        // by a clearing update.
+        use crate::agent::agent_tests::{
+            MockChannel, MockToolExecutor, create_test_registry, mock_provider_with_vision,
+        };
+        let provider = mock_provider_with_vision(vec!["ok".to_owned()]);
+        let channel = MockChannel::new(vec![]);
+        let statuses = std::sync::Arc::clone(&channel.statuses);
+        let mut agent = crate::agent::Agent::new(
+            provider,
+            channel,
+            create_test_registry(),
+            None,
+            5,
+            MockToolExecutor::no_tools(),
+        );
+        // A qualified `server:tool` name, matching real MCP dispatch (`McpTool::qualified_name`).
+        let tc = make_tool_use_request("id-media-status", "srv:tool");
+        let mut result_parts = Vec::new();
+        let mut images_attached = 0usize;
+
+        agent
+            .process_one_tool_result(
+                &tc,
+                "id-media-status",
+                &std::time::Instant::now(),
+                Ok(Some(tool_output_with_media(1))),
+                &mut result_parts,
+                &mut Vec::new(),
+                &mut false,
+                &mut None,
+                &mut Vec::new(),
+                &mut images_attached,
+            )
+            .await
+            .unwrap();
+
+        let recorded = statuses.lock().unwrap();
+        assert!(
+            recorded
+                .iter()
+                .any(|s| s == "Image attached from mcp:srv (1)"),
+            "expected a source-labeled status update, got {recorded:?}"
+        );
+        // Deliberately NOT self-cleared (M2): an immediate clear with zero work between set
+        // and clear would blank the label before the render loop ever sees it, making the
+        // mandatory source-label indicator invisible. It must stay set until the next
+        // natural status update replaces it.
+        assert!(
+            !recorded.last().is_some_and(String::is_empty),
+            "status must not be self-cleared immediately, got {recorded:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn process_one_tool_result_drops_media_when_provider_not_vision_capable() {
         use crate::agent::agent_tests::{
             MockChannel, MockToolExecutor, create_test_registry, mock_provider,

--- a/crates/zeph-core/src/agent/tool_execution/tool_result.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tool_result.rs
@@ -485,7 +485,8 @@ impl<C: Channel> Agent<C> {
                 media,
                 result_parts,
                 images_attached_this_turn,
-            );
+            )
+            .await;
         }
 
         Ok(())
@@ -504,7 +505,7 @@ impl<C: Channel> Agent<C> {
     /// 400/422. Both multi-provider implementations enforce this at dispatch time:
     /// `TriageRouter::chat_with_tools` (escalate-or-strip) and `RouterProvider::chat_with_tools`
     /// (per-provider strip on every dispatch branch — Cascade/Bandit/Ema/Thompson).
-    fn emit_media_parts(
+    async fn emit_media_parts(
         &mut self,
         tool_name: &str,
         media: Vec<zeph_llm::ImageData>,
@@ -519,7 +520,11 @@ impl<C: Channel> Agent<C> {
             );
             return;
         }
+        let server_id = tool_name
+            .split_once(':')
+            .map_or(tool_name, |(server, _)| server);
         let max_images_per_turn = self.runtime.config.mcp_media.max_images_per_turn;
+        let mut attached = 0usize;
         for img in media {
             if *images_attached_this_turn >= max_images_per_turn {
                 tracing::warn!(
@@ -531,6 +536,21 @@ impl<C: Channel> Agent<C> {
             }
             result_parts.push(MessagePart::Image(Box::new(img)));
             *images_attached_this_turn += 1;
+            attached += 1;
+        }
+        if attached > 0 {
+            // Mandatory TUI status indicator (CLAUDE.md "TUI Rules") — surfaces which MCP
+            // server contributed an image attached to the outgoing LLM request. Deliberately
+            // NOT self-cleared: with zero work between a set and a clear on the last-write-wins
+            // `StatusTx` slot, an immediate `send_status_best_effort("")` would blank the label
+            // before the render loop ever has a chance to pick it up, making it invisible. Left
+            // set so the next natural status update (following tool call, LLM response) replaces
+            // it once real work actually happens.
+            self.channel
+                .send_status_best_effort(&format!(
+                    "Image attached from mcp:{server_id} ({attached})"
+                ))
+                .await;
         }
     }
 

--- a/crates/zeph-mcp/src/executor.rs
+++ b/crates/zeph-mcp/src/executor.rs
@@ -44,6 +44,9 @@ pub struct McpToolExecutor {
     max_images_per_result: usize,
     /// Audit logger for MCP media accept/reject decisions.
     audit_logger: Option<Arc<zeph_tools::AuditLogger>>,
+    /// Status sender for the mandatory TUI/CLI decode spinner (`CLAUDE.md` "TUI Rules").
+    /// `None` disables the indicator only — sanitization still runs.
+    status_tx: Option<zeph_llm::provider::StatusTx>,
 }
 
 impl McpToolExecutor {
@@ -60,6 +63,7 @@ impl McpToolExecutor {
             media_sanitizer: None,
             max_images_per_result: 0,
             audit_logger: None,
+            status_tx: None,
         }
     }
 
@@ -83,6 +87,17 @@ impl McpToolExecutor {
     #[must_use]
     pub fn with_audit(mut self, logger: Arc<zeph_tools::AuditLogger>) -> Self {
         self.audit_logger = Some(logger);
+        self
+    }
+
+    /// Attach a status sender used to surface a `"Decoding MCP image…"` indicator while
+    /// [`zeph_sanitizer::MediaSanitizer::sanitize_image`]'s `spawn_blocking` decode runs
+    /// (`CLAUDE.md` "TUI Rules" — every background/implicit operation needs a visible
+    /// status indicator). Without this, decoding is silent in the UI; sanitization itself
+    /// is unaffected.
+    #[must_use]
+    pub fn with_status_tx(mut self, tx: zeph_llm::provider::StatusTx) -> Self {
+        self.status_tx = Some(tx);
         self
     }
 
@@ -127,6 +142,13 @@ impl McpToolExecutor {
         };
         if !self.manager.media_passthrough_allowed(server_id).await {
             return Vec::new();
+        }
+
+        let has_images = content
+            .iter()
+            .any(|b| matches!(b, rmcp::model::ContentBlock::Image(_)));
+        if has_images {
+            self.send_status("Decoding MCP image\u{2026}");
         }
 
         let mut media = Vec::new();
@@ -179,7 +201,19 @@ impl McpToolExecutor {
                 }
             }
         }
+        if has_images {
+            self.send_status("");
+        }
         media
+    }
+
+    /// Send a best-effort status update via [`Self::status_tx`], when attached. Mirrors the
+    /// `let _ = stx.send(...)` idiom used for MCP OAuth status messages
+    /// (`crates/zeph-mcp/src/manager/connect.rs`).
+    fn send_status(&self, text: &str) {
+        if let Some(ref tx) = self.status_tx {
+            let _ = tx.send(text.to_owned());
+        }
     }
 
     /// Log an accepted MCP media validation via the tool audit path (spec-072 AC-14).
@@ -568,6 +602,55 @@ mod tests {
             .collect_media("srv", "tool", std::slice::from_ref(&mismatched))
             .await;
         assert!(media.is_empty(), "MIME mismatch must be rejected (AC-4)");
+    }
+
+    #[tokio::test]
+    async fn collect_media_emits_decode_status_and_clears_it() {
+        let entry = media_entry("srv", true, crate::manager::McpTrustLevel::Untrusted);
+        let mgr = Arc::new(McpManager::new(
+            vec![entry],
+            vec![],
+            PolicyEnforcer::new(vec![]),
+        ));
+        let tools = Arc::new(RwLock::new(vec![]));
+        let sanitizer = Arc::new(zeph_sanitizer::MediaSanitizer::new(
+            &zeph_config::McpMediaConfig::default(),
+        ));
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let executor = McpToolExecutor::new(mgr, tools)
+            .with_media(sanitizer, 4)
+            .with_status_tx(tx);
+
+        let media = executor
+            .collect_media("srv", "tool", std::slice::from_ref(&png_image_block()))
+            .await;
+        assert_eq!(media.len(), 1);
+
+        assert_eq!(rx.try_recv().unwrap(), "Decoding MCP image\u{2026}");
+        assert_eq!(
+            rx.try_recv().unwrap(),
+            "",
+            "status must be cleared once decoding finishes"
+        );
+        assert!(rx.try_recv().is_err(), "no further status messages");
+    }
+
+    #[tokio::test]
+    async fn collect_media_skips_status_when_no_images_in_result() {
+        let entry = media_entry("srv", true, crate::manager::McpTrustLevel::Untrusted);
+        let executor = executor_with_media(entry);
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let executor = executor.with_status_tx(tx);
+
+        let text_block = rmcp::model::ContentBlock::text("no images here".to_owned());
+        let media = executor
+            .collect_media("srv", "tool", std::slice::from_ref(&text_block))
+            .await;
+        assert!(media.is_empty());
+        assert!(
+            rx.try_recv().is_err(),
+            "no status update when there are no image blocks to decode"
+        );
     }
 
     #[test]

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -2617,7 +2617,7 @@ pub(crate) async fn run_acp_server(
 ///
 /// Returns an error if the agent stack cannot be built or the server fails to bind.
 #[cfg(feature = "acp-http")]
-#[allow(clippy::too_many_lines)]
+#[allow(clippy::too_many_lines, clippy::too_many_arguments)] // CLI/env passthrough for one session-bootstrap call; grouping into a struct would not reduce complexity
 pub(crate) async fn run_acp_http_server(
     config_path: Option<&std::path::Path>,
     vault_backend: Option<&str>,

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -803,10 +803,15 @@ async fn build_acp_deps(
     };
     let mcp_shared_tools = std::sync::Arc::new(RwLock::new(mcp_tools.clone()));
     let mut mcp_executor =
-        zeph_mcp::McpToolExecutor::new(mcp_manager.clone(), mcp_shared_tools.clone()).with_media(
+        zeph_mcp::McpToolExecutor::new(mcp_manager.clone(), mcp_shared_tools.clone());
+    if config.cli.no_mcp_media {
+        tracing::info!("--no-mcp-media: MCP image passthrough disabled for this session");
+    } else {
+        mcp_executor = mcp_executor.with_media(
             std::sync::Arc::new(zeph_sanitizer::MediaSanitizer::new(&config.mcp.media)),
             config.mcp.media.max_images_per_result,
         );
+    }
     if let Some(ref logger) = acp_audit_logger {
         mcp_executor = mcp_executor.with_audit(std::sync::Arc::clone(logger));
     }
@@ -2504,10 +2509,19 @@ pub(crate) async fn run_acp_server(
     cli_auth_methods: Vec<String>,
     cli_message_ids: Option<bool>,
     safe_mode: bool,
+    no_mcp_media: bool,
 ) -> anyhow::Result<()> {
     use std::sync::Arc;
 
-    let app = AppBuilder::new(config_path, vault_backend, vault_key, vault_path, safe_mode).await?;
+    let app = AppBuilder::new(
+        config_path,
+        vault_backend,
+        vault_key,
+        vault_path,
+        safe_mode,
+        no_mcp_media,
+    )
+    .await?;
     let (mut deps, _keepalive) = Box::pin(build_acp_deps(&app, None, None)).await?;
     let available_models = std::sync::Arc::clone(&deps.acp_available_models);
     let provider = deps.provider.clone();
@@ -2612,11 +2626,20 @@ pub(crate) async fn run_acp_http_server(
     bind_override: Option<&str>,
     auth_token_override: Option<String>,
     safe_mode: bool,
+    no_mcp_media: bool,
 ) -> anyhow::Result<()> {
     use std::sync::Arc;
     use tokio::sync::RwLock;
 
-    let app = AppBuilder::new(config_path, vault_backend, vault_key, vault_path, safe_mode).await?;
+    let app = AppBuilder::new(
+        config_path,
+        vault_backend,
+        vault_key,
+        vault_path,
+        safe_mode,
+        no_mcp_media,
+    )
+    .await?;
     log_acp_runtime_paths(app.config(), app.config_path());
     let bind_addr = bind_override.map_or_else(|| app.config().acp.http_bind.clone(), str::to_owned);
 

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -81,6 +81,14 @@ pub(crate) struct ToolSetup {
     /// Pass the same `Arc` to `AgentBuilder::with_risk_chain_accumulator` so
     /// `begin_turn()` resets the per-turn score at each turn boundary.
     pub(crate) risk_chain_accumulator: Arc<zeph_tools::RiskChainAccumulator>,
+    /// `true` when the built `mcp_executor` had a `MediaSanitizer` attached (spec-072 P3,
+    /// #6241). `false` when `--no-mcp-media` disabled it for the session. Read only by
+    /// `build_tool_setup`'s own tests (`build_tool_setup_no_mcp_media_disables_media_sanitizer`)
+    /// — no production call site needs it, since the concrete `McpToolExecutor` is folded
+    /// into the type-erased `executor: DynExecutor` above and cannot be introspected
+    /// afterward any other way.
+    #[allow(dead_code)]
+    pub(crate) mcp_media_enabled: bool,
 }
 
 #[derive(Clone)]
@@ -428,6 +436,7 @@ pub(crate) async fn build_tool_setup(
     with_tool_events: bool,
     bare: bool,
     safe_mode: bool,
+    no_mcp_media: bool,
     runtime_ctx: RuntimeContext,
     age_vault: Option<&Arc<std::sync::RwLock<zeph_core::vault::AgeVaultProvider>>>,
     status_tx: Option<tokio::sync::mpsc::UnboundedSender<String>>,
@@ -533,8 +542,8 @@ pub(crate) async fn build_tool_setup(
         runtime_ctx.suppress_stderr(),
         age_vault,
     );
-    if let Some(tx) = status_tx {
-        mcp_manager_builder = mcp_manager_builder.with_status_tx(tx);
+    if let Some(ref tx) = status_tx {
+        mcp_manager_builder = mcp_manager_builder.with_status_tx(tx.clone());
     }
     mcp_manager_builder =
         crate::bootstrap::wire_trust_calibration(mcp_manager_builder, config, pool).await;
@@ -589,10 +598,19 @@ pub(crate) async fn build_tool_setup(
 
     let mcp_shared_tools = Arc::new(RwLock::new(mcp_tools.clone()));
     let mut mcp_executor =
-        zeph_mcp::McpToolExecutor::new(mcp_manager.clone(), mcp_shared_tools.clone()).with_media(
+        zeph_mcp::McpToolExecutor::new(mcp_manager.clone(), mcp_shared_tools.clone());
+    let mcp_media_enabled = !no_mcp_media;
+    if no_mcp_media {
+        tracing::info!("--no-mcp-media: MCP image passthrough disabled for this session");
+    } else {
+        mcp_executor = mcp_executor.with_media(
             Arc::new(zeph_sanitizer::MediaSanitizer::new(&config.mcp.media)),
             config.mcp.media.max_images_per_result,
         );
+        if let Some(ref tx) = status_tx {
+            mcp_executor = mcp_executor.with_status_tx(tx.clone());
+        }
+    }
     if let Some(ref logger) = audit_logger {
         mcp_executor = mcp_executor.with_audit(Arc::clone(logger));
     }
@@ -636,6 +654,7 @@ pub(crate) async fn build_tool_setup(
         background_completion_rx: Some(bg_completion_rx),
         shell_executor_handle,
         risk_chain_accumulator,
+        mcp_media_enabled,
     }
 }
 
@@ -2941,6 +2960,62 @@ mod tests {
             "expected Some(pipeline) when config.quality.self_check is true and \
              QualityConfig::validate() passes with the default per_call_timeout_ms/ \
              latency_budget_ms/min_evidence values"
+        );
+    }
+
+    /// #6241 Gap B (tester): closes the gap where only the upstream `ExecutionMode.no_mcp_media`
+    /// bool-plumbing was tested — this proves `build_tool_setup` itself actually skips
+    /// attaching a `MediaSanitizer` to the built `McpToolExecutor` when the kill-switch is set,
+    /// not just that the flag flows through unchanged.
+    #[tokio::test]
+    async fn build_tool_setup_no_mcp_media_disables_media_sanitizer() {
+        let config = Config::load(Path::new("/nonexistent")).unwrap();
+        let pool = memory_pool().await;
+        let provider = offline_provider();
+        let tool_setup = build_tool_setup(
+            &config,
+            zeph_tools::PermissionPolicy::default(),
+            false,
+            true, // bare: skip any real MCP connection attempts
+            false,
+            true, // no_mcp_media
+            RuntimeContext::default(),
+            None,
+            None,
+            Some(&pool),
+            &provider,
+            None,
+        )
+        .await;
+        assert!(
+            !tool_setup.mcp_media_enabled,
+            "--no-mcp-media must disable the MediaSanitizer attachment"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_tool_setup_media_enabled_by_default() {
+        let config = Config::load(Path::new("/nonexistent")).unwrap();
+        let pool = memory_pool().await;
+        let provider = offline_provider();
+        let tool_setup = build_tool_setup(
+            &config,
+            zeph_tools::PermissionPolicy::default(),
+            false,
+            true, // bare: skip any real MCP connection attempts
+            false,
+            false, // no_mcp_media
+            RuntimeContext::default(),
+            None,
+            None,
+            Some(&pool),
+            &provider,
+            None,
+        )
+        .await;
+        assert!(
+            tool_setup.mcp_media_enabled,
+            "MediaSanitizer must be attached when --no-mcp-media is not set"
         );
     }
 

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -429,7 +429,11 @@ async fn drain_embedding_guard_events(
     }
 }
 
-#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::too_many_lines,
+    clippy::fn_params_excessive_bools
+)]
 pub(crate) async fn build_tool_setup(
     config: &Config,
     permission_policy: zeph_tools::PermissionPolicy,

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -195,6 +195,13 @@ impl AppBuilder {
     /// together into `config.cli.safe_mode` rather than one silently overriding
     /// the other.
     ///
+    /// `no_mcp_media` forces MCP image passthrough off for this session
+    /// (`--no-mcp-media`, spec-072). OR'd into `config.cli.no_mcp_media` the same way as
+    /// `safe_mode` above (no env overlay for this flag — CLI-only), so every entry point
+    /// that builds its `McpToolExecutor` from `app.config()` (runner, daemon, ACP) reads a
+    /// single, correctly-populated source of truth instead of each needing its own
+    /// case-by-case plumbing.
+    ///
     /// # Errors
     ///
     /// Returns [`BootstrapError`] if config loading, validation, vault backend parsing,
@@ -205,10 +212,12 @@ impl AppBuilder {
         vault_key_override: Option<&Path>,
         vault_path_override: Option<&Path>,
         safe_mode: bool,
+        no_mcp_media: bool,
     ) -> Result<Self, BootstrapError> {
         let config_path = resolve_config_path(config_override);
         let mut config = Config::load(&config_path)?;
         config.cli.safe_mode |= safe_mode;
+        config.cli.no_mcp_media |= no_mcp_media;
         config.validate()?;
         config.llm.check_legacy_format()?;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -292,6 +292,13 @@ pub(crate) struct Cli {
     #[arg(long)]
     pub(crate) safe_mode: bool,
 
+    /// Force MCP image passthrough (spec-072) off for this session, regardless of
+    /// per-server `media_passthrough` or `[mcp.media]` config. Quick incident-response
+    /// kill-switch — MCP tool calls and text results are unaffected; only image
+    /// decode/attach is disabled. Session-scoped only; never persisted to config.toml.
+    #[arg(long)]
+    pub(crate) no_mcp_media: bool,
+
     /// Emit structured JSON events to stdout (JSONL, one event per line).
     /// Safe for piping into `jq`. Forces all log output to stderr.
     /// Mutually exclusive with `--tui` and `--acp`.

--- a/src/commands/ingest.rs
+++ b/src/commands/ingest.rs
@@ -18,7 +18,7 @@ pub(crate) async fn handle_ingest(
 ) -> anyhow::Result<()> {
     // Non-interactive data command (Qdrant ingestion), not a troubleshooting session with
     // customization sources to isolate — `safe_mode` is deliberately `false`, not omitted.
-    let app = AppBuilder::new(config_path, None, None, None, false).await?;
+    let app = AppBuilder::new(config_path, None, None, None, false, false).await?;
     let config = app.config();
 
     let qdrant = QdrantOps::new(

--- a/src/commands/knowledge.rs
+++ b/src/commands/knowledge.rs
@@ -267,7 +267,7 @@ async fn resolve_effective_max(max_documents: usize, config_path: Option<&Path>)
     if max_documents > 0 {
         return max_documents;
     }
-    AppBuilder::new(config_path, None, None, None, false)
+    AppBuilder::new(config_path, None, None, None, false, false)
         .await
         .map_or(0, |a| a.config().knowledge.max_documents)
 }
@@ -668,7 +668,7 @@ async fn build_ingest_resources(
     provider_override: Option<&str>,
     yes: bool,
 ) -> anyhow::Result<(IngestionPipeline, IngestLedger, String, String)> {
-    let app = AppBuilder::new(config_path, None, None, None, false).await?;
+    let app = AppBuilder::new(config_path, None, None, None, false, false).await?;
     let config = app.config();
     let qdrant = QdrantOps::new(
         &config.memory.qdrant_url,
@@ -932,7 +932,7 @@ async fn run_graph_ingest(
     root: &Path,
     config_path: Option<&Path>,
 ) -> anyhow::Result<()> {
-    let app = AppBuilder::new(config_path, None, None, None, false).await?;
+    let app = AppBuilder::new(config_path, None, None, None, false, false).await?;
     let config = app.config();
 
     // Enforce transcript_scope (INV-6: only "current-project" is supported).
@@ -1542,7 +1542,7 @@ async fn handle_external_agent_ingest(
     println!("  Ingesting {total} document(s) into knowledge graph…");
 
     // Phase 3: write to graph via SemanticMemory.
-    let app = AppBuilder::new(config_path, None, None, None, false).await?;
+    let app = AppBuilder::new(config_path, None, None, None, false, false).await?;
     let app_config = app.config();
     let (provider, _status_tx, _status_rx) = app.build_provider().await?;
     // #5444 S1: build_memory (via attach_reasoning_memory) would otherwise destructively
@@ -1706,7 +1706,7 @@ async fn handle_rollback(
     yes: bool,
     config_path: Option<&Path>,
 ) -> anyhow::Result<()> {
-    let app = AppBuilder::new(config_path, None, None, None, false).await?;
+    let app = AppBuilder::new(config_path, None, None, None, false, false).await?;
     let config = app.config();
 
     let store = SqliteStore::new(&config.memory.sqlite_path)
@@ -1794,7 +1794,7 @@ async fn handle_rollback(
 ///
 /// Returns an error when config loading or database access fails.
 async fn handle_status(config_path: Option<&Path>) -> anyhow::Result<()> {
-    let app = AppBuilder::new(config_path, None, None, None, false).await?;
+    let app = AppBuilder::new(config_path, None, None, None, false, false).await?;
     let config = app.config();
 
     let store = SqliteStore::new(&config.memory.sqlite_path)
@@ -2463,7 +2463,7 @@ collection = "{collection}"
         let dir = tempfile::tempdir().unwrap();
         let config_path = write_ollama_test_config(dir.path(), "unused_collection", Some("embed"));
 
-        let app = AppBuilder::new(Some(&config_path), None, None, None, false)
+        let app = AppBuilder::new(Some(&config_path), None, None, None, false, false)
             .await
             .expect("AppBuilder::new should succeed with a valid ollama-only config");
         let config = app.config();
@@ -2488,7 +2488,7 @@ collection = "{collection}"
         let dir = tempfile::tempdir().unwrap();
         let config_path = write_ollama_test_config(dir.path(), "unused_collection", None);
 
-        let app = AppBuilder::new(Some(&config_path), None, None, None, false)
+        let app = AppBuilder::new(Some(&config_path), None, None, None, false, false)
             .await
             .expect("AppBuilder::new should succeed with a valid ollama-only config");
         let config = app.config();
@@ -2778,7 +2778,7 @@ collection = "zeph_test_reasoning_guard_unused_documents"
         let _ = qdrant.delete_collection(collection).await;
         qdrant.ensure_collection(collection, 4).await.unwrap();
 
-        let app = AppBuilder::new(Some(&config_path), None, None, None, false)
+        let app = AppBuilder::new(Some(&config_path), None, None, None, false, false)
             .await
             .expect("AppBuilder::new should succeed with a valid ollama+qdrant config");
         let config = app.config();
@@ -2834,7 +2834,7 @@ collection = "zeph_test_reasoning_guard_unused_documents"
         // memory.reasoning.enabled defaults to false.
         let config_path = write_ollama_test_config(dir.path(), "unused_collection", Some("embed"));
 
-        let app = AppBuilder::new(Some(&config_path), None, None, None, false)
+        let app = AppBuilder::new(Some(&config_path), None, None, None, false, false)
             .await
             .expect("AppBuilder::new should succeed with a valid ollama-only config");
         let config = app.config();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -468,10 +468,19 @@ pub(crate) async fn run_daemon(
     vault_key: Option<&std::path::Path>,
     vault_path: Option<&std::path::Path>,
     safe_mode: bool,
+    no_mcp_media: bool,
 ) -> anyhow::Result<()> {
     use zeph_core::daemon::{ComponentHandle, DaemonSupervisor, PidGuard};
 
-    let app = AppBuilder::new(config_path, vault, vault_key, vault_path, safe_mode).await?;
+    let app = AppBuilder::new(
+        config_path,
+        vault,
+        vault_key,
+        vault_path,
+        safe_mode,
+        no_mcp_media,
+    )
+    .await?;
     let config = app.config();
 
     // Atomically acquire the daemon pid file lock — fails fast with `AlreadyRunning` if another
@@ -694,7 +703,7 @@ pub(crate) async fn run_daemon(
         daemon_runtime_ctx.suppress_stderr(),
         app.age_vault_arc(),
     )
-    .with_status_tx(status_tx);
+    .with_status_tx(status_tx.clone());
     let mcp_manager_builder = crate::bootstrap::wire_trust_calibration(
         mcp_manager_builder,
         config,
@@ -714,10 +723,17 @@ pub(crate) async fn run_daemon(
     let shutdown_mcp_manager = std::sync::Arc::clone(&mcp_manager);
     let mcp_shared_tools = std::sync::Arc::new(RwLock::new(mcp_tools.clone()));
     let mut mcp_executor =
-        zeph_mcp::McpToolExecutor::new(mcp_manager.clone(), mcp_shared_tools.clone()).with_media(
-            std::sync::Arc::new(zeph_sanitizer::MediaSanitizer::new(&config.mcp.media)),
-            config.mcp.media.max_images_per_result,
-        );
+        zeph_mcp::McpToolExecutor::new(mcp_manager.clone(), mcp_shared_tools.clone());
+    if config.cli.no_mcp_media {
+        tracing::info!("--no-mcp-media: MCP image passthrough disabled for this session");
+    } else {
+        mcp_executor = mcp_executor
+            .with_media(
+                std::sync::Arc::new(zeph_sanitizer::MediaSanitizer::new(&config.mcp.media)),
+                config.mcp.media.max_images_per_result,
+            )
+            .with_status_tx(status_tx.clone());
+    }
     if let Some(ref logger) = daemon_audit_logger {
         mcp_executor = mcp_executor.with_audit(std::sync::Arc::clone(logger));
     }

--- a/src/execution_mode.rs
+++ b/src/execution_mode.rs
@@ -19,6 +19,7 @@ pub(crate) struct ExecutionMode {
     pub(crate) safe_mode: bool,
     pub(crate) json: bool,
     pub(crate) auto: bool,
+    pub(crate) no_mcp_media: bool,
 }
 
 impl ExecutionMode {
@@ -29,6 +30,7 @@ impl ExecutionMode {
             safe_mode: cli.safe_mode || cfg.cli.safe_mode,
             json: cli.json || cfg.cli.json,
             auto: cli.auto || cfg.cli.auto,
+            no_mcp_media: cli.no_mcp_media || cfg.cli.no_mcp_media,
         }
     }
 }
@@ -60,7 +62,24 @@ mod tests {
     #[test]
     fn all_false_by_default() {
         let mode = ExecutionMode::default();
-        assert!(!mode.bare && !mode.safe_mode && !mode.json && !mode.auto);
+        assert!(!mode.bare && !mode.safe_mode && !mode.json && !mode.auto && !mode.no_mcp_media);
+    }
+
+    #[test]
+    fn cli_no_mcp_media_flag_activates_kill_switch() {
+        let mut cli = default_cli();
+        cli.no_mcp_media = true;
+        let mode = ExecutionMode::from_cli_and_config(&cli, &Config::default());
+        assert!(mode.no_mcp_media);
+        assert!(!mode.bare);
+    }
+
+    #[test]
+    fn config_no_mcp_media_activates_kill_switch() {
+        let mut cfg = Config::default();
+        cfg.cli.no_mcp_media = true;
+        let mode = ExecutionMode::from_cli_and_config(&default_cli(), &cfg);
+        assert!(mode.no_mcp_media);
     }
 
     #[test]

--- a/src/init/mcp.rs
+++ b/src/init/mcp.rs
@@ -199,6 +199,22 @@ pub(super) fn step_mcp_remote(state: &mut WizardState) -> anyhow::Result<()> {
             _ => McpTrustLevel::Untrusted,
         };
 
+        // Sandboxed servers always hard-block media passthrough regardless of the answer
+        // (spec-072) — skip the interactive prompt entirely so the wizard doesn't offer a
+        // no-op choice; `resolve_media_passthrough` still re-asserts the invariant.
+        let prompt_answer = if trust_level == McpTrustLevel::Sandboxed {
+            false
+        } else {
+            Confirm::new()
+                .with_prompt(
+                    "Enable image passthrough for this server? (images returned by this tool \
+                     will be shown to vision-capable models)",
+                )
+                .default(false)
+                .interact()?
+        };
+        let media_passthrough = resolve_media_passthrough(trust_level, prompt_answer);
+
         state.mcp_remote_servers.push(McpServerConfig {
             id,
             command: None,
@@ -216,7 +232,7 @@ pub(super) fn step_mcp_remote(state: &mut WizardState) -> anyhow::Result<()> {
             tool_metadata: std::collections::HashMap::new(),
             elicitation_enabled: None,
             env_isolation: None,
-            media_passthrough: false,
+            media_passthrough,
         });
 
         println!("Server added.");
@@ -263,4 +279,39 @@ pub(super) fn step_mcp_discovery(state: &mut WizardState) -> anyhow::Result<()> 
 
     println!();
     Ok(())
+}
+
+/// Whether `media_passthrough` should end up `true` for a server, given its resolved
+/// trust level and the wizard's `prompt_answer` (irrelevant when Sandboxed — the caller
+/// should skip asking and pass `false`).
+///
+/// Sandboxed servers always resolve to `false` regardless of `prompt_answer`: passthrough
+/// is hard-blocked for them at runtime by `McpManager::media_passthrough_allowed`
+/// (spec-072 C2), so the wizard must never suggest it is actually enabled for one. Extracted
+/// as a pure function so the invariant is unit-testable without driving `dialoguer` I/O.
+fn resolve_media_passthrough(trust_level: McpTrustLevel, prompt_answer: bool) -> bool {
+    trust_level != McpTrustLevel::Sandboxed && prompt_answer
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_media_passthrough_sandboxed_forces_false() {
+        assert!(!resolve_media_passthrough(McpTrustLevel::Sandboxed, true));
+        assert!(!resolve_media_passthrough(McpTrustLevel::Sandboxed, false));
+    }
+
+    #[test]
+    fn resolve_media_passthrough_untrusted_follows_prompt_answer() {
+        assert!(resolve_media_passthrough(McpTrustLevel::Untrusted, true));
+        assert!(!resolve_media_passthrough(McpTrustLevel::Untrusted, false));
+    }
+
+    #[test]
+    fn resolve_media_passthrough_trusted_follows_prompt_answer() {
+        assert!(resolve_media_passthrough(McpTrustLevel::Trusted, true));
+        assert!(!resolve_media_passthrough(McpTrustLevel::Trusted, false));
+    }
 }

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -2400,6 +2400,79 @@ mod tests {
     }
 
     #[test]
+    fn build_config_mcp_remote_server_media_passthrough_round_trips() {
+        // spec-072 P3: the wizard's per-server image-passthrough prompt result must reach
+        // `config.mcp.servers` unchanged (#6241).
+        let state = WizardState {
+            mcp_remote_servers: vec![McpServerConfig {
+                id: "vision-tool".to_owned(),
+                command: None,
+                args: Vec::new(),
+                env: std::collections::HashMap::new(),
+                url: Some("https://mcp.example.com".to_owned()),
+                timeout: 30,
+                policy: zeph_config::McpPolicy::default(),
+                headers: std::collections::HashMap::new(),
+                oauth: None,
+                trust_level: McpTrustLevel::Untrusted,
+                tool_allowlist: None,
+                expected_tools: Vec::new(),
+                roots: Vec::new(),
+                tool_metadata: std::collections::HashMap::new(),
+                elicitation_enabled: None,
+                env_isolation: None,
+                media_passthrough: true,
+            }],
+            ..single_provider_state()
+        };
+        let config = build_config(&state);
+        let server = config
+            .mcp
+            .servers
+            .iter()
+            .find(|s| s.id == "vision-tool")
+            .expect("server must be present in config.mcp.servers");
+        assert!(
+            server.media_passthrough,
+            "media_passthrough=true must round-trip from WizardState to Config"
+        );
+    }
+
+    #[test]
+    fn build_config_mcp_remote_server_media_passthrough_defaults_false() {
+        let state = WizardState {
+            mcp_remote_servers: vec![McpServerConfig {
+                id: "text-tool".to_owned(),
+                command: None,
+                args: Vec::new(),
+                env: std::collections::HashMap::new(),
+                url: Some("https://mcp.example.com".to_owned()),
+                timeout: 30,
+                policy: zeph_config::McpPolicy::default(),
+                headers: std::collections::HashMap::new(),
+                oauth: None,
+                trust_level: McpTrustLevel::Untrusted,
+                tool_allowlist: None,
+                expected_tools: Vec::new(),
+                roots: Vec::new(),
+                tool_metadata: std::collections::HashMap::new(),
+                elicitation_enabled: None,
+                env_isolation: None,
+                media_passthrough: false,
+            }],
+            ..single_provider_state()
+        };
+        let config = build_config(&state);
+        let server = config
+            .mcp
+            .servers
+            .iter()
+            .find(|s| s.id == "text-tool")
+            .expect("server must be present in config.mcp.servers");
+        assert!(!server.media_passthrough, "default-No must stay false");
+    }
+
+    #[test]
     fn build_config_claude_skips_embedding_model() {
         let state = WizardState {
             provider: Some(ProviderKind::Claude),

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -430,6 +430,7 @@ fn configured_acp_autostart_transport(config: &Config, cli: &Cli) -> Option<AcpT
 }
 
 #[cfg(feature = "acp")]
+#[allow(clippy::too_many_lines)]
 async fn run_configured_acp_autostart(cli: &Cli, transport: AcpTransport) -> anyhow::Result<()> {
     let config_path = cli.config.clone();
     let vault_backend = cli.vault.clone();

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -436,6 +436,7 @@ async fn run_configured_acp_autostart(cli: &Cli, transport: AcpTransport) -> any
     let vault_key = cli.vault_key.clone();
     let vault_path = cli.vault_path.clone();
     let safe_mode = crate::execution_mode::resolve_safe_mode_flag(cli.safe_mode);
+    let no_mcp_media = cli.no_mcp_media;
 
     match transport {
         AcpTransport::Stdio => {
@@ -448,6 +449,7 @@ async fn run_configured_acp_autostart(cli: &Cli, transport: AcpTransport) -> any
                 Vec::new(),
                 None,
                 safe_mode,
+                no_mcp_media,
             ))
             .await
         }
@@ -461,6 +463,7 @@ async fn run_configured_acp_autostart(cli: &Cli, transport: AcpTransport) -> any
                 None,
                 None,
                 safe_mode,
+                no_mcp_media,
             ))
             .await
         }
@@ -476,6 +479,7 @@ async fn run_configured_acp_autostart(cli: &Cli, transport: AcpTransport) -> any
                     Vec::new(),
                     None,
                     safe_mode,
+                    no_mcp_media,
                 ) => result,
                 result = run_acp_http_server(
                     config_path.as_deref(),
@@ -485,6 +489,7 @@ async fn run_configured_acp_autostart(cli: &Cli, transport: AcpTransport) -> any
                     None,
                     None,
                     safe_mode,
+                    no_mcp_media,
                 ) => result,
             }
         }
@@ -503,6 +508,7 @@ async fn run_configured_acp_autostart(cli: &Cli, transport: AcpTransport) -> any
                 Vec::new(),
                 None,
                 safe_mode,
+                no_mcp_media,
             ))
             .await
         }
@@ -522,6 +528,7 @@ async fn run_configured_acp_autostart(cli: &Cli, transport: AcpTransport) -> any
                 Vec::new(),
                 None,
                 safe_mode,
+                no_mcp_media,
             ))
             .await
         }
@@ -1159,6 +1166,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
             cli.vault_key.as_deref(),
             cli.vault_path.as_deref(),
             crate::execution_mode::resolve_safe_mode_flag(cli.safe_mode),
+            cli.no_mcp_media,
         ))
         .await;
     }
@@ -1187,6 +1195,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
             cli.acp_auth_method,
             cli_message_ids,
             crate::execution_mode::resolve_safe_mode_flag(cli.safe_mode),
+            cli.no_mcp_media,
         ))
         .await;
     }
@@ -1201,6 +1210,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
             cli.acp_http_bind.as_deref(),
             cli.acp_auth_token,
             crate::execution_mode::resolve_safe_mode_flag(cli.safe_mode),
+            cli.no_mcp_media,
         ))
         .await;
     }
@@ -1219,6 +1229,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         cli.vault_key.as_deref(),
         cli.vault_path.as_deref(),
         crate::execution_mode::resolve_safe_mode_flag(cli.safe_mode),
+        cli.no_mcp_media,
     )
     .await?;
 
@@ -1583,6 +1594,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
             with_tool_events,
             exec_mode.bare,
             exec_mode.safe_mode,
+            exec_mode.no_mcp_media,
             runtime_ctx,
             app.age_vault_arc(),
             Some(agent_status_tx.clone()),
@@ -1599,6 +1611,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         with_tool_events,
         exec_mode.bare,
         exec_mode.safe_mode,
+        exec_mode.no_mcp_media,
         runtime_ctx,
         app.age_vault_arc(),
         Some(agent_status_tx.clone()),

--- a/src/serve/deps.rs
+++ b/src/serve/deps.rs
@@ -198,7 +198,17 @@ pub(crate) async fn build_serve_deps(
 ) -> anyhow::Result<(ServeAgentDeps, Option<String>)> {
     use crate::bootstrap::AppBuilder;
 
-    let app = AppBuilder::new(config_path, vault_backend, vault_key, vault_path, safe_mode).await?;
+    // Serve wires no hooks or MCP tools today (see `ServeSessionsArgs::safe_mode` doc), so
+    // there is no media-passthrough surface to gate here — pass `false` unconditionally.
+    let app = AppBuilder::new(
+        config_path,
+        vault_backend,
+        vault_key,
+        vault_path,
+        safe_mode,
+        false,
+    )
+    .await?;
     let auth_token = resolve_auth_token(&app).await;
 
     let cancel = tokio_util::sync::CancellationToken::new();

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -223,12 +223,15 @@ async fn run_serve_with_acp(
     http_addr: SocketAddr,
     max_sessions: usize,
 ) -> anyhow::Result<()> {
+    // Serve wires no hooks or MCP tools today (see `ServeSessionsArgs::safe_mode` doc), so
+    // there is no media-passthrough surface to gate here — pass `false` unconditionally.
     let app = crate::bootstrap::AppBuilder::new(
         config_path,
         args.vault_backend.as_deref(),
         args.vault_key.as_deref(),
         args.vault_path.as_deref(),
         args.safe_mode,
+        false,
     )
     .await?;
     let serve_config = app.config().serve.clone();


### PR DESCRIPTION
## Summary

Completes the P3 phase of the MCP image passthrough feature (spec-072), building on the
merged P2 MediaSanitizer work (#6331/#6240):

- `--init`: MCP remote-server wizard now asks "Enable image passthrough for this server?"
  (default No); Sandboxed-trust servers skip the prompt since passthrough is always
  hard-blocked for them at runtime regardless of the flag.
- `--migrate-config`: new step 89 backfills `media_passthrough = false` on existing
  `[[mcp.servers]]` entries and appends a commented `[mcp.media]` advisory block for
  configs written before this feature existed.
- TUI/CLI status indicators (mandatory per `CLAUDE.md` TUI Rules): a `"Decoding MCP
  image…"` spinner during `MediaSanitizer::sanitize_image`'s decode, and a source-labeled
  `"Image attached from mcp:<server> (<n>)"` status when validated images are attached to
  the outgoing LLM request.
- `--no-mcp-media`: an opt-in global CLI kill-switch for incident response, with full
  parity across the CLI/TUI runner, daemon, and both ACP entry points (threaded through
  `AppBuilder::new`, mirroring the existing `safe_mode` pattern).

## Review notes

- Reduced `new-feature` chain (no architect — scope was fully concrete from the merged P2
  work; no perf/security validators — no hot path or new security-critical logic).
- impl-critic's first pass found a significant gap: the initially-proposed `--no-mcp-media`
  fix path was broken (`config.cli.no_mcp_media` had no populator), so the flag would have
  silently no-op'd in daemon/ACP modes — the project's recurring "wire-X-into-daemon/acp"
  defect class. Fixed properly via explicit parameter threading into
  `AppBuilder::new`/`run_daemon`/`run_acp_server`/`run_acp_http_server`, verified end-to-end
  by both impl-critic and the reviewer independently.
- tester found 2 real AC-relevant test gaps (Sandboxed-skip decision logic, kill-switch
  end-to-end effect) — both closed with new tests in the fix round.
- Reviewer independently re-verified the `AppBuilder::new` call-site ripple across the
  whole workspace (17 sites) and ran the full commit-gate suite (fmt/clippy/nextest/rustdoc)
  clean.

## Acceptance criteria

- [x] `--init` wizard prompt (default No, Sandboxed-forced-false, unit tested)
- [x] `--migrate-config` step 89 (idempotent, unit tested)
- [x] TUI/CLI status indicators for decode + source-labeled attach
- [x] `--no-mcp-media` kill-switch with CLI/daemon/ACP parity
- [x] Playbook: `.local/testing/playbooks/mcp-media-passthrough.md`
- [x] Coverage-status rows added (main repo root)
- [x] CHANGELOG.md entry
- [x] mdBook docs (`book/src/guides/mcp.md`, `book/src/reference/cli.md`)

## Test plan

- [x] Full workspace nextest suite: 13891 passed, 0 failures/regressions
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` clean
- [x] Rustdoc gate clean
- [ ] Live-session playbook scenarios (opt-in round-trip, TUI indicators, migrate idempotency, `--init` walkthrough) — pending, tracked as `Untested` in coverage-status.md per project convention

Closes #6241