### PR TITLE
fix(channels): coordinate elicit()/confirm() readline with the background stdin reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   context-usage estimate (`AgentEvent::ContextEstimate`) never reached the input block title.
   Added both missing overrides to `impl Channel for AppChannel`, following the existing
   `dispatch_app_channel!` pattern used by the other 19 forwarded methods.
+- `zeph-channels`: `CliChannel::elicit()` and `CliChannel::confirm()` each raced the persistent
+  background chat-input reader (`run_tty_reader`) for terminal keystrokes: both sides
+  independently called into crossterm's process-wide `event::read()`, which has no concept of
+  "which caller should receive this event," so a keystroke typed during an MCP elicitation
+  prompt (now reachable end-to-end since #6388) or a `y/N` confirmation could be silently stolen
+  by the background reader instead (#6398). Fixed by making the background reader's read loop
+  interruptible (`line_editor::read_line_yieldable`, polling with a 50ms timeout instead of
+  blocking indefinitely) and gating exclusive terminal access with a shared
+  `StdinCoordination` (`AtomicBool` + `tokio::sync::Notify`) that `elicit()`/`confirm()` acquire
+  via an RAII `ElicitGuard` for the duration of the prompt — the background reader waits on
+  `Notify` (no polling) until the guard drops, at which point it resumes. Any partially-typed
+  chat input is discarded when the background reader yields.
 - `zeph-memory`: `SemanticMemory::run_quality_gate` hardcoded `recent_embeddings` to `&[]` on
   its only production call site, so `QualityGate::evaluate`'s `Redundant`-rejection path —
   already unit-tested and working — could never fire on a real conversation (#6387). Added

--- a/crates/zeph-channels/src/cli.rs
+++ b/crates/zeph-channels/src/cli.rs
@@ -17,8 +17,10 @@
 
 use std::collections::VecDeque;
 use std::io::{BufReader, IsTerminal};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
-use tokio::sync::mpsc;
+use tokio::sync::{Notify, mpsc};
 use zeph_common::path_guard::{PathRejection, classify_relative_path};
 use zeph_core::channel::{
     Attachment, AttachmentKind, Channel, ChannelError, ChannelMessage, ElicitationField,
@@ -26,6 +28,58 @@ use zeph_core::channel::{
 };
 
 use crate::line_editor::{self, ReadLineResult};
+
+/// Coordinates exclusive terminal access between the persistent background
+/// chat-input reader ([`run_tty_reader`]) and one-shot `elicit()`/`confirm()`
+/// prompts.
+///
+/// Both readers ultimately call into crossterm's process-wide
+/// `event::read()`, which has no concept of "which caller should receive
+/// this event" — without this coordination, keystrokes typed during an
+/// elicitation/confirmation prompt can be stolen by the background
+/// chat-input reader instead (#6398).
+#[derive(Debug)]
+struct StdinCoordination {
+    /// Set while an `elicit()`/`confirm()` prompt owns the terminal. Polled by
+    /// `run_tty_reader`'s interruptible read loop.
+    elicit_active: AtomicBool,
+    /// Notified when `elicit_active` transitions back to `false`, so the
+    /// paused background reader wakes without busy-polling.
+    resume: Notify,
+}
+
+impl StdinCoordination {
+    fn new() -> Self {
+        Self {
+            elicit_active: AtomicBool::new(false),
+            resume: Notify::new(),
+        }
+    }
+}
+
+/// RAII guard granting an `elicit()`/`confirm()` prompt exclusive terminal
+/// access for its lifetime.
+///
+/// Acquiring sets [`StdinCoordination::elicit_active`]; dropping — on any
+/// exit path, including future cancellation — clears it and wakes the paused
+/// background reader via [`StdinCoordination::resume`].
+struct ElicitGuard<'a> {
+    coord: &'a StdinCoordination,
+}
+
+impl<'a> ElicitGuard<'a> {
+    fn acquire(coord: &'a StdinCoordination) -> Self {
+        coord.elicit_active.store(true, Ordering::Release);
+        Self { coord }
+    }
+}
+
+impl Drop for ElicitGuard<'_> {
+    fn drop(&mut self) {
+        self.coord.elicit_active.store(false, Ordering::Release);
+        self.coord.resume.notify_one();
+    }
+}
 
 const STDIN_CHANNEL_CAPACITY: usize = 32;
 
@@ -160,12 +214,23 @@ async fn process_line(
 
 /// Background stdin reader for TTY mode.
 ///
-/// Spawns a `tokio::task::spawn_blocking` per line (using `line_editor::read_line`
-/// which manages crossterm raw mode internally).
-async fn run_tty_reader(mut history: Option<InputHistory>, tx: mpsc::Sender<ChannelMessage>) {
+/// Spawns a `tokio::task::spawn_blocking` per line (using
+/// `line_editor::read_line_yieldable`, which manages crossterm raw mode
+/// internally). Before each read attempt, waits for `coord.elicit_active` to
+/// clear so that an active `elicit()`/`confirm()` prompt has exclusive
+/// terminal access — see [`StdinCoordination`].
+async fn run_tty_reader(
+    mut history: Option<InputHistory>,
+    tx: mpsc::Sender<ChannelMessage>,
+    coord: Arc<StdinCoordination>,
+) {
     let mut pending_attachments: Vec<Attachment> = Vec::new();
 
     loop {
+        while coord.elicit_active.load(Ordering::Acquire) {
+            coord.resume.notified().await;
+        }
+
         let entries: Vec<String> = history
             .as_ref()
             .map(|h| h.entries().iter().cloned().collect())
@@ -175,14 +240,19 @@ async fn run_tty_reader(mut history: Option<InputHistory>, tx: mpsc::Sender<Chan
         // NOTE: raw spawn_blocking is correct here — this is interactive terminal I/O (crossterm
         // raw mode), not a CPU-bound agent task. Routing through task_supervisor's semaphore
         // would starve the UI when 8 agent tasks are in-flight.
-        let Ok(Ok(result)) =
-            tokio::task::spawn_blocking(move || line_editor::read_line("You: ", &entries)).await
+        let coord_for_blocking = Arc::clone(&coord);
+        let Ok(Ok(result)) = tokio::task::spawn_blocking(move || {
+            line_editor::read_line_yieldable("You: ", &entries, &coord_for_blocking.elicit_active)
+        })
+        .await
         else {
             break;
         };
         crate::terminal_title::clear_action_required("zeph");
 
         let line = match result {
+            // The wait-loop above will now block until elicit()/confirm() releases the terminal.
+            ReadLineResult::Yielded => continue,
             ReadLineResult::Interrupted | ReadLineResult::Eof => break,
             ReadLineResult::Line(l) => l,
         };
@@ -231,6 +301,10 @@ async fn run_piped_reader(mut history: Option<InputHistory>, tx: mpsc::Sender<Ch
         let line = match result {
             ReadLineResult::Interrupted | ReadLineResult::Eof => break,
             ReadLineResult::Line(l) => l,
+            // `read_line_piped` never yields; the reader loop above only calls it. Handled
+            // gracefully (not `unreachable!()`) so a future refactor accidentally routing this
+            // path through the yieldable variant degrades instead of panicking.
+            ReadLineResult::Yielded => continue,
         };
 
         match process_line(line, false, &mut history, &mut pending_attachments).await {
@@ -262,10 +336,11 @@ fn spawn_stdin_reader(
     is_tty: bool,
     history: Option<InputHistory>,
     tx: mpsc::Sender<ChannelMessage>,
+    coord: Arc<StdinCoordination>,
 ) {
     tokio::spawn(async move {
         if is_tty {
-            run_tty_reader(history, tx).await;
+            run_tty_reader(history, tx, coord).await;
         } else {
             run_piped_reader(history, tx).await;
         }
@@ -326,6 +401,9 @@ pub struct CliChannel {
     input_rx: Option<mpsc::Receiver<ChannelMessage>>,
     /// Pending configuration consumed when the background task is first spawned.
     pending: Option<PendingReader>,
+    /// Shared terminal-access coordination between the background chat-input
+    /// reader and `elicit()`/`confirm()` prompts. See [`StdinCoordination`].
+    stdin_coord: Arc<StdinCoordination>,
 }
 
 impl CliChannel {
@@ -345,6 +423,7 @@ impl CliChannel {
                 history: None,
                 is_tty,
             }),
+            stdin_coord: Arc::new(StdinCoordination::new()),
         }
     }
 
@@ -379,6 +458,7 @@ impl CliChannel {
                 history: Some(history),
                 is_tty,
             }),
+            stdin_coord: Arc::new(StdinCoordination::new()),
         }
     }
 
@@ -391,7 +471,12 @@ impl CliChannel {
                 .take()
                 .expect("PendingReader consumed before input_rx was set");
             let (tx, rx) = mpsc::channel(STDIN_CHANNEL_CAPACITY);
-            spawn_stdin_reader(pending.is_tty, pending.history, tx);
+            spawn_stdin_reader(
+                pending.is_tty,
+                pending.history,
+                tx,
+                Arc::clone(&self.stdin_coord),
+            );
             self.input_rx = Some(rx);
         }
         self.input_rx.as_mut().expect("input_rx set above")
@@ -484,6 +569,7 @@ impl Channel for CliChannel {
             tracing::debug!("non-interactive stdin, auto-declining confirmation");
             return Ok(false);
         }
+        let _guard = ElicitGuard::acquire(&self.stdin_coord);
         let prompt = format!("{prompt} [y/N]: ");
         // NOTE: raw spawn_blocking is intentional — interactive terminal readline; not an agent
         // task, so the task_supervisor semaphore does not apply.
@@ -494,7 +580,13 @@ impl Channel for CliChannel {
 
         match result {
             ReadLineResult::Line(line) => Ok(line.trim().eq_ignore_ascii_case("y")),
-            ReadLineResult::Interrupted | ReadLineResult::Eof => Ok(false),
+            // `read_line` (non-yieldable) never actually returns `Yielded`; folded in here
+            // (rather than a separate `unreachable!()` arm) so a future refactor routing this
+            // call through the yieldable variant degrades to a declined confirmation instead of
+            // panicking.
+            ReadLineResult::Interrupted | ReadLineResult::Eof | ReadLineResult::Yielded => {
+                Ok(false)
+            }
         }
     }
 
@@ -530,6 +622,8 @@ impl Channel for CliChannel {
             return Ok(ElicitationResponse::Declined);
         }
 
+        let _guard = ElicitGuard::acquire(&self.stdin_coord);
+
         println!(
             "\n[MCP server '{}' is requesting input]",
             request.server_name
@@ -560,7 +654,11 @@ impl Channel for CliChannel {
                         return Ok(ElicitationResponse::Declined);
                     }
                 }
-                ReadLineResult::Interrupted | ReadLineResult::Eof => {
+                // `read_line` (non-yieldable) never actually returns `Yielded`; folded in here
+                // (rather than a separate `unreachable!()` arm) so a future refactor routing
+                // this call through the yieldable variant degrades to a cancelled elicitation
+                // instead of panicking.
+                ReadLineResult::Interrupted | ReadLineResult::Eof | ReadLineResult::Yielded => {
                     return Ok(ElicitationResponse::Cancelled);
                 }
             }
@@ -650,6 +748,105 @@ mod tests {
     fn cli_channel_default() {
         let ch = CliChannel::default();
         let _ = format!("{ch:?}");
+    }
+
+    #[test]
+    fn elicit_guard_acquire_sets_flag_true() {
+        let coord = StdinCoordination::new();
+        assert!(!coord.elicit_active.load(Ordering::Acquire));
+        let _guard = ElicitGuard::acquire(&coord);
+        assert!(coord.elicit_active.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn elicit_guard_drop_clears_flag() {
+        let coord = StdinCoordination::new();
+        {
+            let _guard = ElicitGuard::acquire(&coord);
+            assert!(coord.elicit_active.load(Ordering::Acquire));
+        }
+        assert!(!coord.elicit_active.load(Ordering::Acquire));
+    }
+
+    #[tokio::test]
+    async fn elicit_guard_drop_wakes_a_notified_waiter() {
+        let coord = Arc::new(StdinCoordination::new());
+        let guard = ElicitGuard::acquire(&coord);
+
+        let waiter_coord = Arc::clone(&coord);
+        let waiter = tokio::spawn(async move {
+            waiter_coord.resume.notified().await;
+        });
+
+        // Give the waiter a chance to register before the guard drops.
+        tokio::task::yield_now().await;
+        drop(guard);
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), waiter)
+            .await
+            .expect("waiter should wake within timeout")
+            .expect("waiter task should not panic");
+    }
+
+    /// Mirrors `run_tty_reader`'s wait loop exactly, so this test exercises the
+    /// actual consumer-side coordination pattern (not just `ElicitGuard` in
+    /// isolation).
+    async fn wait_for_resume(coord: &StdinCoordination) {
+        while coord.elicit_active.load(Ordering::Acquire) {
+            coord.resume.notified().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn stdin_coord_wait_loop_blocks_while_guard_held_then_resumes_on_drop() {
+        let coord = Arc::new(StdinCoordination::new());
+        let guard = ElicitGuard::acquire(&coord);
+
+        let waiter_coord = Arc::clone(&coord);
+        let waiter = tokio::spawn(async move { wait_for_resume(&waiter_coord).await });
+
+        tokio::task::yield_now().await;
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert!(
+            !waiter.is_finished(),
+            "wait loop must stay blocked while the guard is held"
+        );
+
+        drop(guard);
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), waiter)
+            .await
+            .expect("wait loop should exit within timeout after guard drop")
+            .expect("waiter task should not panic");
+    }
+
+    #[tokio::test]
+    async fn stdin_coord_wait_loop_ignores_spurious_notify_while_flag_still_true() {
+        let coord = Arc::new(StdinCoordination::new());
+        coord.elicit_active.store(true, Ordering::Release);
+
+        let waiter_coord = Arc::clone(&coord);
+        let waiter = tokio::spawn(async move { wait_for_resume(&waiter_coord).await });
+
+        tokio::task::yield_now().await;
+
+        // A notify while the flag is still true must not let the waiter exit —
+        // the `while` (not `if`) re-checks the flag after waking. Regressing this
+        // to `if` would let the background reader race elicit()/confirm() again.
+        coord.resume.notify_one();
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert!(
+            !waiter.is_finished(),
+            "waiter must not exit while elicit_active remains true"
+        );
+
+        coord.elicit_active.store(false, Ordering::Release);
+        coord.resume.notify_one();
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), waiter)
+            .await
+            .expect("wait loop should exit within timeout")
+            .expect("waiter task should not panic");
     }
 
     #[tokio::test]
@@ -795,6 +992,7 @@ mod tests {
             accumulated: String::new(),
             input_rx: Some(rx),
             pending: None,
+            stdin_coord: Arc::new(StdinCoordination::new()),
         };
 
         // Pre-fill the channel with a message (simulates background reader

--- a/crates/zeph-channels/src/line_editor.rs
+++ b/crates/zeph-channels/src/line_editor.rs
@@ -3,25 +3,31 @@
 
 //! Minimal terminal line editor used by [`CliChannel`].
 //!
-//! This module provides two reading functions that cover the two stdin modes:
+//! This module provides reading functions that cover the CLI's stdin modes:
 //!
 //! * [`read_line`] — for interactive TTY sessions.  Uses crossterm raw mode to
 //!   implement cursor movement, history navigation, and `Ctrl-C`/`Ctrl-D`
 //!   handling without relying on any external readline library.
+//! * [`read_line_yieldable`] — same as `read_line`, but polls for events
+//!   instead of blocking, so it can voluntarily relinquish exclusive terminal
+//!   access to a concurrent elicitation/confirmation prompt (see
+//!   [`ReadLineResult::Yielded`]).
 //! * [`read_line_piped`] — for non-TTY (piped) stdin.  Reads one line at a
 //!   time from a [`BufRead`] source with a 1 MiB safety limit.
 //!
-//! Both functions return [`ReadLineResult`] so the caller can handle EOF,
+//! All functions return [`ReadLineResult`] so the caller can handle EOF,
 //! interruption, and normal input in a single `match`.
 //!
 //! [`CliChannel`]: crate::CliChannel
 //! [`BufRead`]: std::io::BufRead
 
 use std::io::{self, BufRead, Read, Write, stdout};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 use crossterm::{
     cursor,
-    event::{self, Event, KeyCode, KeyModifiers},
+    event::{self, Event, KeyCode, KeyEvent, KeyModifiers},
     terminal::{self, ClearType},
 };
 
@@ -38,6 +44,11 @@ pub enum ReadLineResult {
     Interrupted,
     /// End-of-file was reached (`Ctrl-D` on empty input, or the pipe closed).
     Eof,
+    /// The read was voluntarily abandoned because another caller (an active
+    /// elicitation/confirmation prompt) needs exclusive terminal access.
+    ///
+    /// Only ever returned by [`read_line_yieldable`].
+    Yielded,
 }
 
 struct RawModeGuard;
@@ -122,82 +133,173 @@ pub fn read_line(prompt: &str, history: &[String]) -> io::Result<ReadLineResult>
             continue;
         }
 
-        match (key.modifiers, key.code) {
-            (KeyModifiers::CONTROL, KeyCode::Char('c')) => {
-                write!(stdout(), "\r\n")?;
-                stdout().flush()?;
-                return Ok(ReadLineResult::Interrupted);
-            }
-            (KeyModifiers::CONTROL, KeyCode::Char('d')) if input.is_empty() => {
-                write!(stdout(), "\r\n")?;
-                stdout().flush()?;
-                return Ok(ReadLineResult::Eof);
-            }
-            (_, KeyCode::Enter) => {
-                write!(stdout(), "\r\n")?;
-                stdout().flush()?;
-                return Ok(ReadLineResult::Line(input));
-            }
-            (KeyModifiers::CONTROL, KeyCode::Char('a')) | (_, KeyCode::Home) => {
-                cursor_pos = 0;
-            }
-            (KeyModifiers::CONTROL, KeyCode::Char('e')) | (_, KeyCode::End) => {
-                cursor_pos = char_count(&input);
-            }
-            (KeyModifiers::CONTROL, KeyCode::Char('u')) => {
-                input.clear();
-                cursor_pos = 0;
-            }
-            (KeyModifiers::ALT, KeyCode::Backspace) => {
-                let boundary = prev_word_boundary(&input, cursor_pos);
-                let start = byte_offset(&input, boundary);
-                let end = byte_offset(&input, cursor_pos);
-                input.drain(start..end);
-                cursor_pos = boundary;
-            }
-            (_, KeyCode::Backspace) if cursor_pos > 0 => {
-                let off = byte_offset(&input, cursor_pos - 1);
-                input.remove(off);
-                cursor_pos -= 1;
-            }
-            (_, KeyCode::Delete) if cursor_pos < char_count(&input) => {
-                let off = byte_offset(&input, cursor_pos);
-                input.remove(off);
-            }
-            (_, KeyCode::Left) => {
-                cursor_pos = cursor_pos.saturating_sub(1);
-            }
-            (_, KeyCode::Right) if cursor_pos < char_count(&input) => {
-                cursor_pos += 1;
-            }
-            (_, KeyCode::Up) => {
-                navigate_history_up(
-                    history,
-                    &mut input,
-                    &mut cursor_pos,
-                    &mut history_index,
-                    &mut draft,
-                );
-            }
-            (_, KeyCode::Down) => {
-                navigate_history_down(
-                    history,
-                    &mut input,
-                    &mut cursor_pos,
-                    &mut history_index,
-                    &mut draft,
-                );
-            }
-            (_, KeyCode::Char(c)) => {
-                let off = byte_offset(&input, cursor_pos);
-                input.insert(off, c);
-                cursor_pos += 1;
-            }
-            _ => {}
+        if let Some(result) = handle_key_event(
+            key,
+            &mut input,
+            &mut cursor_pos,
+            history,
+            &mut history_index,
+            &mut draft,
+        )? {
+            return Ok(result);
         }
 
         render(prompt, &input, cursor_pos)?;
     }
+}
+
+/// Read a single line from the terminal, yielding back to the caller when
+/// `yield_requested` becomes `true` instead of blocking indefinitely inside
+/// `crossterm::event::read()`.
+///
+/// Behaves exactly like [`read_line`] except that it checks `yield_requested`
+/// at the top of every loop iteration and polls for the next event with a
+/// short timeout (50ms) instead of blocking on it directly. Checking the flag
+/// before `event::poll` (rather than only inside the poll-timeout branch) is
+/// required so a set flag preempts even under continuous sub-50ms-gap
+/// keystroke arrivals, where `poll` would otherwise always return `true` and
+/// the timeout branch would never run. When the flag is set, the call returns
+/// [`ReadLineResult::Yielded`] instead of continuing to wait — this lets a
+/// concurrent caller (e.g. an active elicitation/confirmation prompt) take
+/// over exclusive terminal access without racing this reader for keystrokes.
+///
+/// This closes the *starvation* window (an in-progress keystroke stream)
+/// completely, but there remains a bounded ~50ms *acquisition* window between
+/// the concurrent caller setting `yield_requested` and this loop's current
+/// `event::poll` call returning — accepted as an intentional MVP tradeoff
+/// (the common case is a user reacting to a freshly-printed prompt, not
+/// already mid-keystroke) rather than adding a full ack/notify handshake.
+///
+/// Any input typed so far is discarded when yielding.
+///
+/// # Errors
+///
+/// Returns `io::Error` if enabling raw mode, polling/reading an event, or
+/// writing to stdout fails.
+pub fn read_line_yieldable(
+    prompt: &str,
+    history: &[String],
+    yield_requested: &AtomicBool,
+) -> io::Result<ReadLineResult> {
+    let _guard = RawModeGuard::enter()?;
+
+    let mut input = String::new();
+    let mut cursor_pos: usize = 0;
+    let mut history_index: Option<usize> = None;
+    let mut draft = String::new();
+
+    render(prompt, &input, cursor_pos)?;
+
+    loop {
+        // Checked before polling (not just on timeout) so a continuous
+        // sub-50ms keystroke stream cannot starve this check indefinitely.
+        if yield_requested.load(Ordering::Acquire) {
+            return Ok(ReadLineResult::Yielded);
+        }
+
+        if !event::poll(Duration::from_millis(50))? {
+            continue;
+        }
+
+        let Event::Key(key) = event::read()? else {
+            continue;
+        };
+        if key.kind != event::KeyEventKind::Press {
+            continue;
+        }
+
+        if let Some(result) = handle_key_event(
+            key,
+            &mut input,
+            &mut cursor_pos,
+            history,
+            &mut history_index,
+            &mut draft,
+        )? {
+            return Ok(result);
+        }
+
+        render(prompt, &input, cursor_pos)?;
+    }
+}
+
+/// Apply a single key event to the in-progress input line.
+///
+/// Returns `Ok(Some(result))` when the line is complete (Enter, `Ctrl-C`, or
+/// `Ctrl-D` on empty input) and the caller should stop reading; `Ok(None)` to
+/// keep looping. Shared between [`read_line`] and [`read_line_yieldable`] so
+/// the two entry points stay behaviorally identical.
+fn handle_key_event(
+    key: KeyEvent,
+    input: &mut String,
+    cursor_pos: &mut usize,
+    history: &[String],
+    history_index: &mut Option<usize>,
+    draft: &mut String,
+) -> io::Result<Option<ReadLineResult>> {
+    match (key.modifiers, key.code) {
+        (KeyModifiers::CONTROL, KeyCode::Char('c')) => {
+            write!(stdout(), "\r\n")?;
+            stdout().flush()?;
+            return Ok(Some(ReadLineResult::Interrupted));
+        }
+        (KeyModifiers::CONTROL, KeyCode::Char('d')) if input.is_empty() => {
+            write!(stdout(), "\r\n")?;
+            stdout().flush()?;
+            return Ok(Some(ReadLineResult::Eof));
+        }
+        (_, KeyCode::Enter) => {
+            write!(stdout(), "\r\n")?;
+            stdout().flush()?;
+            return Ok(Some(ReadLineResult::Line(std::mem::take(input))));
+        }
+        (KeyModifiers::CONTROL, KeyCode::Char('a')) | (_, KeyCode::Home) => {
+            *cursor_pos = 0;
+        }
+        (KeyModifiers::CONTROL, KeyCode::Char('e')) | (_, KeyCode::End) => {
+            *cursor_pos = char_count(input);
+        }
+        (KeyModifiers::CONTROL, KeyCode::Char('u')) => {
+            input.clear();
+            *cursor_pos = 0;
+        }
+        (KeyModifiers::ALT, KeyCode::Backspace) => {
+            let boundary = prev_word_boundary(input, *cursor_pos);
+            let start = byte_offset(input, boundary);
+            let end = byte_offset(input, *cursor_pos);
+            input.drain(start..end);
+            *cursor_pos = boundary;
+        }
+        (_, KeyCode::Backspace) if *cursor_pos > 0 => {
+            let off = byte_offset(input, *cursor_pos - 1);
+            input.remove(off);
+            *cursor_pos -= 1;
+        }
+        (_, KeyCode::Delete) if *cursor_pos < char_count(input) => {
+            let off = byte_offset(input, *cursor_pos);
+            input.remove(off);
+        }
+        (_, KeyCode::Left) => {
+            *cursor_pos = cursor_pos.saturating_sub(1);
+        }
+        (_, KeyCode::Right) if *cursor_pos < char_count(input) => {
+            *cursor_pos += 1;
+        }
+        (_, KeyCode::Up) => {
+            navigate_history_up(history, input, cursor_pos, history_index, draft);
+        }
+        (_, KeyCode::Down) => {
+            navigate_history_down(history, input, cursor_pos, history_index, draft);
+        }
+        (_, KeyCode::Char(c)) => {
+            let off = byte_offset(input, *cursor_pos);
+            input.insert(off, c);
+            *cursor_pos += 1;
+        }
+        _ => {}
+    }
+
+    Ok(None)
 }
 
 fn navigate_history_up(


### PR DESCRIPTION
## Summary

- `CliChannel::elicit()` and `confirm()` each independently spawned a blocking readline that raced the persistent `run_tty_reader` background task for the same crossterm terminal-input primitive — whichever won the OS scheduling stole the keystroke, so a response typed at an active elicitation or `y/N` confirmation prompt was frequently consumed by the background chat-input reader instead, ending the round trip in a client-side timeout.
- Added a shared `StdinCoordination` (`AtomicBool` + `tokio::sync::Notify`) guarded by an RAII `ElicitGuard` that `elicit()`/`confirm()` acquire for the duration of the prompt; `run_tty_reader` waits on the guard before reading and uses a new `read_line_yieldable` variant that polls with a 50ms timeout instead of blocking indefinitely.
- The yield flag is checked at the *top* of every loop iteration (not just on poll timeout), closing a liveness gap caught during code review where continuous sub-50ms keystroke arrivals would otherwise prevent the background reader from ever noticing it should yield.
- `confirm()`'s `y/N` prompt had the identical unguarded race (same defect class, not mentioned in the issue title) and is fixed in the same PR.
- `TuiChannel` does not share this bug — its `confirm()`/`elicit()` already route through a `oneshot` to the single TUI event loop, which owns the sole terminal reader.

Closes #6398

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler,testing" -E 'package(zeph-channels)'` — 284/284 passed, including 5 new unit tests (`ElicitGuard` acquire/drop/notify semantics, and the `run_tty_reader`-side consumer wait-loop pattern with a mutation-tested `while`-vs-`if` regression guard)
- [x] `cargo test --doc -p zeph-channels` and rustdoc gate — clean
- [x] Live end-to-end verification in a tmux pty against the CI-1411 fixture MCP server (`fake_mcp_elicit_server_ci1411.py`), sending the elicitation field response as fast, unpaused keystrokes to specifically stress the continuous-typing scenario: round trip completed cleanly (`elicitation action=accept content={'confirm': True}`), no 60s timeout, no stolen keystrokes. Confirmed the background chat-input reader resumes normally for a follow-up chat message afterward.