### PR TITLE
fix(llm): attach MCP image siblings to Ollama tool-role messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-llm` (`ollama`): `convert_message_structured` dropped `MessagePart::Image` siblings
+  on messages carrying a `ToolResult` part — the function early-returned
+  `ChatMessage::tool(content)` built only from concatenated tool-result text, discarding any
+  validated image pushed alongside it by `emit_media_parts` (MCP image passthrough,
+  `media_passthrough = true`). The image never reached the Ollama API request (#6374).
+  `ollama-rs` does not role-restrict `ChatMessage.images`, so the tool-role message now
+  attaches the same siblings via `.with_images(...)` (mirroring the existing pattern in
+  `convert_message`) when at least one `MessagePart::Image` is present.
 - `zeph-core`: `DebugDumper::dump_tool_output` — the per-tool-call raw dump written before
   truncation/summarization, with `scrub_content`/`redact_binary_blobs` redaction applied
   (#6315) — had no reachable production call site; the only callers were `#[cfg(test)]`-gated

--- a/crates/zeph-llm/src/ollama.rs
+++ b/crates/zeph-llm/src/ollama.rs
@@ -608,20 +608,32 @@ fn convert_message_structured(msg: &Message) -> ChatMessage {
             })
             .collect::<Vec<_>>()
             .join("\n");
-        return ChatMessage::tool(content);
+        let tool_message = ChatMessage::tool(content);
+        // Sibling Image parts (e.g. from MCP media passthrough) must not be dropped:
+        // ollama-rs does not role-restrict ChatMessage.images, so attach them here too.
+        let images = extract_images(msg);
+        return if images.is_empty() {
+            tool_message
+        } else {
+            tool_message.with_images(images)
+        };
     }
     convert_message(msg)
 }
 
-fn convert_message(msg: &Message) -> ChatMessage {
-    let images: Vec<OllamaImage> = msg
-        .parts
+/// Collect all `MessagePart::Image` siblings from a message, base64-encoded for `ollama-rs`.
+fn extract_images(msg: &Message) -> Vec<OllamaImage> {
+    msg.parts
         .iter()
         .filter_map(|p| match p {
             MessagePart::Image(img) => Some(OllamaImage::from_base64(STANDARD.encode(&img.data))),
             _ => None,
         })
-        .collect();
+        .collect()
+}
+
+fn convert_message(msg: &Message) -> ChatMessage {
+    let images = extract_images(msg);
 
     let text = msg.to_llm_content().to_string();
 
@@ -1267,6 +1279,38 @@ mod tests {
             ollama_rs::generation::chat::MessageRole::Tool
         );
         assert_eq!(chat_msg.content, "file list");
+        assert!(chat_msg.images.is_none());
+    }
+
+    #[test]
+    fn convert_message_structured_tool_result_with_image_sibling_attaches_image() {
+        use base64::{Engine, engine::general_purpose::STANDARD};
+
+        let data = vec![0xFFu8, 0xD8, 0xFF];
+        let msg = Message::from_parts(
+            Role::User,
+            vec![
+                MessagePart::ToolResult {
+                    tool_use_id: "id1".into(),
+                    content: "file list".into(),
+                    is_error: false,
+                },
+                MessagePart::Image(Box::new(ImageData {
+                    data: data.clone(),
+                    mime_type: "image/jpeg".into(),
+                })),
+            ],
+        );
+        let chat_msg = convert_message_structured(&msg);
+        assert_eq!(
+            chat_msg.role,
+            ollama_rs::generation::chat::MessageRole::Tool
+        );
+        assert_eq!(chat_msg.content, "file list");
+        let images = chat_msg.images.expect("image sibling must be attached");
+        assert_eq!(images.len(), 1);
+        let img_debug = format!("{:?}", images[0]);
+        assert!(img_debug.contains(&STANDARD.encode(&data)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `convert_message_structured` in `crates/zeph-llm/src/ollama.rs` early-returned `ChatMessage::tool(content)` built only from concatenated tool-result text whenever a message carried a `MessagePart::ToolResult`, silently dropping any `MessagePart::Image` sibling pushed alongside it by MCP image passthrough (`media_passthrough = true`). The validated image was decoded and paid for but never reached the Ollama API request, defeating spec-072 P2 MCP image passthrough for any Ollama-backed deployment.
- Extracted a shared `extract_images(msg: &Message) -> Vec<OllamaImage>` helper (reused by the existing `convert_message`) and attach the images via `.with_images()` on the tool-role `ChatMessage` when non-empty.
- `ollama-rs` 0.3.5's `ChatMessage.images` field is not role-restricted, so images can be attached directly to the `role: "tool"` message rather than re-homed onto the next turn.

Closes #6374

## Live verification (LLM Serialization Gate)

Ran two trials directly against a local Ollama server using `gemma4:26b` (the model named in the issue's own reproduction steps), each with a randomly generated test PNG (unusual background/marker color pair, random corner) to rule out the model guessing a common default by chance:

| Trial | Expected (bg/corner/marker) | With `images` attached (this fix) | Without `images` (pre-fix behavior) |
|---|---|---|---|
| 0 | magenta / top-right / maroon | magenta / top-right / maroon (exact match) | white / bottom-right / blue (wrong) |
| 1 | maroon / top-right / teal | maroon / top-right / teal (exact match) | white / top-left / blue (wrong) |

Both `with-images` requests returned HTTP 200 and the model correctly reported the exact generated colors and corner. Both `without-images` control requests (simulating the pre-fix dropped-image behavior) also returned HTTP 200 but the model hallucinated a wrong generic answer, confirming it has no access to the actual image content without the fix. This validates the server accepts and the model attends to images on a `role: "tool"` message.

## Test plan

- [x] `cargo +nightly fmt --check` (workspace)
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 13986 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `gitleaks protect --staged --no-banner --redact` — no leaks
- [x] New regression test `convert_message_structured_tool_result_with_image_sibling_attaches_image` — verified it fails without the fix and passes with it
- [x] Live Ollama round-trip against `gemma4:26b` (see above)