### PR TITLE
fix(ci): gate ci-status on detect-changes result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -687,13 +687,14 @@ jobs:
   ci-status:
     name: CI Status
     if: always()
-    needs: [cla, lint-shellcheck, lint-fmt, lint-clippy, msrv, build-tests, build-tests-postgres, test, integration, coverage, docker-build-and-scan, bundle-check, validate-specs, build-postgres, rustdoc, release-build, release-build-full]
+    needs: [detect-changes, cla, lint-shellcheck, lint-fmt, lint-clippy, msrv, build-tests, build-tests-postgres, test, integration, coverage, docker-build-and-scan, bundle-check, validate-specs, build-postgres, rustdoc, release-build, release-build-full]
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
       - name: Check all jobs
         run: |
           results=(
+            "${{ needs.detect-changes.result }}"
             "${{ needs.cla.result }}"
             "${{ needs.lint-shellcheck.result }}"
             "${{ needs.lint-fmt.result }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `.github/workflows/ci.yml`: the `ci-status` gate job did not depend on `detect-changes`
+  and never checked its `result`. GitHub Actions marks every job with
+  `needs: detect-changes` as `skipped` (not `failure`) when `detect-changes` itself fails,
+  and `ci-status`'s check loop already treated `skipped` as an acceptable result — so a
+  hard failure in `detect-changes` (e.g. the `dorny/paths-filter` action erroring) cascaded
+  into an all-`skipped` downstream that `ci-status` reported as "All jobs passed",
+  incorrectly marking the PR mergeable. `detect-changes` is now included in `ci-status`'s
+  `needs` array and `results` check.
 - `zeph-core`: `cached_prompt_tokens` was never recomputed after `rebuild_system_prompt`
   rewrote `messages[0]` with the real, per-turn-filtered system prompt, leaving the counter
   pinned at whatever value it held before the rebuild — on turn 0 this was the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   which Renovate had bumped past the version `ollama-rs` actually depends on, breaking the
   `rustls-tls` feature name in the process.
 
+- **zeph-llm**: fixed a `full`/`postgres`-only build breakage from the same `rust-minor-patch`
+  bundle (#6324) that the fix above missed — the `gonka` feature (pulled in only by the
+  `full`/`bench` bundles and the postgres workspace check, not the default CI feature set) was
+  never exercised locally before that PR merged. `k256`'s `elliptic-curve` bump to 0.14
+  deprecated `ToEncodedPoint` in favor of `ToSec1Point`, and `build.warnings` denies the
+  resulting deprecation warning; `crates/zeph-llm/src/gonka/signer.rs` now imports and calls
+  `ToSec1Point`/`to_sec1_point` instead.
+
 ### Testing
 
 - **zeph-orchestration** / **zeph-subagent**: closed three coverage gaps in the idle-timeout

--- a/crates/zeph-llm/src/gonka/signer.rs
+++ b/crates/zeph-llm/src/gonka/signer.rs
@@ -27,7 +27,7 @@
 
 use base64::Engine as _;
 use k256::ecdsa::signature::hazmat::PrehashSigner as _;
-use k256::elliptic_curve::sec1::ToEncodedPoint as _;
+use k256::elliptic_curve::sec1::ToSec1Point as _;
 use ripemd::Digest as _;
 use zeroize::Zeroizing;
 
@@ -149,7 +149,7 @@ impl RequestSigner {
 fn derive_address(pubkey: &k256::PublicKey, chain_prefix: &str) -> String {
     use bech32::{Bech32, Hrp};
 
-    let compressed = pubkey.to_encoded_point(true);
+    let compressed = pubkey.to_sec1_point(true);
     let sha_hash = sha2::Sha256::digest(compressed.as_bytes());
     let sha_bytes: &[u8] = &sha_hash[..];
     let ripe_hash = ripemd::Ripemd160::digest(sha_bytes);


### PR DESCRIPTION
## Summary

- `ci-status`, the final required merge-gate job, never listed `detect-changes` in its `needs:` and never checked its result.
- Every substantive job depends on `detect-changes`, so a failure in `detect-changes` cascades to `skipped` on all of them via GitHub Actions' default dependency-skip behavior.
- `ci-status` already treats `skipped` as an acceptable result, so a hard failure in `detect-changes` produced an all-`skipped` downstream that was reported as passing — PRs could merge with no CI having actually run.
- Fix adds `detect-changes` to `ci-status`'s `needs:` array and its result to the checked `results` array. `detect-changes` has no `if:` of its own, so it can only resolve to `success`/`failure`/`cancelled` — both failure modes are already correctly rejected by the existing success-or-skipped check, no further special-casing needed.

## Test plan

- [x] `fy lint .github/workflows/ci.yml` — no new errors
- [x] `actionlint` — clean
- [x] `gitleaks protect --staged` — no leaks
- [ ] CI run on this PR itself exercises the updated `ci-status` job end-to-end