### PR TITLE
fix(core,tui): wire classifier metrics into sanitizer, flash single tool calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-core`: the sanitizer's ML-backed injection and PII classifier calls
+  (`ContentSanitizer::classify_injection`/`detect_pii`) were never recorded in the TUI
+  metrics panel (#6382). The shared `Arc<ClassifierMetrics>` ring buffer they record into was
+  never constructed in production — `runtime.metrics.classifier_metrics` stayed `None`
+  regardless of config, so `push_classifier_metrics()` was permanently a no-op. `MetricsState::new`
+  now allocates the `Arc` unconditionally at agent construction, before any builder-chain call
+  runs, so it is available to `with_security`'s sanitizer construction (and to
+  `with_llm_classifier`'s existing feedback-classifier wiring, which was equally dead)
+  regardless of builder call order.
+- `zeph-tui`: a completed tool call that rendered as a single (non-grouped)
+  `MessageGroup::Single` entry never received the completion-flash highlight, even though
+  `App::maybe_flash_completed_group` already recorded a flash for group-size-1 runs (#6383).
+  The flash-style patch was only applied in the `MessageGroup::Grouped` render arm; the
+  `Single` arm now applies the same `patch_flash_style` check, so a lone tool completion
+  flashes identically to a grouped one.
 - `src/channel.rs`: `impl Channel for AppChannel` forwarded most `Channel` trait methods via
   `dispatch_app_channel!` but never overrode `elicit()` or `send_context_estimate()`, so both
   calls fell through to the trait's default methods instead of reaching `AnyChannel`/`TuiChannel`'s

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -1029,8 +1029,14 @@ impl<C: Channel> Agent<C> {
     /// rate limiter, and pre-execution verifiers.
     #[must_use]
     pub fn with_security(mut self, security: SecurityConfig, timeouts: TimeoutConfig) -> Self {
-        self.services.security.sanitizer =
-            zeph_sanitizer::ContentSanitizer::new(&security.content_isolation);
+        let sanitizer = zeph_sanitizer::ContentSanitizer::new(&security.content_isolation);
+        #[cfg(feature = "classifiers")]
+        let sanitizer = if let Some(ref m) = self.runtime.metrics.classifier_metrics {
+            sanitizer.with_classifier_metrics(std::sync::Arc::clone(m))
+        } else {
+            sanitizer
+        };
+        self.services.security.sanitizer = sanitizer;
         self.services.security.exfiltration_guard =
             zeph_sanitizer::exfiltration::ExfiltrationGuard::new(
                 security.exfiltration_guard.clone(),

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -644,8 +644,10 @@ pub(crate) struct MetricsState {
     /// Set to `true` when Claude extended context (`enable_extended_context = true`) is active.
     /// Read from config at build time, not derived from provider internals.
     pub(crate) extended_context: bool,
-    /// Shared classifier latency ring buffer. Populated by `ContentSanitizer` (injection, PII)
-    /// and `LlmClassifier` (feedback). `None` when classifiers are not configured.
+    /// Shared classifier latency ring buffer, allocated unconditionally at agent construction
+    /// (before any builder call) so it is available regardless of builder-chain ordering.
+    /// Recorded into by `ContentSanitizer` (injection, PII) and `LlmClassifier` (feedback);
+    /// stays empty (all-`None` percentiles) when no classifier is configured.
     pub(crate) classifier_metrics: Option<Arc<zeph_llm::ClassifierMetrics>>,
     /// Rolling window of per-turn latency samples (last 10 turns).
     pub(crate) timing_window: std::collections::VecDeque<crate::metrics::TurnTimings>,
@@ -1490,7 +1492,9 @@ impl MetricsState {
             cost_tracker: None,
             token_counter,
             extended_context: false,
-            classifier_metrics: None,
+            classifier_metrics: Some(Arc::new(zeph_llm::ClassifierMetrics::new(
+                zeph_llm::classifier::metrics::DEFAULT_RING_BUFFER_SIZE,
+            ))),
             timing_window: std::collections::VecDeque::new(),
             pending_timings: crate::metrics::TurnTimings::default(),
             histogram_recorder: None,

--- a/crates/zeph-core/src/agent/tests/agent_tests/lifecycle_tests.rs
+++ b/crates/zeph-core/src/agent/tests/agent_tests/lifecycle_tests.rs
@@ -87,6 +87,123 @@ async fn agent_with_security_sets_config() {
     assert_eq!(agent.runtime.config.timeouts.llm_seconds, 60);
 }
 
+/// Quick sanity check for #6382: the sanitizer built by the real `with_security`
+/// production path must share the same `classifier_metrics` Arc that
+/// `push_classifier_metrics()`/TUI read, so a PII detector call recorded on the
+/// sanitizer is visible through `agent.runtime.metrics.classifier_metrics`.
+#[cfg(feature = "classifiers")]
+#[tokio::test]
+async fn agent_with_security_wires_classifier_metrics_into_sanitizer() {
+    use std::future::Future;
+    use std::pin::Pin;
+    use zeph_llm::classifier::{PiiDetector, PiiResult};
+
+    struct MockPiiDetector;
+
+    impl PiiDetector for MockPiiDetector {
+        fn detect_pii<'a>(
+            &'a self,
+            _text: &'a str,
+        ) -> Pin<Box<dyn Future<Output = Result<PiiResult, zeph_llm::LlmError>> + Send + 'a>>
+        {
+            Box::pin(async move {
+                Ok(PiiResult {
+                    spans: vec![],
+                    has_pii: false,
+                })
+            })
+        }
+
+        fn backend_name(&self) -> &'static str {
+            "mock"
+        }
+    }
+
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+
+    let agent = Agent::new(provider, channel, registry, None, 5, executor)
+        .with_security(SecurityConfig::default(), TimeoutConfig::default())
+        .with_pii_detector(Arc::new(MockPiiDetector), 0.75);
+
+    assert!(agent.runtime.metrics.classifier_metrics.is_some());
+
+    let _ = agent.services.security.sanitizer.detect_pii("hello").await;
+
+    let snapshot = agent
+        .runtime
+        .metrics
+        .classifier_metrics
+        .as_ref()
+        .unwrap()
+        .snapshot();
+    assert_eq!(snapshot.pii.call_count, 1);
+}
+
+/// Companion to `agent_with_security_wires_classifier_metrics_into_sanitizer`: exercises the
+/// injection-classifier path (`classify_injection`) rather than PII, through the same real
+/// `Agent::new(...).with_security(...).with_injection_classifier(...)` production chain.
+#[cfg(feature = "classifiers")]
+#[tokio::test]
+async fn agent_with_security_wires_classifier_metrics_into_injection_classifier() {
+    use std::future::Future;
+    use std::pin::Pin;
+    use zeph_llm::classifier::{ClassificationResult, ClassifierBackend};
+
+    struct MockInjectionBackend;
+
+    impl ClassifierBackend for MockInjectionBackend {
+        fn classify<'a>(
+            &'a self,
+            _text: &'a str,
+        ) -> Pin<
+            Box<dyn Future<Output = Result<ClassificationResult, zeph_llm::LlmError>> + Send + 'a>,
+        > {
+            Box::pin(async move {
+                Ok(ClassificationResult {
+                    label: "SAFE".to_string(),
+                    score: 0.1,
+                    is_positive: false,
+                    spans: vec![],
+                })
+            })
+        }
+
+        fn backend_name(&self) -> &'static str {
+            "mock"
+        }
+    }
+
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+
+    let agent = Agent::new(provider, channel, registry, None, 5, executor)
+        .with_security(SecurityConfig::default(), TimeoutConfig::default())
+        .with_injection_classifier(Arc::new(MockInjectionBackend), 5000, 0.8, 0.5);
+
+    assert!(agent.runtime.metrics.classifier_metrics.is_some());
+
+    let _ = agent
+        .services
+        .security
+        .sanitizer
+        .classify_injection("hello")
+        .await;
+
+    let snapshot = agent
+        .runtime
+        .metrics
+        .classifier_metrics
+        .as_ref()
+        .unwrap()
+        .snapshot();
+    assert_eq!(snapshot.injection.call_count, 1);
+}
+
 #[tokio::test]
 async fn agent_run_handles_empty_channel() {
     let provider = mock_provider(vec![]);

--- a/crates/zeph-tui/src/widgets/chat.rs
+++ b/crates/zeph-tui/src/widgets/chat.rs
@@ -286,8 +286,12 @@ fn collect_message_lines_from(
 
                 let is_user = msg.role == MessageRole::User;
                 let user_bg = theme.user_message_bg;
+                let flash_active = flash_groups.contains(idx);
 
                 for mut line in msg_lines {
+                    if flash_active {
+                        patch_flash_style(&mut line, flash_style);
+                    }
                     if is_user {
                         line.spans.insert(0, Span::styled("\u{258e} ", accent));
                         for span in &mut line.spans {
@@ -353,9 +357,7 @@ fn collect_message_lines_from(
                 let flash_active = flash_groups.contains(start_idx);
                 for mut line in group_lines {
                     if flash_active {
-                        for span in &mut line.spans {
-                            span.style = span.style.patch(flash_style);
-                        }
+                        patch_flash_style(&mut line, flash_style);
                     }
                     line.spans.insert(0, Span::raw("  "));
                     lines.push(line);
@@ -364,6 +366,14 @@ fn collect_message_lines_from(
         }
     }
     (lines, all_md_links, message_line_starts)
+}
+
+/// Patch every span in `line` with `flash_style`, used to highlight a just-completed
+/// tool message/group for the duration of its flash window (see `App::maybe_flash_completed_group`).
+fn patch_flash_style(line: &mut Line<'static>, flash_style: Style) {
+    for span in &mut line.spans {
+        span.style = span.style.patch(flash_style);
+    }
 }
 
 /// Split matching substrings out of `lines` into their own [`Span`]s styled with
@@ -2329,6 +2339,73 @@ mod tests {
         let groups = group_messages(&msgs);
         assert_eq!(groups.len(), 1);
         assert_matches!(groups[0], MessageGroup::Single { .. });
+    }
+
+    /// Regression test for #6383: the `MessageGroup::Single` arm of `collect_message_lines_from`
+    /// must apply the completion flash style to a lone (non-grouped) completed tool message,
+    /// the same way the `MessageGroup::Grouped` arm already applies it to grouped tool cells.
+    /// Drives the real `collect_message_lines_from` render path (not `patch_flash_style` in
+    /// isolation) with a completed tool message whose index is in `flash_groups`, mirroring how
+    /// `App::maybe_flash_completed_group` records a flash for `group_size` == 1 runs.
+    #[test]
+    fn single_tool_message_flash_applies_style() {
+        let theme = Theme::default();
+        let messages = vec![make_tool_msg("$ echo hi\nhi")];
+        let flash_style = ratatui::style::Style::default().fg(ratatui::style::Color::Magenta);
+
+        let mut cache = crate::app::RenderCache::default();
+        let (flashed_lines, _, _) = collect_message_lines_from(
+            &messages,
+            None,
+            &mut cache,
+            80,
+            76,
+            &theme,
+            false,
+            ToolDensity::Inline,
+            false,
+            0,
+            false,
+            0,
+            &std::collections::HashSet::from([0]),
+            flash_style,
+            None,
+        );
+        let flashed_has_magenta = flashed_lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .any(|s| s.style.fg == Some(ratatui::style::Color::Magenta));
+        assert!(
+            flashed_has_magenta,
+            "Single-arm tool message must receive flash_style when its index is in flash_groups"
+        );
+
+        let mut cache = crate::app::RenderCache::default();
+        let (unflashed_lines, _, _) = collect_message_lines_from(
+            &messages,
+            None,
+            &mut cache,
+            80,
+            76,
+            &theme,
+            false,
+            ToolDensity::Inline,
+            false,
+            0,
+            false,
+            0,
+            &std::collections::HashSet::new(),
+            flash_style,
+            None,
+        );
+        let unflashed_has_magenta = unflashed_lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .any(|s| s.style.fg == Some(ratatui::style::Color::Magenta));
+        assert!(
+            !unflashed_has_magenta,
+            "tool message must not carry flash_style when its index is absent from flash_groups"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- The sanitizer's injection/PII classifier calls were never recorded in TUI metrics: the shared `Arc<ClassifierMetrics>` was never constructed in production (not just unwired at the sanitizer-construction call site as originally filed) — `runtime.metrics.classifier_metrics` stayed `None` regardless of config. Fixed by allocating the Arc eagerly and unconditionally in `MetricsState::new()`, before any builder-chain call runs, then wiring it into `with_security()`'s sanitizer construction. This also fixes `with_llm_classifier`'s previously-dead feedback-classifier metrics wiring as a side effect.
- The TUI completion flash never rendered for a single (non-grouped) tool call: the flash-active check only existed in the `MessageGroup::Grouped` render arm, not the sibling `Single` arm. Added the same check to the `Single` arm via a small shared `patch_flash_style` helper.

Closes #6382
Closes #6383

## Test plan
- [x] New regression test exercising the real `Agent::new().with_security().with_pii_detector()` builder chain, asserting the PII classifier's call is recorded in `runtime.metrics.classifier_metrics`
- [x] New regression test for the injection classifier path via the same real builder chain
- [x] New regression test exercising the actual `collect_message_lines_from` render path, asserting a `MessageGroup::Single` tool completion gets `tool_accent` styling while its flash tick is active
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` clean
- [x] `cargo clippy -p zeph-core -p zeph-sanitizer --all-targets --features "classifiers,scheduler" -- -D warnings` clean (standard feature set alone compiles out the #6382 wiring, so this pass was required to actually validate it)
- [x] `cargo nextest run` clean on both the standard workspace feature set and the `classifiers`-gated tests (zeph-core lifecycle_tests, zeph-tui full suite) — no regressions
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace` clean
- [x] `gitleaks protect --staged` — no leaks
- [ ] Live tmux-pty re-verification of both fixes (unit/render-path-tested only so far) — flagged as a follow-up in `.local/testing/playbooks/tui.md` (S17) and `.local/testing/playbooks/tui-micro-delights.md` for next CI cycle