### PR TITLE
fix(memory): prevent stuck singleton leaves from starving TiMem consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   as graph extraction so raw tool output and injection-flagged content never enter the tree.
   Best-effort: a single lightweight `INSERT ... RETURNING id`, no LLM/embedding call, failures
   logged and never propagated.
+- `zeph-memory`'s `SqliteStore::load_tree_leaves_unconsolidated` loaded the oldest
+  `batch_size` unconsolidated leaves every consolidation sweep; leaves that fail to cluster
+  (singletons) never get a `parent_id`, so once more than `batch_size` singletons accumulate,
+  every sweep kept re-loading and re-embedding the same stuck oldest set, permanently starving
+  newer leaves out of consideration (#6393). Pre-existing bug, unreachable before #6384 gave
+  `insert_tree_leaf` a production caller. Added a `consolidation_attempts`/`last_attempted_at`
+  pair on `memory_tree` (migration 111, both dialects) that `run_tree_consolidation_sweep` bumps
+  for every loaded node that does not end up consolidated; `load_tree_leaves_unconsolidated` and
+  `load_tree_level` now select the batch by true LRU priority
+  (`COALESCE(last_attempted_at, created_at) ASC`, `consolidation_attempts`/`id` as deterministic
+  tiebreakers) instead of strict age. A leaf that keeps losing the race has its touch time frozen
+  in the past while every competing leaf's touch time refreshes to "now" each time it's tried, so
+  the frozen leaf's priority strictly increases until it wins — a bounded-wait guarantee, within
+  a number of sweeps proportional to the existing backlog size, even under a sustained stream of
+  brand-new arrivals, not just a bias (implementation-critique follow-up: the initial
+  `consolidation_attempts ASC, created_at ASC` ordering was only a bias that a sustained new-leaf
+  stream could still defeat). Note this is not an *immediate* per-bump property: a leaf touched
+  this sweep is briefly the freshest timestamp in the table and correctly keeps winning over
+  anything created moments later, until it is left behind by a further sweep touching something
+  else (code-review follow-up: 2 regression tests originally proved this only via a same-second
+  `SQLite` timestamp tie rather than genuine precedence — now backdate explicit multi-sweep
+  timelines instead). Selection priority and presentation order are deliberately decoupled: the
+  returned batch is always re-sorted to `created_at ASC` because `cluster_by_similarity`'s greedy
+  leader algorithm requires that exact order for deterministic
+  clustering across sweeps.
 - `zeph-orchestration` / `zeph-core`: an orchestrated `/plan` task was marked `Completed` even
   when every real tool call it attempted failed, including `policy_blocked` security-gate
   denials — task completion status was decided purely by "did the sub-agent's turn finish

--- a/crates/zeph-db/migrations/postgres/111_memory_tree_starvation_guard.sql
+++ b/crates/zeph-db/migrations/postgres/111_memory_tree_starvation_guard.sql
@@ -1,0 +1,16 @@
+-- TiMem leaf-starvation guard (#6393): singleton leaves that never cluster kept getting
+-- re-loaded as the oldest `parent_id IS NULL` rows on every sweep, permanently blocking
+-- newer leaves from ever being considered once more than `batch_size` singletons accumulate.
+-- `consolidation_attempts`/`last_attempted_at` let the load queries in memory_tree.rs order by
+-- true LRU (`COALESCE(last_attempted_at, created_at) ASC`) instead of strict oldest-first: a
+-- leaf that keeps losing the race has its touch time frozen in the past while every competing
+-- leaf's touch time refreshes to "now" each time it's tried, so the frozen leaf's priority
+-- strictly increases until it wins — a bounded-wait guarantee even under a sustained stream of
+-- brand-new arrivals, not just a bias (see memory_tree.rs `load_tree_leaves_unconsolidated`).
+ALTER TABLE memory_tree ADD COLUMN consolidation_attempts BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE memory_tree ADD COLUMN last_attempted_at TIMESTAMPTZ;
+
+-- Serves the `ORDER BY COALESCE(last_attempted_at, created_at) ASC` load queries at any level.
+CREATE INDEX IF NOT EXISTS idx_memory_tree_unconsolidated_attempts
+    ON memory_tree(level, parent_id, COALESCE(last_attempted_at, created_at))
+    WHERE parent_id IS NULL;

--- a/crates/zeph-db/migrations/sqlite/111_memory_tree_starvation_guard.sql
+++ b/crates/zeph-db/migrations/sqlite/111_memory_tree_starvation_guard.sql
@@ -1,0 +1,16 @@
+-- TiMem leaf-starvation guard (#6393): singleton leaves that never cluster kept getting
+-- re-loaded as the oldest `parent_id IS NULL` rows on every sweep, permanently blocking
+-- newer leaves from ever being considered once more than `batch_size` singletons accumulate.
+-- `consolidation_attempts`/`last_attempted_at` let the load queries in memory_tree.rs order by
+-- true LRU (`COALESCE(last_attempted_at, created_at) ASC`) instead of strict oldest-first: a
+-- leaf that keeps losing the race has its touch time frozen in the past while every competing
+-- leaf's touch time refreshes to "now" each time it's tried, so the frozen leaf's priority
+-- strictly increases until it wins — a bounded-wait guarantee even under a sustained stream of
+-- brand-new arrivals, not just a bias (see memory_tree.rs `load_tree_leaves_unconsolidated`).
+ALTER TABLE memory_tree ADD COLUMN consolidation_attempts INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE memory_tree ADD COLUMN last_attempted_at TEXT;
+
+-- Serves the `ORDER BY COALESCE(last_attempted_at, created_at) ASC` load queries at any level.
+CREATE INDEX IF NOT EXISTS idx_memory_tree_unconsolidated_attempts
+    ON memory_tree(level, parent_id, COALESCE(last_attempted_at, created_at))
+    WHERE parent_id IS NULL;

--- a/crates/zeph-memory/src/semantic/tree_consolidation.rs
+++ b/crates/zeph-memory/src/semantic/tree_consolidation.rs
@@ -11,6 +11,7 @@
 //! Each cluster merge runs in its own transaction via `mark_nodes_consolidated`.
 //! The full sweep never holds a write lock across multiple clusters.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -141,6 +142,8 @@ pub async fn run_tree_consolidation_sweep(
             continue;
         }
 
+        let candidate_ids: Vec<i64> = candidates.iter().map(|row| row.id).collect();
+
         let embedded = embed_candidates(
             provider,
             &candidates,
@@ -148,6 +151,11 @@ pub async fn run_tree_consolidation_sweep(
         )
         .await;
         if embedded.len() < config.min_cluster_size {
+            // Bumps every loaded candidate, including ones that embedded fine but were left
+            // without enough surviving peers to reach `min_cluster_size` — a peer's transient
+            // embed failure costs them one attempt too. Harmless one-step bias in practice
+            // (`min_cluster_size` is small, so this only fires when nearly all embeds fail).
+            bump_stuck_attempts(store, &candidate_ids, level).await;
             continue;
         }
 
@@ -157,64 +165,17 @@ pub async fn run_tree_consolidation_sweep(
             config.min_cluster_size,
         );
 
-        for cluster in clusters {
-            if cluster.len() < config.min_cluster_size {
-                continue;
-            }
+        let consolidated_ids =
+            merge_clusters(store, provider, clusters, level, config, &mut result).await;
 
-            let child_ids: Vec<i64> = cluster.iter().map(|(id, _, _)| *id).collect();
-            let contents: Vec<&str> = cluster
-                .iter()
-                .map(|(_, content, _)| content.as_str())
-                .collect();
-
-            let summary = match merge_via_llm(provider, &contents).await {
-                Ok(s) => s,
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        level,
-                        child_count = cluster.len(),
-                        "tree consolidation: LLM merge failed, skipping cluster"
-                    );
-                    continue;
-                }
-            };
-
-            if summary.is_empty() {
-                continue;
-            }
-
-            let token_count = i64::try_from(summary.split_whitespace().count()).unwrap_or(i64::MAX);
-            let source_ids_json =
-                serde_json::to_string(&child_ids).unwrap_or_else(|_| "[]".to_string());
-
-            // Atomic cluster consolidation: INSERT parent + UPDATE children in one transaction.
-            match store
-                .consolidate_cluster(
-                    i64::from(level + 1),
-                    &summary,
-                    &source_ids_json,
-                    token_count,
-                    &child_ids,
-                )
-                .await
-            {
-                Ok(_) => {}
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        level,
-                        child_count = cluster.len(),
-                        "tree consolidation: cluster persist failed, skipping"
-                    );
-                    continue;
-                }
-            }
-
-            result.clusters_merged += 1;
-            result.nodes_created += 1;
-        }
+        // Nodes that end up consolidated this sweep drop out of the load query naturally
+        // (`parent_id` gets set); everything else keeps failing to cluster and must have its
+        // attempt count bumped so the next sweep's load query deprioritizes it (#6393).
+        let stuck_ids: Vec<i64> = candidate_ids
+            .into_iter()
+            .filter(|id| !consolidated_ids.contains(id))
+            .collect();
+        bump_stuck_attempts(store, &stuck_ids, level).await;
     }
 
     if result.nodes_created > 0 {
@@ -222,6 +183,102 @@ pub async fn run_tree_consolidation_sweep(
     }
 
     Ok(result)
+}
+
+/// Merge every cluster of at least `config.min_cluster_size` nodes into a parent node via LLM
+/// summarization, updating `result` in place. Returns the set of child node ids that were
+/// actually consolidated (persisted successfully) — everything else in the level's candidate
+/// set is left for the caller to mark as a failed attempt (#6393).
+async fn merge_clusters(
+    store: &SqliteStore,
+    provider: &AnyProvider,
+    clusters: Vec<Vec<(i64, String, Vec<f32>)>>,
+    level: u32,
+    config: &TreeConsolidationConfig,
+    result: &mut TreeConsolidationResult,
+) -> HashSet<i64> {
+    let mut consolidated_ids: HashSet<i64> = HashSet::new();
+
+    for cluster in clusters {
+        if cluster.len() < config.min_cluster_size {
+            continue;
+        }
+
+        let child_ids: Vec<i64> = cluster.iter().map(|(id, _, _)| *id).collect();
+        let contents: Vec<&str> = cluster
+            .iter()
+            .map(|(_, content, _)| content.as_str())
+            .collect();
+
+        let summary = match merge_via_llm(provider, &contents).await {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    level,
+                    child_count = cluster.len(),
+                    "tree consolidation: LLM merge failed, skipping cluster"
+                );
+                continue;
+            }
+        };
+
+        if summary.is_empty() {
+            continue;
+        }
+
+        let token_count = i64::try_from(summary.split_whitespace().count()).unwrap_or(i64::MAX);
+        let source_ids_json =
+            serde_json::to_string(&child_ids).unwrap_or_else(|_| "[]".to_string());
+
+        // Atomic cluster consolidation: INSERT parent + UPDATE children in one transaction.
+        match store
+            .consolidate_cluster(
+                i64::from(level + 1),
+                &summary,
+                &source_ids_json,
+                token_count,
+                &child_ids,
+            )
+            .await
+        {
+            Ok(_) => {
+                consolidated_ids.extend(&child_ids);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    level,
+                    child_count = cluster.len(),
+                    "tree consolidation: cluster persist failed, skipping"
+                );
+                continue;
+            }
+        }
+
+        result.clusters_merged += 1;
+        result.nodes_created += 1;
+    }
+
+    consolidated_ids
+}
+
+/// Bump the consolidation-attempt counter for nodes that were loaded this sweep but did not
+/// end up consolidated, so the next sweep's load query deprioritizes them (#6393). Best-effort:
+/// a failure here does not fail the sweep, it only means those nodes stay at their current
+/// attempt count and may be reloaded sooner than intended on the next sweep.
+async fn bump_stuck_attempts(store: &SqliteStore, node_ids: &[i64], level: u32) {
+    if node_ids.is_empty() {
+        return;
+    }
+    if let Err(e) = store.bump_consolidation_attempts(node_ids).await {
+        tracing::warn!(
+            error = %e,
+            level,
+            count = node_ids.len(),
+            "tree consolidation: failed to bump consolidation attempts"
+        );
+    }
 }
 
 /// Concurrency cap for embed calls — matches `embed_concurrency` default (#2677).
@@ -429,5 +486,173 @@ mod tests {
         let total_items: usize = clusters.iter().map(Vec::len).sum();
         // All items across all clusters are unique (no double-assignment).
         assert_eq!(total_items, 3);
+    }
+
+    async fn make_store() -> SqliteStore {
+        SqliteStore::with_pool_size(":memory:", 1)
+            .await
+            .expect("in-memory store")
+    }
+
+    fn test_config() -> TreeConsolidationConfig {
+        TreeConsolidationConfig {
+            enabled: true,
+            sweep_interval_secs: 3600,
+            batch_size: 2,
+            similarity_threshold: 0.9,
+            max_level: 1,
+            min_cluster_size: 2,
+            embed_timeout_secs: 5,
+        }
+    }
+
+    /// Backdates `last_attempted_at` for `ids` to an exact, controlled value — used to build
+    /// deterministic multi-sweep timelines in tests without depending on real wall-clock gaps.
+    async fn backdate_last_attempted(store: &SqliteStore, ids: &[i64], timestamp: &str) {
+        for &id in ids {
+            zeph_db::query(zeph_db::sql!(
+                "UPDATE memory_tree SET last_attempted_at = ? WHERE id = ?"
+            ))
+            .bind(timestamp)
+            .bind(id)
+            .execute(store.pool())
+            .await
+            .expect("backdate last_attempted_at");
+        }
+    }
+
+    /// Backdates `created_at` for `ids` — see [`backdate_last_attempted`].
+    async fn backdate_created_at(store: &SqliteStore, ids: &[i64], timestamp: &str) {
+        for &id in ids {
+            zeph_db::query(zeph_db::sql!(
+                "UPDATE memory_tree SET created_at = ? WHERE id = ?"
+            ))
+            .bind(timestamp)
+            .bind(id)
+            .execute(store.pool())
+            .await
+            .expect("backdate created_at");
+        }
+    }
+
+    /// #6393 regression, hardened per code review (2026-07-17T18-50-48-review.md Critical #1):
+    /// verifies `run_tree_consolidation_sweep` (the real production code path) wires
+    /// `bump_stuck_attempts` correctly when a cluster stays below `min_cluster_size`, and that
+    /// the resulting deprioritization is not permanent. The original version of this test
+    /// asserted a fresh leaf wins the very next load immediately after one bump — false under
+    /// real timing (a just-bumped leaf's touch is the freshest in the table and correctly keeps
+    /// winning until it is left behind by a later sweep); this version backdates the sweep's
+    /// own bump explicitly, so the assertion holds regardless of how fast the test executes.
+    #[tokio::test]
+    async fn sweep_bumps_attempts_and_stale_stuck_batch_does_not_starve_new_leaf() {
+        let store = make_store().await;
+        let config = test_config();
+
+        let leaf1 = store.insert_tree_leaf("stuck one", 5).await.expect("l1");
+        let leaf2 = store.insert_tree_leaf("stuck two", 5).await.expect("l2");
+
+        // One of the two embed calls fails, so `embedded.len() == 1 < min_cluster_size == 2`:
+        // both loaded candidates end up unconsolidated ("stuck") this sweep.
+        let provider = AnyProvider::Mock(
+            zeph_llm::mock::MockProvider::default()
+                .with_embedding(vec![1.0, 0.0])
+                .with_errors(vec![zeph_llm::error::LlmError::Timeout]),
+        );
+
+        run_tree_consolidation_sweep(&store, &provider, &config)
+            .await
+            .expect("sweep");
+
+        // Both stuck leaves must still be present and unconsolidated (no cluster formed) —
+        // proves the sweep ran the expected embed-failure path and called `bump_stuck_attempts`.
+        let stuck_ids: std::collections::HashSet<i64> = store
+            .load_tree_leaves_unconsolidated(10)
+            .await
+            .expect("load")
+            .into_iter()
+            .map(|r| r.id)
+            .collect();
+        assert!(stuck_ids.contains(&leaf1));
+        assert!(stuck_ids.contains(&leaf2));
+
+        // The sweep's own `bump_stuck_attempts` call (the production wiring verified above)
+        // already set `last_attempted_at` to real "now". Pin it to a controlled, known value
+        // (T=1) so the rest of this test is fully deterministic regardless of how fast it runs.
+        backdate_last_attempted(&store, &[leaf1, leaf2], "2000-01-01 00:00:01").await;
+
+        // A new leaf created strictly *after* that touch (T=2) does not win the very next
+        // load — a just-touched leaf's timestamp is still older (smaller) than anything created
+        // right after it, so leaf1/leaf2 correctly keep winning for now. This is the real,
+        // "not immediate" property: a bump does not instantly lose to a leaf created around the
+        // same moment (code review #6393 Critical #1 — the original version of this test
+        // asserted the opposite and only passed via a same-second timestamp tie).
+        let fresh = store.insert_tree_leaf("fresh leaf", 5).await.expect("l3");
+        backdate_created_at(&store, &[fresh], "2000-01-01 00:00:02").await;
+
+        let immediate: std::collections::HashSet<i64> = store
+            .load_tree_leaves_unconsolidated(1)
+            .await
+            .expect("load immediate")
+            .into_iter()
+            .map(|r| r.id)
+            .collect();
+        assert!(
+            immediate == std::collections::HashSet::from([leaf1])
+                || immediate == std::collections::HashSet::from([leaf2]),
+            "a just-touched stuck leaf must still outrank a leaf created immediately \
+             afterward, got {immediate:?}"
+        );
+
+        // A second sweep-equivalent touch of leaf1/leaf2 (T=3), still without `fresh` ever
+        // being touched, pushes their timestamp past `fresh`'s frozen T=2 — `fresh` must then
+        // win: the bounded, real multi-sweep starvation guard, not a false single-bump
+        // immediacy claim.
+        backdate_last_attempted(&store, &[leaf1, leaf2], "2000-01-01 00:00:03").await;
+        let next_batch = store
+            .load_tree_leaves_unconsolidated(1)
+            .await
+            .expect("load next batch");
+        assert_eq!(
+            next_batch.len(),
+            1,
+            "batch_size limit of 1 must be respected"
+        );
+        assert_eq!(
+            next_batch[0].id, fresh,
+            "a leaf that predates the stuck batch's most recent touch must win once it is \
+             touched again without the fresh leaf ever being touched itself"
+        );
+    }
+
+    /// #6393: normal clustering (leaves that DO cluster successfully) must behave exactly as
+    /// before — the new attempts tracking must not interfere when a cluster actually forms.
+    #[tokio::test]
+    async fn sweep_still_merges_a_successfully_clustered_batch() {
+        let store = make_store().await;
+        let config = test_config();
+
+        store.insert_tree_leaf("alpha", 5).await.expect("l1");
+        store.insert_tree_leaf("beta", 5).await.expect("l2");
+
+        // Both leaves embed to the same vector, so they merge into one cluster of size 2.
+        let provider = AnyProvider::Mock(
+            zeph_llm::mock::MockProvider::default().with_embedding(vec![1.0, 0.0]),
+        );
+
+        let result = run_tree_consolidation_sweep(&store, &provider, &config)
+            .await
+            .expect("sweep");
+
+        assert_eq!(result.clusters_merged, 1);
+        assert_eq!(result.nodes_created, 1);
+
+        let leaves = store
+            .load_tree_leaves_unconsolidated(10)
+            .await
+            .expect("load");
+        assert!(
+            leaves.is_empty(),
+            "successfully clustered leaves must be consolidated, not left as candidates"
+        );
     }
 }

--- a/crates/zeph-memory/src/store/memory_tree.rs
+++ b/crates/zeph-memory/src/store/memory_tree.rs
@@ -92,18 +92,39 @@ impl SqliteStore {
         // `consolidated_at`/`created_at` are `TIMESTAMPTZ` on Postgres (`TEXT` on SQLite);
         // project both through `Dialect::select_as_text`, aliased back to their original
         // names so `#[derive(sqlx::FromRow)]` still binds them into the `String`/`Option<String>`
-        // fields below. `ORDER BY` is table-qualified so it sorts on the native timestamp.
+        // fields below.
         let consolidated_at_sel =
             <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("consolidated_at");
         let created_at_sel =
             <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+        // Inner query SELECTs the batch by true LRU priority (least-recently-touched first,
+        // `COALESCE(last_attempted_at, created_at)` treats a never-attempted leaf's own creation
+        // as its initial "touch"); `consolidation_attempts`/`id` break exact-timestamp ties
+        // deterministically. This is a genuine bounded-wait guarantee, not just a bias: a leaf
+        // that keeps losing the race has its touch time frozen in the past while every
+        // competing leaf's touch time keeps refreshing to "now" each time it's tried, so the
+        // frozen leaf's relative priority strictly increases until it wins — even under a
+        // sustained stream of brand-new arrivals (#6393 follow-up, critic S1/M1).
+        //
+        // The outer query re-sorts the selected batch by `created_at ASC` because
+        // `cluster_by_similarity` requires that exact presentation order for deterministic
+        // clustering (see the INVARIANT comment on `cluster_by_similarity` in
+        // `semantic/tree_consolidation.rs`) — selection priority and presentation order are
+        // deliberately decoupled.
         let raw = format!(
             "SELECT id, level, parent_id, content, source_ids, token_count,
                     {consolidated_at_sel} AS consolidated_at, {created_at_sel} AS created_at
-             FROM memory_tree
-             WHERE level = 0 AND parent_id IS NULL
-             ORDER BY memory_tree.created_at ASC
-             LIMIT ?"
+             FROM (
+                 SELECT id, level, parent_id, content, source_ids, token_count,
+                        consolidated_at, created_at
+                 FROM memory_tree
+                 WHERE level = 0 AND parent_id IS NULL
+                 ORDER BY COALESCE(last_attempted_at, created_at) ASC,
+                          consolidation_attempts ASC,
+                          id ASC
+                 LIMIT ?
+             ) AS batch
+             ORDER BY batch.created_at ASC, batch.id ASC"
         );
         let query_sql = zeph_db::rewrite_placeholders(&raw);
         let rows: Vec<MemoryTreeRow> = query_as(sqlx::AssertSqlSafe(query_sql))
@@ -130,13 +151,23 @@ impl SqliteStore {
             <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("consolidated_at");
         let created_at_sel =
             <ActiveDialect as zeph_db::dialect::Dialect>::select_as_text("created_at");
+        // Same true-LRU starvation guard as `load_tree_leaves_unconsolidated` (#6393), applied
+        // to higher-level consolidation too since the same stuck-singleton pattern can occur
+        // there.
         let raw = format!(
             "SELECT id, level, parent_id, content, source_ids, token_count,
                     {consolidated_at_sel} AS consolidated_at, {created_at_sel} AS created_at
-             FROM memory_tree
-             WHERE level = ? AND parent_id IS NULL
-             ORDER BY memory_tree.created_at ASC
-             LIMIT ?"
+             FROM (
+                 SELECT id, level, parent_id, content, source_ids, token_count,
+                        consolidated_at, created_at
+                 FROM memory_tree
+                 WHERE level = ? AND parent_id IS NULL
+                 ORDER BY COALESCE(last_attempted_at, created_at) ASC,
+                          consolidation_attempts ASC,
+                          id ASC
+                 LIMIT ?
+             ) AS batch
+             ORDER BY batch.created_at ASC, batch.id ASC"
         );
         let query_sql = zeph_db::rewrite_placeholders(&raw);
         let rows: Vec<MemoryTreeRow> = query_as(sqlx::AssertSqlSafe(query_sql))
@@ -231,6 +262,47 @@ impl SqliteStore {
             query(sqlx::AssertSqlSafe(query_sql.as_str()))
                 .bind(parent_id)
                 .bind(child_id)
+                .execute(&mut *tx)
+                .await?;
+        }
+
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Record a failed consolidation attempt for a batch of nodes (#6393).
+    ///
+    /// Increments `consolidation_attempts` and refreshes `last_attempted_at` for every id in
+    /// `node_ids`. Called after a sweep loads nodes but they do not end up consolidated (no
+    /// cluster formed, or the cluster's merge/persist failed). `last_attempted_at` is read by
+    /// `load_tree_leaves_unconsolidated`/`load_tree_level` as the primary LRU ordering key
+    /// (`COALESCE(last_attempted_at, created_at) ASC`): resetting it to "now" pushes a
+    /// just-failed node to the back of the priority queue, which is what guarantees every node
+    /// is re-considered within a bounded number of sweeps regardless of how many new nodes keep
+    /// arriving — a node that never wins the race has its touch time frozen further and further
+    /// in the past relative to fresh arrivals, so its priority strictly increases until it wins.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query fails.
+    pub async fn bump_consolidation_attempts(&self, node_ids: &[i64]) -> Result<(), MemoryError> {
+        if node_ids.is_empty() {
+            return Ok(());
+        }
+
+        let mut tx = self.pool().begin().await?;
+
+        let now = <ActiveDialect as zeph_db::dialect::Dialect>::NOW;
+        let raw = format!(
+            "UPDATE memory_tree
+             SET consolidation_attempts = consolidation_attempts + 1,
+                 last_attempted_at = {now}
+             WHERE id = ?"
+        );
+        let query_sql = zeph_db::rewrite_placeholders(&raw);
+        for &node_id in node_ids {
+            query(sqlx::AssertSqlSafe(query_sql.as_str()))
+                .bind(node_id)
                 .execute(&mut *tx)
                 .await?;
         }
@@ -437,5 +509,205 @@ mod tests {
         let store = make_store().await;
         // Should not fail on empty slice.
         store.mark_nodes_consolidated(&[], 999).await.expect("noop");
+    }
+
+    #[tokio::test]
+    async fn load_tree_leaves_unconsolidated_empty_tree_is_empty() {
+        let store = make_store().await;
+        let leaves = store
+            .load_tree_leaves_unconsolidated(10)
+            .await
+            .expect("load");
+        assert!(leaves.is_empty());
+    }
+
+    #[tokio::test]
+    async fn bump_consolidation_attempts_empty_slice_is_noop() {
+        let store = make_store().await;
+        store.bump_consolidation_attempts(&[]).await.expect("noop");
+    }
+
+    /// Backdates `last_attempted_at` for `ids` to an exact, controlled value — used to build
+    /// deterministic multi-sweep timelines in tests without depending on real wall-clock gaps.
+    async fn backdate_last_attempted(store: &SqliteStore, ids: &[i64], timestamp: &str) {
+        for &id in ids {
+            zeph_db::query(zeph_db::sql!(
+                "UPDATE memory_tree SET last_attempted_at = ? WHERE id = ?"
+            ))
+            .bind(timestamp)
+            .bind(id)
+            .execute(store.pool())
+            .await
+            .expect("backdate last_attempted_at");
+        }
+    }
+
+    /// Backdates `created_at` for `ids` — see [`backdate_last_attempted`].
+    async fn backdate_created_at(store: &SqliteStore, ids: &[i64], timestamp: &str) {
+        for &id in ids {
+            zeph_db::query(zeph_db::sql!(
+                "UPDATE memory_tree SET created_at = ? WHERE id = ?"
+            ))
+            .bind(timestamp)
+            .bind(id)
+            .execute(store.pool())
+            .await
+            .expect("backdate created_at");
+        }
+    }
+
+    async fn load_ids(store: &SqliteStore, limit: usize) -> std::collections::HashSet<i64> {
+        store
+            .load_tree_leaves_unconsolidated(limit)
+            .await
+            .expect("load")
+            .into_iter()
+            .map(|r| r.id)
+            .collect()
+    }
+
+    /// #6393 regression, hardened per code review (2026-07-17T18-50-48-review.md Critical #1):
+    /// the original version of this test relied on a real bump landing in the same `SQLite`
+    /// second as the following load/insert to pass — a same-second timestamp tie, not genuine
+    /// LRU precedence, and empirically false once a real time gap exists (a just-bumped leaf's
+    /// touch time is "now," which is *older* than anything created strictly afterward, so it
+    /// correctly keeps winning until it is left behind by a *later* sweep touching something
+    /// else). This version backdates every timestamp explicitly, so the assertions hold
+    /// regardless of how fast the test executes, and it demonstrates the real, bounded (not
+    /// immediate) starvation-prevention property across two sweep cycles: a bump does not lose
+    /// to a leaf created around the same moment, but a leaf that predates every touch in the
+    /// table eventually wins once the actively-cycling leaves are touched again without it.
+    #[tokio::test]
+    async fn bump_consolidation_attempts_prevents_permanent_starvation() {
+        let store = make_store().await;
+
+        let stuck_a = store.insert_tree_leaf("stuck a", 1).await.expect("stuck_a");
+        let stuck_b = store.insert_tree_leaf("stuck b", 1).await.expect("stuck_b");
+
+        // Sweep 1 touches (bumps) stuck_a/stuck_b — exercises the real method, then pins its
+        // effect to a controlled, known value (T=1) so the rest of this test is deterministic.
+        store
+            .bump_consolidation_attempts(&[stuck_a, stuck_b])
+            .await
+            .expect("bump 1");
+        backdate_last_attempted(&store, &[stuck_a, stuck_b], "2000-01-01 00:00:01").await;
+
+        // `waiting` is created strictly *after* that touch (T=2). It does NOT win the very next
+        // load — a just-touched leaf's timestamp is still older (smaller) than anything created
+        // after it, so stuck_a/stuck_b correctly keep winning for now. This is the real,
+        // "not immediate" property: a bump does not instantly lose to a leaf created around the
+        // same moment.
+        let waiting = store
+            .insert_tree_leaf("waiting, created after sweep 1's touch", 1)
+            .await
+            .expect("waiting");
+        backdate_created_at(&store, &[waiting], "2000-01-01 00:00:02").await;
+
+        let batch1 = load_ids(&store, 1).await;
+        assert!(
+            batch1 == std::collections::HashSet::from([stuck_a])
+                || batch1 == std::collections::HashSet::from([stuck_b]),
+            "a just-touched stuck leaf must still outrank a leaf created immediately \
+             afterward, got {batch1:?}"
+        );
+
+        // Sweep 2 touches stuck_a/stuck_b *again* (T=3), still without `waiting` ever being
+        // touched. `waiting`'s frozen T=2 is now the oldest timestamp in the table and must
+        // finally win: the bounded, real multi-sweep starvation guard, not a false single-bump
+        // immediacy claim.
+        store
+            .bump_consolidation_attempts(&[stuck_a, stuck_b])
+            .await
+            .expect("bump 2");
+        backdate_last_attempted(&store, &[stuck_a, stuck_b], "2000-01-01 00:00:03").await;
+
+        let batch2 = load_ids(&store, 1).await;
+        assert_eq!(
+            batch2,
+            std::collections::HashSet::from([waiting]),
+            "a leaf that predates the actively-cycling leaves' most recent touch must win once \
+             they are touched again without it ever being touched itself"
+        );
+    }
+
+    /// #6393 follow-up (critic S1): the ordering must be a genuine bounded-wait guarantee, not
+    /// just a bias that a sustained stream of brand-new leaves can defeat. A leaf whose last
+    /// (failed) attempt was long ago must outrank leaves created moments ago, no matter how many
+    /// of them arrive — because `COALESCE(last_attempted_at, created_at)` for the frozen leaf is
+    /// far in the past, while every fresh arrival's virtual touch time is "now".
+    #[tokio::test]
+    async fn load_tree_leaves_unconsolidated_prioritizes_stale_touch_over_sustained_new_arrivals() {
+        let store = make_store().await;
+
+        let stuck = store
+            .insert_tree_leaf("stuck singleton", 1)
+            .await
+            .expect("stuck");
+        // Simulate a leaf that was tried once, long ago, and has been losing the race ever
+        // since — its `last_attempted_at` never got refreshed because it never won a batch slot.
+        zeph_db::query(zeph_db::sql!(
+            "UPDATE memory_tree
+             SET consolidation_attempts = 5, last_attempted_at = '2000-01-01 00:00:00'
+             WHERE id = ?"
+        ))
+        .bind(stuck)
+        .execute(store.pool())
+        .await
+        .expect("backdate stuck leaf");
+
+        // A burst of brand-new leaves "arriving now" — the adversarial scenario where a naive
+        // attempts-only ordering would let fresh arrivals monopolize every batch forever.
+        for i in 0..5 {
+            store
+                .insert_tree_leaf(&format!("fresh leaf {i}"), 1)
+                .await
+                .expect("fresh");
+        }
+
+        let batch = store
+            .load_tree_leaves_unconsolidated(1)
+            .await
+            .expect("load");
+        assert_eq!(batch.len(), 1);
+        assert_eq!(
+            batch[0].id, stuck,
+            "a leaf neglected since 2000 must outrank leaves created moments ago"
+        );
+    }
+
+    /// #6393 follow-up: selection priority (LRU) and presentation order (`created_at ASC`) are
+    /// deliberately decoupled — `cluster_by_similarity`'s greedy leader algorithm requires the
+    /// returned `Vec` to stay in `created_at ASC` order for deterministic clustering, regardless
+    /// of which rows the LRU ordering picked or in what priority.
+    #[tokio::test]
+    async fn load_tree_leaves_unconsolidated_returns_created_at_order_even_when_priority_differs() {
+        let store = make_store().await;
+
+        let older = store
+            .insert_tree_leaf("older, but recently retried", 1)
+            .await
+            .expect("older");
+        let newer = store
+            .insert_tree_leaf("newer, never attempted", 1)
+            .await
+            .expect("newer");
+
+        // Give `older` the lowest selection priority (touched "now") even though it has the
+        // earlier `created_at` — both still fit in a batch_size=2 load.
+        store
+            .bump_consolidation_attempts(&[older])
+            .await
+            .expect("bump older");
+
+        let batch = store
+            .load_tree_leaves_unconsolidated(2)
+            .await
+            .expect("load");
+        let ids: Vec<i64> = batch.iter().map(|r| r.id).collect();
+        assert_eq!(
+            ids,
+            [older, newer],
+            "returned rows must stay in created_at ASC order regardless of selection priority"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- `load_tree_leaves_unconsolidated` loaded the oldest `batch_size` unconsolidated leaves every consolidation sweep. Leaves that never cluster (singletons) keep `parent_id` NULL forever, so once more than `batch_size` singletons accumulate, every sweep re-loads and re-embeds the same stuck oldest set — newer leaves with real memorable content never get a chance to be considered.
- Pre-existing bug, unreachable before #6384 (PR #6392) gave `insert_tree_leaf` a production caller; flagged out of scope during that PR's implementation critique.
- Adds a `consolidation_attempts`/`last_attempted_at` pair on `memory_tree` (migration 111, sqlite + postgres) that `run_tree_consolidation_sweep` bumps for every loaded node that does not end up consolidated. Both `load_tree_leaves_unconsolidated` and `load_tree_level` now order by true LRU (`COALESCE(last_attempted_at, created_at) ASC`, with `consolidation_attempts`/`id` as deterministic tiebreakers) instead of strict age — a bounded-wait guarantee, not just a bias, since a stuck leaf's touch time freezes in the past while competing leaves' touch times keep refreshing to "now".
- Selection priority and presentation order are decoupled via a subquery, since `cluster_by_similarity`'s greedy leader algorithm requires `created_at ASC` for deterministic clustering regardless of which rows were selected.

Closes #6393

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (14119 passed, 0 failed, 35 skipped)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `gitleaks protect --staged --no-banner --redact`
- [x] `zeph-db` migration parity tests (sqlite/postgres dialect symmetry for migration 111)
- [x] New regression tests directly disprove the original starvation scenario and the critic's sustained-new-arrival counterexample via explicit backdated multi-sweep timelines (not real wall-clock dependent)
- [x] Production wiring confirmed real (not dead code): `run_tree_consolidation_sweep` is reached from the supervised `mem-tree-consolidation` background task, not just from tests