### PR TITLE
build(docker): bump rust base image to 1.97.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **build(docker): bump `docker/Dockerfile.dev` builder base image from `rust:1.96-slim`
+  to `rust:1.97.1-slim`**, re-pinned to the resolved digest for the new tag. Consistent
+  with the workspace's declared `rust-version = "1.97"` MSRV in `Cargo.toml`; the
+  production `docker/Dockerfile` is unaffected since it copies a prebuilt binary onto
+  `distroless/static-debian12` rather than building from a `rust:*` image.
+
 - `zeph-experiments`: `ParameterKind::as_str`, `ParameterKind::is_integer`,
   `ConfigSnapshot::get`, and `ConfigSnapshot::set` are now exhaustive matches over
   every current variant instead of relying on a wildcard arm (`_ => "unknown"` /

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM rust:1.96-slim@sha256:31ee7fc65186be7e0e0ccb3f2ca305f14e4739e7642a1ae65753aa5d7b874523 AS builder
+FROM rust:1.97.1-slim@sha256:754a8924e308fb20a327febeda1a07053a2b0fd7474b5ac1cc460a6d33ab18f3 AS builder
 
 ARG CARGO_FEATURES=""
 


### PR DESCRIPTION
## Summary
- Bump `docker/Dockerfile.dev` builder base image from `rust:1.96-slim` to `rust:1.97.1-slim`, re-pinned to the resolved digest for the new tag.
- Consistent with the workspace's declared `rust-version = "1.97"` MSRV in `Cargo.toml`.
- Production `docker/Dockerfile` is unaffected — it copies a prebuilt binary onto `distroless/static-debian12` rather than building from a `rust:*` image.

## Test plan
- [x] Resolved the digest via `docker pull rust:1.97.1-slim` + `docker inspect`, cross-checked (not guessed/reused from old tag)
- [x] Swept `docker/*.yml` and `.github/workflows/*.yml` for other hardcoded Rust version references — none found
- [x] `docker build -f docker/Dockerfile.dev --target builder .` — toolchain resolved to `1.97.1`, full workspace compiled successfully (final release-binary LTO link step hit a local Docker Desktop VM memory limit, unrelated to the version bump)