### PR TITLE
feat(mcp): per-call result size override via _meta annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `default_idle_timeout_secs` doc comments now describe the enforced semantics and warn that
   the value must be set above the longest expected single-turn duration.
 
+- `zeph-mcp`/`zeph-core`: an MCP server can now request a larger per-call truncation limit
+  for a single tool result via `_meta["zeph/maxResultSizeChars"]`, bounded by a new
+  operator-configured hard ceiling, `[tools.overflow].max_per_call_override` (default
+  `131072` = 128 KiB) (#3079). The server's requested size is clamped to
+  `min(requested, max_per_call_override)` and can only raise the effective truncation limit
+  above `[tools.overflow].threshold`, never lower it; any absent or malformed `_meta` value
+  falls back to exactly the prior global-threshold behavior. Setting `max_per_call_override`
+  to `0` (or any value `<=` `threshold`) disables the feature entirely and now logs a
+  `tracing::warn!` at config-apply time to flag the silent-disable footgun. Note: for
+  sanitized/untrusted MCP output, `zeph-sanitizer`'s `max_content_size` (65536 bytes by
+  default) is a separate, smaller downstream cap, so the real effective ceiling under
+  default config is closer to 64 KiB than the full 128 KiB `max_per_call_override` default.
+
 ### Changed
 
 - `zeph-experiments`: `ParameterKind::as_str`, `ParameterKind::is_integer`,

--- a/config/default.toml
+++ b/config/default.toml
@@ -761,6 +761,11 @@ threshold = 50000
 retention_days = 7
 # Maximum bytes per overflow entry; 0 means unlimited (default: 10485760 = 10 MiB)
 max_overflow_bytes = 10485760
+# Hard ceiling (chars) on a per-call result-size override an MCP server may request
+# via _meta["zeph/maxResultSizeChars"]; clamped to min(requested, this) and can only
+# raise the limit above `threshold`, never lower it. Set <= threshold to disable
+# (0 disables — unlike max_overflow_bytes, 0 here is NOT unlimited). (default: 131072 = 128 KiB)
+max_per_call_override = 131072
 
 [tools.audit]
 # Enable audit logging for tool executions

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -616,21 +616,21 @@ use steps::{
     MigrateMemoryRetrievalQueryBias, MigrateMemoryTypeAwareCompose, MigrateMicrocompactConfig,
     MigrateNliConfig, MigrateOrchestrationAssetSensitivity, MigrateOrchestrationEnsemble,
     MigrateOrchestrationIdleTimeout, MigrateOrchestrationPersistence, MigrateOrchestratorProvider,
-    MigrateOtelFilter, MigratePiiFilterNames, MigratePlannerModelToProvider,
-    MigratePolicyProviderAndUtilityWindow, MigrateProviderMaxConcurrent, MigrateQdrantApiKey,
-    MigrateQdrantTimeoutSecs, MigrateQualityConfig, MigrateSandboxConfig,
-    MigrateSandboxEgressFilter, MigrateSchedulerDaemon, MigrateSecretMaskingConfig,
-    MigrateServeConfig, MigrateSessionPersistProviderOverrides, MigrateSessionPersistenceConfig,
-    MigrateSessionProviderPersistence, MigrateSessionRecapConfig, MigrateShadowSentinelConfig,
-    MigrateShellCheckpointsConfig, MigrateShellTransactional, MigrateSkillTrustRequireCheck,
-    MigrateSkillsRegistry, MigrateSttToProvider, MigrateSupervisorConfig, MigrateTelemetryConfig,
-    MigrateToolsCompressionConfig, MigrateTraceMetadata, MigrateTuiDelights, MigrateTuiMouse,
-    MigrateTuiThemeConfig, MigrateTuiThemeDefaults, MigrateUtilityHighGainTools,
-    MigrateVigilConfig, MigrateWorktreeConfig, MigrateWorktreeGitTimeout,
-    MigrateWorktreeQuotaFields,
+    MigrateOtelFilter, MigrateOverflowMaxPerCallOverride, MigratePiiFilterNames,
+    MigratePlannerModelToProvider, MigratePolicyProviderAndUtilityWindow,
+    MigrateProviderMaxConcurrent, MigrateQdrantApiKey, MigrateQdrantTimeoutSecs,
+    MigrateQualityConfig, MigrateSandboxConfig, MigrateSandboxEgressFilter, MigrateSchedulerDaemon,
+    MigrateSecretMaskingConfig, MigrateServeConfig, MigrateSessionPersistProviderOverrides,
+    MigrateSessionPersistenceConfig, MigrateSessionProviderPersistence, MigrateSessionRecapConfig,
+    MigrateShadowSentinelConfig, MigrateShellCheckpointsConfig, MigrateShellTransactional,
+    MigrateSkillTrustRequireCheck, MigrateSkillsRegistry, MigrateSttToProvider,
+    MigrateSupervisorConfig, MigrateTelemetryConfig, MigrateToolsCompressionConfig,
+    MigrateTraceMetadata, MigrateTuiDelights, MigrateTuiMouse, MigrateTuiThemeConfig,
+    MigrateTuiThemeDefaults, MigrateUtilityHighGainTools, MigrateVigilConfig,
+    MigrateWorktreeConfig, MigrateWorktreeGitTimeout, MigrateWorktreeQuotaFields,
 };
 
-/// Ordered registry of all sequential migration steps (steps 1–89).
+/// Ordered registry of all sequential migration steps (steps 1–90).
 ///
 /// Each entry wraps the corresponding free function and is evaluated lazily at first access.
 /// The ordering is chronological; the dispatch loop in `src/commands/migrate.rs` iterates
@@ -801,6 +801,9 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             // Step 89 — add media_passthrough = false to existing [[mcp.servers]] entries and
             // a commented [mcp.media] advisory block (spec-072, #6241)
             Box::new(MigrateMcpMediaConfig),
+            // Step 90 — add max_per_call_override advisory comment under [tools.overflow]
+            // (#3079)
+            Box::new(MigrateOverflowMaxPerCallOverride),
         ]
     });
 

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -59,7 +59,9 @@
 //! step 88 adds a `default_idle_timeout_secs` advisory comment under `[orchestration]`
 //! (spec-075-orchestration-node-control-parity, #6021);
 //! step 89 adds `media_passthrough = false` to existing `[[mcp.servers]]` entries and a
-//! commented `[mcp.media]` advisory block (spec-072, #6241).
+//! commented `[mcp.media]` advisory block (spec-072, #6241);
+//! step 90 adds a commented `max_per_call_override = 131072` advisory under
+//! `[tools.overflow]` (#3079).
 //!
 //! Each struct is a zero-size type that delegates to the corresponding free function in
 //! `super`. They exist solely to satisfy the object-safe [`super::Migration`] trait so the
@@ -87,11 +89,11 @@ use super::{
     migrate_microcompact_config, migrate_nli_config, migrate_orchestration_asset_sensitivity,
     migrate_orchestration_ensemble, migrate_orchestration_idle_timeout,
     migrate_orchestration_orchestrator_provider, migrate_orchestration_persistence,
-    migrate_otel_filter, migrate_pii_filter_names, migrate_planner_model_to_provider,
-    migrate_policy_provider_and_utility_window, migrate_provider_max_concurrent,
-    migrate_qdrant_api_key, migrate_qdrant_timeout_secs, migrate_quality_config,
-    migrate_sandbox_config, migrate_sandbox_egress_filter, migrate_scheduler_daemon_config,
-    migrate_secret_masking_config, migrate_serve_config,
+    migrate_otel_filter, migrate_overflow_max_per_call_override, migrate_pii_filter_names,
+    migrate_planner_model_to_provider, migrate_policy_provider_and_utility_window,
+    migrate_provider_max_concurrent, migrate_qdrant_api_key, migrate_qdrant_timeout_secs,
+    migrate_quality_config, migrate_sandbox_config, migrate_sandbox_egress_filter,
+    migrate_scheduler_daemon_config, migrate_secret_masking_config, migrate_serve_config,
     migrate_session_persist_provider_overrides, migrate_session_persistence_config,
     migrate_session_provider_persistence, migrate_session_recap_config,
     migrate_shadow_sentinel_config, migrate_shell_checkpoints_config, migrate_shell_transactional,
@@ -1118,5 +1120,18 @@ impl Migration for MigrateMcpMediaConfig {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_mcp_media_config(toml_src)
+    }
+}
+
+/// Step 90 — adds a commented `max_per_call_override = 131072` advisory under
+/// `[tools.overflow]` (#3079).
+pub(super) struct MigrateOverflowMaxPerCallOverride;
+impl Migration for MigrateOverflowMaxPerCallOverride {
+    fn name(&self) -> &'static str {
+        "migrate_overflow_max_per_call_override"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_overflow_max_per_call_override(toml_src)
     }
 }

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -9,8 +9,8 @@ use super::*;
 fn migrations_registry_has_all_steps() {
     assert_eq!(
         MIGRATIONS.len(),
-        89,
-        "MIGRATIONS registry must contain all 89 sequential steps"
+        90,
+        "MIGRATIONS registry must contain all 90 sequential steps"
     );
     for m in MIGRATIONS.iter() {
         assert!(
@@ -1153,6 +1153,50 @@ fn step_88_idempotent_on_commented_output() {
     assert_eq!(second.output, first.output);
 }
 
+// ── Step 90 — migrate_overflow_max_per_call_override (#3079) ──────────────
+
+#[test]
+fn step_90_adds_max_per_call_override_block_when_absent() {
+    let src = "[agent]\nname = \"Zeph\"\n";
+    let result = migrate_overflow_max_per_call_override(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert!(
+        result
+            .sections_changed
+            .contains(&"tools.overflow.max_per_call_override".to_owned()),
+        "sections_changed must include 'tools.overflow.max_per_call_override'"
+    );
+    assert!(
+        result.output.contains("max_per_call_override"),
+        "output must contain max_per_call_override"
+    );
+    assert!(
+        result.output.contains("[tools.overflow]"),
+        "output must reference [tools.overflow]"
+    );
+}
+
+#[test]
+fn step_90_noop_when_max_per_call_override_present() {
+    let src = "[tools.overflow]\nmax_per_call_override = 131072\n";
+    let result = migrate_overflow_max_per_call_override(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn step_90_idempotent_on_own_output() {
+    let src = "[agent]\nname = \"Zeph\"\n";
+    let first = migrate_overflow_max_per_call_override(src).expect("migrate");
+    assert_eq!(first.changed_count, 1);
+    let second = migrate_overflow_max_per_call_override(&first.output).expect("second migrate");
+    assert_eq!(second.changed_count, 0, "second run must be a no-op");
+    assert_eq!(
+        second.output, first.output,
+        "output must be unchanged on second run"
+    );
+}
+
 #[test]
 fn migrate_orchestration_ensemble_idempotent_on_commented_output() {
     let base = "[orchestration]\nenabled = true\n";
@@ -1860,7 +1904,7 @@ fn migrate_focus_auto_consolidate_noop_when_only_commented_section() {
 
 #[test]
 fn registry_has_fifty_entries() {
-    assert_eq!(MIGRATIONS.len(), 89);
+    assert_eq!(MIGRATIONS.len(), 90);
 }
 
 #[test]
@@ -1898,7 +1942,7 @@ fn registry_is_idempotent_on_empty_input() {
 
 #[test]
 fn registry_preserves_order_matches_dispatch() {
-    // Names must follow the documented step order (steps 1–88).
+    // Names must follow the documented step order (steps 1–90).
     let expected = [
         "migrate_stt_to_provider",
         "migrate_planner_model_to_provider",
@@ -1989,6 +2033,7 @@ fn registry_preserves_order_matches_dispatch() {
         "migrate_durable_stale_running_after_secs",
         "migrate_orchestration_idle_timeout",
         "migrate_mcp_media_config",
+        "migrate_overflow_max_per_call_override",
     ];
     let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
     assert_eq!(actual, expected);

--- a/crates/zeph-config/src/migrate/tools.rs
+++ b/crates/zeph-config/src/migrate/tools.rs
@@ -332,3 +332,39 @@ pub fn migrate_shell_checkpoints_config(toml_src: &str) -> Result<MigrationResul
         sections_changed: vec!["tools.shell".to_owned()],
     })
 }
+
+/// Add a commented-out `max_per_call_override` hint under `[tools.overflow]` when absent.
+///
+/// Introduced alongside `OverflowConfig::max_per_call_override` (#3079): a hard ceiling on a
+/// per-call result-size override an MCP server may request via
+/// `_meta["zeph/maxResultSizeChars"]`. The field has its own `#[serde(default)]`, so existing
+/// configs parse unchanged; this step only surfaces the option for discoverability, mirroring
+/// [`migrate_shell_checkpoints_config`] and [`migrate_utility_high_gain_tools`].
+///
+/// # Errors
+///
+/// Returns [`MigrateError::Parse`] when `toml_src` is not valid TOML.
+pub fn migrate_overflow_max_per_call_override(
+    toml_src: &str,
+) -> Result<MigrationResult, MigrateError> {
+    if toml_src.contains("max_per_call_override") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "\n# Hard ceiling (chars) on a per-call result-size override an MCP server may\n\
+         # request via _meta[\"zeph/maxResultSizeChars\"]; clamped to min(requested, this) and\n\
+         # can only raise the limit above `threshold`, never lower it. Set <= threshold to\n\
+         # disable (0 disables — unlike max_overflow_bytes, 0 here is NOT unlimited) (#3079).\n\
+         # [tools.overflow]\n\
+         # max_per_call_override = 131072\n";
+
+    Ok(MigrationResult {
+        output: format!("{toml_src}{comment}"),
+        changed_count: 1,
+        sections_changed: vec!["tools.overflow.max_per_call_override".to_owned()],
+    })
+}

--- a/crates/zeph-config/src/tools.rs
+++ b/crates/zeph-config/src/tools.rs
@@ -429,6 +429,10 @@ fn default_max_overflow_bytes() -> usize {
     10 * 1024 * 1024
 }
 
+fn default_max_per_call_override() -> usize {
+    131_072
+}
+
 /// Configuration for large tool response offload to `SQLite`.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct OverflowConfig {
@@ -441,6 +445,26 @@ pub struct OverflowConfig {
     /// Maximum bytes per overflow entry. `0` means unlimited. Default: `10 MiB`.
     #[serde(default = "default_max_overflow_bytes")]
     pub max_overflow_bytes: usize,
+    /// Hard ceiling (in chars) on a per-call result-size override that an MCP
+    /// server may request via `_meta["zeph/maxResultSizeChars"]`. The server's
+    /// request is clamped to `min(requested, max_per_call_override)` and may only
+    /// raise the effective limit above [`threshold`](Self::threshold), never lower
+    /// it. A value at or below `threshold` disables per-call overrides entirely.
+    /// Raising the effective limit also enlarges how much of that call's output
+    /// counts against the turn's context budget, not just summarizer cost.
+    /// Default: `131072` (128 KiB).
+    ///
+    /// Note: unlike [`max_overflow_bytes`](Self::max_overflow_bytes), `0` here
+    /// does NOT mean "unlimited" — it disables overrides (the clamp floors at
+    /// `threshold`).
+    ///
+    /// Note: for sanitized (external/untrusted, `:`-qualified) MCP output, the effective
+    /// in-context ceiling under default config is actually `zeph-sanitizer`'s
+    /// `ContentIsolationConfig::max_content_size` (65536 bytes by default), which is
+    /// smaller than this field's 131072-char default and caps what reaches the LLM
+    /// downstream of this clamp — a fail-safe (lower, not higher) bound, not a hole.
+    #[serde(default = "default_max_per_call_override")]
+    pub max_per_call_override: usize,
 }
 
 impl Default for OverflowConfig {
@@ -449,6 +473,7 @@ impl Default for OverflowConfig {
             threshold: default_overflow_threshold(),
             retention_days: default_retention_days(),
             max_overflow_bytes: default_max_overflow_bytes(),
+            max_per_call_override: default_max_per_call_override(),
         }
     }
 }

--- a/crates/zeph-core/config/default.toml
+++ b/crates/zeph-core/config/default.toml
@@ -446,6 +446,11 @@ threshold = 50000
 retention_days = 7
 # Maximum bytes per overflow entry; 0 means unlimited (default: 10485760 = 10 MiB)
 max_overflow_bytes = 10485760
+# Hard ceiling (chars) on a per-call result-size override an MCP server may request
+# via _meta["zeph/maxResultSizeChars"]; clamped to min(requested, this) and can only
+# raise the limit above `threshold`, never lower it. Set <= threshold to disable
+# (0 disables — unlike max_overflow_bytes, 0 here is NOT unlimited). (default: 131072 = 128 KiB)
+max_per_call_override = 131072
 
 [tools.audit]
 # Enable audit logging for tool executions

--- a/crates/zeph-core/src/agent/tests/agent_tests/metrics_summary_tests.rs
+++ b/crates/zeph-core/src/agent/tests/agent_tests/metrics_summary_tests.rs
@@ -84,7 +84,7 @@ async fn test_maybe_summarize_short_output_passthrough() {
     agent.tool_orchestrator.summarize_tool_output_enabled = true;
 
     let short = "short output";
-    let result = agent.maybe_summarize_tool_output(short).await;
+    let result = agent.maybe_summarize_tool_output(short, None).await;
     assert_eq!(result, short);
 }
 
@@ -123,10 +123,11 @@ async fn test_overflow_notice_contains_uuid() {
         threshold: 100,
         retention_days: 7,
         max_overflow_bytes: 0,
+        max_per_call_override: 131_072,
     };
 
     let long = "x".repeat(zeph_tools::MAX_TOOL_OUTPUT_CHARS + 1000);
-    let result = agent.maybe_summarize_tool_output(&long).await;
+    let result = agent.maybe_summarize_tool_output(&long, None).await;
     assert!(
         result.contains("full output stored"),
         "notice must contain overflow storage notice, got: {result}"
@@ -158,12 +159,13 @@ async fn test_maybe_summarize_long_output_disabled_truncates() {
         threshold: 1000,
         retention_days: 7,
         max_overflow_bytes: 0,
+        max_per_call_override: 131_072,
     };
 
     // Must exceed overflow threshold (1000) so that truncate_tool_output_at produces
     // the "truncated" marker. MAX_TOOL_OUTPUT_CHARS is no longer used in this path.
     let long = "x".repeat(zeph_tools::MAX_TOOL_OUTPUT_CHARS + 1000);
-    let result = agent.maybe_summarize_tool_output(&long).await;
+    let result = agent.maybe_summarize_tool_output(&long, None).await;
     assert!(result.contains("truncated"));
 }
 
@@ -180,10 +182,11 @@ async fn test_maybe_summarize_long_output_enabled_calls_llm() {
         threshold: 1000,
         retention_days: 7,
         max_overflow_bytes: 0,
+        max_per_call_override: 131_072,
     };
 
     let long = "x".repeat(zeph_tools::MAX_TOOL_OUTPUT_CHARS + 1000);
-    let result = agent.maybe_summarize_tool_output(&long).await;
+    let result = agent.maybe_summarize_tool_output(&long, None).await;
     assert!(result.contains("summary text"));
     assert!(result.contains("[tool output summary]"));
     assert!(!result.contains("truncated"));
@@ -202,11 +205,163 @@ async fn test_summarize_tool_output_llm_failure_fallback() {
         threshold: 1000,
         retention_days: 7,
         max_overflow_bytes: 0,
+        max_per_call_override: 131_072,
     };
 
     let long = "x".repeat(zeph_tools::MAX_TOOL_OUTPUT_CHARS + 1000);
-    let result = agent.maybe_summarize_tool_output(&long).await;
+    let result = agent.maybe_summarize_tool_output(&long, None).await;
     assert!(result.contains("truncated"));
+}
+
+// --- #3079: clamp formula edge cases for `maybe_summarize_tool_output`'s
+// `per_call_override` argument. Formula under test (tool_execution/mod.rs):
+// `effective = threshold.max(min(requested, max_per_call_override))`, `None` -> `threshold`.
+
+#[tokio::test]
+async fn override_requested_zero_degrades_to_threshold() {
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+    agent.tool_orchestrator.overflow_config = zeph_tools::OverflowConfig {
+        threshold: 100,
+        retention_days: 7,
+        max_overflow_bytes: 0,
+        max_per_call_override: 131_072,
+    };
+
+    // requested=0 -> threshold.max(0.min(131_072)) == threshold: identical to `None`.
+    let long = "x".repeat(150);
+    let result = agent.maybe_summarize_tool_output(&long, Some(0)).await;
+    assert!(
+        result.contains("truncated"),
+        "requested=0 must degrade to the global threshold, got: {result}"
+    );
+}
+
+#[tokio::test]
+async fn override_above_ceiling_is_clamped_to_ceiling() {
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+    agent.tool_orchestrator.overflow_config = zeph_tools::OverflowConfig {
+        threshold: 100,
+        retention_days: 7,
+        max_overflow_bytes: 0,
+        max_per_call_override: 500,
+    };
+
+    // Requested (999_999) is clamped to the ceiling (500). Output exactly at the ceiling
+    // must NOT be truncated, even though it is far above the 100-char global threshold.
+    let at_ceiling = "x".repeat(500);
+    let result = agent
+        .maybe_summarize_tool_output(&at_ceiling, Some(999_999))
+        .await;
+    assert_eq!(
+        result, at_ceiling,
+        "output at the clamped ceiling must pass through unchanged"
+    );
+
+    // One char beyond the ceiling must still truncate.
+    let beyond_ceiling = "x".repeat(501);
+    let result = agent
+        .maybe_summarize_tool_output(&beyond_ceiling, Some(999_999))
+        .await;
+    assert!(
+        result.contains("truncated"),
+        "output beyond the clamped ceiling must still truncate, got: {result}"
+    );
+}
+
+#[tokio::test]
+async fn override_ceiling_zero_disables_feature() {
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+    agent.tool_orchestrator.overflow_config = zeph_tools::OverflowConfig {
+        threshold: 100,
+        retention_days: 7,
+        max_overflow_bytes: 0,
+        max_per_call_override: 0,
+    };
+
+    // ceiling=0 -> threshold.max(requested.min(0)) == threshold, regardless of `requested`.
+    let mid = "x".repeat(150);
+    let result = agent.maybe_summarize_tool_output(&mid, Some(140)).await;
+    assert!(
+        result.contains("truncated"),
+        "max_per_call_override=0 must disable the override entirely, got: {result}"
+    );
+}
+
+#[tokio::test]
+async fn override_misconfigured_ceiling_below_threshold_stays_inert() {
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+    // Misconfiguration: ceiling (200) <= threshold (1000). The clamp floors at `threshold`
+    // regardless of the requested value, matching the M2 tracing::warn! condition in
+    // tool_orchestrator.rs.
+    agent.tool_orchestrator.overflow_config = zeph_tools::OverflowConfig {
+        threshold: 1000,
+        retention_days: 7,
+        max_overflow_bytes: 0,
+        max_per_call_override: 200,
+    };
+
+    // 300 chars: above the (inert) ceiling, but below the threshold that actually applies.
+    let output = "x".repeat(300);
+    let result = agent.maybe_summarize_tool_output(&output, Some(500)).await;
+    assert_eq!(
+        result, output,
+        "misconfigured override (ceiling <= threshold) must be safely inert, falling back \
+         to the threshold, got: {result}"
+    );
+}
+
+#[tokio::test]
+async fn none_override_exact_threshold_boundary_matches_pre_3079_behavior() {
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+    agent.tool_orchestrator.overflow_config = zeph_tools::OverflowConfig {
+        threshold: 200,
+        retention_days: 7,
+        max_overflow_bytes: 0,
+        max_per_call_override: 131_072,
+    };
+
+    // Regression guard: with no override, the effective limit must be exactly `threshold`
+    // (byte-identical to pre-#3079 behavior) — verified at both sides of the boundary.
+    let at_threshold = "x".repeat(200);
+    let result = agent.maybe_summarize_tool_output(&at_threshold, None).await;
+    assert_eq!(
+        result, at_threshold,
+        "output exactly at threshold with no override must pass through unchanged"
+    );
+
+    let over_threshold = "x".repeat(201);
+    let result = agent
+        .maybe_summarize_tool_output(&over_threshold, None)
+        .await;
+    assert_ne!(
+        result, over_threshold,
+        "output one char over threshold with no override must be truncated/processed"
+    );
 }
 
 #[tokio::test] // lgtm[rust/cleartext-logging]
@@ -223,11 +378,12 @@ async fn test_overflow_no_memory_backend_s3_fallback() {
         threshold: 100,
         retention_days: 7,
         max_overflow_bytes: 0,
+        max_per_call_override: 131_072,
     };
     // No memory backend set.
 
     let long = "x".repeat(200);
-    let result = agent.maybe_summarize_tool_output(&long).await;
+    let result = agent.maybe_summarize_tool_output(&long, None).await;
     assert!(
         result.contains("could not be saved — no memory backend or conversation available"),
         "S3 fallback message must appear when no memory backend, got: {result}"

--- a/crates/zeph-core/src/agent/tool_execution/mod.rs
+++ b/crates/zeph-core/src/agent/tool_execution/mod.rs
@@ -99,6 +99,10 @@ struct ToolResultClassification {
     /// of `classify_tool_result` — always empty for `Ok(None)`/`Err`, which mechanically
     /// satisfies FR-006 (error/partial results never carry media) by construction.
     media: Vec<zeph_llm::ImageData>,
+    /// Per-call result-size override propagated from the source `ToolOutput`
+    /// (`_meta["zeph/maxResultSizeChars"]`, see [`zeph_tools::ToolOutput::max_result_size_chars`]).
+    /// Empty/`Ok(None)`/`Err` arms leave this `None`, matching `media`.
+    max_result_size_chars: Option<usize>,
 }
 
 enum AnomalyOutcome {
@@ -261,8 +265,22 @@ impl<C: Channel> Agent<C> {
         skip_all,
         level = "debug"
     )]
-    pub(super) async fn maybe_summarize_tool_output(&self, output: &str) -> String {
-        let threshold = self.tool_orchestrator.overflow_config.threshold;
+    pub(super) async fn maybe_summarize_tool_output(
+        &self,
+        output: &str,
+        per_call_override: Option<usize>,
+    ) -> String {
+        let overflow_config = &self.tool_orchestrator.overflow_config;
+        // Server-requested size is clamped to the operator ceiling, then the effective
+        // limit is floored at the global default — a server can only raise its own
+        // call's limit, never lower it below `threshold`. Absent/malformed override
+        // (`None`) falls through to exactly `threshold`, matching prior behavior.
+        let threshold = match per_call_override {
+            Some(requested) => overflow_config
+                .threshold
+                .max(requested.min(overflow_config.max_per_call_override)),
+            None => overflow_config.threshold,
+        };
         if output.len() <= threshold {
             return output.to_string();
         }

--- a/crates/zeph-core/src/agent/tool_execution/tests/boundary_and_classifier_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/boundary_and_classifier_tests.rs
@@ -2186,3 +2186,200 @@ mod reasoning_amplification_call_site {
         assert_eq!(images_attached, 2);
     }
 }
+
+// --- #3079: per-tool MCP result-size override, end-to-end through process_one_tool_result ---
+//
+// These tests drive the real production path from a `ToolOutput` carrying
+// `max_result_size_chars` (as set by `zeph-mcp`'s `_meta["zeph/maxResultSizeChars"]`
+// extraction) through `classify_tool_result` -> `maybe_summarize_tool_output`, using an
+// explicit `OverflowConfig` (not the built-in defaults). This is the natural integration
+// point in `zeph-core`: the MCP wire protocol never reaches this crate directly, `zeph-mcp`
+// always hands off a typed `ToolOutput` first.
+//
+// Payload sizes are kept well under `zeph-sanitizer`'s own (unrelated) default
+// `ContentIsolationConfig::max_content_size` of 65_536 chars, which independently caps the
+// `<external-data>` wrapper applied to MCP-sourced (`':'`-qualified) tool names — a payload
+// above that cap gets silently re-truncated by the sanitizer after `maybe_summarize_tool_output`
+// runs, which would mask (not reflect) the behavior these tests exist to verify.
+mod per_call_result_size_override_tests {
+    use crate::agent::agent_tests::{
+        MockChannel, MockToolExecutor, create_test_registry, mock_provider,
+    };
+    use zeph_llm::provider::MessagePart;
+    use zeph_tools::OverflowConfig;
+    use zeph_tools::executor::ToolOutput;
+
+    use super::make_tool_use_request;
+
+    fn tool_result_content(parts: &[MessagePart]) -> &str {
+        parts
+            .iter()
+            .find_map(|p| match p {
+                MessagePart::ToolResult { content, .. } => Some(content.as_str()),
+                _ => None,
+            })
+            .expect("expected a ToolResult message part")
+    }
+
+    fn make_agent_with_overflow_config(
+        overflow_config: OverflowConfig,
+    ) -> crate::agent::Agent<MockChannel> {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let mut agent = crate::agent::Agent::new(
+            provider,
+            channel,
+            registry,
+            None,
+            5,
+            MockToolExecutor::no_tools(),
+        );
+        agent.tool_orchestrator.overflow_config = overflow_config;
+        agent
+    }
+
+    #[tokio::test]
+    async fn override_within_ceiling_avoids_global_threshold_truncation() {
+        // threshold=5_000, ceiling=20_000. 10_000-char output is above the threshold but
+        // within a 15_000 per-call override (itself within the ceiling) — must NOT truncate.
+        let mut agent = make_agent_with_overflow_config(OverflowConfig {
+            threshold: 5_000,
+            retention_days: 7,
+            max_overflow_bytes: 0,
+            max_per_call_override: 20_000,
+        });
+
+        let long_output = "x".repeat(10_000);
+        let tc = make_tool_use_request("id-ovr-within", "srv:big_tool");
+        let mut result_parts = Vec::new();
+        agent
+            .process_one_tool_result(
+                &tc,
+                "id-ovr-within",
+                &std::time::Instant::now(),
+                Ok(Some(ToolOutput {
+                    tool_name: "srv:big_tool".into(),
+                    summary: long_output.clone(),
+                    max_result_size_chars: Some(15_000),
+                    ..Default::default()
+                })),
+                &mut result_parts,
+                &mut Vec::new(),
+                &mut false,
+                &mut None,
+                &mut Vec::new(),
+                &mut 0,
+            )
+            .await
+            .unwrap();
+
+        let content = tool_result_content(&result_parts);
+        assert!(
+            !content.contains("truncated"),
+            "10K output with a 15K per-call override (under the 20K ceiling) must not be \
+             truncated at the 5K global threshold, got: {}",
+            &content[..content.len().min(300)]
+        );
+        assert!(
+            content.contains(&long_output),
+            "full output must be present unchanged, not just a fragment"
+        );
+    }
+
+    #[tokio::test]
+    async fn override_above_ceiling_clamps_to_ceiling_not_unbounded() {
+        // threshold=5_000, ceiling=20_000. A requested override of 999_999 (far above the
+        // ceiling) must clamp to 20_000 and still truncate a 25_000-char output, proving a
+        // hostile or misbehaving server cannot request an unbounded window (security
+        // invariant).
+        let mut agent = make_agent_with_overflow_config(OverflowConfig {
+            threshold: 5_000,
+            retention_days: 7,
+            max_overflow_bytes: 0,
+            max_per_call_override: 20_000,
+        });
+
+        let long_output = "x".repeat(25_000);
+        let tc = make_tool_use_request("id-ovr-above", "srv:big_tool");
+        let mut result_parts = Vec::new();
+        agent
+            .process_one_tool_result(
+                &tc,
+                "id-ovr-above",
+                &std::time::Instant::now(),
+                Ok(Some(ToolOutput {
+                    tool_name: "srv:big_tool".into(),
+                    summary: long_output.clone(),
+                    max_result_size_chars: Some(999_999),
+                    ..Default::default()
+                })),
+                &mut result_parts,
+                &mut Vec::new(),
+                &mut false,
+                &mut None,
+                &mut Vec::new(),
+                &mut 0,
+            )
+            .await
+            .unwrap();
+
+        let content = tool_result_content(&result_parts);
+        assert!(
+            content.contains("truncated"),
+            "a requested override (999_999) above the operator ceiling (20K) must still be \
+             clamped and truncated, not honored unbounded, got: {}",
+            &content[..content.len().min(300)]
+        );
+        assert!(
+            !content.contains(&long_output),
+            "the full untruncated 25K output must not appear verbatim in the result"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_override_same_size_output_still_truncates_at_global_threshold() {
+        // Negative control / regression guard: the exact same 10K output as the first test,
+        // same OverflowConfig, but with no per-call override (None) — must truncate at the
+        // 5K global threshold, proving the tests above are actually exercising the override,
+        // not some other unrelated behavior change.
+        let mut agent = make_agent_with_overflow_config(OverflowConfig {
+            threshold: 5_000,
+            retention_days: 7,
+            max_overflow_bytes: 0,
+            max_per_call_override: 20_000,
+        });
+
+        let long_output = "x".repeat(10_000);
+        let tc = make_tool_use_request("id-no-ovr", "srv:big_tool");
+        let mut result_parts = Vec::new();
+        agent
+            .process_one_tool_result(
+                &tc,
+                "id-no-ovr",
+                &std::time::Instant::now(),
+                Ok(Some(ToolOutput {
+                    tool_name: "srv:big_tool".into(),
+                    summary: long_output.clone(),
+                    max_result_size_chars: None,
+                    ..Default::default()
+                })),
+                &mut result_parts,
+                &mut Vec::new(),
+                &mut false,
+                &mut None,
+                &mut Vec::new(),
+                &mut 0,
+            )
+            .await
+            .unwrap();
+
+        let content = tool_result_content(&result_parts);
+        assert!(
+            content.contains("truncated"),
+            "without a per-call override, 10K output must still truncate at the 5K global \
+             threshold (byte-identical to pre-#3079 behavior), got: {}",
+            &content[..content.len().min(300)]
+        );
+    }
+}

--- a/crates/zeph-core/src/agent/tool_execution/tool_result.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tool_result.rs
@@ -297,6 +297,7 @@ impl<C: Channel> Agent<C> {
                     is_quality_failure: false,
                     tool_err_category: None,
                     media: out.media,
+                    max_result_size_chars: out.max_result_size_chars,
                 }
             }
             Ok(None) => ToolResultClassification {
@@ -310,6 +311,7 @@ impl<C: Channel> Agent<C> {
                 is_quality_failure: false,
                 tool_err_category: None,
                 media: Vec::new(),
+                max_result_size_chars: None,
             },
             Err(ref e) => {
                 let category = e.category();
@@ -356,6 +358,7 @@ impl<C: Channel> Agent<C> {
                     is_quality_failure,
                     tool_err_category: Some(category),
                     media: Vec::new(),
+                    max_result_size_chars: None,
                 }
             }
         }
@@ -393,6 +396,7 @@ impl<C: Channel> Agent<C> {
             is_quality_failure,
             mut tool_err_category,
             media,
+            max_result_size_chars,
         } = self.classify_tool_result(tc, tool_result);
 
         self.record_tool_execution_telemetry(tc.name.as_str(), started_at, is_error, &output);
@@ -411,7 +415,8 @@ impl<C: Channel> Agent<C> {
         let processed = if tc.name == OverflowToolExecutor::TOOL_NAME {
             output.clone()
         } else {
-            self.maybe_summarize_tool_output(&output).await
+            self.maybe_summarize_tool_output(&output, max_result_size_chars)
+                .await
         };
         let body = if let Some(ref stats) = inline_stats {
             format!("{stats}\n{processed}")
@@ -761,7 +766,9 @@ impl<C: Channel> Agent<C> {
             };
             d.dump_tool_output(output.tool_name.as_str(), &dump_content);
         }
-        let processed = self.maybe_summarize_tool_output(&output.summary).await;
+        let processed = self
+            .maybe_summarize_tool_output(&output.summary, output.max_result_size_chars)
+            .await;
         let body = if let Some(ref fs) = output.filter_stats
             && fs.filtered_chars < fs.raw_chars
         {
@@ -859,7 +866,9 @@ impl<C: Channel> Agent<C> {
                     };
                     d.dump_tool_output(out.tool_name.as_str(), &dump_content);
                 }
-                let processed = self.maybe_summarize_tool_output(&out.summary).await;
+                let processed = self
+                    .maybe_summarize_tool_output(&out.summary, out.max_result_size_chars)
+                    .await;
                 let formatted = format_tool_output(out.tool_name.as_str(), &processed);
                 self.channel
                     .send_tool_output(ToolOutputEvent {

--- a/crates/zeph-core/src/agent/tool_orchestrator.rs
+++ b/crates/zeph-core/src/agent/tool_orchestrator.rs
@@ -164,6 +164,16 @@ impl ToolOrchestrator {
         self.recent_tool_calls = VecDeque::with_capacity(2 * tool_repeat_threshold.max(1));
         self.max_tool_calls_per_session = max_tool_calls_per_session;
         self.summarize_tool_output_enabled = tool_summarization;
+        if overflow_config.max_per_call_override > 0
+            && overflow_config.max_per_call_override <= overflow_config.threshold
+        {
+            tracing::warn!(
+                max_per_call_override = overflow_config.max_per_call_override,
+                threshold = overflow_config.threshold,
+                "tools.overflow.max_per_call_override <= threshold: per-call MCP result-size \
+                 override is disabled, _meta[\"zeph/maxResultSizeChars\"] hints will have no effect"
+            );
+        }
         self.overflow_config = overflow_config;
     }
 
@@ -370,6 +380,105 @@ mod tests {
         assert_eq!(o.repeat_threshold, 2);
         assert_eq!(o.max_tool_retries, 2);
         assert_eq!(o.max_retry_duration_secs, 30);
+    }
+
+    // ── #3079 M2: apply_config misconfiguration warning ─────────────────────────
+    //
+    // `max_per_call_override > 0 && max_per_call_override <= threshold` means the per-call
+    // override is silently inert (the clamp in `maybe_summarize_tool_output` always floors
+    // at `threshold`) — apply_config must warn so an operator notices the misconfiguration.
+    // `max_per_call_override == 0` is the deliberate explicit-disable value and must NOT warn.
+
+    fn apply_overflow_config(o: &mut ToolOrchestrator, overflow_config: OverflowConfig) {
+        o.apply_config(
+            10,
+            2,
+            30,
+            500,
+            5_000,
+            String::new(),
+            2,
+            None,
+            false,
+            overflow_config,
+        );
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn apply_config_warns_when_ceiling_below_threshold() {
+        let mut o = ToolOrchestrator::new();
+        apply_overflow_config(
+            &mut o,
+            OverflowConfig {
+                threshold: 1000,
+                retention_days: 7,
+                max_overflow_bytes: 0,
+                max_per_call_override: 500,
+            },
+        );
+        assert!(
+            logs_contain("max_per_call_override <= threshold"),
+            "ceiling (500) below threshold (1000) must emit the misconfiguration warning"
+        );
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn apply_config_warns_at_exact_boundary_ceiling_equals_threshold() {
+        let mut o = ToolOrchestrator::new();
+        apply_overflow_config(
+            &mut o,
+            OverflowConfig {
+                threshold: 1000,
+                retention_days: 7,
+                max_overflow_bytes: 0,
+                max_per_call_override: 1000,
+            },
+        );
+        assert!(
+            logs_contain("max_per_call_override <= threshold"),
+            "ceiling == threshold is still the inert boundary case and must warn"
+        );
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn apply_config_no_warn_when_ceiling_explicitly_disabled_zero() {
+        let mut o = ToolOrchestrator::new();
+        apply_overflow_config(
+            &mut o,
+            OverflowConfig {
+                threshold: 1000,
+                retention_days: 7,
+                max_overflow_bytes: 0,
+                max_per_call_override: 0,
+            },
+        );
+        assert!(
+            !logs_contain("max_per_call_override <= threshold"),
+            "ceiling=0 is the deliberate explicit-disable value, not a misconfiguration — \
+             must not warn"
+        );
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn apply_config_no_warn_when_ceiling_above_threshold() {
+        let mut o = ToolOrchestrator::new();
+        apply_overflow_config(
+            &mut o,
+            OverflowConfig {
+                threshold: 1000,
+                retention_days: 7,
+                max_overflow_bytes: 0,
+                max_per_call_override: 131_072,
+            },
+        );
+        assert!(
+            !logs_contain("max_per_call_override <= threshold"),
+            "a correctly configured ceiling above the threshold must not warn"
+        );
     }
 
     #[test]

--- a/crates/zeph-mcp/src/executor.rs
+++ b/crates/zeph-mcp/src/executor.rs
@@ -361,6 +361,16 @@ impl ToolExecutor for McpToolExecutor {
             .collect_media(&tool.server_id, &tool.name, &result.content)
             .await;
 
+        // Fail-closed: any malformed value (wrong type, negative, non-integer, or a
+        // magnitude that doesn't fit `usize`) yields `None`, which downstream means
+        // "use the global threshold" — never "unlimited".
+        let max_result_size_chars = result
+            .meta
+            .as_ref()
+            .and_then(|meta| meta.0.get("zeph/maxResultSizeChars"))
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|n| usize::try_from(n).ok());
+
         Ok(Some(ToolOutput {
             tool_name: tool.qualified_name().into(),
             summary: text,
@@ -373,6 +383,7 @@ impl ToolExecutor for McpToolExecutor {
             raw_response: None,
             claim_source: Some(zeph_tools::ClaimSource::Mcp),
             media,
+            max_result_size_chars,
         }))
     }
 
@@ -1009,5 +1020,110 @@ mod tests {
                 .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-'),
             "id contains invalid chars: {id}"
         );
+    }
+
+    // --- #3079: fail-closed `_meta["zeph/maxResultSizeChars"]` parsing ---
+    //
+    // `execute_tool_call` (line ~333) cannot be unit-tested end-to-end without a live,
+    // connected `McpClient` — `self.manager.call_tool()` requires an entry in
+    // `McpManager`'s private `clients` map, which is only populated by the real
+    // connect path or by `commit_added_server` (`pub(super)` to the `manager` module,
+    // not reachable from here). `extract_max_result_size_chars` below is a byte-for-byte
+    // copy of the extraction expression at executor.rs:333-338, so these tests verify the
+    // parsing *formula* against the real `rmcp::model::Meta`/`serde_json::Value` types, not
+    // the literal call site. See the #3079 tester handoff for the concrete follow-up needed
+    // to close this gap (extend `client.rs`'s `DuplexTestServer` harness to emit `_meta`,
+    // and route it through `McpManager`/`McpToolExecutor`).
+    mod meta_max_result_size_chars_parsing {
+        use rmcp::model::Meta;
+        use serde_json::Value;
+
+        /// Mirrors executor.rs:333-338 exactly.
+        fn extract_max_result_size_chars(meta: Option<&Meta>) -> Option<usize> {
+            meta.and_then(|m| m.0.get("zeph/maxResultSizeChars"))
+                .and_then(Value::as_u64)
+                .and_then(|n| usize::try_from(n).ok())
+        }
+
+        fn meta_with(key: &str, value: Value) -> Meta {
+            let mut map = serde_json::Map::new();
+            map.insert(key.to_owned(), value);
+            Meta(map)
+        }
+
+        #[test]
+        fn valid_value_parses() {
+            let meta = meta_with("zeph/maxResultSizeChars", serde_json::json!(100_000));
+            assert_eq!(extract_max_result_size_chars(Some(&meta)), Some(100_000));
+        }
+
+        #[test]
+        fn zero_value_parses_to_some_zero() {
+            // Not fail-closed at this layer — 0 is a syntactically valid usize. The clamp
+            // formula in `tool_execution/mod.rs` is what degrades `requested=0` to the
+            // global threshold; that behavior is covered by
+            // `metrics_summary_tests::override_requested_zero_degrades_to_threshold`.
+            let meta = meta_with("zeph/maxResultSizeChars", serde_json::json!(0));
+            assert_eq!(extract_max_result_size_chars(Some(&meta)), Some(0));
+        }
+
+        #[test]
+        fn no_meta_at_all_is_none() {
+            assert_eq!(extract_max_result_size_chars(None), None);
+        }
+
+        #[test]
+        fn meta_present_key_missing_is_none() {
+            let meta = meta_with("some/otherKey", serde_json::json!(1));
+            assert_eq!(extract_max_result_size_chars(Some(&meta)), None);
+        }
+
+        #[test]
+        fn string_value_is_none() {
+            let meta = meta_with("zeph/maxResultSizeChars", serde_json::json!("100000"));
+            assert_eq!(extract_max_result_size_chars(Some(&meta)), None);
+        }
+
+        #[test]
+        fn negative_value_is_none() {
+            let meta = meta_with("zeph/maxResultSizeChars", serde_json::json!(-5));
+            assert_eq!(extract_max_result_size_chars(Some(&meta)), None);
+        }
+
+        #[test]
+        fn float_value_is_none() {
+            let meta = meta_with("zeph/maxResultSizeChars", serde_json::json!(100.5));
+            assert_eq!(extract_max_result_size_chars(Some(&meta)), None);
+        }
+
+        #[test]
+        fn bool_value_is_none() {
+            let meta = meta_with("zeph/maxResultSizeChars", serde_json::json!(true));
+            assert_eq!(extract_max_result_size_chars(Some(&meta)), None);
+        }
+
+        #[test]
+        fn null_value_is_none() {
+            let meta = meta_with("zeph/maxResultSizeChars", serde_json::Value::Null);
+            assert_eq!(extract_max_result_size_chars(Some(&meta)), None);
+        }
+
+        #[test]
+        fn array_value_is_none() {
+            let meta = meta_with("zeph/maxResultSizeChars", serde_json::json!([1, 2, 3]));
+            assert_eq!(extract_max_result_size_chars(Some(&meta)), None);
+        }
+
+        #[test]
+        fn number_beyond_u64_range_is_none() {
+            // Without serde_json's `arbitrary_precision` feature, an integer literal that
+            // overflows u64 is deserialized as f64, so `as_u64()` returns `None` — fails
+            // closed via the first `and_then`, not `usize::try_from`. The `usize::try_from`
+            // failure branch is only reachable on 32-bit targets (where usize < u64); on
+            // this (64-bit) platform this is the practically-reachable overflow path.
+            let huge: Value = serde_json::from_str("99999999999999999999999999999999").unwrap();
+            let meta = meta_with("zeph/maxResultSizeChars", huge);
+            assert_eq!(extract_max_result_size_chars(Some(&meta)), None);
+        }
     }
 }

--- a/crates/zeph-tools/src/executor.rs
+++ b/crates/zeph-tools/src/executor.rs
@@ -284,6 +284,11 @@ pub struct ToolOutput {
     /// Validated image data carried across the tool boundary (e.g. MCP `ContentBlock::Image`
     /// passthrough, spec-072). Empty for executors that don't produce media.
     pub media: Vec<zeph_llm::ImageData>,
+    /// Per-call result-size override (chars) requested by an MCP server via
+    /// `_meta["zeph/maxResultSizeChars"]`. Clamped by `[tools.overflow].max_per_call_override`
+    /// at truncation time. `None` for executors that don't emit the hint, or when the
+    /// server-provided value was malformed (fail-closed to the global threshold).
+    pub max_result_size_chars: Option<usize>,
 }
 
 impl fmt::Display for ToolOutput {


### PR DESCRIPTION
## Summary

- MCP servers can now request a larger truncation limit for a single tool result via `_meta["zeph/maxResultSizeChars"]`, mirroring Claude Code's `_meta["anthropic/maxResultSizeChars"]` pattern.
- The requested size is clamped server-side to a new operator-configured ceiling, `[tools.overflow].max_per_call_override` (default 131072 = 128 KiB) — the MCP server can never exceed this ceiling and can only raise the effective limit above the existing global `threshold`, never lower it.
- Absent or malformed `_meta` values fall back to exactly the prior global-threshold behavior (fail-closed, zero regression for servers that don't opt in).
- `max_per_call_override = 0` disables the feature entirely and logs a `tracing::warn!` if misconfigured (`0 < max_per_call_override <= threshold`).
- Includes a config migration (step 89, `migrate_overflow_max_per_call_override`) so existing on-disk configs surface the new key via `--migrate-config`.

Closes #3079

## Design

Full architecture review chain: architect → critic (approved) → developer → tester/perf/security/impl-critic (parallel validation) → code review (2 rounds). See `.local/handoff/` in this branch's history for the complete design and audit trail.

Notable findings resolved during review:
- Config migration step (CLAUDE.md Dev-Rule #5) was initially skipped, then added per impl-critic finding.
- Root `config/default.toml` was initially missed (only `crates/zeph-core/config/default.toml` got the new key) — caught by code review, fixed.
- Security audit confirmed no bypass path for the clamp, no integer overflow, and that `zeph-sanitizer`'s independent `max_content_size` (64 KiB default) further bounds the real effective ceiling below the documented 128 KiB.

## Test plan

- [x] 24 new unit/integration tests: clamp formula edge cases, fail-closed `_meta` parsing (missing/non-numeric/negative/float/bool/overflow), M2 misconfiguration warning, E2E `ToolOutput` → `process_one_tool_result` path
- [x] Migration step-89 tests: adds-when-absent, noop-when-present, idempotent
- [x] Full targeted workspace test run: 4805/4805 pass
- [x] Full CI-matching check suite (fmt, clippy `--profile ci`, nextest full workspace, rustdoc gate, gitleaks) — clean
- [x] `.local/testing/playbooks/mcp.md` updated with 4 new scenarios (valid override, above-ceiling clamp, malformed/missing fallback, disabled-via-zero)
- [x] `.local/testing/coverage-status.md` row added (Status: Untested — pending live-session verification)