### PR TITLE
fix(core): wire dump_tool_output into production tool-result path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-core`: `DebugDumper::dump_tool_output` — the per-tool-call raw dump written before
+  truncation/summarization, with `scrub_content`/`redact_binary_blobs` redaction applied
+  (#6315) — had no reachable production call site; the only callers were `#[cfg(test)]`-gated
+  legacy functions (`process_successful_tool_output`, `handle_confirmation_required`) that are
+  no longer part of the real tool-result path (#6364). `process_one_tool_result`
+  (`tool_execution/tool_result.rs`) now calls `dump_tool_output` for every non-error result,
+  after classification but before `maybe_summarize_tool_output` truncates or summarizes it, so
+  debug dumps capture a blob that would otherwise be summarized away before it ever reaches
+  message history. Since `handle_confirmation_phase` resolves confirmation-required tool calls
+  into the same `tool_results` batch that `process_one_tool_result` processes, the
+  confirmation-required path is covered by the same call site with no extra wiring needed. The
+  legacy `#[cfg(test)]`-only functions remain test-only scaffolding (retained to exercise
+  `sanitize_tool_output`/`maybe_summarize_tool_output` via a simpler single-call harness) and
+  are now documented as such.
 - `zeph-llm` (`candle` feature): migrated off `hf-hub` 0.5's `api::sync::{Api, ApiBuilder}` to
   the 1.0 API (`HFClient`/`HFClientSync`, `split_id`, `.model(owner, name).download_file()
   .filename(...).send()`) across all seven `HuggingFace` Hub download call sites

--- a/crates/zeph-core/src/agent/tool_execution/tests/dump_raw_tool_output_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/dump_raw_tool_output_tests.rs
@@ -1,0 +1,353 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Regression coverage for #6364: `DebugDumper::dump_tool_output` had no reachable production
+//! call site — the only callers were `#[cfg(test)]`-gated legacy functions. These tests drive
+//! the real `process_one_tool_result` path (not `DebugDumper::dump_tool_output` in isolation)
+//! and assert a dump file is actually written to disk, which is the exact defect class the fix
+//! (`dump_raw_tool_output`, `tool_result.rs`) closes. Reverting that call site makes
+//! `process_one_tool_result_writes_raw_dump_file_on_success` fail.
+
+use std::path::Path;
+use std::time::Duration;
+
+use zeph_llm::provider::MessagePart;
+use zeph_sanitizer::pii::{PiiFilter, PiiFilterConfig};
+use zeph_tools::OverflowConfig;
+use zeph_tools::executor::{ToolError, ToolOutput};
+
+use crate::agent::agent_tests::{
+    MockChannel, MockToolExecutor, create_test_registry, mock_provider,
+};
+use crate::debug_dump::{DebugDumper, DumpFormat};
+
+fn make_tool_use_request(id: &str, name: &str) -> zeph_llm::provider::ToolUseRequest {
+    zeph_llm::provider::ToolUseRequest {
+        id: id.into(),
+        name: name.into(),
+        input: serde_json::json!({"command": "echo test"}),
+    }
+}
+
+fn make_agent_with_dumper(dumper: DebugDumper) -> crate::agent::Agent<MockChannel> {
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let mut agent = crate::agent::Agent::new(
+        provider,
+        channel,
+        registry,
+        None,
+        5,
+        MockToolExecutor::no_tools(),
+    );
+    agent.runtime.debug.debug_dumper = Some(dumper);
+    agent
+}
+
+/// Polls the dumper's timestamped session subdirectory for `filename`, up to ~1s — writes go
+/// through `DebugDumper::write`'s `spawn_blocking` fire-and-forget task, so they are not
+/// necessarily on disk the instant `process_one_tool_result` returns. Mirrors the
+/// `read_dump_file` helper in `debug_dump::tests`.
+async fn wait_for_dump_file(base_dir: &Path, filename: &str) -> Option<String> {
+    let session = std::fs::read_dir(base_dir).ok()?.next()?.ok()?.path();
+    let path = session.join(filename);
+    for _ in 0..200 {
+        if let Ok(content) = std::fs::read_to_string(&path)
+            && !content.is_empty()
+        {
+            return Some(content);
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    None
+}
+
+/// Lists every filename actually written to the dumper's session subdirectory, after a brief
+/// settle delay for any in-flight `spawn_blocking` writes. Used for negative assertions ("this
+/// filename must never appear") where polling-until-present doesn't apply.
+async fn dump_dir_filenames(base_dir: &Path) -> Vec<String> {
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let Some(Ok(session_entry)) = std::fs::read_dir(base_dir).ok().and_then(|mut e| e.next())
+    else {
+        return Vec::new();
+    };
+    std::fs::read_dir(session_entry.path())
+        .map(|entries| {
+            entries
+                .filter_map(std::result::Result::ok)
+                .map(|e| e.file_name().to_string_lossy().into_owned())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[tokio::test]
+async fn process_one_tool_result_writes_raw_dump_file_on_success() {
+    let dir = tempfile::tempdir().unwrap();
+    let dumper = DebugDumper::new(dir.path(), DumpFormat::Json).unwrap();
+    let mut agent = make_agent_with_dumper(dumper);
+
+    let tc = make_tool_use_request("id-dump-ok", "bash");
+    agent
+        .process_one_tool_result(
+            &tc,
+            "id-dump-ok",
+            &std::time::Instant::now(),
+            Ok(Some(ToolOutput {
+                tool_name: "bash".into(),
+                summary: "hello from bash".into(),
+                ..Default::default()
+            })),
+            &mut Vec::new(),
+            &mut Vec::new(),
+            &mut false,
+            &mut None,
+            &mut Vec::new(),
+            &mut 0,
+        )
+        .await
+        .unwrap();
+
+    let content = wait_for_dump_file(dir.path(), "0000-tool-bash.txt")
+        .await
+        .expect(
+            "process_one_tool_result must write a raw tool-output dump file via \
+             dump_raw_tool_output (#6364) — no file appeared within 1s",
+        );
+    assert!(
+        content.contains("hello from bash"),
+        "dump file must contain the raw tool output, got: {content}"
+    );
+}
+
+#[tokio::test]
+async fn process_one_tool_result_dump_captures_raw_output_before_truncation() {
+    // Proves the dump is the *raw, pre-summarization* output (per dump_raw_tool_output's doc
+    // comment), not the truncated text actually sent to the LLM: a low overflow threshold
+    // forces truncation of the channel-facing content, while the dump file must still hold
+    // the full, untruncated output.
+    let dir = tempfile::tempdir().unwrap();
+    let dumper = DebugDumper::new(dir.path(), DumpFormat::Json).unwrap();
+    let mut agent = make_agent_with_dumper(dumper);
+    agent.tool_orchestrator.overflow_config = OverflowConfig {
+        threshold: 100,
+        retention_days: 7,
+        max_overflow_bytes: 0,
+        max_per_call_override: 1_000,
+    };
+
+    // Interspersed with spaces so it never forms a long contiguous base64-alphabet run —
+    // `DebugDumper::dump_tool_output` independently applies `redact_binary_blobs`, which would
+    // otherwise redact a purely-repeated-letter blob before this assertion ever sees it.
+    let long_output = "raw output segment ".repeat(400);
+    let tc = make_tool_use_request("id-dump-raw", "srv:big_tool");
+    let mut result_parts = Vec::new();
+    agent
+        .process_one_tool_result(
+            &tc,
+            "id-dump-raw",
+            &std::time::Instant::now(),
+            Ok(Some(ToolOutput {
+                tool_name: "srv:big_tool".into(),
+                summary: long_output.clone(),
+                ..Default::default()
+            })),
+            &mut result_parts,
+            &mut Vec::new(),
+            &mut false,
+            &mut None,
+            &mut Vec::new(),
+            &mut 0,
+        )
+        .await
+        .unwrap();
+
+    let content = wait_for_dump_file(dir.path(), "0000-tool-srv_big_tool.txt")
+        .await
+        .expect("dump file must be written for a successful tool call");
+    assert!(
+        content.contains(&long_output),
+        "dump must contain the FULL raw output, not the truncated version sent to the LLM"
+    );
+
+    let sent_content = result_parts
+        .iter()
+        .find_map(|p| match p {
+            MessagePart::ToolResult { content, .. } => Some(content.as_str()),
+            _ => None,
+        })
+        .expect("expected a ToolResult message part");
+    assert!(
+        sent_content.len() < long_output.len(),
+        "sanity check: LLM-facing content must actually be truncated relative to the raw \
+         output, otherwise this test isn't exercising the raw-vs-summarized distinction"
+    );
+}
+
+#[tokio::test]
+async fn process_one_tool_result_dump_scrubs_pii_when_filter_enabled() {
+    let dir = tempfile::tempdir().unwrap();
+    let dumper = DebugDumper::new(dir.path(), DumpFormat::Json).unwrap();
+    let mut agent = make_agent_with_dumper(dumper);
+    agent.services.security.pii_filter = PiiFilter::new(PiiFilterConfig {
+        enabled: true,
+        ..Default::default()
+    });
+
+    let tc = make_tool_use_request("id-pii-on", "bash");
+    agent
+        .process_one_tool_result(
+            &tc,
+            "id-pii-on",
+            &std::time::Instant::now(),
+            Ok(Some(ToolOutput {
+                tool_name: "bash".into(),
+                summary: "contact me at alice@example.com".into(),
+                ..Default::default()
+            })),
+            &mut Vec::new(),
+            &mut Vec::new(),
+            &mut false,
+            &mut None,
+            &mut Vec::new(),
+            &mut 0,
+        )
+        .await
+        .unwrap();
+
+    let content = wait_for_dump_file(dir.path(), "0000-tool-bash.txt")
+        .await
+        .expect("dump file must be written for a successful tool call");
+    assert!(
+        !content.contains("alice@example.com"),
+        "raw email must not reach disk when the agent's PII filter is enabled, got: {content}"
+    );
+}
+
+#[tokio::test]
+async fn process_one_tool_result_dump_keeps_content_when_pii_filter_disabled() {
+    // Explicitly disabled (the agent's actual default has the PII filter *enabled* — see
+    // `SecurityState::default()`). `scrub_content`/`redact_binary_blobs` (applied
+    // unconditionally inside `DebugDumper::dump_tool_output`) target secrets/paths/binary
+    // blobs, not emails, so a plain email must survive to disk verbatim in this configuration —
+    // this is the negative control proving the PII-enabled test above is actually exercising
+    // `dump_raw_tool_output`'s PII branch, not some other redaction layer.
+    let dir = tempfile::tempdir().unwrap();
+    let dumper = DebugDumper::new(dir.path(), DumpFormat::Json).unwrap();
+    let mut agent = make_agent_with_dumper(dumper);
+    agent.services.security.pii_filter = PiiFilter::new(PiiFilterConfig {
+        enabled: false,
+        ..Default::default()
+    });
+
+    let tc = make_tool_use_request("id-pii-off", "bash");
+    agent
+        .process_one_tool_result(
+            &tc,
+            "id-pii-off",
+            &std::time::Instant::now(),
+            Ok(Some(ToolOutput {
+                tool_name: "bash".into(),
+                summary: "contact me at alice@example.com".into(),
+                ..Default::default()
+            })),
+            &mut Vec::new(),
+            &mut Vec::new(),
+            &mut false,
+            &mut None,
+            &mut Vec::new(),
+            &mut 0,
+        )
+        .await
+        .unwrap();
+
+    let content = wait_for_dump_file(dir.path(), "0000-tool-bash.txt")
+        .await
+        .expect("dump file must be written for a successful tool call");
+    assert!(
+        content.contains("alice@example.com"),
+        "with the PII filter disabled (default), the dump must retain the original content, \
+         got: {content}"
+    );
+}
+
+#[tokio::test]
+async fn process_one_tool_result_skips_raw_dump_on_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let dumper = DebugDumper::new(dir.path(), DumpFormat::Json).unwrap();
+    let mut agent = make_agent_with_dumper(dumper);
+
+    let tc = make_tool_use_request("id-err-dump", "bash");
+    let err = ToolError::InvalidParams {
+        message: "missing required field 'command'".into(),
+    };
+    agent
+        .process_one_tool_result(
+            &tc,
+            "id-err-dump",
+            &std::time::Instant::now(),
+            Err(err),
+            &mut Vec::new(),
+            &mut Vec::new(),
+            &mut false,
+            &mut None,
+            &mut Vec::new(),
+            &mut 0,
+        )
+        .await
+        .unwrap();
+
+    let filenames = dump_dir_filenames(dir.path()).await;
+    assert!(
+        filenames.iter().any(|f| f.contains("tool-error-bash")),
+        "sanity check: the pre-existing (unrelated) dump_tool_error call site in \
+         classify_tool_result should still fire on error, got: {filenames:?}"
+    );
+    assert!(
+        !filenames.iter().any(|f| f.ends_with("-tool-bash.txt")),
+        "dump_raw_tool_output must be a no-op for is_error=true results — errors are dumped via \
+         dump_tool_error instead, got: {filenames:?}"
+    );
+}
+
+#[tokio::test]
+async fn process_one_tool_result_dump_is_noop_when_debug_dumps_disabled() {
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let mut agent = crate::agent::Agent::new(
+        provider,
+        channel,
+        registry,
+        None,
+        5,
+        MockToolExecutor::no_tools(),
+    );
+    assert!(
+        agent.runtime.debug.debug_dumper.is_none(),
+        "precondition: debug dumps must be disabled by default"
+    );
+
+    let tc = make_tool_use_request("id-no-dump", "bash");
+    // Must complete without panicking when there is no dumper to write through.
+    agent
+        .process_one_tool_result(
+            &tc,
+            "id-no-dump",
+            &std::time::Instant::now(),
+            Ok(Some(ToolOutput {
+                tool_name: "bash".into(),
+                summary: "no dumper attached".into(),
+                ..Default::default()
+            })),
+            &mut Vec::new(),
+            &mut Vec::new(),
+            &mut false,
+            &mut None,
+            &mut Vec::new(),
+            &mut 0,
+        )
+        .await
+        .unwrap();
+}

--- a/crates/zeph-core/src/agent/tool_execution/tests/mod.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/mod.rs
@@ -3,6 +3,7 @@
 
 mod apply_tier_results_tests;
 mod boundary_and_classifier_tests;
+mod dump_raw_tool_output_tests;
 mod focus_tests;
 mod hook_block_cap_tests;
 mod mage_escalation_tests;

--- a/crates/zeph-core/src/agent/tool_execution/tool_result.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tool_result.rs
@@ -197,6 +197,25 @@ impl<C: Channel> Agent<C> {
         }
     }
 
+    /// Writes the raw, pre-summarization tool output to the debug dump directory, so a blob
+    /// that later gets truncated or summarized away is still recoverable (#6364). No-op when
+    /// debug dumps are disabled or the result was an error (errors go through
+    /// `dump_tool_error` in `classify_tool_result` instead).
+    fn dump_raw_tool_output(&self, tool_name: &str, is_error: bool, output: &str) {
+        if is_error {
+            return;
+        }
+        let Some(ref d) = self.runtime.debug.debug_dumper else {
+            return;
+        };
+        let dump_content = if self.services.security.pii_filter.is_enabled() {
+            self.services.security.pii_filter.scrub(output).into_owned()
+        } else {
+            output.to_owned()
+        };
+        d.dump_tool_output(tool_name, &dump_content);
+    }
+
     fn handle_tool_failure_outcomes(
         &mut self,
         output: &str,
@@ -412,6 +431,8 @@ impl<C: Channel> Agent<C> {
         );
         let _ = self.record_anomaly_outcome(anomaly_outcome).await;
 
+        self.dump_raw_tool_output(tc.name.as_str(), is_error, &output);
+
         let processed = if tc.name == OverflowToolExecutor::TOOL_NAME {
             output.clone()
         } else {
@@ -621,6 +642,12 @@ impl<C: Channel> Agent<C> {
             .insert(skill_name, tool_name.to_owned());
     }
 
+    // Legacy sequential-dispatch harness, superseded in production by
+    // `process_one_tool_result`/`handle_confirmation_phase` (tier_loop.rs), which processes
+    // every tool result — including confirmation-resolved ones — through the same batched path.
+    // Retained `#[cfg(test)]`-only to keep exercising `sanitize_tool_output`/
+    // `maybe_summarize_tool_output`/`dump_tool_output` via a simpler single-call harness; not
+    // dead in the sense of untested, but unreachable from any production call site (#6364).
     #[cfg(test)]
     pub(super) async fn handle_tool_result(
         &mut self,
@@ -727,6 +754,9 @@ impl<C: Channel> Agent<C> {
         Ok(false)
     }
 
+    // This function's `dump_tool_output` call below is one of the two legacy sites whose
+    // green `#[cfg(test)]` coverage gave false confidence that `dump_tool_output` was reachable
+    // in production — it wasn't (#6364). See the retention note above `handle_tool_result`.
     #[cfg(test)]
     async fn process_successful_tool_output(
         &mut self,
@@ -828,6 +858,9 @@ impl<C: Channel> Agent<C> {
         Ok(true)
     }
 
+    // This function's `dump_tool_output` call below is the other legacy site whose green
+    // `#[cfg(test)]` coverage gave false confidence that `dump_tool_output` was reachable in
+    // production — it wasn't (#6364). See the retention note above `handle_tool_result`.
     #[cfg(test)]
     async fn handle_confirmation_required(
         &mut self,


### PR DESCRIPTION
## Summary

- `DebugDumper::dump_tool_output` (raw pre-summarization tool-output debug dump, added in #6315) had no reachable production call site — every caller was `#[cfg(test)]`-gated, so the dedicated forensic artifact was never produced in a real session despite `[debug] enabled = true`.
- Add `dump_raw_tool_output`, called from `process_one_tool_result` (the real production tool-result path) right after result classification and before `maybe_summarize_tool_output` truncates or summarizes the output — so a blob that would otherwise be summarized away before reaching message history is still captured, PII-scrubbed if enabled, no-op on error (errors go through the pre-existing `dump_tool_error`) or when debug dumps are disabled.
- Confirmation-required tool calls are covered by the same call site with no extra wiring: `handle_confirmation_phase` resolves confirmed results into the same batch that `process_one_tool_result` processes.
- The legacy `#[cfg(test)]`-only functions (`handle_tool_result`, `process_successful_tool_output`, `handle_confirmation_required`) are retained as test scaffolding and documented as such — their green coverage is what let this defect go unnoticed.

Closes #6364

## Test plan

- [x] New regression test module `dump_raw_tool_output_tests.rs` drives `process_one_tool_result` end-to-end (the real production path, not the legacy `#[cfg(test)]` harness), covering: success writes a dump file, raw content captured before truncation, PII-filter-enabled/disabled scrubbing, no-op on error, no-op when debug dumps disabled.
- [x] Spot-checked the new tests are genuine regression guards by temporarily reverting the fix to a no-op — 4/6 new tests failed as expected.
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy --profile ci -p zeph-core --all-targets --features scheduler -- -D warnings` clean
- [x] `cargo nextest run -p zeph-core --features scheduler --lib --bins` — full suite passes (2020/2020, 2 skipped)
- [x] `cargo build -p zeph-core --features scheduler` clean after rebase onto latest `origin/main`
- [x] No playbook / `coverage-status.md` update required — this reconnects an existing feature's (#6315) production call site rather than adding new user-facing functionality; #6315's existing coverage-status row already tracks this feature.