### PR TITLE
fix(orchestration): mark task Failed when all tool calls were policy-blocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   as graph extraction so raw tool output and injection-flagged content never enter the tree.
   Best-effort: a single lightweight `INSERT ... RETURNING id`, no LLM/embedding call, failures
   logged and never propagated.
+- `zeph-orchestration` / `zeph-core`: an orchestrated `/plan` task was marked `Completed` even
+  when every real tool call it attempted failed, including `policy_blocked` security-gate
+  denials — task completion status was decided purely by "did the sub-agent's turn finish
+  without throwing an exception," never by inspecting what its tool calls actually did (#6380).
+  `DagScheduler::handle_completed_outcome` now inspects the task's tool-call trace
+  (`ToolCallSummary.ok`) before finalizing status: for the `RunInline` dispatch path, where the
+  trace is already known synchronously, a task whose every tool call failed is routed through
+  the existing failure machinery instead of being marked `Completed`. For the spawn dispatch
+  path, where the trace previously was only ever reconstructed when the opt-in
+  `verify_completeness` flag was enabled (default `false`, so never reconstructed in the
+  issue's repro config), a new `SchedulerAction::CheckToolOutcome` is now emitted
+  unconditionally after every task completion; its handler (calling
+  `DagScheduler::correct_completed_to_failed_if_all_tool_calls_failed` from
+  `scheduler_loop.rs`) resolves the trace from the sub-agent transcript and corrects the task's
+  status from `Completed` to `Failed` post-hoc if every call failed. The post-hoc correction is
+  deliberately lighter-weight than a full failure-machinery reuse (no cascade/lineage/retry
+  side effects) to avoid double-counting the task in `CascadeDetector::RegionHealth`, since its
+  original `Completed` transition already recorded a success outcome before the async
+  correction could run. `TaskStatus::Failed` already rendered correctly in the TUI `PlanView`
+  (red color, error marker) — no TUI changes were needed. Scoped to total task failure (100%
+  of tool calls failed); partial-failure / write-type-specific detection is out of scope
+  (`ToolCallSummary` has no read/write classification field).
 - `zeph-llm` (`ollama`): `convert_message_structured` dropped `MessagePart::Image` siblings
   on messages carrying a `ToolResult` part — the function early-returned
   `ChatMessage::tool(content)` built only from concatenated tool-result text, discarding any

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -572,6 +572,25 @@ impl<C: crate::channel::Channel> Agent<C> {
                             );
                         }
                     }
+                    SchedulerAction::CheckToolOutcome {
+                        task_id,
+                        tool_trace,
+                    } => {
+                        // #6380: deterministic, always-on check (never gated on
+                        // verify_completeness) — a task whose every real tool call failed
+                        // (including policy_blocked denials) must not remain Completed.
+                        // Same trace-resolution contract as SchedulerAction::Verify below.
+                        let task = scheduler.graph().tasks.get(task_id.index()).cloned();
+                        if let Some(task) = task {
+                            let resolved_tool_trace: Option<
+                                Vec<zeph_orchestration::ToolCallSummary>,
+                            > = tool_trace.or_else(|| self.build_tool_trace_for_task(&task));
+                            scheduler.correct_completed_to_failed_if_all_tool_calls_failed(
+                                task_id,
+                                resolved_tool_trace.as_deref(),
+                            );
+                        }
+                    }
                     SchedulerAction::Verify {
                         task_id,
                         output,
@@ -1720,5 +1739,177 @@ mod tests {
                 .is_empty(),
             "canceled sub-agent handle must be reaped, not leaked"
         );
+    }
+
+    // ── #6380: spawn-path total tool-call failure must not leave a task Completed ──────
+
+    /// Regression test for issue #6380 (the actual reported repro path): a `/plan`-orchestrated
+    /// task dispatched via `Spawn` whose sub-agent's only real tool call was rejected
+    /// (`is_error: true`, e.g. `policy_blocked`) must not be reported `Completed` by
+    /// `run_scheduler_loop`, even with `verify_completeness` left at its default `false` — the
+    /// bug this fix closes is specifically that the opt-in `Verify` action never ran for this
+    /// config, so nothing ever inspected the tool outcome. This drives the real
+    /// `SchedulerAction::CheckToolOutcome` handler arm end-to-end: spawn dispatch, sub-agent
+    /// tool-call failure, transcript-based trace reconstruction, and the status correction.
+    #[tokio::test]
+    async fn run_scheduler_loop_corrects_spawn_task_to_failed_when_all_tool_calls_policy_blocked() {
+        use crate::agent::agent_tests::*;
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+        use zeph_llm::provider::{ChatResponse, ToolUseRequest};
+        use zeph_orchestration::{
+            DagScheduler, GraphStatus, RuleBasedRouter, TaskGraph, TaskNode, TaskStatus,
+        };
+        use zeph_subagent::{SubAgentDef, SubAgentManager};
+        use zeph_tools::executor::ToolError;
+
+        let mut graph = TaskGraph::new("goal");
+        graph.tasks.push(TaskNode::new(0, "t", "do a task"));
+
+        let def =
+            SubAgentDef::parse("---\nname: worker\ndescription: A worker\n---\n\nDo things.\n")
+                .unwrap();
+
+        let config = zeph_config::OrchestrationConfig::default();
+        assert!(
+            !config.verify_completeness,
+            "repro precondition: issue #6380 reproduces with verify_completeness at its \
+             default (false) — the fix must not rely on the opt-in verify feature"
+        );
+        let mut scheduler = DagScheduler::new(
+            graph,
+            &config,
+            Box::new(RuleBasedRouter),
+            vec![def.clone()],
+            None,
+        )
+        .unwrap();
+
+        // Sub-agent's LLM narrates a single tool call, then a final "done" text turn — the
+        // tool call itself is rejected by the executor below, simulating a policy_blocked
+        // denial (same `is_error: true` transcript shape either way; see policy_gate.rs).
+        let (mock, _counter) = MockProvider::default().with_tool_use(vec![
+            ChatResponse::ToolUse {
+                text: None,
+                tool_calls: vec![ToolUseRequest {
+                    id: "call-1".into(),
+                    name: "write".into(),
+                    input: serde_json::json!({ "path": "out.txt" }),
+                }],
+                thinking_blocks: vec![],
+            },
+            ChatResponse::Text("done".into()),
+        ]);
+        let provider = AnyProvider::Mock(mock);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::new(vec![Err(ToolError::Blocked {
+            command: "write".into(),
+        })]);
+        let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+        agent.services.orchestration.orchestration_config = config;
+
+        let mut mgr = SubAgentManager::new(4);
+        mgr.definitions_mut().push(def);
+        agent.services.orchestration.subagent_manager = Some(mgr);
+
+        let token = tokio_util::sync::CancellationToken::new();
+        let status = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            agent.run_scheduler_loop(&mut scheduler, 1, token),
+        )
+        .await
+        .expect("run_scheduler_loop must not hang")
+        .unwrap();
+
+        assert_eq!(
+            scheduler.graph().tasks[0].status,
+            TaskStatus::Failed,
+            "spawn-dispatched task whose every real tool call was policy_blocked must be \
+             corrected to Failed by SchedulerAction::CheckToolOutcome, not remain Completed \
+             -- this is the actual issue #6380 repro path (PlanView reads per-task status)"
+        );
+        // Known, deliberate scope limit (critic finding S1, .local/handoff/*-critic.md):
+        // the spawn-path correction is status-only and does not re-run graph completion, so
+        // a single-task plan's overall GraphStatus stays Completed even though its only task
+        // was just corrected to Failed. Pinning this down so a future change to propagate the
+        // correction is a conscious decision, not an accidental behavior change caught here.
+        assert_eq!(
+            status,
+            GraphStatus::Completed,
+            "documents the current accepted tradeoff: post-hoc task correction does not \
+             recompute graph-level status (see critic finding S1)"
+        );
+    }
+
+    /// Companion no-op case for the previous test: a spawn-dispatched task whose sub-agent's
+    /// tool call actually succeeded must not be touched by `CheckToolOutcome` and must remain
+    /// `Completed`.
+    #[tokio::test]
+    async fn run_scheduler_loop_leaves_spawn_task_completed_when_tool_call_succeeds() {
+        use crate::agent::agent_tests::*;
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+        use zeph_llm::provider::{ChatResponse, ToolUseRequest};
+        use zeph_orchestration::{
+            DagScheduler, GraphStatus, RuleBasedRouter, TaskGraph, TaskNode, TaskStatus,
+        };
+        use zeph_subagent::{SubAgentDef, SubAgentManager};
+
+        let mut graph = TaskGraph::new("goal");
+        graph.tasks.push(TaskNode::new(0, "t", "do a task"));
+
+        let def =
+            SubAgentDef::parse("---\nname: worker\ndescription: A worker\n---\n\nDo things.\n")
+                .unwrap();
+
+        let config = zeph_config::OrchestrationConfig::default();
+        let mut scheduler = DagScheduler::new(
+            graph,
+            &config,
+            Box::new(RuleBasedRouter),
+            vec![def.clone()],
+            None,
+        )
+        .unwrap();
+
+        let (mock, _counter) = MockProvider::default().with_tool_use(vec![
+            ChatResponse::ToolUse {
+                text: None,
+                tool_calls: vec![ToolUseRequest {
+                    id: "call-1".into(),
+                    name: "read".into(),
+                    input: serde_json::json!({ "path": "in.txt" }),
+                }],
+                thinking_blocks: vec![],
+            },
+            ChatResponse::Text("done".into()),
+        ]);
+        let provider = AnyProvider::Mock(mock);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::with_output("read", "file contents");
+        let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+        agent.services.orchestration.orchestration_config = config;
+
+        let mut mgr = SubAgentManager::new(4);
+        mgr.definitions_mut().push(def);
+        agent.services.orchestration.subagent_manager = Some(mgr);
+
+        let token = tokio_util::sync::CancellationToken::new();
+        let status = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            agent.run_scheduler_loop(&mut scheduler, 1, token),
+        )
+        .await
+        .expect("run_scheduler_loop must not hang")
+        .unwrap();
+
+        assert_eq!(
+            scheduler.graph().tasks[0].status,
+            TaskStatus::Completed,
+            "a genuinely successful tool call must not be corrected away from Completed"
+        );
+        assert_eq!(status, GraphStatus::Completed);
     }
 }

--- a/crates/zeph-orchestration/src/scheduler/mod.rs
+++ b/crates/zeph-orchestration/src/scheduler/mod.rs
@@ -124,6 +124,29 @@ pub enum SchedulerAction {
         /// Surface"). Transient: never persisted in `TaskResult`.
         tool_trace: Option<Vec<crate::verifier::ToolCallSummary>>,
     },
+    /// Request a deterministic tool-outcome check for a just-completed task (issue #6380).
+    ///
+    /// Emitted **unconditionally** from `tick()` for every `Completed` task — unlike
+    /// [`SchedulerAction::Verify`], this is not gated behind `verify_completeness`: the
+    /// check is a cheap, deterministic scan over already-known or fetchable tool-call
+    /// outcomes (no LLM call), so it is safe to always run. It exists because task
+    /// completion status was previously decided purely by "did the sub-agent's turn finish
+    /// without throwing an exception," never by inspecting what its tool calls actually did
+    /// — so a task whose every real tool call was denied by policy (`policy_blocked`) or
+    /// otherwise failed was still marked `Completed` with zero real work performed.
+    ///
+    /// The caller must resolve `tool_trace` the same way as `Verify::tool_trace`: `Some` for
+    /// `RunInline` tasks (already known at emission time), `None` for the spawn dispatch
+    /// path — reconstruct it from the sub-agent transcript, then call
+    /// [`DagScheduler::correct_completed_to_failed_if_all_tool_calls_failed`] with the
+    /// resolved trace.
+    CheckToolOutcome {
+        /// Task whose tool trace should be inspected.
+        task_id: TaskId,
+        /// Real tool-call trace collected in-loop for `RunInline` tasks (`Some`), or `None`
+        /// for spawn-path tasks — same resolution contract as `Verify::tool_trace`.
+        tool_trace: Option<Vec<crate::verifier::ToolCallSummary>>,
+    },
 }
 
 /// Event sent by a sub-agent loop when it terminates.

--- a/crates/zeph-orchestration/src/scheduler/tick/mod.rs
+++ b/crates/zeph-orchestration/src/scheduler/tick/mod.rs
@@ -22,6 +22,27 @@ struct CompletedTaskData {
     tool_trace: Option<Vec<crate::verifier::ToolCallSummary>>,
 }
 
+/// `true` when `trace` is non-empty and every call in it failed (`ok == false`) — including
+/// `policy_blocked` denials. Issue #6380: a task can finish its sub-agent loop without
+/// throwing an exception while every real tool call it attempted was rejected, producing
+/// zero actual work. An empty trace is deliberately *not* treated as total failure (a task
+/// that made no tool calls at all — e.g. pure reasoning/narration — is not this defect).
+///
+/// # Known limitation: mixed traces are not caught
+///
+/// A trace with even one successful call (any `ok == true` entry) is *not* flagged by this
+/// heuristic, even if every write-type call in it failed. This is plausibly the common
+/// real-world shape of #6380: read-type tools (`read`, `grep`, `list_directory`, ...) are not
+/// present in `zeph_common::quarantine::QUARANTINE_DENIED`, so a quarantined sub-agent that
+/// successfully reads context before every write call is policy-blocked produces exactly this
+/// uncaught mixed trace — it still ends up `Completed` despite having produced zero durable
+/// work. Catching that shape needs a read/write classification field on `ToolCallSummary`,
+/// which is out of scope for this fix (see `ToolCallSummary::ok`'s own doc comment and the
+/// #6380 fix's scope note); tracked as a follow-up.
+fn all_tool_calls_failed(trace: &[crate::verifier::ToolCallSummary]) -> bool {
+    !trace.is_empty() && trace.iter().all(|c| !c.ok)
+}
+
 impl DagScheduler {
     /// Process pending events and produce actions for the caller.
     ///
@@ -582,6 +603,26 @@ impl DagScheduler {
             tool_trace,
         } = completed;
 
+        // #6380: when the real tool-call trace is already known synchronously (RunInline
+        // dispatch path — always `Some`, per `TaskOutcome::Completed`'s doc comment) and
+        // every call in it failed, route through the existing failure machinery instead of
+        // marking the task Completed. This branches out before any Completed-side-effect
+        // runs (cascade record_outcome, downstream unblocking), so there is no double-count
+        // risk here — unlike the spawn dispatch path, whose tool_trace is always `None` at
+        // this call site and is corrected post-hoc via the `CheckToolOutcome` action emitted
+        // below instead (see `DagScheduler::correct_completed_to_failed_if_all_tool_calls_failed`
+        // for why that correction is deliberately lighter-weight than a full re-route here).
+        if let Some(trace) = tool_trace.as_ref()
+            && all_tool_calls_failed(trace)
+        {
+            let error = format!(
+                "all {} tool call(s) in this task failed or were policy-blocked; \
+                 narration: {output}",
+                trace.len()
+            );
+            return self.handle_failed_outcome(task_id, &error);
+        }
+
         self.graph_dirty = true;
         self.graph.tasks[task_id.index()].status = TaskStatus::Completed;
         self.graph.tasks[task_id.index()].result = Some(TaskResult {
@@ -626,20 +667,102 @@ impl DagScheduler {
             }
         }
 
+        // #6380: always request a deterministic tool-outcome check — unlike Verify below,
+        // this is cheap (no LLM call) and must run regardless of verify_completeness, since
+        // that flag defaults to false and the defect this guards against has nothing to do
+        // with completeness verification.
+        let mut actions = vec![SchedulerAction::CheckToolOutcome {
+            task_id,
+            tool_trace: tool_trace.clone(),
+        }];
+
         // Emit Verify action when verify_completeness is enabled.
         // The replan budget is enforced inside inject_tasks() — the observation
         // (emitting Verify) must not be gated on the mutation budget, or tasks
         // after budget exhaustion never receive verification at all.
         // max_replans=0 still emits Verify; gaps are logged only (no inject_tasks call).
         if self.verify_completeness {
-            vec![SchedulerAction::Verify {
+            actions.push(SchedulerAction::Verify {
                 task_id,
                 output,
                 tool_trace,
-            }]
-        } else {
-            Vec::new()
+            });
         }
+        actions
+    }
+
+    /// Post-hoc correction for a `Completed` task whose real tool-call trace shows every
+    /// call failed, including `policy_blocked` denials (issue #6380). No-op (returns
+    /// `false`) when `tool_trace` is `None`, empty, or contains at least one successful
+    /// call, and when the task is no longer `Completed` (already corrected, or moved on to
+    /// some other status by a later transition — never clobber that).
+    ///
+    /// # Design note: why this is not a `handle_failed_outcome` reuse
+    ///
+    /// This method is called from the `SchedulerAction::CheckToolOutcome` handler, which
+    /// always runs *after* `handle_completed_outcome`'s full `Completed` side-effect set has
+    /// already executed for this task: `cascade_detector.record_outcome` was already called
+    /// with `succeeded = true`, and downstream tasks were already unblocked to `Ready` (that
+    /// unblocking is intentionally not gated on any later verification — see the identical,
+    /// pre-existing precedent for `SchedulerAction::Verify` at the `Completed` transition).
+    /// Routing this correction through `handle_failed_outcome` instead would double-record
+    /// this task in [`crate::cascade::CascadeDetector`]'s `RegionHealth` (once as success,
+    /// once as failure) and could trigger a fan-out/chain cascade abort off that stale
+    /// dual-counted state — skewing failure-rate metrics that `FailureStrategy` and
+    /// whole-plan verify (#6379) rely on for accuracy, for a comparatively rare correction
+    /// path. So this method deliberately only flips `TaskStatus` and annotates
+    /// `TaskResult::output`; it does not touch `cascade_detector`, `lineage_chains`, or any
+    /// retry/abort machinery.
+    ///
+    /// (The synchronously-available `RunInline` case does not go through this method at all —
+    /// `handle_completed_outcome` detects total tool-call failure *before* running any
+    /// `Completed` side effect and routes straight to `handle_failed_outcome`, so no
+    /// double-counting question arises there.)
+    ///
+    /// # Consequence: downstream is not retroactively unwound
+    ///
+    /// Because the correction is status-only, dependents of this task that were already
+    /// unblocked to `Ready` (or already dispatched/`Running`) before this method runs are
+    /// **not** retroactively canceled — they proceed as if the task had genuinely completed.
+    /// Likewise, `GraphStatus` can remain `Completed` for the whole plan even though this one
+    /// constituent task ends up `TaskStatus::Failed`: nothing here re-evaluates the graph's
+    /// overall terminal status. A caller inspecting only `GraphStatus` will not learn that a
+    /// task silently failed after the fact; per-task status (e.g. via `TaskGraphSnapshot`,
+    /// which the TUI `PlanView` already renders) is the only reliable signal for this case.
+    pub fn correct_completed_to_failed_if_all_tool_calls_failed(
+        &mut self,
+        task_id: TaskId,
+        tool_trace: Option<&[crate::verifier::ToolCallSummary]>,
+    ) -> bool {
+        let Some(trace) = tool_trace else {
+            return false;
+        };
+        if !all_tool_calls_failed(trace) {
+            return false;
+        }
+        let Some(task) = self.graph.tasks.get_mut(task_id.index()) else {
+            return false;
+        };
+        if task.status != TaskStatus::Completed {
+            return false;
+        }
+
+        tracing::warn!(
+            task_id = %task_id,
+            tool_call_count = trace.len(),
+            "correcting task status Completed -> Failed: all tool calls failed or were \
+             policy-blocked (#6380)"
+        );
+        task.status = TaskStatus::Failed;
+        if let Some(result) = task.result.as_mut() {
+            result.output = format!(
+                "{} [corrected: all {} tool call(s) failed or were policy-blocked]",
+                result.output,
+                trace.len()
+            );
+        }
+        self.graph_dirty = true;
+        true
     }
 
     /// Apply the Failed outcome branch: build lineage, evaluate cascade abort, propagate failure.

--- a/crates/zeph-orchestration/src/scheduler/tick/tests.rs
+++ b/crates/zeph-orchestration/src/scheduler/tick/tests.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use super::*;
 use crate::scheduler::tests::*;
+use crate::verifier::ToolCallSummary;
 
 #[test]
 fn test_tick_produces_spawn_for_ready() {
@@ -2205,5 +2206,322 @@ fn take_graph_dirty_true_after_timeout() {
     assert!(
         !scheduler.take_graph_dirty(),
         "take_graph_dirty must reset to false on second call"
+    );
+}
+
+// ── #6380: total tool-call failure must not leave a task Completed ────────────
+
+fn make_running_task(scheduler: &mut DagScheduler, task_id: TaskId, handle_id: &str) {
+    scheduler.graph.tasks[task_id.index()].status = TaskStatus::Running;
+    scheduler.running.insert(
+        task_id,
+        RunningTask {
+            agent_handle_id: handle_id.to_string(),
+            agent_def_name: "worker".to_string(),
+            started_at: std::time::Instant::now(),
+            admission_permit: None,
+            last_progress_at: None,
+        },
+    );
+}
+
+fn completed_event(
+    task_id: TaskId,
+    handle_id: &str,
+    tool_trace: Option<Vec<ToolCallSummary>>,
+) -> TaskEvent {
+    TaskEvent {
+        task_id,
+        agent_handle_id: handle_id.to_string(),
+        outcome: TaskOutcome::Completed {
+            output: "narration".to_string(),
+            artifacts: vec![],
+            tool_trace,
+        },
+    }
+}
+
+#[test]
+fn handle_completed_outcome_all_tools_failed_marks_task_failed() {
+    // Part A (RunInline path): every real tool call in the synchronously-available trace
+    // failed (including policy_blocked denials) — the task must not remain Completed.
+    let graph = graph_from_nodes(vec![make_node(0, &[])]);
+    let mut scheduler = make_scheduler(graph);
+    make_running_task(&mut scheduler, TaskId(0), "h0");
+
+    scheduler.buffered_events.push_back(completed_event(
+        TaskId(0),
+        "h0",
+        Some(vec![
+            ToolCallSummary {
+                tool: "create_directory".to_string(),
+                args_summary: None,
+                ok: false,
+            },
+            ToolCallSummary {
+                tool: "write".to_string(),
+                args_summary: None,
+                ok: false,
+            },
+        ]),
+    ));
+
+    scheduler.tick();
+
+    assert_eq!(
+        scheduler.graph.tasks[0].status,
+        TaskStatus::Failed,
+        "a task whose every tool call failed must be marked Failed, not Completed"
+    );
+}
+
+#[test]
+fn handle_completed_outcome_mixed_tool_trace_preserves_completed() {
+    // Partial failure is explicitly out of scope (issue #6380, Part D) — a task with at
+    // least one successful tool call must still complete normally.
+    let graph = graph_from_nodes(vec![make_node(0, &[])]);
+    let mut scheduler = make_scheduler(graph);
+    make_running_task(&mut scheduler, TaskId(0), "h0");
+
+    scheduler.buffered_events.push_back(completed_event(
+        TaskId(0),
+        "h0",
+        Some(vec![
+            ToolCallSummary {
+                tool: "write".to_string(),
+                args_summary: None,
+                ok: false,
+            },
+            ToolCallSummary {
+                tool: "read".to_string(),
+                args_summary: None,
+                ok: true,
+            },
+        ]),
+    ));
+
+    scheduler.tick();
+
+    assert_eq!(
+        scheduler.graph.tasks[0].status,
+        TaskStatus::Completed,
+        "a mixed trace (at least one successful tool call) must preserve Completed"
+    );
+}
+
+#[test]
+fn handle_completed_outcome_empty_tool_trace_preserves_completed() {
+    // A task that made zero tool calls (pure reasoning/narration) is deliberately not
+    // treated as total failure, per `all_tool_calls_failed`'s doc comment.
+    let graph = graph_from_nodes(vec![make_node(0, &[])]);
+    let mut scheduler = make_scheduler(graph);
+    make_running_task(&mut scheduler, TaskId(0), "h0");
+
+    scheduler
+        .buffered_events
+        .push_back(completed_event(TaskId(0), "h0", Some(vec![])));
+
+    scheduler.tick();
+
+    assert_eq!(
+        scheduler.graph.tasks[0].status,
+        TaskStatus::Completed,
+        "an empty tool trace (no tool calls made) must preserve Completed"
+    );
+}
+
+#[test]
+fn handle_completed_outcome_none_tool_trace_preserves_completed() {
+    // Pre-existing behavior (spawn dispatch path before the CheckToolOutcome correction
+    // runs) must not regress: `tool_trace: None` never triggers the Part A check.
+    let graph = graph_from_nodes(vec![make_node(0, &[])]);
+    let mut scheduler = make_scheduler(graph);
+    make_running_task(&mut scheduler, TaskId(0), "h0");
+
+    scheduler
+        .buffered_events
+        .push_back(completed_event(TaskId(0), "h0", None));
+
+    scheduler.tick();
+
+    assert_eq!(
+        scheduler.graph.tasks[0].status,
+        TaskStatus::Completed,
+        "tool_trace: None must preserve Completed (no synchronous trace available)"
+    );
+}
+
+#[test]
+fn handle_completed_outcome_all_tools_failed_does_not_double_count_cascade() {
+    // Part A branches out via `handle_failed_outcome` *before* any Completed-branch side
+    // effect runs, so the task must be recorded in `CascadeDetector::RegionHealth` exactly
+    // once (as a failure), never twice (once success, once failure).
+    let graph = graph_from_nodes(vec![make_node(0, &[])]);
+    let config = zeph_config::OrchestrationConfig {
+        cascade_routing: true,
+        topology_selection: true,
+        ..make_config()
+    };
+    let defs = vec![make_def("worker")];
+    let mut scheduler =
+        DagScheduler::new(graph, &config, Box::new(FirstRouter), defs, None).unwrap();
+    assert!(
+        scheduler.cascade_detector.is_some(),
+        "test precondition: cascade_detector must be enabled"
+    );
+    make_running_task(&mut scheduler, TaskId(0), "h0");
+
+    scheduler.buffered_events.push_back(completed_event(
+        TaskId(0),
+        "h0",
+        Some(vec![ToolCallSummary {
+            tool: "write".to_string(),
+            args_summary: None,
+            ok: false,
+        }]),
+    ));
+
+    scheduler.tick();
+
+    assert_eq!(scheduler.graph.tasks[0].status, TaskStatus::Failed);
+    let health = scheduler
+        .cascade_detector
+        .as_ref()
+        .unwrap()
+        .region_health()
+        .get(&TaskId(0))
+        .expect("region health must be recorded for this task's region");
+    assert_eq!(
+        health.total_tasks, 1,
+        "task must be recorded exactly once in RegionHealth, not double-counted \
+         (success then failure): {health:?}"
+    );
+    assert_eq!(
+        health.failed_tasks, 1,
+        "the single recorded outcome must be a failure"
+    );
+}
+
+// ── DagScheduler::correct_completed_to_failed_if_all_tool_calls_failed ────────
+
+fn scheduler_with_completed_task() -> (DagScheduler, TaskId) {
+    let graph = graph_from_nodes(vec![make_node(0, &[])]);
+    let mut scheduler = make_scheduler(graph);
+    let task_id = TaskId(0);
+    scheduler.graph.tasks[task_id.index()].status = TaskStatus::Completed;
+    scheduler.graph.tasks[task_id.index()].result = Some(TaskResult {
+        output: "original output".to_string(),
+        artifacts: vec![],
+        duration_ms: 10,
+        agent_id: Some("agent-1".to_string()),
+        agent_def: Some("worker".to_string()),
+    });
+    let _ = scheduler.take_graph_dirty(); // reset dirty flag set by DagScheduler::new()/init
+    (scheduler, task_id)
+}
+
+#[test]
+fn correct_completed_to_failed_noop_on_none_trace() {
+    let (mut scheduler, task_id) = scheduler_with_completed_task();
+    let corrected = scheduler.correct_completed_to_failed_if_all_tool_calls_failed(task_id, None);
+    assert!(!corrected);
+    assert_eq!(
+        scheduler.graph.tasks[task_id.index()].status,
+        TaskStatus::Completed
+    );
+    assert!(!scheduler.take_graph_dirty());
+}
+
+#[test]
+fn correct_completed_to_failed_noop_on_all_ok_trace() {
+    let (mut scheduler, task_id) = scheduler_with_completed_task();
+    let trace = vec![ToolCallSummary {
+        tool: "read".to_string(),
+        args_summary: None,
+        ok: true,
+    }];
+    let corrected =
+        scheduler.correct_completed_to_failed_if_all_tool_calls_failed(task_id, Some(&trace));
+    assert!(!corrected);
+    assert_eq!(
+        scheduler.graph.tasks[task_id.index()].status,
+        TaskStatus::Completed
+    );
+    assert!(!scheduler.take_graph_dirty());
+}
+
+#[test]
+fn correct_completed_to_failed_noop_on_empty_trace() {
+    let (mut scheduler, task_id) = scheduler_with_completed_task();
+    let corrected =
+        scheduler.correct_completed_to_failed_if_all_tool_calls_failed(task_id, Some(&[]));
+    assert!(!corrected);
+    assert_eq!(
+        scheduler.graph.tasks[task_id.index()].status,
+        TaskStatus::Completed
+    );
+}
+
+#[test]
+fn correct_completed_to_failed_noop_when_task_not_completed() {
+    // Must never clobber a later transition — e.g. a task already Failed by a different
+    // path, or still Running.
+    let (mut scheduler, task_id) = scheduler_with_completed_task();
+    scheduler.graph.tasks[task_id.index()].status = TaskStatus::Failed;
+    let trace = vec![ToolCallSummary {
+        tool: "write".to_string(),
+        args_summary: None,
+        ok: false,
+    }];
+    let corrected =
+        scheduler.correct_completed_to_failed_if_all_tool_calls_failed(task_id, Some(&trace));
+    assert!(
+        !corrected,
+        "correction must no-op when the task's current status is not Completed"
+    );
+    assert_eq!(
+        scheduler.graph.tasks[task_id.index()].status,
+        TaskStatus::Failed
+    );
+}
+
+#[test]
+fn correct_completed_to_failed_success_flips_status_and_marks_output() {
+    let (mut scheduler, task_id) = scheduler_with_completed_task();
+    let trace = vec![
+        ToolCallSummary {
+            tool: "write".to_string(),
+            args_summary: None,
+            ok: false,
+        },
+        ToolCallSummary {
+            tool: "bash".to_string(),
+            args_summary: None,
+            ok: false,
+        },
+    ];
+    let corrected =
+        scheduler.correct_completed_to_failed_if_all_tool_calls_failed(task_id, Some(&trace));
+    assert!(corrected);
+    assert_eq!(
+        scheduler.graph.tasks[task_id.index()].status,
+        TaskStatus::Failed
+    );
+    let output = &scheduler.graph.tasks[task_id.index()]
+        .result
+        .as_ref()
+        .unwrap()
+        .output;
+    assert!(
+        output.starts_with("original output"),
+        "correction must append to, not replace, the original output: {output}"
+    );
+    assert!(
+        output.contains("corrected") && output.contains('2'),
+        "correction marker must be present and mention the failed call count: {output}"
+    );
+    assert!(
+        scheduler.take_graph_dirty(),
+        "a genuine status correction must set graph_dirty"
     );
 }


### PR DESCRIPTION
## Summary

`/plan`-orchestrated tasks were reported `Completed` in the PlanView TUI even when every tool call the sub-agent attempted was rejected by security policy (`policy_blocked`, quarantined trust floor) and zero filesystem artifacts were produced — no error indicator anywhere, only a vague hedge in the final aggregated summary. `handle_completed_outcome()` unconditionally set `TaskStatus::Completed` without ever inspecting the task's tool-call outcomes, on every dispatch path, and this happened on the default config (`verify_completeness = false`) since the tool trace needed to detect it was never even reconstructed unless the opt-in verifier feature was enabled.

- **`RunInline` dispatch path**: a task whose (non-empty) tool trace has every call `ok == false` now routes through the existing failure machinery (`handle_failed_outcome`) *before* any `Completed`-branch side effect runs — full cascade/lineage/retry parity, no double-counting.
- **Spawn dispatch path** (the issue's actual repro — `.zeph/agents/*.md` sub-agents): a new, always-on `SchedulerAction::CheckToolOutcome` (not gated behind `verify_completeness`, unlike the sibling `Verify` action) reconstructs the transcript trace post-hoc and applies a deliberately lightweight status-only correction (`Completed` → `Failed`). This intentionally skips cascade/lineage/retry handling — by the time this correction runs, the task's original `Completed` transition already recorded a success and already unblocked downstream tasks, so re-running full failure machinery would double-count `RegionHealth`.
- No TUI changes were needed — `TaskStatus::Failed` already renders correctly (red + error marker) in the PlanView widget.

**Scope**: this fix targets *total* task failure (100% of tool calls failed), matching the issue's repro. It is explicitly documented (in the new doc comments) that:
- A mixed trace (e.g. a successful read before a policy-blocked write) is **not** caught by this heuristic — confirmed independently that read-type tools are not in `QUARANTINE_DENIED`, so they pass under a `quarantined` trust floor while writes are denied. This is plausibly the *common* real-world shape of this defect, not a rare edge case — tracked as a follow-up (see below).
- The spawn-path correction is status-only: downstream dependents already unblocked before the correction lands are not retroactively canceled, and the overall `GraphStatus` can stay `Completed` even though a constituent task is `Failed` — tracked as a follow-up (see below).

## Follow-up issues

Two scope boundaries identified during adversarial review are being filed as tracked follow-ups rather than expanding this PR:
- Spawn-path failure propagation (dependents not canceled, `GraphStatus` divergence from the `RunInline` path)
- Partial-failure / write-type-specific detection (elevated priority — confirmed common, not rare, since read-type tools pass under the quarantined trust floor)

## Test plan

- [x] 15 new tests: 10 unit (`crates/zeph-orchestration/src/scheduler/tick/tests.rs`) covering all-failed/mixed/empty/`None` trace cases and the `correct_completed_to_failed_if_all_tool_calls_failed` idempotency guards; 2 `#[tokio::test]` integration tests (`crates/zeph-core/src/agent/scheduler_loop.rs`) driving a real spawn-dispatched sub-agent through a mocked `policy_blocked` tool denial with `verify_completeness = false` (the issue's actual repro configuration)
- [x] Both most load-bearing tests verified via revert-and-confirm-failure methodology (fail without the fix, pass with it restored)
- [x] Full workspace `cargo nextest`: 13998 passed, 0 failed, 35 skipped
- [x] `cargo +nightly fmt --check`: clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`: clean
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`): clean
- [x] `gitleaks protect --staged`: no leaks found
- [ ] Live `/plan` session reproducing the issue's exact repro (skill-matcher-fallback → quarantined trust floor → write-tool policy block) — not run this cycle; structural/unit + real-spawn-dispatch-integration coverage exists, see `.local/testing/coverage-status.md` and `playbooks/orchestration-plan.md` Scenario 6

Closes #6380