### PR TITLE
fix(channels): forward elicit() and send_context_estimate() on AppChannel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `src/channel.rs`: `impl Channel for AppChannel` forwarded most `Channel` trait methods via
+  `dispatch_app_channel!` but never overrode `elicit()` or `send_context_estimate()`, so both
+  calls fell through to the trait's default methods instead of reaching `AnyChannel`/`TuiChannel`'s
+  real implementations. `elicit()`'s default unconditionally returns `Declined`, so every MCP
+  elicitation request was auto-declined regardless of channel — the CLI's real per-field
+  readline prompting (`crates/zeph-channels/src/cli.rs`) and the TUI's modal dialog
+  (`crates/zeph-tui/src/widgets/elicitation.rs`) were unreachable through the actual `zeph`
+  binary (#6388). `send_context_estimate()`'s default silently no-ops, so the TUI's real-time
+  context-usage estimate (`AgentEvent::ContextEstimate`) never reached the input block title.
+  Added both missing overrides to `impl Channel for AppChannel`, following the existing
+  `dispatch_app_channel!` pattern used by the other 19 forwarded methods.
 - `zeph-memory`: `SemanticMemory::run_quality_gate` hardcoded `recent_embeddings` to `&[]` on
   its only production call site, so `QualityGate::evaluate`'s `Redundant`-rejection path —
   already unit-tested and working — could never fire on a real conversation (#6387). Added

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -16,7 +16,8 @@ use zeph_common::TaskSupervisor;
 use crate::execution_mode::ExecutionMode;
 #[cfg(feature = "tui")]
 use zeph_core::channel::{
-    Channel, ChannelError, ChannelMessage, StopHint, ToolOutputEvent, ToolStartEvent,
+    Channel, ChannelError, ChannelMessage, ElicitationRequest, ElicitationResponse, StopHint,
+    ToolOutputEvent, ToolStartEvent,
 };
 use zeph_core::config::Config;
 use zeph_core::json_event_sink::JsonEventSink;
@@ -62,6 +63,12 @@ impl Channel for AppChannel {
     async fn confirm(&mut self, prompt: &str) -> Result<bool, ChannelError> {
         dispatch_app_channel!(self, confirm, prompt)
     }
+    async fn elicit(
+        &mut self,
+        request: ElicitationRequest,
+    ) -> Result<ElicitationResponse, ChannelError> {
+        dispatch_app_channel!(self, elicit, request)
+    }
     fn try_recv(&mut self) -> Option<ChannelMessage> {
         match self {
             Self::Standard(c) => c.try_recv(),
@@ -87,6 +94,9 @@ impl Channel for AppChannel {
     }
     async fn send_queue_count(&mut self, count: usize) -> Result<(), ChannelError> {
         dispatch_app_channel!(self, send_queue_count, count)
+    }
+    async fn send_context_estimate(&mut self, tokens: usize) -> Result<(), ChannelError> {
+        dispatch_app_channel!(self, send_context_estimate, tokens)
     }
     async fn send_diff(
         &mut self,
@@ -408,6 +418,80 @@ mod tests {
         ch.notify_foreground_subagent_completed("sa-id", "planner", true)
             .await
             .unwrap();
+        // 19. send_context_estimate
+        ch.send_context_estimate(4096).await.unwrap();
+        // 20. elicit — skipped (CliChannel auto-declines on non-tty stdin regardless
+        // of forwarding correctness; real dispatch is verified separately below via
+        // TuiChannel, whose response only arrives if AppChannel forwards the call).
+    }
+
+    /// Regression test for #6388: `AppChannel::elicit` must forward to the
+    /// wrapped channel's real implementation, not fall through to
+    /// `Channel::elicit`'s default (auto-decline) method. `TuiChannel::elicit`
+    /// only resolves once a response is sent down its `oneshot` channel, so if
+    /// forwarding were missing this test would hang or observe `Declined`
+    /// without ever receiving the `ElicitationRequest` event.
+    #[tokio::test]
+    async fn app_channel_forwards_elicit_to_real_implementation() {
+        use zeph_core::channel::{ElicitationRequest, ElicitationResponse};
+        use zeph_tui::{AgentEvent, TuiChannel};
+
+        let (_user_tx, user_rx) = tokio::sync::mpsc::channel(1);
+        let (agent_tx, mut agent_rx) = tokio::sync::mpsc::channel(1);
+        let mut ch = AppChannel::Tui(TuiChannel::new(user_rx, agent_tx));
+
+        let request = ElicitationRequest {
+            server_name: "test-server".to_owned(),
+            message: "provide input".to_owned(),
+            fields: vec![],
+        };
+        let elicit_task = tokio::spawn(async move { ch.elicit(request).await });
+
+        let event = agent_rx
+            .recv()
+            .await
+            .expect("elicit() must forward an AgentEvent instead of auto-declining");
+        let response_tx = match event {
+            AgentEvent::ElicitationRequest { response_tx, .. } => response_tx,
+            other => panic!("expected AgentEvent::ElicitationRequest, got {other:?}"),
+        };
+        response_tx
+            .send(ElicitationResponse::Accepted(
+                serde_json::json!({"ok": true}),
+            ))
+            .unwrap();
+
+        let result = elicit_task.await.unwrap().unwrap();
+        assert!(
+            matches!(result, ElicitationResponse::Accepted(_)),
+            "expected Accepted, got {result:?}"
+        );
+    }
+
+    /// Regression test for #6388 follow-up gap: `AppChannel::send_context_estimate`
+    /// must forward to `TuiChannel`'s real implementation (which emits an
+    /// `AgentEvent::ContextEstimate`), not silently no-op via the trait default.
+    #[tokio::test]
+    async fn app_channel_forwards_send_context_estimate_to_real_implementation() {
+        use zeph_tui::{AgentEvent, TuiChannel};
+
+        let (_user_tx, user_rx) = tokio::sync::mpsc::channel(1);
+        let (agent_tx, mut agent_rx) = tokio::sync::mpsc::channel(4);
+        let mut ch = AppChannel::Tui(TuiChannel::new(user_rx, agent_tx));
+
+        ch.send_context_estimate(4096).await.unwrap();
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(5), agent_rx.recv())
+            .await
+            .expect(
+                "send_context_estimate() must forward an AgentEvent instead of no-op'ing \
+                 (timed out waiting for it)",
+            )
+            .expect("agent_tx channel closed unexpectedly");
+        match event {
+            AgentEvent::ContextEstimate(tokens) => assert_eq!(tokens, 4096),
+            other => panic!("expected AgentEvent::ContextEstimate, got {other:?}"),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- `impl Channel for AppChannel` (`src/channel.rs`) forwarded most `Channel` trait methods via `dispatch_app_channel!` but never overrode `elicit()` or `send_context_estimate()`, so both calls silently fell through to the trait's default methods instead of reaching `CliChannel`/`TuiChannel`'s real, already-unit-tested implementations.
- `elicit()`'s default unconditionally returns `Declined`, so every MCP server-driven elicitation request was auto-declined in both CLI and TUI modes regardless of `[mcp] elicitation_enabled`. `send_context_estimate()`'s default silently no-ops, so the TUI's real-time context-usage estimate never reached the input block title.
- Added both missing overrides, following the existing `dispatch_app_channel!` pattern used by the other forwarded methods.
- Live-verified against a real stdio MCP fixture server: the `[MCP server '...' is requesting input]` banner and the real per-field prompt now fire, where previously the request was auto-declined in under 1ms with no visible indication.

Note: this fix makes elicitation prompts reachable again, but a separate, pre-existing bug (#6398, filed during this fix's live verification) means the CLI accept path can race against the background chat-input reader for stdin and time out client-side — that is a distinct root cause, not caused by this change, and is tracked separately.

Closes #6388

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 14007 passed, 0 failed, 35 skipped
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked`
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `gitleaks protect --staged --no-banner --redact` — no leaks
- [x] New regression tests added for both overrides (`app_channel_forwards_elicit_to_real_implementation`, `app_channel_forwards_send_context_estimate_to_real_implementation`), each independently revert-verified to fail (not pass vacuously) when its override is removed
- [x] Live e2e verification via tmux against a real stdio MCP fixture server confirms the CLI elicitation prompt now fires