### PR TITLE
fix(orchestration): raise verifier_timeout_secs default to 120s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   call fail dependency resolution (`hf-hub` does not have that feature`), breaking clippy,
   nextest archiving, rustdoc, and bundle-check CI jobs regardless of whether the `candle`
   feature was actually enabled for a given job.
+- `zeph-config`: `orchestration.verifier_timeout_secs` default raised from 30s to 120s
+  (#6366). `PlanVerifier::verify()`'s LLM call to a local Ollama `verify_provider` in the
+  20B+ parameter range (e.g. `gemma4:26b` — the same model class the #6278/#6287 grounding
+  fix's own playbook recommends for reproduction) commonly needs 60-120s, so the previous
+  30s default reliably timed out, hit the existing fail-open path, and marked the task
+  `Completed` without ever calling `ground()` — silently skipping the entire tool-call
+  grounding safety net in exactly the deployment shape it was built for. `config/default.toml`
+  and the field's doc comment now document the 20B+ local-model timeout requirement.
 - `.github/workflows/ci.yml`: the `ci-status` gate job did not depend on `detect-changes`
   and never checked its `result`. GitHub Actions marks every job with
   `needs: detect-changes` as `skipped` (not `failure`) when `detect-changes` itself fails,

--- a/config/default.toml
+++ b/config/default.toml
@@ -1176,8 +1176,11 @@ verify_completeness = false
 # aggregator_timeout_secs = 60
 # Timeout in seconds for planner LLM calls (0 rejected by validation). Default: 120.
 # planner_timeout_secs = 120
-# Timeout in seconds for verifier LLM calls (0 rejected by validation). Default: 30.
-# verifier_timeout_secs = 30
+# Timeout in seconds for verifier LLM calls (0 rejected by validation). Default: 120.
+# Local Ollama models in the 20B+ range (e.g. gemma4:26b) commonly need 60-120s; a low
+# timeout here causes fail-open on essentially every verification and silently skips the
+# tool-call grounding safety net (spec 009, #6278/#6287) — see #6366.
+# verifier_timeout_secs = 120
 
 # ORCH-style deterministic verifier ensemble-merge (arXiv:2602.01797), opt-in, default off.
 # See specs/073-orch-ensemble-merge/spec.md.

--- a/crates/zeph-config/src/experiment.rs
+++ b/crates/zeph-config/src/experiment.rs
@@ -181,7 +181,7 @@ fn default_planner_timeout_secs() -> u64 {
 }
 
 fn default_verifier_timeout_secs() -> u64 {
-    30
+    120
 }
 
 fn default_ensemble_ema_alpha() -> f64 {
@@ -520,10 +520,14 @@ pub struct OrchestrationConfig {
     #[serde(default = "default_planner_timeout_secs")]
     pub planner_timeout_secs: u64,
 
-    /// Timeout in seconds for verifier LLM calls (per-task and whole-plan). Default: 30.
+    /// Timeout in seconds for verifier LLM calls (per-task and whole-plan). Default: 120.
     ///
-    /// On timeout the verifier returns a fail-open result (`complete = true`, no gaps).
-    /// Matches the existing `predicate_timeout_secs` default.
+    /// On timeout the verifier returns a fail-open result (`complete = true`, no gaps) and
+    /// `ground()` is never called, so the entire tool-call grounding safety net (spec 009,
+    /// #6278/#6287) silently never runs for that verification. Local Ollama models in the
+    /// 20B+ parameter range (e.g. `gemma4:26b`) commonly take 60-120s to respond, so a low
+    /// timeout here causes fail-open to trigger on essentially every verification when
+    /// `verify_provider` targets such a model — see #6366.
     /// Set to `0` is rejected by `Config::validate()`.
     #[serde(default = "default_verifier_timeout_secs")]
     pub verifier_timeout_secs: u64,
@@ -961,5 +965,12 @@ mod tests {
         let toml_in = "enabled = true\n";
         let cfg: OrchestrationConfig = toml::from_str(toml_in).expect("deserialize");
         assert_eq!(cfg.default_idle_timeout_secs, None);
+    }
+
+    #[test]
+    fn orchestration_config_default_verifier_timeout_secs_is_120() {
+        // #6366: the previous 30s default reliably timed out PlanVerifier::verify() against
+        // 20B+ local Ollama models, causing fail-open to silently skip ground().
+        assert_eq!(OrchestrationConfig::default().verifier_timeout_secs, 120);
     }
 }


### PR DESCRIPTION
## Summary
- `orchestration.verifier_timeout_secs` defaulted to 30s, which reliably timed out `PlanVerifier::verify()`'s LLM call against local 20B+ Ollama models (e.g. `gemma4:26b`, the model class the #6278/#6287 grounding fix's own playbook recommends for reproduction)
- Each timeout hit the existing fail-open path, marking the task `Completed` without ever calling `ground()` — silently defeating the tool-call grounding safety net in exactly the deployment shape it was built for
- Raised the default to 120s and documented the 60-120s local-model timeout requirement in the doc comment and `config/default.toml`

Closes #6366

## Test plan
- [x] `cargo nextest run -p zeph-config -p zeph-orchestration --features llm-planning` — 1383/1383 passed
- [x] Added regression test `orchestration_config_default_verifier_timeout_secs_is_120` asserting the new default
- [x] Full CI-matching gate: `cargo +nightly fmt --check`, `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`, `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (13968 passed), rustdoc gate, `gitleaks protect --staged` — all clean
- [x] Updated `CHANGELOG.md` and `config/default.toml`