### PR TITLE
fix(memory): wire insert_tree_leaf and recent-embeddings fetch into production paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-memory`: `SemanticMemory::run_quality_gate` hardcoded `recent_embeddings` to `&[]` on
+  its only production call site, so `QualityGate::evaluate`'s `Redundant`-rejection path —
+  already unit-tested and working — could never fire on a real conversation (#6387). Added
+  `SemanticMemory::fetch_recent_embeddings`, which loads the last `recent_window` messages for
+  the conversation via `SqliteStore::load_history` and resolves their vectors through
+  `EmbeddingStore::get_vectors` (the same pair the MMR re-ranking path already uses), and wired
+  it into `run_quality_gate` in place of the empty slice. Fails open (empty vec) when no vector
+  store is attached or any lookup step errors, matching the gate's existing fail-open contract.
+- `zeph-memory`'s `SqliteStore::insert_tree_leaf` — the only writer of the `memory_tree`
+  table — had zero production call sites, so the `mem-tree-consolidation` background loop
+  (`config.memory.tree.enabled`) always found zero unconsolidated leaves and ran forever as a
+  no-op (#6384). `zeph-core`'s `Agent::persist_message` now calls a new `Agent::insert_tree_leaf`
+  helper right after a message is persisted, reusing the same tool-result/injection skip guards
+  as graph extraction so raw tool output and injection-flagged content never enter the tree.
+  Best-effort: a single lightweight `INSERT ... RETURNING id`, no LLM/embedding call, failures
+  logged and never propagated.
 - `zeph-llm` (`ollama`): `convert_message_structured` dropped `MessagePart::Image` siblings
   on messages carrying a `ToolResult` part — the function early-returned
   `ChatMessage::tool(content)` built only from concatenated tool-result text, discarding any

--- a/crates/zeph-core/src/agent/persistence/extract.rs
+++ b/crates/zeph-core/src/agent/persistence/extract.rs
@@ -14,6 +14,38 @@ use zeph_agent_persistence::graph::{build_graph_extraction_config, collect_conte
 use zeph_llm::provider::{LlmProvider as _, MessagePart, Role};
 
 impl<C: Channel> Agent<C> {
+    /// Insert a leaf node into the `TiMem` memory tree (#6384).
+    ///
+    /// `SqliteStore::insert_tree_leaf` is the only writer of the `memory_tree` table; without
+    /// this call the `mem-tree-consolidation` background loop always finds zero unconsolidated
+    /// leaves and runs forever as a no-op. Runs inline — a single `INSERT ... RETURNING id`,
+    /// no LLM/embedding call — right after the message is persisted, reusing the same
+    /// tool-result/injection skip guards as [`Self::enqueue_graph_extraction_task`] so raw tool
+    /// output and injection-flagged content never enter the tree.
+    ///
+    /// Best-effort: failures are logged and never propagated, mirroring the other post-persist
+    /// enrichment steps in this module.
+    pub(super) async fn insert_tree_leaf(
+        &self,
+        content: &str,
+        has_injection_flags: bool,
+        has_tool_result_parts: bool,
+    ) {
+        if !self.services.memory.subsystems.tree_config.enabled {
+            return;
+        }
+        if has_tool_result_parts || has_injection_flags || content.trim().is_empty() {
+            return;
+        }
+        let Some(memory) = &self.services.memory.persistence.memory else {
+            return;
+        };
+        let token_count = i64::try_from(content.split_whitespace().count()).unwrap_or(i64::MAX);
+        if let Err(e) = memory.sqlite().insert_tree_leaf(content, token_count).await {
+            tracing::warn!(error = %e, "TiMem: failed to insert tree leaf");
+        }
+    }
+
     /// Prepare graph extraction guards in foreground, then enqueue heavy work via supervisor.
     ///
     /// Guards (enabled check, injection/tool-result skip) stay on the foreground path.

--- a/crates/zeph-core/src/agent/persistence/store.rs
+++ b/crates/zeph-core/src/agent/persistence/store.rs
@@ -143,6 +143,10 @@ impl<C: Channel> Agent<C> {
         self.enqueue_graph_extraction_task(content, has_injection_flags, has_tool_result_parts)
             .await;
 
+        // TiMem tree leaf insertion: feeds the mem-tree-consolidation background loop (#6384).
+        self.insert_tree_leaf(content, has_injection_flags, has_tool_result_parts)
+            .await;
+
         // Persona extraction: run only for user messages that are not tool results and not injected.
         if role == Role::User && !has_tool_result_parts && !has_injection_flags {
             self.enqueue_persona_extraction_task();

--- a/crates/zeph-core/src/agent/persistence/tests.rs
+++ b/crates/zeph-core/src/agent/persistence/tests.rs
@@ -489,6 +489,147 @@ async fn unsummarized_count_not_incremented_without_memory() {
     assert_eq!(agent.services.memory.persistence.unsummarized_count, 0);
 }
 
+// #6384 regression: unit tests for insert_tree_leaf guard conditions.
+mod tree_leaf_insertion_guards {
+    use super::*;
+
+    async fn agent_with_tree(provider: &AnyProvider, tree_enabled: bool) -> Agent<MockChannel> {
+        let memory = test_memory(&AnyProvider::Mock(zeph_llm::mock::MockProvider::default())).await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let mut agent = Agent::new(
+            provider.clone(),
+            MockChannel::new(vec![]),
+            create_test_registry(),
+            None,
+            5,
+            MockToolExecutor::no_tools(),
+        )
+        .with_memory(std::sync::Arc::new(memory), cid, 50, 5, 100);
+        agent.services.memory.subsystems.tree_config.enabled = tree_enabled;
+        agent
+    }
+
+    #[tokio::test]
+    async fn disabled_config_guard_skips_insert() {
+        // tree.enabled=false → no row must ever reach memory_tree.
+        let provider = mock_provider(vec![]);
+        let agent = agent_with_tree(&provider, false).await;
+        let memory = agent.services.memory.persistence.memory.as_ref().unwrap();
+
+        agent.insert_tree_leaf("I use Rust", false, false).await;
+
+        assert_eq!(
+            memory.sqlite().count_tree_nodes().await.unwrap(),
+            0,
+            "tree.enabled=false must prevent insert_tree_leaf from writing a row"
+        );
+    }
+
+    #[tokio::test]
+    async fn injection_flag_guard_skips_insert() {
+        let provider = mock_provider(vec![]);
+        let agent = agent_with_tree(&provider, true).await;
+        let memory = agent.services.memory.persistence.memory.as_ref().unwrap();
+
+        agent.insert_tree_leaf("I use Rust", true, false).await;
+
+        assert_eq!(
+            memory.sqlite().count_tree_nodes().await.unwrap(),
+            0,
+            "injection flag must prevent tree leaf insertion"
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_result_parts_guard_skips_insert() {
+        // Mirrors the graph-extraction FIX-1 guard: tool output is raw structured data, not
+        // conversational content, and must not seed the memory tree.
+        let provider = mock_provider(vec![]);
+        let agent = agent_with_tree(&provider, true).await;
+        let memory = agent.services.memory.persistence.memory.as_ref().unwrap();
+
+        agent
+            .insert_tree_leaf(
+                "[tool_result: abc123]\nprovider_type = \"claude\"",
+                false,
+                true, // has_tool_result_parts
+            )
+            .await;
+
+        assert_eq!(
+            memory.sqlite().count_tree_nodes().await.unwrap(),
+            0,
+            "tool result content must not be inserted into the memory tree"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_content_guard_skips_insert() {
+        let provider = mock_provider(vec![]);
+        let agent = agent_with_tree(&provider, true).await;
+        let memory = agent.services.memory.persistence.memory.as_ref().unwrap();
+
+        agent.insert_tree_leaf("   ", false, false).await;
+
+        assert_eq!(
+            memory.sqlite().count_tree_nodes().await.unwrap(),
+            0,
+            "whitespace-only content must not be inserted into the memory tree"
+        );
+    }
+
+    #[tokio::test]
+    async fn happy_path_inserts_leaf() {
+        // Core #6384 regression: with tree.enabled=true and no guards tripped, a real row
+        // must land in memory_tree — before this fix, insert_tree_leaf had zero call sites
+        // and the consolidation loop always found zero unconsolidated leaves.
+        let provider = mock_provider(vec![]);
+        let agent = agent_with_tree(&provider, true).await;
+        let memory = agent.services.memory.persistence.memory.as_ref().unwrap();
+
+        agent
+            .insert_tree_leaf("I use Rust for systems programming", false, false)
+            .await;
+
+        assert_eq!(
+            memory.sqlite().count_tree_nodes().await.unwrap(),
+            1,
+            "happy-path call must insert exactly one leaf row"
+        );
+
+        let leaves = memory
+            .sqlite()
+            .load_tree_leaves_unconsolidated(10)
+            .await
+            .unwrap();
+        assert_eq!(leaves.len(), 1);
+        assert_eq!(leaves[0].content, "I use Rust for systems programming");
+    }
+
+    #[tokio::test]
+    async fn persist_message_end_to_end_inserts_tree_leaf() {
+        // #6384 regression, the actual defect: the other 5 tests in this module call
+        // `Agent::insert_tree_leaf` directly, so they would stay green even if the `store.rs`
+        // call site were dropped again (confirmed by tester: reverting only that call site
+        // left all 5 passing). This test goes through the real production entry point,
+        // `persist_message`, mirroring how the #6387 regression test goes through `remember()`.
+        let provider = mock_provider(vec![]);
+        let mut agent = agent_with_tree(&provider, true).await;
+
+        agent
+            .persist_message(Role::User, "I use Rust for systems programming", &[], false)
+            .await;
+
+        let memory = agent.services.memory.persistence.memory.as_ref().unwrap();
+        assert_eq!(
+            memory.sqlite().count_tree_nodes().await.unwrap(),
+            1,
+            "persist_message must reach insert_tree_leaf and write a memory_tree row \
+             when tree.enabled=true"
+        );
+    }
+}
+
 // R-CRIT-01: unit tests for enqueue_graph_extraction_task guard conditions.
 mod graph_extraction_guards {
     use super::*;

--- a/crates/zeph-memory/src/semantic/recall.rs
+++ b/crates/zeph-memory/src/semantic/recall.rs
@@ -474,8 +474,11 @@ impl SemanticMemory {
         let Some(gate) = &self.quality_gate else {
             return false;
         };
+        let recent_embeddings = self
+            .fetch_recent_embeddings(conversation_id, gate.config().recent_window)
+            .await;
         if gate
-            .evaluate(content, self.effective_embed_provider(), &[])
+            .evaluate(content, self.effective_embed_provider(), &recent_embeddings)
             .await
             .is_none()
         {
@@ -486,6 +489,51 @@ impl SemanticMemory {
                 .await;
         }
         true
+    }
+
+    /// Fetch embeddings for the most recent `limit` messages in `conversation_id`, for use as
+    /// the `recent_embeddings` window in [`crate::quality_gate::QualityGate::evaluate`] (#6387).
+    ///
+    /// Reuses the same `SqliteStore::load_history` + `EmbeddingStore::get_vectors` pair the MMR
+    /// re-ranking path uses (see [`Self::recall_merge_and_rank`]) rather than a bespoke query.
+    /// Called before the candidate message is persisted, so the returned window never includes it.
+    ///
+    /// Fails open: returns an empty vec (which makes `information_value` score as novel) when no
+    /// vector store is attached, `limit == 0`, or any lookup step errors.
+    async fn fetch_recent_embeddings(
+        &self,
+        conversation_id: ConversationId,
+        limit: usize,
+    ) -> Vec<Vec<f32>> {
+        let Some(qdrant) = &self.qdrant else {
+            return Vec::new();
+        };
+        if limit == 0 {
+            return Vec::new();
+        }
+        let limit_u32 = u32::try_from(limit).unwrap_or(u32::MAX);
+        let recent_messages = match self.sqlite.load_history(conversation_id, limit_u32).await {
+            Ok(messages) => messages,
+            Err(e) => {
+                tracing::warn!("quality_gate: failed to load recent history: {e:#}");
+                return Vec::new();
+            }
+        };
+        let ids: Vec<MessageId> = recent_messages
+            .iter()
+            .filter_map(|m| m.metadata.db_id)
+            .map(MessageId)
+            .collect();
+        if ids.is_empty() {
+            return Vec::new();
+        }
+        match qdrant.get_vectors(&ids).await {
+            Ok(vec_map) => vec_map.into_values().collect(),
+            Err(e) => {
+                tracing::warn!("quality_gate: failed to fetch recent embeddings: {e:#}");
+                Vec::new()
+            }
+        }
     }
 
     /// Record the admission training sample for a message that passed every gate, when an

--- a/crates/zeph-memory/src/semantic/tests/recall.rs
+++ b/crates/zeph-memory/src/semantic/tests/recall.rs
@@ -933,6 +933,114 @@ async fn remember_categorized_skips_quality_gate() {
     );
 }
 
+/// #6387 regression: `run_quality_gate` used to hardcode `recent_embeddings` to `&[]`, making
+/// `QualityRejectionReason::Redundant` permanently unreachable via `remember()` in production.
+/// Attaches a real (SQLite-backed) vector store — the mock provider returns the same fixed
+/// embedding for every call, so the second `remember()` must find the first message's embedding
+/// via `fetch_recent_embeddings` and be rejected as redundant.
+#[tokio::test]
+async fn remember_quality_gate_rejects_redundant_using_real_recent_embeddings() {
+    let mut mock = MockProvider::default();
+    mock.supports_embeddings = true;
+    let provider = AnyProvider::Mock(mock.with_embedding(vec![0.1_f32; 384]));
+
+    let sqlite = SqliteStore::new(":memory:").await.unwrap();
+    let pool = sqlite.pool().clone();
+    let qdrant = Some(Arc::new(
+        crate::embedding_store::EmbeddingStore::new_sqlite(pool),
+    ));
+
+    let gate_config = crate::quality_gate::QualityGateConfig {
+        enabled: true,
+        threshold: 0.5,
+        information_value_weight: 0.9,
+        reference_completeness_weight: 0.05,
+        contradiction_weight: 0.05,
+        recent_window: 32,
+        ..crate::quality_gate::QualityGateConfig::default()
+    };
+
+    let memory = SemanticMemory {
+        sqlite,
+        qdrant,
+        provider,
+        embed_provider: None,
+        embedding_model: "test-model".into(),
+        vector_weight: 0.7,
+        keyword_weight: 0.3,
+        temporal_decay: super::super::TemporalDecay::Disabled,
+        temporal_decay_half_life_days: 30,
+        mmr_reranking: super::super::MmrReranking::Disabled,
+        mmr_lambda: 0.7,
+        importance_scoring: super::super::ImportanceScoring::Disabled,
+        importance_weight: 0.15,
+        token_counter: Arc::new(TokenCounter::new()),
+        graph_store: None,
+        experience: None,
+        community_detection_failures: Arc::new(AtomicU64::new(0)),
+        graph_extraction_count: Arc::new(AtomicU64::new(0)),
+        graph_extraction_failures: Arc::new(AtomicU64::new(0)),
+        last_qdrant_warn: Arc::new(AtomicU64::new(0)),
+        tier_boost_semantic: 1.3,
+        admission_control: Some(Arc::new(make_always_admit_admission())),
+        quality_gate: Some(Arc::new(crate::quality_gate::QualityGate::new(gate_config))),
+        key_facts_dedup_threshold: 0.95,
+        embed_tasks: std::sync::Mutex::new(tokio::task::JoinSet::new()),
+        retrieval_depth: 0,
+        search_prompt_template: String::new(),
+        depth_below_limit_warned: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        missing_placeholder_warned: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        reasoning: None,
+        query_bias_correction: super::super::QueryBiasCorrection::Disabled,
+        query_bias_profile_weight: 0.25,
+        profile_centroid: tokio::sync::RwLock::new(None),
+        profile_centroid_ttl_secs: 300,
+        hebbian_reinforcement: super::super::HebbianReinforcement::Disabled,
+        hebbian_lr: 0.1,
+        hebbian_spread: crate::HelaSpreadRuntime::default(),
+        retrieval_failure_logger: None,
+        summarization_llm_timeout_secs: 60,
+        query_sensitive_cost: false,
+        five_signal: None,
+        embed_timeout: std::time::Duration::from_secs(5),
+        graph_cancel: std::sync::Mutex::new(Vec::new()),
+    };
+
+    let cid = memory.sqlite.create_conversation().await.unwrap();
+
+    let first = memory
+        .remember(
+            cid,
+            "user",
+            "The Rust compiler enforces memory safety through the borrow checker.",
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(
+        first.is_some(),
+        "first message has no recent embeddings yet, must be admitted"
+    );
+
+    // Let the background embed task (spawned by `remember`) finish writing the vector.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let second = memory
+        .remember(
+            cid,
+            "user",
+            "The Rust compiler enforces memory safety through the borrow checker.",
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(
+        second.is_none(),
+        "second identical message must be rejected as Redundant once fetch_recent_embeddings \
+         wires the first message's real embedding into the quality gate"
+    );
+}
+
 #[tokio::test]
 async fn no_admission_control_configured_proceeds_without_recording_sample() {
     // test_semantic_memory() leaves admission_control = None, so run_admission_gate must


### PR DESCRIPTION
## Summary

Fixes two `zeph-memory` dead-wiring defects found during live CI testing (ci-1408/ci-1409), both of the same class: a producer/consumer pair where the consumer runs correctly but the producer side was never actually called in production.

- `SqliteStore::insert_tree_leaf` had zero production call sites, so the TiMem tree consolidation background loop (`start_tree_consolidation_loop`) ran on schedule forever but always found zero leaves to consolidate. Wired `Agent::insert_tree_leaf` into `Agent::persist_message`, reusing the same guards as the existing `enqueue_graph_extraction_task` call, gated on `config.memory.tree.enabled` (default `false`, zero overhead for default deployments).
- `SemanticMemory::run_quality_gate` hardcoded `recent_embeddings` to `&[]`, so `QualityGate::evaluate`'s Redundant-content rejection path was permanently unreachable — every write scored as maximally novel regardless of actual duplication. Added `SemanticMemory::fetch_recent_embeddings`, scoped to the current conversation and bounded by `config.recent_window`, reusing the existing `load_history` + `get_vectors` pair already used by the MMR re-ranking path (no new embedding-provider calls).

Closes #6384
Closes #6387

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml` scoped to `zeph-core`/`zeph-memory` (full workspace CI feature set) — all green
- [x] Rustdoc gate clean for both touched crates
- [x] New regression test for #6384 (`persist_message_end_to_end_inserts_tree_leaf`) goes through `persist_message` end-to-end and was independently verified (by two teammates) to fail when the wiring is reverted
- [x] New regression test for #6387 (`remember_quality_gate_rejects_redundant_using_real_recent_embeddings`) independently verified to fail when `recent_embeddings` reverts to `&[]`
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] `.local/testing/coverage-status.md` rows updated (Blocked → Partial) for both components

## Follow-up (not in scope for this PR)

Adversarial review surfaced a pre-existing, now-reachable issue: `load_tree_leaves_unconsolidated` loads oldest leaves by `parent_id IS NULL` with no starvation guard, so singleton (non-clustering) leaves can permanently block newer leaves from ever being swept once they exceed `batch_size`. This bug predates this PR (it was unreachable while the tree had zero writers) and is being filed separately as a P3 follow-up.