### PR TITLE
feat(testing): add plugin_manifest fuzz target and coverage reporting

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -5,9 +5,7 @@ on:
     - cron: "0 0 * * 1"
   workflow_dispatch:
 
-permissions:
-  contents: read
-  issues: write
+permissions: {}
 
 env:
   CARGO_TERM_COLOR: always
@@ -17,6 +15,9 @@ jobs:
     name: Fuzz (${{ matrix.target }})
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: read
+      issues: write
     strategy:
       fail-fast: false
       matrix:
@@ -29,6 +30,8 @@ jobs:
             budget: 300
           - target: config_toml
             budget: 120
+          - target: plugin_manifest
+            budget: 300
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -104,4 +107,83 @@ jobs:
         with:
           name: fuzz-artifacts-${{ matrix.target }}
           path: fuzz/artifacts/${{ matrix.target }}/
+          if-no-files-found: ignore
+
+  coverage:
+    name: Coverage (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - skill_frontmatter
+          - skill_extensions
+          - chunk_file
+          - config_toml
+          - plugin_manifest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - uses: dtolnay/rust-toolchain@4fd1da8b0805d2d2e936788875a7d65dbd677dc2 # nightly
+        with:
+          components: llvm-tools-preview
+
+      - uses: taiki-e/install-action@afc483d62172accfff644fa56e82b4dab50727fc # cargo-fuzz, cargo-binutils
+        with:
+          tool: cargo-fuzz, cargo-binutils
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: fuzz -> target
+          prefix-key: fuzz-coverage-${{ matrix.target }}
+
+      # Visibility only: replays the committed seed corpus (no libFuzzer mutation) through an
+      # instrumented binary to report which lines/branches the corpus reaches. Does not run
+      # crash-finding — that's the `fuzz` job above — and continue-on-error here means a
+      # tooling failure in this step must never fail the crash-finding `fuzz` job.
+      - name: Generate coverage profile
+        id: coverage
+        continue-on-error: true
+        working-directory: fuzz
+        run: cargo +nightly fuzz coverage ${{ matrix.target }}
+
+      # Uses `rust-cov` (the cargo-binutils-installed llvm-cov wrapper) directly rather than
+      # the `cargo cov --` subcommand: cargo-binutils 0.4.0's `cargo cov`/`cargo profdata`
+      # subcommand parsing panics unconditionally on a clap `ArgAction` incompatibility
+      # (`arg 'no-default-features's 'ArgAction' should be one of 'SetTrue', 'SetFalse'`),
+      # confirmed even on bare `cargo cov -- --help`. `rust-cov` itself is unaffected.
+      - name: Text coverage report
+        if: steps.coverage.outcome == 'success'
+        continue-on-error: true
+        working-directory: fuzz
+        run: |
+          triple="$(rustc -vV | sed -n 's/^host: //p')"
+          bin="target/${triple}/coverage/${triple}/release/${{ matrix.target }}"
+          rust-cov report \
+            --instr-profile="coverage/${{ matrix.target }}/coverage.profdata" \
+            "$bin" \
+            | tee "coverage-${{ matrix.target }}.txt"
+
+      - name: HTML coverage report
+        if: steps.coverage.outcome == 'success'
+        continue-on-error: true
+        working-directory: fuzz
+        run: |
+          triple="$(rustc -vV | sed -n 's/^host: //p')"
+          bin="target/${triple}/coverage/${triple}/release/${{ matrix.target }}"
+          rust-cov show \
+            --instr-profile="coverage/${{ matrix.target }}/coverage.profdata" \
+            "$bin" \
+            --format=html --output-dir="coverage-html-${{ matrix.target }}"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: always()
+        with:
+          name: fuzz-coverage-${{ matrix.target }}
+          path: |
+            fuzz/coverage-${{ matrix.target }}.txt
+            fuzz/coverage-html-${{ matrix.target }}/
           if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ zeph.log
 *.session
 /fuzz/target
 /fuzz/artifacts
+/fuzz/coverage
+/fuzz/coverage-*.txt
+/fuzz/coverage-html-*/
 
 # Track per-directory agent guides despite the global AGENTS.md ignore
 !AGENTS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Coverage-guided fuzzing harnesses (cargo-fuzz) for SKILL.md frontmatter, skill extensions,
   AST chunker, and TOML config parsing (#6365).
+- **`plugin_manifest` fuzz target** (#6370): 5th cargo-fuzz target, fuzzing
+  `toml::from_str::<zeph_plugins::manifest::PluginManifest>` — the `plugin.toml` deserializer
+  parsed at multiple untrusted marketplace/registry ingestion points. Hand-authored seed corpus
+  under `fuzz/corpus/plugin_manifest/`; wired into the weekly `fuzz.yml` CI matrix (300s budget).
+- **cargo-fuzz coverage reporting in CI** (#6373): `.github/workflows/fuzz.yml` now generates a
+  source-coverage report (text + HTML) per fuzz target against its committed seed corpus,
+  uploaded as a workflow artifact. Gives visibility into whether corpus-gated code paths (e.g.
+  the `skill_frontmatter`/`skill_extensions` structural gates) are actually reached — does not
+  change pass/fail semantics of the existing crash-finding job.
 
 - **MCP image passthrough — config/CLI/TUI surface** (spec-072 P3, #6241): completes the
   opt-in MCP image passthrough feature (#6331) with the remaining integration points.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -829,6 +829,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3260,6 +3270,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4247,6 +4268,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4339,6 +4370,7 @@ dependencies = [
  "toml",
  "zeph-config",
  "zeph-index",
+ "zeph-plugins",
  "zeph-skills",
 ]
 
@@ -4430,6 +4462,31 @@ dependencies = [
  "zeph-config",
  "zeph-db",
  "zeph-llm",
+]
+
+[[package]]
+name = "zeph-plugins"
+version = "0.22.1"
+dependencies = [
+ "dirs",
+ "flate2",
+ "futures",
+ "hex",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "tar",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml",
+ "tracing",
+ "walkdir",
+ "zeph-common",
+ "zeph-config",
+ "zeph-skills",
+ "zeph-tools",
 ]
 
 [[package]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,6 +15,7 @@ libfuzzer-sys = "0.4.13"
 toml = "1.1.2"
 zeph-config = { path = "../crates/zeph-config" }
 zeph-index = { path = "../crates/zeph-index", features = ["sqlite"] }
+zeph-plugins = { path = "../crates/zeph-plugins", features = ["sqlite"] }
 zeph-skills = { path = "../crates/zeph-skills" }
 
 [[bin]]
@@ -41,6 +42,13 @@ bench = false
 [[bin]]
 name = "config_toml"
 path = "fuzz_targets/config_toml.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "plugin_manifest"
+path = "fuzz_targets/plugin_manifest.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -28,6 +28,11 @@ rustup toolchain install nightly
 | `skill_extensions` | `zeph_skills::extensions::parse_extensions` — the `serde_norway` YAML sub-block deserializer | raw `&str` |
 | `chunk_file` | `zeph_index::chunker::chunk_file` across all 9 `Lang` variants (tree-sitter parse + chunk boundary logic) | structured `Input { lang_selector: u8, source: String }` |
 | `config_toml` | `toml::from_str::<zeph_config::Config>` — Zeph's config deserialization graph (defaults, validation), not the TOML tokenizer itself (already OSS-Fuzzed upstream) | raw `&str` |
+| `plugin_manifest` | `toml::from_str::<zeph_plugins::manifest::PluginManifest>` — the `plugin.toml` deserialization graph, parsed at multiple untrusted marketplace/registry ingestion points (`manager/registry.rs`, `store.rs`, `install.rs`, `security.rs`) | raw `&str` |
+
+`PluginSource` (`manager/registry.rs:561`) is a separate, also-untrusted TOML parse point — an
+attacker-bundled `.plugin-source.toml` inside a plugin archive — intentionally left unfuzzed by
+`plugin_manifest`'s scope; a candidate for a future 6th target.
 
 ## Running a target locally
 
@@ -42,6 +47,22 @@ run (as CI does), pass `-max_total_time=<seconds>`:
 ```bash
 cargo +nightly fuzz run skill_frontmatter -- -max_total_time=300
 ```
+
+**Corpus pollution warning**: by default, `cargo fuzz run <target>` uses `fuzz/corpus/<target>/`
+as libFuzzer's live corpus directory — any input that increases coverage is written back into
+it automatically, even for a short exploratory run. That directory is git-tracked (it's the
+committed seed corpus), so an unqualified local run followed by `git add` can stage thousands of
+hash-named junk files alongside the intended seeds. For any local run that isn't specifically
+about growing the committed corpus on purpose, point libFuzzer at a scratch directory instead by
+passing it as a positional `CORPUS` argument:
+
+```bash
+mkdir -p /tmp/fuzz-scratch && cargo +nightly fuzz run skill_frontmatter /tmp/fuzz-scratch -- -max_total_time=20
+```
+
+After any run against the real corpus directory (intentional or not), run
+`git status fuzz/corpus/<target>/` before staging anything, and remove files that aren't
+deliberately-added seeds.
 
 ## Reproducing a crash
 
@@ -75,6 +96,12 @@ useful.
 - **`chunk_file`**: generated from real source files in this repo — see byte layout below.
 - **`config_toml`**: copied from `crates/zeph-config/config/default.toml` and
   `crates/zeph-config/tests/fixtures/acp_pr4_v0_19.toml`.
+- **`plugin_manifest`**: hand-authored `plugin.toml`-style manifests (no in-repo fixture files
+  existed) covering the `[plugin]` table, `[[skills]]`, `[[mcp.servers]]`, `[config.*]` overlay,
+  and `dependencies`, modeled on `PluginManifest`'s field structure and the inline manifest
+  strings used by `crates/zeph-plugins/src/manager/tests.rs` and `overlay.rs`.
+  `PluginManifest` requires a `[plugin]` table with `name` and `version` — seeds give the fuzzer
+  a valid envelope to mutate from.
 
 ### `chunk_file` seed byte layout
 
@@ -123,26 +150,81 @@ rather than a seed). Re-run it after adding new representative sample files:
 4. Seed `fuzz/corpus/<name>/` — check whether the target function has an early structural gate
    (a required prefix, a required key, a magic byte) that raw mutation is unlikely to satisfy; if
    so, seeding is mandatory, not optional.
-5. Add the target to the matrix in `.github/workflows/fuzz.yml` with an appropriate
-   `-max_total_time` budget.
+5. Add the target to the `fuzz` job's matrix in `.github/workflows/fuzz.yml` with an appropriate
+   `-max_total_time` budget, and to the `coverage` job's target list (see below).
 
-## Follow-up: `plugin_manifest` target (not implemented here)
+## Coverage reports
 
-A strong candidate for a 5th target: `zeph_plugins::manifest::PluginManifest` (pub, `Deserialize`,
-`crates/zeph-plugins/src/manifest.rs:37`), parsed via `toml::from_str::<PluginManifest>` at
-`crates/zeph-plugins/src/manager/registry.rs:432,531,561` (also `PluginSource` at line 561),
-`store.rs:49`, `install.rs:44`, and `security.rs:147`. Unlike `config_toml` (a trusted, user-owned
-file), plugin manifests originate from **untrusted marketplace/registry sources** — the same
-threat model as `skill_frontmatter` — making this a higher-value target than `config_toml`. Left
-out of this PR to keep scope tight; tracked as a follow-up issue.
+The `fuzz` job above only hunts for crashes; it doesn't tell you what fraction of a target's
+code the seed corpus actually exercises. A separate `coverage` job in `.github/workflows/fuzz.yml`
+runs on the same schedule (weekly + manual `workflow_dispatch`) and generates a source-coverage
+report per target by replaying its committed seed corpus — no libFuzzer mutation — through an
+instrumented binary. This is **visibility only**: `coverage` is a separate job from `fuzz`, and
+`continue-on-error: true` on every coverage-*generation* step means a tooling failure there never
+fails the crash-finding `fuzz` job. (An infra failure — checkout, toolchain setup, tool install,
+cache restore — is not wrapped in `continue-on-error` and would still redden the `coverage` job
+itself, but it can never touch `fuzz`.) No coverage threshold is enforced.
+
+This matters most for `skill_frontmatter` and `skill_extensions`, whose target functions have an
+early structural gate (`split_frontmatter`'s `---`-delimited envelope check;
+`parse_extensions`'s `extensions:` key check) — a coverage report is the only automated way to
+confirm the committed seeds actually get past the gate and reach the code being fuzzed.
+
+### Running coverage locally
+
+Requires the `llvm-tools-preview` rustup component (provides `llvm-profdata`/`llvm-cov`) and
+`cargo-binutils` (installs the `rust-cov`/`rust-profdata` binaries used below — **not** the
+`cargo cov`/`cargo profdata` subcommand wrappers: cargo-binutils 0.4.0's subcommand argument
+parsing panics unconditionally on a clap `ArgAction` incompatibility, confirmed even on a bare
+`cargo cov -- --help`; `rust-cov` itself is unaffected and is what CI uses):
+
+```bash
+rustup component add llvm-tools-preview --toolchain nightly
+cargo install cargo-binutils --locked
+```
+
+Generate the coverage profile for a target (replays its `fuzz/corpus/<target>/` seeds):
+
+```bash
+cd fuzz
+cargo +nightly fuzz coverage <target>
+```
+
+This writes `fuzz/coverage/<target>/coverage.profdata` and builds an instrumented binary under
+`fuzz/target/<triple>/coverage/<triple>/release/<target>` (`<triple>` is your host triple, e.g.
+`x86_64-unknown-linux-gnu` in CI or `aarch64-apple-darwin` on Apple Silicon — check with
+`rustc -vV | grep host`).
+
+View a text summary:
+
+```bash
+rust-cov report \
+  --instr-profile=coverage/<target>/coverage.profdata \
+  target/<triple>/coverage/<triple>/release/<target>
+```
+
+Or a richer, browsable HTML report:
+
+```bash
+rust-cov show \
+  --instr-profile=coverage/<target>/coverage.profdata \
+  target/<triple>/coverage/<triple>/release/<target> \
+  --format=html --output-dir=coverage-html-<target>
+# open coverage-html-<target>/index.html
+```
+
+In CI, both the text report and the HTML directory are uploaded as the `fuzz-coverage-<target>`
+workflow artifact on every scheduled/dispatched run.
 
 ## Build-time note
 
 The detached `fuzz/` workspace has its own `Cargo.lock` and pulls `zeph-index` (features =
 `["sqlite"]`), which transitively compiles `sqlx`, `zeph-llm`, `zeph-memory`,
 `zeph-db`, `zeph-tools`, and 5 tree-sitter grammars — all ASan-instrumented (cargo-fuzz's
-default). A cold build of this graph is the dominant cost of a CI run, not the fuzzing itself;
-`.github/workflows/fuzz.yml` uses `Swatinem/rust-cache` keyed on `fuzz/Cargo.lock` to amortize
-this across scheduled runs. If build time becomes a recurring problem, a slimmer `zeph-index`
-feature that excludes the DB/LLM stack is a possible future optimization (tracked as a
-conditional follow-up issue, not implemented here).
+default). `zeph-plugins` (features = `["sqlite"]`) shares most of that graph via `zeph-tools`/
+`zeph-skills` and adds `reqwest`, `tar`, `flate2`, and `sha2` on top — no meaningfully new build
+cost beyond what `zeph-index` already pulls in. A cold build of this graph is the dominant cost
+of a CI run, not the fuzzing itself; `.github/workflows/fuzz.yml` uses `Swatinem/rust-cache`
+keyed on `fuzz/Cargo.lock` to amortize this across scheduled runs. If build time becomes a
+recurring problem, a slimmer `zeph-index` feature that excludes the DB/LLM stack is a possible
+future optimization (tracked as a conditional follow-up issue, not implemented here).

--- a/fuzz/corpus/plugin_manifest/config_overlay.toml
+++ b/fuzz/corpus/plugin_manifest/config_overlay.toml
@@ -1,0 +1,10 @@
+[plugin]
+name = "safe-overlay"
+version = "0.1.0"
+description = "test"
+
+[config.skills]
+disambiguation_threshold = 0.05
+
+[config.tools]
+blocked_commands = ["rm -rf"]

--- a/fuzz/corpus/plugin_manifest/dependencies.toml
+++ b/fuzz/corpus/plugin_manifest/dependencies.toml
@@ -1,0 +1,6 @@
+[plugin]
+name = "dependent-plugin"
+version = "0.2.0"
+description = "depends on another plugin"
+auto_update = true
+dependencies = ["base-plugin", "shared-utils"]

--- a/fuzz/corpus/plugin_manifest/full.toml
+++ b/fuzz/corpus/plugin_manifest/full.toml
@@ -1,0 +1,20 @@
+[plugin]
+name = "git-workflows"
+version = "0.1.0"
+description = "Git workflow skills and MCP git server"
+auto_update = false
+dependencies = ["core-utils"]
+
+[[skills]]
+path = "skills/git-commit"
+
+[[skills]]
+path = "skills/git-rebase"
+
+[[mcp.servers]]
+id = "git"
+command = "mcp-git"
+args = ["--repo", "."]
+
+[config.tools]
+blocked_commands = ["git push --force"]

--- a/fuzz/corpus/plugin_manifest/invalid_name.toml
+++ b/fuzz/corpus/plugin_manifest/invalid_name.toml
@@ -1,0 +1,6 @@
+[plugin]
+name = "INVALID"
+version = "0.1.0"
+
+[config.tools]
+blocked_commands = ["evil"]

--- a/fuzz/corpus/plugin_manifest/mcp_server.toml
+++ b/fuzz/corpus/plugin_manifest/mcp_server.toml
@@ -1,0 +1,8 @@
+[plugin]
+name = "mcp-test"
+version = "0.1.0"
+description = "test"
+
+[[mcp.servers]]
+id = "bad-server"
+command = "dangerous-binary"

--- a/fuzz/corpus/plugin_manifest/minimal.toml
+++ b/fuzz/corpus/plugin_manifest/minimal.toml
@@ -1,0 +1,3 @@
+[plugin]
+name = "git-workflows"
+version = "0.1.0"

--- a/fuzz/fuzz_targets/plugin_manifest.rs
+++ b/fuzz/fuzz_targets/plugin_manifest.rs
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &str| {
+    let _ = toml::from_str::<zeph_plugins::manifest::PluginManifest>(data);
+});


### PR DESCRIPTION
## Summary

- Adds a 5th fuzz target `fuzz/fuzz_targets/plugin_manifest.rs` fuzzing `toml::from_str::<zeph_plugins::manifest::PluginManifest>` — the untrusted marketplace/registry plugin manifest ingestion surface (`crates/zeph-plugins/src/manager/{registry,store,install,security}.rs`), same threat model as the already-fuzzed SKILL.md frontmatter target.
- Wires a `coverage` CI job into `.github/workflows/fuzz.yml` that runs `cargo +nightly fuzz coverage <target>` for all 5 targets against their committed seed corpora and uploads text/HTML reports as artifacts. Fully independent job (no `needs:`, no shared outputs) — cannot affect the crash-finding `fuzz` job's pass/fail. Every generation step uses `continue-on-error: true`, since visibility is the goal for this iteration, not gating.
- Works around a cargo-binutils 0.4.0 `cargo cov --`/`cargo profdata --` panic (clap `ArgAction` bug, reproduces even on bare `--help`) by invoking `rust-cov` directly — documented in both the workflow and `fuzz/README.md`.
- Scopes GitHub Actions permissions per-job (`fuzz`: `contents: read` + `issues: write` for its crash-issue-filing step; `coverage`: `contents: read` only) instead of workflow-level, following least privilege.
- `fuzz/README.md` updated: target table, corpus docs, new "Corpus pollution warning" (local `cargo fuzz run` writes coverage-increasing inputs directly into the corpus dir — use a scratch dir or `git status` before staging), and a note that `PluginSource` (`registry.rs:561`) is a separate untrusted parse point intentionally left out of this target's scope.

Closes #6370
Closes #6373

## Test plan

- [x] `cargo +nightly fuzz list` includes `plugin_manifest` (5 targets total)
- [x] Seed corpus present and non-empty: 6 hand-authored `.toml` manifests covering minimal/full/nested-table/array/optional-field/invalid-name shapes
- [x] Local smoke run (`cargo +nightly fuzz run plugin_manifest -- -max_total_time=...`): 0 crashes
- [x] `rust-cov report` locally confirms seed corpus reaches 100% region/line/function coverage of `PluginManifest`'s `Deserialize` path
- [x] `cargo +nightly fmt --check`, `cargo clippy --all-targets -- -D warnings` clean on `fuzz/` (workspace-excluded, checked standalone)
- [x] `fy parse` / `fy lint` clean on `fuzz.yml` (0 errors)
- [x] `gitleaks protect --staged` clean
- [x] `CHANGELOG.md`, `.local/testing/playbooks/fuzzing.md`, `.local/testing/coverage-status.md` updated
- [ ] Follow-up after merge: trigger `workflow_dispatch` on `fuzz.yml` to confirm the `coverage` job goes green in real CI — cargo-fuzz and cargo-binutils aren't in `install-action`'s curated tool manifest, so both install via the slower binstall/cargo-install fallback (same mechanism the existing `fuzz` job already relies on, but unverified for this new job specifically)