### PR TITLE
fix(orchestration): catch mixed-trace policy failures and propagate spawn-path corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,59 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   (red color, error marker) — no TUI changes were needed. Scoped to total task failure (100%
   of tool calls failed); partial-failure / write-type-specific detection is out of scope
   (`ToolCallSummary` has no read/write classification field).
+- `zeph-orchestration` / `zeph-core`: the #6380 all-failed heuristic above did not catch the
+  common real-world shape of the defect — a mixed trace where read-type tool calls succeed
+  (they pass through the `quarantined` trust floor) but every mutating call is policy-blocked
+  (#6397). `ToolCallSummary` now carries an `is_read_only` classification field, populated at
+  both production call sites (`scheduler_loop::tool_trace_from_messages` and
+  `run_inline_tool_loop`) via the new shared `zeph_common::tool_classification::is_readonly_tool`
+  (moved from `zeph-tools`' `permissions::READONLY_TOOLS`, now re-exported there to keep it a
+  single source of truth). `DagScheduler`'s failure heuristic no longer relies on
+  `is_read_only` alone: `READONLY_TOOLS` and `QUARANTINE_DENIED` are **not** complementary —
+  `web_scrape`, `fetch`, `load_skill`, and `invoke_skill` are in both, so a naive
+  `!is_read_only` filter would miss a blocked `fetch`/`invoke_skill` sitting alongside a
+  successful plain `read`. A call now counts toward the heuristic if it mutates state
+  (`!is_read_only`) *or* is itself quarantine-denied (new
+  `zeph_common::quarantine::is_quarantine_denied`, moved from `zeph-tools`'
+  `trust_gate::is_quarantine_denied` for the same single-source-of-truth reason). A task is
+  corrected `Completed` -> `Failed` when every counting call failed, regardless of any
+  successful non-counting (purely read-only, non-quarantine-denied) call; a trace with no
+  counting calls falls back to the original "every call failed" rule, preserving #6380's
+  full-failure case exactly. Known, accepted imprecision (documented on
+  `counts_toward_completion_heuristic`): `is_quarantine_denied` is list-membership only, not
+  actual quarantine trust-floor state, so a *non-quarantined* task whose sole `fetch`/skill
+  call genuinely errored (not policy-blocked) now also counts toward this heuristic — a narrow,
+  deliberately-accepted widening beyond the quarantine-only scope this fix targets.
+- `zeph-orchestration` / `zeph-core`: the spawn-path `Completed` -> `Failed` correction
+  (`DagScheduler::correct_completed_to_failed_if_all_tool_calls_failed`) was status-only —
+  it never canceled already-unblocked dependents or recomputed `GraphStatus`, unlike the
+  `RunInline` path's `handle_failed_outcome`, which calls `dag::propagate_failure` for both
+  (#6396). A new `DagScheduler::propagate_corrected_task_failure`, called by
+  `scheduler_loop.rs` immediately after a successful correction, now calls
+  `dag::propagate_failure` for `Skip`-configured tasks (and `Abort`-configured tasks with no
+  `recovery.state_injection`) to cancel already-`Running` dependents and update `GraphStatus`
+  — safe without double-recording `CascadeDetector::RegionHealth` because `propagate_failure`
+  never touches cascade bookkeeping (that lives exclusively in
+  `handle_completed_outcome`/`handle_failed_outcome`, neither of which this new method calls).
+  For `Retry`/`Ask`-configured tasks, and for `Abort`-configured tasks with
+  `recovery.state_injection` set, generic `propagate_failure` is unsafe here: `Retry` would
+  resurrect the already-`Completed` (cascade-recorded) corrected task back to `Ready` for a
+  redundant redispatch that re-triggers `record_outcome` on its second completion — an actual
+  `RegionHealth` double-count; `Ask` would pause the whole plan post-hoc for a task whose
+  consequences already landed; and `Abort`'s own `try_recover` call (Mode-1 recovery) would
+  flip the just-corrected task straight back to `Completed` with injected output that no
+  already-unblocked dependent would ever see, silently undoing the correction (the same hazard
+  class as `Retry`/`Ask`, just reached via a different code path — found by a delta re-review
+  after the initial `Retry`/`Ask`-only fix). A new `dag::propagate_failure_forced_terminal`
+  bypasses `FailureStrategy` dispatch entirely for all three cases, always applying terminal
+  Abort-style behavior (cancel + fail the graph, no resurrection, no pause, no recovery).
+  `Skip` never needs this — its arm never calls `try_recover`/`try_reroute` — and an
+  `Abort`-configured task with `recovery.route_to` (Mode-2, mutually exclusive with
+  `state_injection`) is also unaffected: `try_reroute` never touches the source task's own
+  status. Dependents that already reached a terminal status (most commonly `Completed`, having
+  consumed the now-invalidated output) before the correction landed are still not
+  retroactively unwound — documented as a deliberate remaining limitation shared with the
+  `RunInline` path.
 - `zeph-llm` (`ollama`): `convert_message_structured` dropped `MessagePart::Image` siblings
   on messages carrying a `ToolResult` part — the function early-returned
   `ChatMessage::tool(content)` built only from concatenated tool-result text, discarding any

--- a/crates/zeph-common/src/lib.rs
+++ b/crates/zeph-common/src/lib.rs
@@ -39,6 +39,7 @@ pub mod spawner;
 pub mod task_supervisor;
 pub mod text;
 pub mod timestamp;
+pub mod tool_classification;
 pub mod trust_level;
 pub mod types;
 

--- a/crates/zeph-common/src/quarantine.rs
+++ b/crates/zeph-common/src/quarantine.rs
@@ -9,9 +9,9 @@
 /// Tools denied when a Quarantined skill is active.
 ///
 /// Uses the actual tool IDs registered by `FileExecutor` and other executors.
-/// MCP tools use a server-prefixed ID (e.g. `filesystem_write_file`). The
-/// `is_quarantine_denied` predicate in `zeph-tools` checks both exact matches and
-/// `_{entry}` suffix matches to cover MCP-wrapped versions of these native tool IDs.
+/// MCP tools use a server-prefixed ID (e.g. `filesystem_write_file`). [`is_quarantine_denied`]
+/// below checks both exact matches and `_{entry}` suffix matches to cover MCP-wrapped
+/// versions of these native tool IDs.
 ///
 /// Public so that `zeph-skills::scanner::check_capability_escalation` can use
 /// this as the single source of truth for quarantine-denied tools.
@@ -39,3 +39,21 @@ pub const QUARANTINE_DENIED: &[&str] = &[
     "load_skill",
     "invoke_skill",
 ];
+
+/// Returns `true` if `tool_id` matches an entry in [`QUARANTINE_DENIED`], either exactly or
+/// as an MCP-wrapped suffix (e.g. `filesystem_write` matches `write`, but
+/// `filesystem_write_file` does not — suffix matching requires a `_` boundary immediately
+/// before the denied entry).
+///
+/// Canonical predicate for `QUARANTINE_DENIED` membership — shared by `zeph-tools`
+/// (`trust_gate::is_quarantine_denied`, re-exported from here) and `zeph-orchestration`,
+/// which uses it alongside `tool_classification::is_readonly_tool` to close the blind spot
+/// where a tool is read-only for autonomy-gating purposes (`READONLY_TOOLS`) yet still
+/// denied under quarantine (`web_scrape`, `fetch`, `load_skill`, `invoke_skill` are in both
+/// lists — see #6397).
+#[must_use]
+pub fn is_quarantine_denied(tool_id: &str) -> bool {
+    QUARANTINE_DENIED
+        .iter()
+        .any(|denied| tool_id == *denied || tool_id.ends_with(&format!("_{denied}")))
+}

--- a/crates/zeph-common/src/tool_classification.rs
+++ b/crates/zeph-common/src/tool_classification.rs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Read-only tool classification shared between `zeph-tools` and `zeph-orchestration`.
+//!
+//! [`READONLY_TOOLS`] is the single source of truth for native tool IDs that are
+//! read-only (no filesystem/state mutation, no code execution). `zeph-tools` uses it to
+//! gate `ReadOnly` autonomy mode and to bypass `Supervised`-mode confirmation for
+//! unconfigured tools (see #5575). `zeph-orchestration` uses it to classify tool calls in
+//! a task's real execution trace as read vs. write-type, so a mixed trace (successful
+//! reads followed by policy-blocked writes) is not mistaken for genuine partial progress
+//! (see #6397).
+
+/// Read-only tool allowlist (available in `ReadOnly` autonomy mode).
+///
+/// Also used, via [`is_readonly_tool`], to bypass the `Supervised`-mode confirmation
+/// default for unconfigured tools — see #5575. A tool added here is trusted to run
+/// without confirmation in *both* modes; do not add anything that mutates state or
+/// executes code.
+pub const READONLY_TOOLS: &[&str] = &[
+    "read",
+    "find_path",
+    "grep",
+    "list_directory",
+    "web_scrape",
+    "fetch",
+    "load_skill",
+    "invoke_skill",
+];
+
+/// Returns `true` if `tool_id` is a native read-only tool.
+///
+/// Reuses the same [`READONLY_TOOLS`] allowlist that gates `ReadOnly` autonomy mode, so
+/// `Supervised` mode's unconfigured-tool bypass (`TrustGateExecutor::check_trust`) cannot
+/// silently diverge from it — see #5575.
+#[must_use]
+pub fn is_readonly_tool(tool_id: &str) -> bool {
+    READONLY_TOOLS.contains(&tool_id)
+}

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -101,6 +101,7 @@ pub(super) fn tool_trace_from_messages(
                     tool: name.clone(),
                     args_summary: tool_execution::summarize_tool_input(input),
                     ok: result_ok.get(id.as_str()).copied().unwrap_or(true),
+                    is_read_only: zeph_common::tool_classification::is_readonly_tool(name),
                 });
             }
         }
@@ -952,19 +953,33 @@ impl<C: crate::channel::Channel> Agent<C> {
                         task_id,
                         tool_trace,
                     } => {
-                        // #6380: deterministic, always-on check (never gated on
-                        // verify_completeness) — a task whose every real tool call failed
-                        // (including policy_blocked denials) must not remain Completed.
-                        // Same trace-resolution contract as SchedulerAction::Verify below.
+                        // #6380/#6397: deterministic, always-on check (never gated on
+                        // verify_completeness) — a task whose every real (or every
+                        // write-type) tool call failed, including policy_blocked denials,
+                        // must not remain Completed. Same trace-resolution contract as
+                        // SchedulerAction::Verify below.
                         let task = scheduler.graph().tasks.get(task_id.index()).cloned();
                         if let Some(task) = task {
                             let resolved_tool_trace: Option<
                                 Vec<zeph_orchestration::ToolCallSummary>,
                             > = tool_trace.or_else(|| self.build_tool_trace_for_task(&task));
-                            scheduler.correct_completed_to_failed_if_all_tool_calls_failed(
-                                task_id,
-                                resolved_tool_trace.as_deref(),
-                            );
+                            let corrected = scheduler
+                                .correct_completed_to_failed_if_all_tool_calls_failed(
+                                    task_id,
+                                    resolved_tool_trace.as_deref(),
+                                );
+                            // #6396: propagate the correction to dependents/graph status —
+                            // parity with the RunInline path's handle_failed_outcome.
+                            if corrected {
+                                let propagation_actions =
+                                    scheduler.propagate_corrected_task_failure(task_id);
+                                if let Some(s) =
+                                    self.cancel_agents_from_actions(propagation_actions)
+                                {
+                                    done_status = Some(s);
+                                    break 'actions;
+                                }
+                            }
                         }
                     }
                     SchedulerAction::Verify {
@@ -1441,6 +1456,9 @@ impl<C: crate::channel::Channel> Agent<C> {
                             tool: tc.name.to_string(),
                             args_summary: tool_execution::summarize_tool_input(&tc.input),
                             ok: !is_error,
+                            is_read_only: zeph_common::tool_classification::is_readonly_tool(
+                                tc.name.as_str(),
+                            ),
                         });
                         result_parts.push(MessagePart::ToolResult {
                             tool_use_id: tc.id.clone(),
@@ -2112,6 +2130,40 @@ mod tests {
         assert_eq!(trace[0].tool, "bash");
         assert_eq!(trace[0].args_summary.as_deref(), Some("cargo test"));
         assert!(trace[0].ok);
+        assert!(
+            !trace[0].is_read_only,
+            "bash is not in zeph_common::tool_classification::READONLY_TOOLS"
+        );
+    }
+
+    /// Companion case: a read-only tool (`read`) must be classified as such in the
+    /// reconstructed trace (#6397 wiring).
+    #[test]
+    fn tool_trace_from_messages_classifies_readonly_tool() {
+        use zeph_llm::provider::{Message, MessagePart, Role};
+
+        let messages = vec![
+            Message::from_parts(
+                Role::Assistant,
+                vec![MessagePart::ToolUse {
+                    id: "call-1".into(),
+                    name: "read".into(),
+                    input: serde_json::json!({ "path": "in.txt" }),
+                }],
+            ),
+            Message::from_parts(
+                Role::User,
+                vec![MessagePart::ToolResult {
+                    tool_use_id: "call-1".into(),
+                    content: "contents".into(),
+                    is_error: false,
+                }],
+            ),
+        ];
+
+        let trace = tool_trace_from_messages(&messages);
+        assert_eq!(trace.len(), 1);
+        assert!(trace[0].is_read_only);
     }
 
     /// Spawns a real "worker" sub-agent through [`crate::agent::Agent`]'s
@@ -2613,16 +2665,217 @@ mod tests {
              corrected to Failed by SchedulerAction::CheckToolOutcome, not remain Completed \
              -- this is the actual issue #6380 repro path (PlanView reads per-task status)"
         );
-        // Known, deliberate scope limit (critic finding S1, .local/handoff/*-critic.md):
-        // the spawn-path correction is status-only and does not re-run graph completion, so
-        // a single-task plan's overall GraphStatus stays Completed even though its only task
-        // was just corrected to Failed. Pinning this down so a future change to propagate the
-        // correction is a conscious decision, not an accidental behavior change caught here.
+        // #6396: the spawn-path correction now propagates via
+        // `DagScheduler::propagate_corrected_task_failure`, giving parity with the
+        // RunInline path's `handle_failed_outcome` — a single-task plan's overall
+        // GraphStatus must reflect its only task having been corrected to Failed, not stay
+        // Completed (the previously-documented S1 limitation this issue closes).
         assert_eq!(
             status,
-            GraphStatus::Completed,
-            "documents the current accepted tradeoff: post-hoc task correction does not \
-             recompute graph-level status (see critic finding S1)"
+            GraphStatus::Failed,
+            "GraphStatus must be recomputed to Failed once the spawn-path correction lands \
+             (issue #6396)"
+        );
+    }
+
+    /// Regression test for issue #6397: a mixed trace (a successful read call followed by a
+    /// policy-blocked write call, in the *same* sub-agent turn) is the common real-world
+    /// shape of #6380 under the `quarantined` trust floor — read-type tools pass through
+    /// while write-type tools are policy-blocked. Unlike the single-call #6380 repro above,
+    /// the trace here contains at least one `ok == true` entry, so this exercises the
+    /// read/write classification added to `ToolCallSummary`, end-to-end through the real
+    /// spawn dispatch, transcript reconstruction, and `CheckToolOutcome` handler arm.
+    #[tokio::test]
+    async fn run_scheduler_loop_corrects_spawn_task_to_failed_on_mixed_trace() {
+        use crate::agent::agent_tests::*;
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+        use zeph_llm::provider::{ChatResponse, ToolUseRequest};
+        use zeph_orchestration::{
+            DagScheduler, GraphStatus, RuleBasedRouter, TaskGraph, TaskNode, TaskStatus,
+        };
+        use zeph_subagent::{SubAgentDef, SubAgentManager};
+        use zeph_tools::executor::ToolError;
+
+        let mut graph = TaskGraph::new("goal");
+        graph.tasks.push(TaskNode::new(0, "t", "do a task"));
+
+        let def =
+            SubAgentDef::parse("---\nname: worker\ndescription: A worker\n---\n\nDo things.\n")
+                .unwrap();
+
+        let config = zeph_config::OrchestrationConfig::default();
+        let mut scheduler = DagScheduler::new(
+            graph,
+            &config,
+            Box::new(RuleBasedRouter),
+            vec![def.clone()],
+            None,
+        )
+        .unwrap();
+
+        // Both tool calls narrated in the same turn: the read succeeds, the write is
+        // policy-blocked by the executor below.
+        let (mock, _counter) = MockProvider::default().with_tool_use(vec![
+            ChatResponse::ToolUse {
+                text: None,
+                tool_calls: vec![
+                    ToolUseRequest {
+                        id: "call-1".into(),
+                        name: "read".into(),
+                        input: serde_json::json!({ "path": "in.txt" }),
+                    },
+                    ToolUseRequest {
+                        id: "call-2".into(),
+                        name: "write".into(),
+                        input: serde_json::json!({ "path": "out.txt" }),
+                    },
+                ],
+                thinking_blocks: vec![],
+            },
+            ChatResponse::Text("done".into()),
+        ]);
+        let provider = AnyProvider::Mock(mock);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::new(vec![
+            Ok(Some(zeph_tools::executor::ToolOutput {
+                tool_name: "read".into(),
+                summary: "file contents".into(),
+                blocks_executed: 1,
+                filter_stats: None,
+                diff: None,
+                streamed: false,
+                terminal_id: None,
+                locations: None,
+                raw_response: None,
+                claim_source: None,
+                ..Default::default()
+            })),
+            Err(ToolError::Blocked {
+                command: "write".into(),
+            }),
+        ]);
+        let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+        agent.services.orchestration.orchestration_config = config;
+
+        let mut mgr = SubAgentManager::new(4);
+        mgr.definitions_mut().push(def);
+        agent.services.orchestration.subagent_manager = Some(mgr);
+
+        let token = tokio_util::sync::CancellationToken::new();
+        let status = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            agent.run_scheduler_loop(&mut scheduler, 1, token),
+        )
+        .await
+        .expect("run_scheduler_loop must not hang")
+        .unwrap();
+
+        assert_eq!(
+            scheduler.graph().tasks[0].status,
+            TaskStatus::Failed,
+            "a mixed trace where the only write-type call was policy-blocked must be \
+             corrected to Failed, even though the read-type call succeeded (#6397)"
+        );
+        assert_eq!(
+            status,
+            GraphStatus::Failed,
+            "GraphStatus must also reflect the correction (#6396)"
+        );
+    }
+
+    /// RunInline-path sibling of the previous test: the `is_read_only` classification wiring
+    /// inside `run_inline_tool_loop` (the second of the two production call sites for
+    /// `zeph_common::tool_classification::is_readonly_tool`) had no dedicated end-to-end
+    /// coverage -- every other mixed-trace test in this file and in
+    /// `zeph-orchestration`'s `scheduler/tick/tests.rs` constructs `ToolCallSummary` values by
+    /// hand, bypassing this call site entirely. Empty `available_agents` makes
+    /// `RuleBasedRouter::route` return `None`, which makes the scheduler emit
+    /// `SchedulerAction::RunInline` instead of `Spawn`.
+    #[tokio::test]
+    async fn run_scheduler_loop_corrects_run_inline_task_to_failed_on_mixed_trace() {
+        use crate::agent::agent_tests::*;
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+        use zeph_llm::provider::{ChatResponse, ToolUseRequest};
+        use zeph_orchestration::{
+            DagScheduler, GraphStatus, RuleBasedRouter, TaskGraph, TaskNode, TaskStatus,
+        };
+        use zeph_tools::executor::ToolError;
+
+        let mut graph = TaskGraph::new("goal");
+        graph.tasks.push(TaskNode::new(0, "t", "do a task"));
+
+        let config = zeph_config::OrchestrationConfig::default();
+        // No SubAgentDef available: RuleBasedRouter::route returns None, forcing RunInline.
+        let mut scheduler =
+            DagScheduler::new(graph, &config, Box::new(RuleBasedRouter), vec![], None).unwrap();
+
+        let (mock, _counter) = MockProvider::default().with_tool_use(vec![
+            ChatResponse::ToolUse {
+                text: None,
+                tool_calls: vec![
+                    ToolUseRequest {
+                        id: "call-1".into(),
+                        name: "read".into(),
+                        input: serde_json::json!({ "path": "in.txt" }),
+                    },
+                    ToolUseRequest {
+                        id: "call-2".into(),
+                        name: "write".into(),
+                        input: serde_json::json!({ "path": "out.txt" }),
+                    },
+                ],
+                thinking_blocks: vec![],
+            },
+            ChatResponse::Text("done".into()),
+        ]);
+        let provider = AnyProvider::Mock(mock);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::new(vec![
+            Ok(Some(zeph_tools::executor::ToolOutput {
+                tool_name: "read".into(),
+                summary: "file contents".into(),
+                blocks_executed: 1,
+                filter_stats: None,
+                diff: None,
+                streamed: false,
+                terminal_id: None,
+                locations: None,
+                raw_response: None,
+                claim_source: None,
+                ..Default::default()
+            })),
+            Err(ToolError::Blocked {
+                command: "write".into(),
+            }),
+        ]);
+        let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+        agent.services.orchestration.orchestration_config = config;
+
+        let token = tokio_util::sync::CancellationToken::new();
+        let status = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            agent.run_scheduler_loop(&mut scheduler, 1, token),
+        )
+        .await
+        .expect("run_scheduler_loop must not hang")
+        .unwrap();
+
+        assert_eq!(
+            scheduler.graph().tasks[0].status,
+            TaskStatus::Failed,
+            "a RunInline task whose only write-type call was policy-blocked must be corrected \
+             to Failed even though its read-type call succeeded -- exercises the \
+             `run_inline_tool_loop` classification call site directly, not just the spawn \
+             path's transcript-reconstruction one (#6397)"
+        );
+        assert_eq!(
+            status,
+            GraphStatus::Failed,
+            "GraphStatus must reflect the correction on the RunInline path too (#6396)"
         );
     }
 

--- a/crates/zeph-orchestration/src/dag.rs
+++ b/crates/zeph-orchestration/src/dag.rs
@@ -849,6 +849,55 @@ pub fn propagate_failure(
     }
 }
 
+/// Forced terminal-failure propagation, bypassing [`FailureStrategy`] dispatch entirely: no
+/// Mode-1 recovery, no Mode-2 reroute, no `Retry` resurrection, no `Ask` pause — just
+/// `graph.status = GraphStatus::Failed` and the list of currently-`Running` tasks to cancel.
+///
+/// Used by `DagScheduler::propagate_corrected_task_failure` (issue #6396) for a task whose
+/// `Completed -> Failed` status was corrected *post-hoc* (issues #6380/#6397), whenever
+/// routing through [`propagate_failure`] unmodified would risk resurrecting or otherwise
+/// undoing that correction:
+///
+/// - Effective `FailureStrategy::Retry` or `FailureStrategy::Ask`. Both branches in
+///   [`propagate_failure`] assume the failing task never produced output — `Retry` resurrects
+///   it to `Ready` for redispatch, `Ask` pauses the whole graph — which is unsafe here: this
+///   task was already `Completed` (cascade accounting already ran via `record_outcome(true)`,
+///   dependents already unblocked) *before* the correction landed. Resurrecting it to `Ready`
+///   would trigger a second, redundant sub-agent dispatch whose eventual completion
+///   re-invokes `record_outcome`, double-counting `CascadeDetector::RegionHealth` — and the
+///   retry cannot repair the plan regardless, since already-unblocked dependents are not
+///   rolled back (see the "Remaining limitation" note on `propagate_corrected_task_failure`).
+/// - Effective `FailureStrategy::Abort` *with* `recovery.state_injection` configured on the
+///   task (critic finding S1-residual, 2026-07-17). `propagate_failure`'s `Abort` arm calls
+///   [`try_recover`] before terminal-failing the graph, which — when `state_injection` is
+///   set — flips the just-corrected task straight back to `TaskStatus::Completed` with
+///   injected output, silently undoing the correction just like the `Retry`/`Ask` case above.
+///
+/// `Skip` configurations never need this: `Skip`'s arm in `propagate_failure` never calls
+/// `try_recover`/`try_reroute`, so it never resurrects the failed task regardless of any
+/// `recovery` configuration, and continues to call [`propagate_failure`] directly. Likewise
+/// an `Abort`-configured task with `recovery.route_to` (Mode-2, no `state_injection` — the two
+/// are mutually exclusive) is unaffected: `try_reroute` never touches the source task's own
+/// status, only activates a Dormant fallback, so it does not defeat the correction.
+///
+/// No-op (returns empty) unless `graph.tasks[failed_id]`'s current status is already
+/// `Failed` — mirrors [`propagate_failure`]'s own guard.
+pub(crate) fn propagate_failure_forced_terminal(
+    graph: &mut TaskGraph,
+    failed_id: TaskId,
+) -> Vec<TaskId> {
+    if graph.tasks[failed_id.index()].status != TaskStatus::Failed {
+        return Vec::new();
+    }
+    graph.status = GraphStatus::Failed;
+    graph
+        .tasks
+        .iter()
+        .filter(|t| t.status == TaskStatus::Running)
+        .map(|t| t.id)
+        .collect()
+}
+
 /// Reset a graph for retry after it has entered `Failed` or `Paused` status.
 ///
 /// - Resets all `Failed` tasks to `Ready` (and clears `retry_count`).

--- a/crates/zeph-orchestration/src/ensemble/verifier.rs
+++ b/crates/zeph-orchestration/src/ensemble/verifier.rs
@@ -554,6 +554,7 @@ mod tests {
             tool: "bash".to_string(),
             args_summary: Some("ls -la".to_string()),
             ok: true,
+            is_read_only: false,
         }];
         match verifier
             .verify(&task, "output", Some(&trace), &test_sanitizer())
@@ -604,6 +605,7 @@ mod tests {
             tool: "bash".to_string(),
             args_summary: Some("cargo test --all-features".to_string()),
             ok: true,
+            is_read_only: false,
         }];
         match verifier
             .verify(&task, "output", Some(&trace), &test_sanitizer())

--- a/crates/zeph-orchestration/src/scheduler/mod.rs
+++ b/crates/zeph-orchestration/src/scheduler/mod.rs
@@ -139,7 +139,10 @@ pub enum SchedulerAction {
     /// `RunInline` tasks (already known at emission time), `None` for the spawn dispatch
     /// path — reconstruct it from the sub-agent transcript, then call
     /// [`DagScheduler::correct_completed_to_failed_if_all_tool_calls_failed`] with the
-    /// resolved trace.
+    /// resolved trace. When that returns `true`, the caller must follow up with
+    /// [`DagScheduler::propagate_corrected_task_failure`] (issue #6396) to cancel
+    /// already-unblocked dependents and recompute `GraphStatus`, giving the spawn path
+    /// parity with the `RunInline` path's `handle_failed_outcome`.
     CheckToolOutcome {
         /// Task whose tool trace should be inspected.
         task_id: TaskId,

--- a/crates/zeph-orchestration/src/scheduler/tick/mod.rs
+++ b/crates/zeph-orchestration/src/scheduler/tick/mod.rs
@@ -23,25 +23,77 @@ struct CompletedTaskData {
     tool_trace: Option<Vec<crate::verifier::ToolCallSummary>>,
 }
 
-/// `true` when `trace` is non-empty and every call in it failed (`ok == false`) — including
-/// `policy_blocked` denials. Issue #6380: a task can finish its sub-agent loop without
-/// throwing an exception while every real tool call it attempted was rejected, producing
-/// zero actual work. An empty trace is deliberately *not* treated as total failure (a task
-/// that made no tool calls at all — e.g. pure reasoning/narration — is not this defect).
+/// `true` when a call counts toward the "did this task do work that matters" judgment used
+/// by `all_tool_calls_failed` — i.e. it is *not* a call the heuristic should silently
+/// ignore even if it succeeded.
 ///
-/// # Known limitation: mixed traces are not caught
+/// This is deliberately **not** just `!is_read_only`. `zeph_common::tool_classification`'s
+/// `READONLY_TOOLS` and `zeph_common::quarantine::QUARANTINE_DENIED` are not complementary:
+/// `web_scrape`, `fetch`, `load_skill`, and `invoke_skill` are in *both* lists — read-only
+/// for autonomy-gating purposes (#5575), yet still denied under the `quarantined` trust
+/// floor. A tool call counts here if it either mutates state (`!is_read_only`) *or* is
+/// itself a quarantine-denied call — a blocked `fetch`/`invoke_skill` is exactly the
+/// exfiltration/side-channel class quarantine exists to stop, so a successful plain `read`
+/// alongside it must not mask the denial (#6397, critic finding S2). An unclassified tool
+/// (not in `READONLY_TOOLS`) already counts via `!is_read_only` — the fail-closed default is
+/// unaffected by this OR.
 ///
-/// A trace with even one successful call (any `ok == true` entry) is *not* flagged by this
-/// heuristic, even if every write-type call in it failed. This is plausibly the common
-/// real-world shape of #6380: read-type tools (`read`, `grep`, `list_directory`, ...) are not
-/// present in `zeph_common::quarantine::QUARANTINE_DENIED`, so a quarantined sub-agent that
-/// successfully reads context before every write call is policy-blocked produces exactly this
-/// uncaught mixed trace — it still ends up `Completed` despite having produced zero durable
-/// work. Catching that shape needs a read/write classification field on `ToolCallSummary`,
-/// which is out of scope for this fix (see `ToolCallSummary::ok`'s own doc comment and the
-/// #6380 fix's scope note); tracked as a follow-up.
+/// # Known imprecision: list membership, not actual quarantine state (critic finding M1)
+///
+/// `zeph_common::quarantine::is_quarantine_denied` is pure list-membership, independent of
+/// whether this task actually ran under the `quarantined` trust floor — `ToolCallSummary`
+/// carries no such field, and no "policy-blocked vs. transient error" distinction either. So
+/// a **non-quarantined** task whose only network/skill call genuinely errored (e.g. `fetch`
+/// timed out) alongside a successful plain `read` is now also flagged by this heuristic, where
+/// before #6397 it stayed `Completed` (a `!is_read_only`-only check would have excluded
+/// `fetch`). This is a deliberate, accepted widening beyond the quarantine-only scope this fix
+/// targets: the shape is narrow (requires *every* counting call to fail with only reads
+/// succeeding), and such a task plausibly did fail to make progress regardless of *why* the
+/// network/skill call failed. Threading real quarantine trust-floor state through
+/// `ToolCallSummary` and into this heuristic would remove the imprecision but is a materially
+/// larger change (new field, new production call-site plumbing from the sub-agent's trust
+/// context) than this fix's scope — left as a conscious tradeoff, not silently accepted.
+fn counts_toward_completion_heuristic(call: &crate::verifier::ToolCallSummary) -> bool {
+    !call.is_read_only || zeph_common::quarantine::is_quarantine_denied(&call.tool)
+}
+
+/// `true` when `trace` is non-empty and the task produced zero durable work — either every
+/// call in it failed (`ok == false`, including `policy_blocked` denials, issue #6380), or —
+/// the mixed-trace case, issue #6397 — every call that `counts_toward_completion_heuristic`
+/// flags failed while some or all of the remaining (read-only, non-quarantine-denied) calls
+/// succeeded.
+///
+/// An empty trace is deliberately *not* treated as total failure (a task that made no tool
+/// calls at all — e.g. pure reasoning/narration — is not this defect).
+///
+/// # Mixed-trace handling (#6397)
+///
+/// A trace containing at least one call that counts (see
+/// `counts_toward_completion_heuristic`) is judged solely on those calls: if all of them
+/// failed, the task is flagged regardless of whether any purely-read-only,
+/// non-quarantine-denied call (`read`, `grep`, `list_directory`, ...) succeeded. This is the
+/// common real-world shape of the underlying defect: under the `quarantined` trust floor, a
+/// quarantined sub-agent that successfully reads context before every mutating or
+/// quarantine-denied call is blocked previously produced an uncaught mixed trace —
+/// `Completed` despite zero durable/permitted work.
+///
+/// A trace containing *no* counting calls (pure, non-denied reads) falls back to the
+/// original "every call failed" rule, so a task that never attempted a mutating or
+/// quarantine-denied call is never flagged off a single blocked read — and the pre-existing
+/// full-failure case (#6380) is preserved exactly.
 fn all_tool_calls_failed(trace: &[crate::verifier::ToolCallSummary]) -> bool {
-    !trace.is_empty() && trace.iter().all(|c| !c.ok)
+    if trace.is_empty() {
+        return false;
+    }
+    let mut counting_calls = trace
+        .iter()
+        .filter(|c| counts_toward_completion_heuristic(c))
+        .peekable();
+    if counting_calls.peek().is_some() {
+        counting_calls.all(|c| !c.ok)
+    } else {
+        trace.iter().all(|c| !c.ok)
+    }
 }
 
 impl DagScheduler {
@@ -612,15 +664,17 @@ impl DagScheduler {
             tool_trace,
         } = completed;
 
-        // #6380: when the real tool-call trace is already known synchronously (RunInline
+        // #6380/#6397: when the real tool-call trace is already known synchronously (RunInline
         // dispatch path — always `Some`, per `TaskOutcome::Completed`'s doc comment) and
-        // every call in it failed, route through the existing failure machinery instead of
-        // marking the task Completed. This branches out before any Completed-side-effect
-        // runs (cascade record_outcome, downstream unblocking), so there is no double-count
-        // risk here — unlike the spawn dispatch path, whose tool_trace is always `None` at
-        // this call site and is corrected post-hoc via the `CheckToolOutcome` action emitted
-        // below instead (see `DagScheduler::correct_completed_to_failed_if_all_tool_calls_failed`
-        // for why that correction is deliberately lighter-weight than a full re-route here).
+        // `all_tool_calls_failed` flags it, route through the existing failure machinery
+        // instead of marking the task Completed. This branches out before any
+        // Completed-side-effect runs (cascade record_outcome, downstream unblocking), so
+        // there is no double-count risk here — unlike the spawn dispatch path, whose
+        // tool_trace is always `None` at this call site and is corrected post-hoc via the
+        // `CheckToolOutcome` action emitted below instead (see
+        // `DagScheduler::correct_completed_to_failed_if_all_tool_calls_failed` and
+        // `DagScheduler::propagate_corrected_task_failure`, #6396, for why that two-step
+        // correction is safe without double-recording this task's own cascade outcome).
         if let Some(trace) = tool_trace.as_ref()
             && all_tool_calls_failed(trace)
         {
@@ -700,11 +754,20 @@ impl DagScheduler {
         actions
     }
 
-    /// Post-hoc correction for a `Completed` task whose real tool-call trace shows every
-    /// call failed, including `policy_blocked` denials (issue #6380). No-op (returns
-    /// `false`) when `tool_trace` is `None`, empty, or contains at least one successful
-    /// call, and when the task is no longer `Completed` (already corrected, or moved on to
-    /// some other status by a later transition — never clobber that).
+    /// Post-hoc correction for a `Completed` task whose real tool-call trace shows zero
+    /// durable/permitted work was done — every call failed (including `policy_blocked`
+    /// denials, issue #6380), or every call that counts toward the heuristic (mutating, or
+    /// quarantine-denied even if classified read-only — see `counts_toward_completion_heuristic`)
+    /// failed while some purely-read-only, non-quarantine-denied calls succeeded (the
+    /// mixed-trace case, issue #6397). No-op (returns `false`) when `tool_trace` is `None`,
+    /// empty, does not meet that condition, or when
+    /// the task is no longer `Completed` (already corrected, or moved on to some other
+    /// status by a later transition — never clobber that).
+    ///
+    /// Callers that get `true` back should follow up with
+    /// [`Self::propagate_corrected_task_failure`] to cancel already-unblocked dependents and
+    /// recompute `GraphStatus` (issue #6396) — this method itself only flips `TaskStatus` and
+    /// annotates `TaskResult::output`.
     ///
     /// # Design note: why this is not a `handle_failed_outcome` reuse
     ///
@@ -721,23 +784,14 @@ impl DagScheduler {
     /// whole-plan verify (#6379) rely on for accuracy, for a comparatively rare correction
     /// path. So this method deliberately only flips `TaskStatus` and annotates
     /// `TaskResult::output`; it does not touch `cascade_detector`, `lineage_chains`, or any
-    /// retry/abort machinery.
+    /// retry/abort machinery. Downstream propagation is a separate, deliberate step — see
+    /// [`Self::propagate_corrected_task_failure`]'s doc comment for why calling
+    /// `dag::propagate_failure` there carries no double-counting risk.
     ///
     /// (The synchronously-available `RunInline` case does not go through this method at all —
     /// `handle_completed_outcome` detects total tool-call failure *before* running any
     /// `Completed` side effect and routes straight to `handle_failed_outcome`, so no
     /// double-counting question arises there.)
-    ///
-    /// # Consequence: downstream is not retroactively unwound
-    ///
-    /// Because the correction is status-only, dependents of this task that were already
-    /// unblocked to `Ready` (or already dispatched/`Running`) before this method runs are
-    /// **not** retroactively canceled — they proceed as if the task had genuinely completed.
-    /// Likewise, `GraphStatus` can remain `Completed` for the whole plan even though this one
-    /// constituent task ends up `TaskStatus::Failed`: nothing here re-evaluates the graph's
-    /// overall terminal status. A caller inspecting only `GraphStatus` will not learn that a
-    /// task silently failed after the fact; per-task status (e.g. via `TaskGraphSnapshot`,
-    /// which the TUI `PlanView` already renders) is the only reliable signal for this case.
     pub fn correct_completed_to_failed_if_all_tool_calls_failed(
         &mut self,
         task_id: TaskId,
@@ -760,7 +814,7 @@ impl DagScheduler {
             task_id = %task_id,
             tool_call_count = trace.len(),
             "correcting task status Completed -> Failed: all tool calls failed or were \
-             policy-blocked (#6380)"
+             policy-blocked (#6380/#6397)"
         );
         task.status = TaskStatus::Failed;
         if let Some(result) = task.result.as_mut() {
@@ -877,6 +931,127 @@ impl DagScheduler {
         }
 
         Vec::new()
+    }
+
+    /// Propagate a just-applied
+    /// [`Self::correct_completed_to_failed_if_all_tool_calls_failed`] correction to the rest
+    /// of the graph (issue #6396): cancels dependents that were already unblocked to
+    /// `Running` before the correction landed, and recomputes `GraphStatus`.
+    ///
+    /// Callers must invoke this only immediately after
+    /// `correct_completed_to_failed_if_all_tool_calls_failed` returned `true` for the same
+    /// `task_id` in the same tick — both `dag::propagate_failure` and
+    /// `dag::propagate_failure_forced_terminal` no-op unless the task's status is already
+    /// `Failed`.
+    ///
+    /// # `Retry`/`Ask` and `Abort`-with-recovery are special-cased to forced propagation
+    ///
+    /// `Skip` configurations always call [`dag::propagate_failure`] directly — the same
+    /// function `handle_failed_outcome` uses for the `RunInline` path, giving the spawn path
+    /// parity with it. `Skip`'s arm never calls `try_recover`/`try_reroute` (it goes straight
+    /// to `skip_subtree`), so it never resurrects the failed task and is safe to apply here
+    /// unmodified regardless of any `recovery` configuration.
+    ///
+    /// `Retry` and `Ask` *always* call `dag::propagate_failure_forced_terminal` instead — see
+    /// critic finding S1 (2026-07-17): `propagate_failure`'s `Retry` branch resurrects the
+    /// task to `Ready` for redispatch, and `Ask` pauses the whole graph, both of which assume
+    /// the task never produced output. That assumption is false here: this task was already
+    /// `Completed` (`cascade_detector.record_outcome(true)` already ran, dependents already
+    /// unblocked) *before* the correction landed. A `Retry` redispatch would trigger a second,
+    /// redundant sub-agent run whose eventual completion re-invokes `record_outcome`,
+    /// double-counting `RegionHealth` — and cannot repair the plan anyway, since
+    /// already-unblocked dependents are not rolled back (see "Remaining limitation" below).
+    /// `Ask` would pause the entire plan post-hoc for a task whose consequences already
+    /// landed.
+    ///
+    /// `Abort` (the default strategy) is safe to route through `propagate_failure` unmodified
+    /// **only when the task has no `recovery.state_injection` configured**. `propagate_failure`'s
+    /// `Abort` arm calls `try_recover` *before* terminal-failing the graph — see critic finding
+    /// S1-residual (2026-07-17): when `state_injection` is set, `try_recover` flips this
+    /// just-corrected task straight back to `Completed` (with injected output that no
+    /// already-unblocked dependent will ever see), silently undoing the correction exactly like
+    /// the `Retry`/`Ask` hazard above. So an `Abort`-configured task with `state_injection` also
+    /// routes through `dag::propagate_failure_forced_terminal`, which skips `try_recover`
+    /// entirely. `try_reroute` (Mode-2 `route_to`) is *not* part of this hazard — unlike
+    /// `try_recover` it never touches the source task's own status, so a plain `Abort` +
+    /// `route_to` (no `state_injection`; the two are mutually exclusive per `RecoveryAction`'s
+    /// doc) still goes through unmodified `propagate_failure` and may activate a Mode-2
+    /// fallback off this correction, which is an accepted, deliberate tradeoff ("on failure,
+    /// run the fallback"), not a defeat of the correction.
+    ///
+    /// See `dag::propagate_failure_forced_terminal`'s doc comment for the full rationale on
+    /// why it is safe to skip recovery/reroute/resurrection entirely.
+    ///
+    /// # Why this is safe (no `RegionHealth` double-counting)
+    ///
+    /// Neither `dag::propagate_failure` nor `dag::propagate_failure_forced_terminal` touches
+    /// `cascade_detector`/`RegionHealth` — that bookkeeping lives exclusively in
+    /// `handle_completed_outcome` and `handle_failed_outcome`, neither of which this method
+    /// calls. This task was already recorded as a success by `handle_completed_outcome`
+    /// before the correction; this method only cancels/skips dependents and updates
+    /// `GraphStatus`, exactly the consequences the original #6380 fix deferred to avoid
+    /// double-recording this task itself. The special-cases above are what make this claim
+    /// actually hold for every `FailureStrategy` (and every `recovery` configuration) —
+    /// routing `Retry`/`Ask`, or `Abort`-with-`state_injection`, through unmodified
+    /// `propagate_failure` would have made the claim false (a redispatch re-invokes
+    /// `record_outcome`; `try_recover` un-fails the task entirely), which is exactly what the
+    /// special-cases prevent.
+    ///
+    /// # Remaining limitation
+    ///
+    /// Dependents that already reached a terminal status (most commonly `Completed`, having
+    /// already consumed this task's now-invalidated output) before this correction landed
+    /// are **not** retroactively unwound — neither propagation function's cancellation/skip
+    /// logic affects dependents already past `Pending`/`Ready`/`Running`. This mirrors the
+    /// `RunInline` path's own limitation (a `Completed` dependent is never revisited there
+    /// either) and is intentionally out of scope here — fully unwinding already-finished
+    /// downstream work would require re-running or invalidating those tasks, a materially
+    /// larger change than restoring propagation parity.
+    pub fn propagate_corrected_task_failure(&mut self, task_id: TaskId) -> Vec<SchedulerAction> {
+        let task = &self.graph.tasks[task_id.index()];
+        let effective_strategy = task
+            .failure_strategy
+            .unwrap_or(self.graph.default_failure_strategy);
+        let has_state_injection = task
+            .recovery
+            .as_ref()
+            .and_then(|r| r.state_injection.as_ref())
+            .is_some();
+        // #6396/S1-residual (critic, 2026-07-17): `Retry`/`Ask` always need the forced-terminal
+        // path (see doc comment above). `Abort`'s own arm in `dag::propagate_failure` also
+        // calls `try_recover` *before* terminal-failing the graph — when `state_injection` is
+        // configured, that would flip this just-corrected task straight back to `Completed`,
+        // silently undoing the correction exactly like the Retry/Ask hazard this method already
+        // guards against. `Skip` never calls `try_recover` (its arm goes straight to
+        // `skip_subtree`), so it is excluded regardless of `state_injection`.
+        let needs_forced_terminal =
+            matches!(
+                effective_strategy,
+                zeph_config::FailureStrategy::Retry | zeph_config::FailureStrategy::Ask
+            ) || (effective_strategy == zeph_config::FailureStrategy::Abort && has_state_injection);
+        let cancel_ids = if needs_forced_terminal {
+            dag::propagate_failure_forced_terminal(&mut self.graph, task_id)
+        } else {
+            dag::propagate_failure(&mut self.graph, task_id, &self.topology.rev_adj)
+        };
+        let mut actions = Vec::new();
+
+        for cancel_task_id in cancel_ids {
+            if let Some(running) = self.running.remove(&cancel_task_id) {
+                actions.push(SchedulerAction::Cancel {
+                    agent_handle_id: running.agent_handle_id,
+                });
+            }
+        }
+
+        if self.graph.status != GraphStatus::Running {
+            self.graph.finished_at = Some(crate::graph::chrono_now());
+            actions.push(SchedulerAction::Done {
+                status: self.graph.status,
+            });
+        }
+
+        actions
     }
 
     /// Apply the Failed outcome branch: build lineage, evaluate cascade abort, propagate failure.

--- a/crates/zeph-orchestration/src/scheduler/tick/tests.rs
+++ b/crates/zeph-orchestration/src/scheduler/tick/tests.rs
@@ -2368,11 +2368,13 @@ fn handle_completed_outcome_all_tools_failed_marks_task_failed() {
                 tool: "create_directory".to_string(),
                 args_summary: None,
                 ok: false,
+                is_read_only: false,
             },
             ToolCallSummary {
                 tool: "write".to_string(),
                 args_summary: None,
                 ok: false,
+                is_read_only: false,
             },
         ]),
     ));
@@ -2387,9 +2389,11 @@ fn handle_completed_outcome_all_tools_failed_marks_task_failed() {
 }
 
 #[test]
-fn handle_completed_outcome_mixed_tool_trace_preserves_completed() {
-    // Partial failure is explicitly out of scope (issue #6380, Part D) — a task with at
-    // least one successful tool call must still complete normally.
+fn handle_completed_outcome_mixed_trace_write_failed_marks_task_failed() {
+    // Issue #6397: a mixed trace (successful read + failed/policy-blocked write) is the
+    // common real-world shape of #6380 under the `quarantined` trust floor — read-type
+    // tools pass through while write-type tools are policy-blocked. The task must be
+    // corrected to Failed even though the read call succeeded.
     let graph = graph_from_nodes(vec![make_node(0, &[])]);
     let mut scheduler = make_scheduler(graph);
     make_running_task(&mut scheduler, TaskId(0), "h0");
@@ -2402,11 +2406,51 @@ fn handle_completed_outcome_mixed_tool_trace_preserves_completed() {
                 tool: "write".to_string(),
                 args_summary: None,
                 ok: false,
+                is_read_only: false,
             },
             ToolCallSummary {
                 tool: "read".to_string(),
                 args_summary: None,
                 ok: true,
+                is_read_only: true,
+            },
+        ]),
+    ));
+
+    scheduler.tick();
+
+    assert_eq!(
+        scheduler.graph.tasks[0].status,
+        TaskStatus::Failed,
+        "a mixed trace where every write-type call failed must be corrected to Failed, \
+         regardless of a successful read-type call"
+    );
+}
+
+#[test]
+fn handle_completed_outcome_mixed_trace_write_succeeded_preserves_completed() {
+    // The inverse of #6397's mixed-trace correction: when the write-type call actually
+    // succeeded, a failed read-type call must not drag the task down to Failed — read
+    // failures carry no weight in the heuristic once real (write-type) work succeeded.
+    let graph = graph_from_nodes(vec![make_node(0, &[])]);
+    let mut scheduler = make_scheduler(graph);
+    make_running_task(&mut scheduler, TaskId(0), "h0");
+
+    scheduler.buffered_events.push_back(completed_event(
+        TaskId(0),
+        "h0",
+        Some(vec![
+            ToolCallSummary {
+                tool: "write".to_string(),
+                args_summary: None,
+                ok: true,
+                is_read_only: false,
+            },
+            ToolCallSummary {
+                tool: "read".to_string(),
+                args_summary: None,
+                ok: false,
+                is_read_only: true,
             },
         ]),
     ));
@@ -2416,7 +2460,8 @@ fn handle_completed_outcome_mixed_tool_trace_preserves_completed() {
     assert_eq!(
         scheduler.graph.tasks[0].status,
         TaskStatus::Completed,
-        "a mixed trace (at least one successful tool call) must preserve Completed"
+        "a mixed trace where the write-type call succeeded must preserve Completed even if \
+         a read-type call failed"
     );
 }
 
@@ -2489,6 +2534,7 @@ fn handle_completed_outcome_all_tools_failed_does_not_double_count_cascade() {
             tool: "write".to_string(),
             args_summary: None,
             ok: false,
+            is_read_only: false,
         }]),
     ));
 
@@ -2550,6 +2596,7 @@ fn correct_completed_to_failed_noop_on_all_ok_trace() {
         tool: "read".to_string(),
         args_summary: None,
         ok: true,
+        is_read_only: true,
     }];
     let corrected =
         scheduler.correct_completed_to_failed_if_all_tool_calls_failed(task_id, Some(&trace));
@@ -2559,6 +2606,259 @@ fn correct_completed_to_failed_noop_on_all_ok_trace() {
         TaskStatus::Completed
     );
     assert!(!scheduler.take_graph_dirty());
+}
+
+#[test]
+fn correct_completed_to_failed_all_read_only_calls_failed_still_corrects() {
+    // The fallback rule (#6380's pre-existing full-failure case) must still fire on a trace
+    // with zero write-type calls: every entry is read-type, and every one of them failed.
+    let (mut scheduler, task_id) = scheduler_with_completed_task();
+    let trace = vec![ToolCallSummary {
+        tool: "read".to_string(),
+        args_summary: None,
+        ok: false,
+        is_read_only: true,
+    }];
+    let corrected =
+        scheduler.correct_completed_to_failed_if_all_tool_calls_failed(task_id, Some(&trace));
+    assert!(
+        corrected,
+        "a trace with no write-type calls must fall back to the 'every call failed' rule"
+    );
+    assert_eq!(
+        scheduler.graph.tasks[task_id.index()].status,
+        TaskStatus::Failed
+    );
+}
+
+#[test]
+fn correct_completed_to_failed_mixed_trace_write_failed_corrects() {
+    // Issue #6397: a mixed trace with a successful read and a failed write must still
+    // correct to Failed — the direct regression test for the scheduler-level heuristic.
+    let (mut scheduler, task_id) = scheduler_with_completed_task();
+    let trace = vec![
+        ToolCallSummary {
+            tool: "read".to_string(),
+            args_summary: None,
+            ok: true,
+            is_read_only: true,
+        },
+        ToolCallSummary {
+            tool: "write".to_string(),
+            args_summary: None,
+            ok: false,
+            is_read_only: false,
+        },
+    ];
+    let corrected =
+        scheduler.correct_completed_to_failed_if_all_tool_calls_failed(task_id, Some(&trace));
+    assert!(
+        corrected,
+        "a mixed trace where the only write-type call failed must correct to Failed"
+    );
+    assert_eq!(
+        scheduler.graph.tasks[task_id.index()].status,
+        TaskStatus::Failed
+    );
+}
+
+#[test]
+fn correct_completed_to_failed_mixed_trace_write_succeeded_preserves_completed() {
+    // Inverse of #6397: a successful write-type call must not be dragged down by a failed
+    // read-type call.
+    let (mut scheduler, task_id) = scheduler_with_completed_task();
+    let trace = vec![
+        ToolCallSummary {
+            tool: "read".to_string(),
+            args_summary: None,
+            ok: false,
+            is_read_only: true,
+        },
+        ToolCallSummary {
+            tool: "write".to_string(),
+            args_summary: None,
+            ok: true,
+            is_read_only: false,
+        },
+    ];
+    let corrected =
+        scheduler.correct_completed_to_failed_if_all_tool_calls_failed(task_id, Some(&trace));
+    assert!(
+        !corrected,
+        "a successful write-type call must preserve Completed even with a failed read"
+    );
+    assert_eq!(
+        scheduler.graph.tasks[task_id.index()].status,
+        TaskStatus::Completed
+    );
+}
+
+#[test]
+fn correct_completed_to_failed_partial_write_success_preserves_completed() {
+    // Real-world shape not covered by the single-write-call tests above: two write-type
+    // calls, one succeeded and one failed, interleaved with a successful read. Partial
+    // write success is genuine progress -- `all_tool_calls_failed` requires *every*
+    // write-type call to have failed, so this must not be corrected.
+    let (mut scheduler, task_id) = scheduler_with_completed_task();
+    let trace = vec![
+        ToolCallSummary {
+            tool: "read".to_string(),
+            args_summary: None,
+            ok: true,
+            is_read_only: true,
+        },
+        ToolCallSummary {
+            tool: "write".to_string(),
+            args_summary: None,
+            ok: true,
+            is_read_only: false,
+        },
+        ToolCallSummary {
+            tool: "write".to_string(),
+            args_summary: None,
+            ok: false,
+            is_read_only: false,
+        },
+    ];
+    let corrected =
+        scheduler.correct_completed_to_failed_if_all_tool_calls_failed(task_id, Some(&trace));
+    assert!(
+        !corrected,
+        "partial write success (one write ok, one write failed) must preserve Completed"
+    );
+    assert_eq!(
+        scheduler.graph.tasks[task_id.index()].status,
+        TaskStatus::Completed
+    );
+}
+
+#[test]
+fn correct_completed_to_failed_blocked_fetch_alongside_successful_read_corrects() {
+    // Critic finding S2 (2026-07-17): `READONLY_TOOLS` and `QUARANTINE_DENIED` are not
+    // complementary -- `fetch`, `web_scrape`, `load_skill`, and `invoke_skill` are in BOTH
+    // lists (read-only for autonomy-gating purposes, yet denied under quarantine). A naive
+    // `!is_read_only` classification would blind-spot a blocked `fetch` here since
+    // `fetch.is_read_only == true`. The fix (`counts_toward_completion_heuristic`) must
+    // still flag this trace: `read` succeeded but the only quarantine-denied call
+    // (`fetch`) was blocked -- exactly the exfiltration/side-channel class quarantine
+    // exists to stop, and it must not be masked by an unrelated successful plain read.
+    let (mut scheduler, task_id) = scheduler_with_completed_task();
+    let trace = vec![
+        ToolCallSummary {
+            tool: "read".to_string(),
+            args_summary: None,
+            ok: true,
+            is_read_only: true,
+        },
+        ToolCallSummary {
+            tool: "fetch".to_string(),
+            args_summary: None,
+            ok: false,
+            is_read_only: true,
+        },
+    ];
+    let corrected =
+        scheduler.correct_completed_to_failed_if_all_tool_calls_failed(task_id, Some(&trace));
+    assert!(
+        corrected,
+        "a blocked fetch (quarantine-denied despite is_read_only == true) alongside a \
+         successful plain read must still correct to Failed"
+    );
+    assert_eq!(
+        scheduler.graph.tasks[task_id.index()].status,
+        TaskStatus::Failed
+    );
+}
+
+#[test]
+fn correct_completed_to_failed_blocked_invoke_skill_alongside_successful_read_corrects() {
+    // Same S2 blind spot as the `fetch` test above, for `invoke_skill` -- also in both
+    // `READONLY_TOOLS` and `QUARANTINE_DENIED` (a skill body can perform arbitrary writes,
+    // critic finding M2).
+    let (mut scheduler, task_id) = scheduler_with_completed_task();
+    let trace = vec![
+        ToolCallSummary {
+            tool: "list_directory".to_string(),
+            args_summary: None,
+            ok: true,
+            is_read_only: true,
+        },
+        ToolCallSummary {
+            tool: "invoke_skill".to_string(),
+            args_summary: None,
+            ok: false,
+            is_read_only: true,
+        },
+    ];
+    let corrected =
+        scheduler.correct_completed_to_failed_if_all_tool_calls_failed(task_id, Some(&trace));
+    assert!(
+        corrected,
+        "a blocked invoke_skill alongside a successful list_directory must correct to Failed"
+    );
+    assert_eq!(
+        scheduler.graph.tasks[task_id.index()].status,
+        TaskStatus::Failed
+    );
+}
+
+#[test]
+fn correct_completed_to_failed_successful_fetch_alongside_failed_read_preserves_completed() {
+    // Inverse of the S2 regression tests above: when the quarantine-denied-but-read-only
+    // call actually succeeded, a failed plain read must not drag the task down -- mirrors
+    // the existing mixed-trace inverse tests for plain write/read.
+    let (mut scheduler, task_id) = scheduler_with_completed_task();
+    let trace = vec![
+        ToolCallSummary {
+            tool: "read".to_string(),
+            args_summary: None,
+            ok: false,
+            is_read_only: true,
+        },
+        ToolCallSummary {
+            tool: "fetch".to_string(),
+            args_summary: None,
+            ok: true,
+            is_read_only: true,
+        },
+    ];
+    let corrected =
+        scheduler.correct_completed_to_failed_if_all_tool_calls_failed(task_id, Some(&trace));
+    assert!(
+        !corrected,
+        "a successful fetch (quarantine-denied-class call) must preserve Completed even with \
+         a failed plain read"
+    );
+    assert_eq!(
+        scheduler.graph.tasks[task_id.index()].status,
+        TaskStatus::Completed
+    );
+}
+
+#[test]
+fn correct_completed_to_failed_plain_read_only_trace_all_failed_still_corrects() {
+    // Fallback-rule regression, refined for the S2 fix: a trace with no counting calls at
+    // all (every entry both is_read_only == true and NOT quarantine-denied) must still fall
+    // back to the "every call failed" rule when every entry failed -- `list_directory` is
+    // read-only and not in QUARANTINE_DENIED, unlike `fetch`/`invoke_skill` above.
+    let (mut scheduler, task_id) = scheduler_with_completed_task();
+    let trace = vec![ToolCallSummary {
+        tool: "list_directory".to_string(),
+        args_summary: None,
+        ok: false,
+        is_read_only: true,
+    }];
+    let corrected =
+        scheduler.correct_completed_to_failed_if_all_tool_calls_failed(task_id, Some(&trace));
+    assert!(
+        corrected,
+        "a trace with zero counting calls (plain, non-denied reads only) must fall back to \
+         the 'every call failed' rule"
+    );
+    assert_eq!(
+        scheduler.graph.tasks[task_id.index()].status,
+        TaskStatus::Failed
+    );
 }
 
 #[test]
@@ -2583,6 +2883,7 @@ fn correct_completed_to_failed_noop_when_task_not_completed() {
         tool: "write".to_string(),
         args_summary: None,
         ok: false,
+        is_read_only: false,
     }];
     let corrected =
         scheduler.correct_completed_to_failed_if_all_tool_calls_failed(task_id, Some(&trace));
@@ -2604,11 +2905,13 @@ fn correct_completed_to_failed_success_flips_status_and_marks_output() {
             tool: "write".to_string(),
             args_summary: None,
             ok: false,
+            is_read_only: false,
         },
         ToolCallSummary {
             tool: "bash".to_string(),
             args_summary: None,
             ok: false,
+            is_read_only: false,
         },
     ];
     let corrected =
@@ -2634,5 +2937,562 @@ fn correct_completed_to_failed_success_flips_status_and_marks_output() {
     assert!(
         scheduler.take_graph_dirty(),
         "a genuine status correction must set graph_dirty"
+    );
+}
+
+// ── DagScheduler::propagate_corrected_task_failure (#6396) ────────────────────
+
+#[test]
+fn propagate_corrected_task_failure_cancels_running_dependent_and_fails_graph() {
+    // Two-task graph: task 1 depends on task 0. Task 0 was already corrected
+    // Completed -> Failed (mirroring the spawn-path CheckToolOutcome flow); task 1 had
+    // already been unblocked and dispatched (Running) before the correction landed. The
+    // default failure strategy (Abort, see `make_config`) must cancel task 1 and fail the
+    // graph — parity with the RunInline path's `handle_failed_outcome`.
+    let graph = graph_from_nodes(vec![make_node(0, &[]), make_node(1, &[0])]);
+    let mut scheduler = make_scheduler(graph);
+
+    scheduler.graph.tasks[0].status = TaskStatus::Completed;
+    scheduler.graph.tasks[0].result = Some(TaskResult {
+        output: "original output".to_string(),
+        artifacts: vec![],
+        duration_ms: 10,
+        agent_id: Some("agent-0".to_string()),
+        agent_def: Some("worker".to_string()),
+    });
+    make_running_task(&mut scheduler, TaskId(1), "h1");
+    let _ = scheduler.take_graph_dirty();
+
+    let trace = vec![ToolCallSummary {
+        tool: "write".to_string(),
+        args_summary: None,
+        ok: false,
+        is_read_only: false,
+    }];
+    let corrected =
+        scheduler.correct_completed_to_failed_if_all_tool_calls_failed(TaskId(0), Some(&trace));
+    assert!(corrected, "test precondition: task 0 must be corrected");
+
+    let actions = scheduler.propagate_corrected_task_failure(TaskId(0));
+
+    assert!(
+        actions.iter().any(
+            |a| matches!(a, SchedulerAction::Cancel { agent_handle_id } if agent_handle_id == "h1")
+        ),
+        "the already-Running dependent must be canceled: {actions:?}"
+    );
+    assert!(
+        actions.iter().any(
+            |a| matches!(a, SchedulerAction::Done { status } if *status == GraphStatus::Failed)
+        ),
+        "GraphStatus leaving Running must emit a Done action: {actions:?}"
+    );
+    assert_eq!(scheduler.graph.status, GraphStatus::Failed);
+    assert!(scheduler.graph.finished_at.is_some());
+    assert!(
+        !scheduler.running.contains_key(&TaskId(1)),
+        "the canceled dependent must be removed from the running map"
+    );
+}
+
+#[test]
+fn propagate_corrected_task_failure_does_not_double_count_cascade() {
+    // #6396's design note: `dag::propagate_failure` never touches `cascade_detector` —
+    // calling it from `propagate_corrected_task_failure` must not change RegionHealth,
+    // which was already recorded (as a success) by `handle_completed_outcome` before the
+    // correction landed.
+    let graph = graph_from_nodes(vec![make_node(0, &[])]);
+    let config = zeph_config::OrchestrationConfig {
+        cascade_routing: true,
+        topology_selection: true,
+        ..make_config()
+    };
+    let defs = vec![make_def("worker")];
+    let mut scheduler =
+        DagScheduler::new(graph, &config, Box::new(FirstRouter), defs, None).unwrap();
+    assert!(
+        scheduler.cascade_detector.is_some(),
+        "test precondition: cascade_detector must be enabled"
+    );
+    make_running_task(&mut scheduler, TaskId(0), "h0");
+
+    // Simulate the spawn dispatch path: tool_trace is None at completion time, so
+    // handle_completed_outcome's #6380 RunInline branch does not fire and the task
+    // completes normally, recording a cascade success.
+    scheduler
+        .buffered_events
+        .push_back(completed_event(TaskId(0), "h0", None));
+    scheduler.tick();
+    assert_eq!(scheduler.graph.tasks[0].status, TaskStatus::Completed);
+
+    let region_health_before = scheduler
+        .cascade_detector
+        .as_ref()
+        .unwrap()
+        .region_health()
+        .get(&TaskId(0))
+        .expect("region health must be recorded")
+        .clone();
+    assert_eq!(region_health_before.total_tasks, 1);
+    assert_eq!(region_health_before.failed_tasks, 0);
+
+    // Post-hoc correction, as CheckToolOutcome would trigger.
+    let trace = vec![
+        ToolCallSummary {
+            tool: "read".to_string(),
+            args_summary: None,
+            ok: true,
+            is_read_only: true,
+        },
+        ToolCallSummary {
+            tool: "write".to_string(),
+            args_summary: None,
+            ok: false,
+            is_read_only: false,
+        },
+    ];
+    let corrected =
+        scheduler.correct_completed_to_failed_if_all_tool_calls_failed(TaskId(0), Some(&trace));
+    assert!(corrected);
+    let _ = scheduler.propagate_corrected_task_failure(TaskId(0));
+
+    assert_eq!(scheduler.graph.tasks[0].status, TaskStatus::Failed);
+    let region_health_after = scheduler
+        .cascade_detector
+        .as_ref()
+        .unwrap()
+        .region_health()
+        .get(&TaskId(0))
+        .expect("region health must still be present")
+        .clone();
+    assert_eq!(
+        region_health_after.total_tasks, region_health_before.total_tasks,
+        "propagate_corrected_task_failure must not change RegionHealth: {region_health_after:?}"
+    );
+    assert_eq!(
+        region_health_after.failed_tasks, region_health_before.failed_tasks,
+        "propagate_corrected_task_failure must not re-record this task as a failure: \
+         {region_health_after:?}"
+    );
+}
+
+#[test]
+fn propagate_corrected_task_failure_noop_when_no_dependents_and_graph_stays_running() {
+    // Skip strategy on a task with no dependents: propagate_failure marks the task
+    // Skipped-subtree (a no-op here since there are no dependents) and does not touch
+    // GraphStatus, since other tasks in the graph are still non-terminal.
+    let graph = graph_from_nodes(vec![make_node(0, &[]), make_node(1, &[])]);
+    let mut scheduler = make_scheduler(graph);
+    scheduler.graph.tasks[0].failure_strategy = Some(zeph_config::FailureStrategy::Skip);
+    scheduler.graph.tasks[0].status = TaskStatus::Completed;
+    scheduler.graph.tasks[0].result = Some(TaskResult {
+        output: "original output".to_string(),
+        artifacts: vec![],
+        duration_ms: 10,
+        agent_id: Some("agent-0".to_string()),
+        agent_def: Some("worker".to_string()),
+    });
+
+    let trace = vec![ToolCallSummary {
+        tool: "write".to_string(),
+        args_summary: None,
+        ok: false,
+        is_read_only: false,
+    }];
+    let corrected =
+        scheduler.correct_completed_to_failed_if_all_tool_calls_failed(TaskId(0), Some(&trace));
+    assert!(corrected);
+
+    let actions = scheduler.propagate_corrected_task_failure(TaskId(0));
+    assert!(
+        actions.is_empty(),
+        "Skip strategy with no running dependents and a still-Running graph must emit no \
+         actions: {actions:?}"
+    );
+    assert_eq!(
+        scheduler.graph.status,
+        GraphStatus::Running,
+        "GraphStatus must remain Running while task 1 is still non-terminal"
+    );
+}
+
+#[test]
+fn propagate_corrected_task_failure_retry_strategy_forces_terminal_failure() {
+    // Critic finding S1 (2026-07-17): under `FailureStrategy::Retry`, generic
+    // `dag::propagate_failure` would resurrect the *same* corrected task back to `Ready` for
+    // another attempt -- but this task was already `Completed` (cascade accounting already
+    // ran, dependents already unblocked) before the correction landed, so a resurrection
+    // would trigger a redundant redispatch and double-count RegionHealth on its second
+    // completion. `propagate_corrected_task_failure` must instead force terminal Abort-style
+    // behavior for Retry, via `dag::propagate_failure_forced_terminal`: the task stays
+    // `Failed` (never resurrected), `retry_count` is untouched, and the graph fails.
+    let graph = graph_from_nodes(vec![make_node(0, &[])]);
+    let mut scheduler = make_scheduler(graph);
+    scheduler.graph.tasks[0].failure_strategy = Some(zeph_config::FailureStrategy::Retry);
+    scheduler.graph.tasks[0].status = TaskStatus::Completed;
+    scheduler.graph.tasks[0].result = Some(TaskResult {
+        output: "original output".to_string(),
+        artifacts: vec![],
+        duration_ms: 10,
+        agent_id: Some("agent-0".to_string()),
+        agent_def: Some("worker".to_string()),
+    });
+    assert_eq!(scheduler.graph.tasks[0].retry_count, 0);
+
+    let trace = vec![ToolCallSummary {
+        tool: "write".to_string(),
+        args_summary: None,
+        ok: false,
+        is_read_only: false,
+    }];
+    let corrected =
+        scheduler.correct_completed_to_failed_if_all_tool_calls_failed(TaskId(0), Some(&trace));
+    assert!(corrected, "test precondition: task 0 must be corrected");
+    assert_eq!(scheduler.graph.tasks[0].status, TaskStatus::Failed);
+
+    let actions = scheduler.propagate_corrected_task_failure(TaskId(0));
+
+    assert_eq!(
+        scheduler.graph.tasks[0].status,
+        TaskStatus::Failed,
+        "Retry must NOT resurrect an already-completed corrected task to Ready -- that would \
+         trigger a redundant redispatch and double-count RegionHealth (critic finding S1)"
+    );
+    assert_eq!(
+        scheduler.graph.tasks[0].retry_count, 0,
+        "no retry attempt was made, so retry_count must not increment"
+    );
+    assert_eq!(
+        scheduler.graph.status,
+        GraphStatus::Failed,
+        "Retry is forced to terminal Abort-style behavior for a post-hoc correction"
+    );
+    assert!(
+        actions.iter().any(
+            |a| matches!(a, SchedulerAction::Done { status } if *status == GraphStatus::Failed)
+        ),
+        "GraphStatus leaving Running must emit a Done action: {actions:?}"
+    );
+}
+
+#[test]
+fn propagate_corrected_task_failure_retry_then_tick_emits_no_spawn() {
+    // Follow-up to the forced-terminal test above: since the task is never resurrected under
+    // Retry, driving an actual `tick()` after the correction must emit zero Spawn actions for
+    // it -- the graph is already terminal (Failed), so tick() returns Done immediately.
+    let graph = graph_from_nodes(vec![make_node(0, &[])]);
+    let mut scheduler = make_scheduler(graph);
+    scheduler.graph.tasks[0].failure_strategy = Some(zeph_config::FailureStrategy::Retry);
+    scheduler.graph.tasks[0].status = TaskStatus::Completed;
+    scheduler.graph.tasks[0].result = Some(TaskResult {
+        output: "original output".to_string(),
+        artifacts: vec![],
+        duration_ms: 10,
+        agent_id: Some("agent-0".to_string()),
+        agent_def: Some("worker".to_string()),
+    });
+
+    let trace = vec![ToolCallSummary {
+        tool: "write".to_string(),
+        args_summary: None,
+        ok: false,
+        is_read_only: false,
+    }];
+    let corrected =
+        scheduler.correct_completed_to_failed_if_all_tool_calls_failed(TaskId(0), Some(&trace));
+    assert!(corrected);
+    let _ = scheduler.propagate_corrected_task_failure(TaskId(0));
+    assert_eq!(scheduler.graph.tasks[0].status, TaskStatus::Failed);
+    assert_eq!(scheduler.graph.status, GraphStatus::Failed);
+
+    let actions = scheduler.tick();
+    let spawn_count = actions
+        .iter()
+        .filter(|a| matches!(a, SchedulerAction::Spawn { task_id, .. } if *task_id == TaskId(0)))
+        .count();
+    assert_eq!(
+        spawn_count, 0,
+        "a task forced to terminal Failed under Retry must never be redispatched: {actions:?}"
+    );
+    assert!(
+        actions.iter().any(
+            |a| matches!(a, SchedulerAction::Done { status } if *status == GraphStatus::Failed)
+        ),
+        "tick() on an already-terminal graph must return Done: {actions:?}"
+    );
+}
+
+#[test]
+fn propagate_corrected_task_failure_ask_strategy_forces_terminal_failure_instead_of_pause() {
+    // Companion to the Retry test: `FailureStrategy::Ask` would normally pause the whole
+    // graph (`GraphStatus::Paused`) via generic `dag::propagate_failure` -- but pausing an
+    // already-completed-then-corrected task's plan post-hoc is equally unsafe/meaningless
+    // here (critic finding S1's `Ask` variant), so it must also force terminal Failed.
+    let graph = graph_from_nodes(vec![make_node(0, &[])]);
+    let mut scheduler = make_scheduler(graph);
+    scheduler.graph.tasks[0].failure_strategy = Some(zeph_config::FailureStrategy::Ask);
+    scheduler.graph.tasks[0].status = TaskStatus::Completed;
+    scheduler.graph.tasks[0].result = Some(TaskResult {
+        output: "original output".to_string(),
+        artifacts: vec![],
+        duration_ms: 10,
+        agent_id: Some("agent-0".to_string()),
+        agent_def: Some("worker".to_string()),
+    });
+
+    let trace = vec![ToolCallSummary {
+        tool: "write".to_string(),
+        args_summary: None,
+        ok: false,
+        is_read_only: false,
+    }];
+    let corrected =
+        scheduler.correct_completed_to_failed_if_all_tool_calls_failed(TaskId(0), Some(&trace));
+    assert!(corrected);
+
+    let actions = scheduler.propagate_corrected_task_failure(TaskId(0));
+
+    assert_eq!(
+        scheduler.graph.status,
+        GraphStatus::Failed,
+        "Ask must not pause the graph for a post-hoc correction -- it is forced to terminal \
+         Failed instead (critic finding S1)"
+    );
+    assert!(
+        actions.iter().any(
+            |a| matches!(a, SchedulerAction::Done { status } if *status == GraphStatus::Failed)
+        ),
+        "GraphStatus leaving Running must emit a Done action: {actions:?}"
+    );
+}
+
+#[test]
+fn propagate_corrected_task_failure_retry_with_state_injection_does_not_recover() {
+    // Regression for the developer's own design note on `propagate_failure_forced_terminal`
+    // (dag.rs): "Considered and rejected including Mode-1 recovery ... `try_recover` would
+    // silently flip the just-corrected `Failed` status back to `Completed`". That claim was
+    // true by code inspection (the forced-terminal function never calls `try_recover`) but
+    // had no test locking it in -- the *generic* `dag::propagate_failure`'s retry-exhausted
+    // arm DOES invoke Mode-1 recovery when `recovery.state_injection` is configured (see
+    // `test_propagate_failure_retry_exhausted_recovers_with_state_injection` in dag.rs), so
+    // this is a real divergence a future refactor could silently reintroduce by routing the
+    // forced-terminal case back through the generic function. Configure the task with a
+    // `state_injection` fallback that *would* flip it back to Completed under the generic
+    // path, and confirm the forced-terminal path leaves it Failed instead.
+    let graph = graph_from_nodes(vec![make_node(0, &[])]);
+    let mut scheduler = make_scheduler(graph);
+    scheduler.graph.tasks[0].failure_strategy = Some(zeph_config::FailureStrategy::Retry);
+    scheduler.graph.tasks[0].max_retries = Some(3);
+    scheduler.graph.tasks[0].retry_count = 3; // at max -- would be "exhausted" under the generic path
+    scheduler.graph.tasks[0].recovery = Some(crate::graph::RecoveryAction {
+        state_injection: Some("fallback output".to_string()),
+        route_to: None,
+    });
+    scheduler.graph.tasks[0].status = TaskStatus::Completed;
+    scheduler.graph.tasks[0].result = Some(TaskResult {
+        output: "original output".to_string(),
+        artifacts: vec![],
+        duration_ms: 10,
+        agent_id: Some("agent-0".to_string()),
+        agent_def: Some("worker".to_string()),
+    });
+
+    let trace = vec![ToolCallSummary {
+        tool: "write".to_string(),
+        args_summary: None,
+        ok: false,
+        is_read_only: false,
+    }];
+    let corrected =
+        scheduler.correct_completed_to_failed_if_all_tool_calls_failed(TaskId(0), Some(&trace));
+    assert!(corrected);
+
+    let _ = scheduler.propagate_corrected_task_failure(TaskId(0));
+
+    assert_eq!(
+        scheduler.graph.tasks[0].status,
+        TaskStatus::Failed,
+        "the forced-terminal path must NOT invoke Mode-1 recovery -- a configured \
+         state_injection fallback must not silently flip the just-corrected Failed status \
+         back to Completed, which no already-unblocked dependent would ever see"
+    );
+    assert_ne!(
+        scheduler.graph.tasks[0]
+            .result
+            .as_ref()
+            .unwrap()
+            .agent_def
+            .as_deref(),
+        Some("__recovery__"),
+        "the recovery marker must never appear -- confirms try_recover was not invoked"
+    );
+    assert_eq!(scheduler.graph.status, GraphStatus::Failed);
+}
+
+#[test]
+fn propagate_corrected_task_failure_abort_with_state_injection_does_not_recover() {
+    // Critic finding S1-residual (2026-07-17): the default `Abort` strategy's arm in
+    // `dag::propagate_failure` calls `try_recover` *before* terminal-failing the graph. When
+    // `recovery.state_injection` is configured, that would flip this just-corrected task
+    // straight back to `Completed` with injected output -- silently undoing the correction
+    // exactly like the `Retry`/`Ask` hazard the sibling test above locks in. This is the
+    // default-strategy companion to `..._retry_with_state_injection_does_not_recover`: no
+    // explicit `failure_strategy` override, relying on `make_config`'s `default_failure_strategy
+    // = Abort`.
+    let graph = graph_from_nodes(vec![make_node(0, &[])]);
+    let mut scheduler = make_scheduler(graph);
+    assert_eq!(
+        scheduler.graph.default_failure_strategy,
+        zeph_config::FailureStrategy::Abort,
+        "test precondition: default strategy must be Abort (unconfigured failure_strategy)"
+    );
+    scheduler.graph.tasks[0].recovery = Some(crate::graph::RecoveryAction {
+        state_injection: Some("fallback output".to_string()),
+        route_to: None,
+    });
+    scheduler.graph.tasks[0].status = TaskStatus::Completed;
+    scheduler.graph.tasks[0].result = Some(TaskResult {
+        output: "original output".to_string(),
+        artifacts: vec![],
+        duration_ms: 10,
+        agent_id: Some("agent-0".to_string()),
+        agent_def: Some("worker".to_string()),
+    });
+
+    let trace = vec![ToolCallSummary {
+        tool: "write".to_string(),
+        args_summary: None,
+        ok: false,
+        is_read_only: false,
+    }];
+    let corrected =
+        scheduler.correct_completed_to_failed_if_all_tool_calls_failed(TaskId(0), Some(&trace));
+    assert!(corrected);
+
+    let actions = scheduler.propagate_corrected_task_failure(TaskId(0));
+
+    assert_eq!(
+        scheduler.graph.tasks[0].status,
+        TaskStatus::Failed,
+        "default Abort strategy + state_injection must NOT invoke Mode-1 recovery on a \
+         post-hoc correction -- the injected fallback would never be seen by dependents that \
+         already consumed the original (now-invalidated) output"
+    );
+    assert_ne!(
+        scheduler.graph.tasks[0]
+            .result
+            .as_ref()
+            .unwrap()
+            .agent_def
+            .as_deref(),
+        Some("__recovery__"),
+        "the recovery marker must never appear -- confirms try_recover was not invoked"
+    );
+    assert_eq!(scheduler.graph.status, GraphStatus::Failed);
+    assert!(
+        actions.iter().any(
+            |a| matches!(a, SchedulerAction::Done { status } if *status == GraphStatus::Failed)
+        ),
+        "GraphStatus leaving Running must emit a Done action: {actions:?}"
+    );
+}
+
+#[test]
+fn propagate_corrected_task_failure_skip_with_state_injection_still_uses_generic_propagate() {
+    // Companion negative test: `Skip`'s arm in `dag::propagate_failure` never calls
+    // `try_recover` (it goes straight to `skip_subtree`), so a `Skip`-configured task with
+    // `state_injection` configured is safe via the *unmodified* generic `propagate_failure`
+    // path -- it must NOT be routed through `propagate_failure_forced_terminal`. Distinguishing
+    // signal: `Skip`'s arm flips the failed task's own status to `Skipped` (not left `Failed`,
+    // unlike the forced-terminal path), which only the generic path does.
+    let graph = graph_from_nodes(vec![make_node(0, &[])]);
+    let mut scheduler = make_scheduler(graph);
+    scheduler.graph.tasks[0].failure_strategy = Some(zeph_config::FailureStrategy::Skip);
+    scheduler.graph.tasks[0].recovery = Some(crate::graph::RecoveryAction {
+        state_injection: Some("fallback output".to_string()),
+        route_to: None,
+    });
+    scheduler.graph.tasks[0].status = TaskStatus::Completed;
+    scheduler.graph.tasks[0].result = Some(TaskResult {
+        output: "original output".to_string(),
+        artifacts: vec![],
+        duration_ms: 10,
+        agent_id: Some("agent-0".to_string()),
+        agent_def: Some("worker".to_string()),
+    });
+
+    let trace = vec![ToolCallSummary {
+        tool: "write".to_string(),
+        args_summary: None,
+        ok: false,
+        is_read_only: false,
+    }];
+    let corrected =
+        scheduler.correct_completed_to_failed_if_all_tool_calls_failed(TaskId(0), Some(&trace));
+    assert!(corrected);
+
+    let _ = scheduler.propagate_corrected_task_failure(TaskId(0));
+
+    assert_eq!(
+        scheduler.graph.tasks[0].status,
+        TaskStatus::Skipped,
+        "Skip's arm must run unmodified (flips to Skipped, not left Failed) even with \
+         state_injection configured -- Skip never calls try_recover, so it needs no \
+         forced-terminal special-case"
+    );
+}
+
+#[test]
+fn propagate_corrected_task_failure_leaves_already_completed_dependent_untouched() {
+    // Documented remaining limitation on `propagate_corrected_task_failure`: a dependent
+    // that already reached a terminal status (typically Completed, having consumed the
+    // now-invalidated output) before the correction landed is not retroactively unwound --
+    // `dag::propagate_failure`'s cancellation/skip/retry logic only affects dependents
+    // still Pending/Ready/Running. This locks in that documented behavior as a regression
+    // test rather than leaving it purely as a doc comment.
+    let graph = graph_from_nodes(vec![make_node(0, &[]), make_node(1, &[0])]);
+    let mut scheduler = make_scheduler(graph);
+
+    scheduler.graph.tasks[0].status = TaskStatus::Completed;
+    scheduler.graph.tasks[0].result = Some(TaskResult {
+        output: "original output".to_string(),
+        artifacts: vec![],
+        duration_ms: 10,
+        agent_id: Some("agent-0".to_string()),
+        agent_def: Some("worker".to_string()),
+    });
+    scheduler.graph.tasks[1].status = TaskStatus::Completed;
+    scheduler.graph.tasks[1].result = Some(TaskResult {
+        output: "dependent already finished using task 0's now-invalidated output".to_string(),
+        artifacts: vec![],
+        duration_ms: 5,
+        agent_id: Some("agent-1".to_string()),
+        agent_def: Some("worker".to_string()),
+    });
+
+    let trace = vec![ToolCallSummary {
+        tool: "write".to_string(),
+        args_summary: None,
+        ok: false,
+        is_read_only: false,
+    }];
+    let corrected =
+        scheduler.correct_completed_to_failed_if_all_tool_calls_failed(TaskId(0), Some(&trace));
+    assert!(corrected);
+
+    let actions = scheduler.propagate_corrected_task_failure(TaskId(0));
+
+    assert_eq!(
+        scheduler.graph.tasks[1].status,
+        TaskStatus::Completed,
+        "a dependent that already completed before the correction landed is not \
+         retroactively unwound (documented limitation)"
+    );
+    assert!(
+        actions.iter().any(
+            |a| matches!(a, SchedulerAction::Done { status } if *status == GraphStatus::Failed)
+        ),
+        "the graph must still terminalize as Failed even though the dependent stayed \
+         Completed -- task 0 itself is Failed and no non-terminal task remains: {actions:?}"
     );
 }

--- a/crates/zeph-orchestration/src/verifier.rs
+++ b/crates/zeph-orchestration/src/verifier.rs
@@ -60,6 +60,23 @@ pub struct ToolCallSummary {
     /// grounding checks claim *existence*, not claim *outcome* (a deliberate, documented
     /// scope limitation; see spec's "Scope" subsection).
     pub ok: bool,
+    /// Whether `tool` is a read-only tool (no durable state mutation), per
+    /// `zeph_common::tool_classification::is_readonly_tool` — the same allowlist
+    /// `zeph-tools` uses to gate `ReadOnly` autonomy mode. `false` covers both explicit
+    /// write/execute/network-type tools and any unclassified tool (the conservative
+    /// default: an unrecognized tool is treated as capable of producing durable side
+    /// effects).
+    ///
+    /// This field alone answers only the autonomy-gating question ("is this tool in the
+    /// `ReadOnly`-mode allowlist"), which is a **different** policy axis than "did this call
+    /// count as real work" — `READONLY_TOOLS` and `zeph_common::quarantine::QUARANTINE_DENIED`
+    /// are not complementary (`web_scrape`, `fetch`, `load_skill`, `invoke_skill` are in
+    /// both). The scheduler's mixed-trace failure heuristic (#6397,
+    /// `scheduler::tick::counts_toward_completion_heuristic`) therefore does **not** use
+    /// `!is_read_only` alone; it also treats a quarantine-denied call as counting even when
+    /// `is_read_only == true`, so a blocked `fetch`/`invoke_skill` is never masked by an
+    /// unrelated successful plain `read`.
+    pub is_read_only: bool,
 }
 
 /// Severity of a detected gap in task output.
@@ -1626,6 +1643,7 @@ mod tests {
             tool: tool.to_string(),
             args_summary: args.map(str::to_string),
             ok,
+            is_read_only: zeph_common::tool_classification::is_readonly_tool(tool),
         }
     }
 

--- a/crates/zeph-tools/src/permissions.rs
+++ b/crates/zeph-tools/src/permissions.rs
@@ -9,32 +9,14 @@ pub(crate) use zeph_config::tools::{
     AutonomyLevel, PermissionAction, PermissionRule, PermissionsConfig,
 };
 
-/// Read-only tool allowlist (available in `ReadOnly` autonomy mode).
+/// Read-only tool allowlist and its `is_readonly_tool` predicate.
 ///
-/// Also used, via [`is_readonly_tool`], to bypass the `Supervised`-mode confirmation
-/// default for unconfigured tools — see #5575. A tool added here is trusted to run
-/// without confirmation in *both* modes; do not add anything that mutates state or
-/// executes code.
-const READONLY_TOOLS: &[&str] = &[
-    "read",
-    "find_path",
-    "grep",
-    "list_directory",
-    "web_scrape",
-    "fetch",
-    "load_skill",
-    "invoke_skill",
-];
-
-/// Returns `true` if `tool_id` is a native read-only tool.
-///
-/// Reuses the same [`READONLY_TOOLS`] allowlist that gates `ReadOnly` autonomy mode, so
-/// `Supervised` mode's unconfigured-tool bypass (`TrustGateExecutor::check_trust`) cannot
-/// silently diverge from it — see #5575.
-#[must_use]
-pub(crate) fn is_readonly_tool(tool_id: &str) -> bool {
-    READONLY_TOOLS.contains(&tool_id)
-}
+/// Canonical definition lives in `zeph_common::tool_classification` — shared with
+/// `zeph-orchestration`, which uses it to classify tool calls in a task's real execution
+/// trace as read vs. write-type (#6397). Re-exported here under the historical names so
+/// existing call sites in this crate (`permissions::READONLY_TOOLS`,
+/// `permissions::is_readonly_tool`) keep working unchanged.
+pub(crate) use zeph_common::tool_classification::{READONLY_TOOLS, is_readonly_tool};
 
 /// Tool permission policy: maps `tool_id` → ordered list of rules.
 /// First matching rule wins; default is `Ask`.

--- a/crates/zeph-tools/src/trust_gate.rs
+++ b/crates/zeph-tools/src/trust_gate.rs
@@ -17,18 +17,13 @@ use crate::executor::{ToolCall, ToolError, ToolExecutor, ToolOutput};
 use crate::permissions::{AutonomyLevel, PermissionAction, PermissionPolicy};
 use crate::registry::ToolDef;
 
-/// Tools denied when a Quarantined skill is active.
+/// Tools denied when a Quarantined skill is active, and the matching predicate.
 ///
-/// Re-exported from `zeph_common::quarantine::QUARANTINE_DENIED` — the canonical definition
-/// lives there so both `zeph-skills` and `zeph-tools` can reference it without a dependency
-/// cycle.
+/// Re-exported from `zeph_common::quarantine` — the canonical definitions live there so
+/// `zeph-skills`, `zeph-tools`, and `zeph-orchestration` can all reference them without a
+/// dependency cycle.
 pub use zeph_common::quarantine::QUARANTINE_DENIED;
-
-pub(crate) fn is_quarantine_denied(tool_id: &str) -> bool {
-    QUARANTINE_DENIED
-        .iter()
-        .any(|denied| tool_id == *denied || tool_id.ends_with(&format!("_{denied}")))
-}
+pub(crate) use zeph_common::quarantine::is_quarantine_denied;
 
 /// Builds the denial message for a Quarantined-trust block.
 ///


### PR DESCRIPTION
## Summary

Follow-up to #6380 / PR #6395. Two grouped fixes to the spawn-path task-completion correction in `zeph-orchestration`'s `DagScheduler`:

- **#6397** — the #6380 all-failed heuristic only caught total task failure (every tool call `ok == false`). Under the `quarantined` trust floor, read-type tools pass through policy checks while write-type tools are denied, so a typical sub-agent trace mixes successful reads with policy-blocked writes — a shape the heuristic missed entirely, leaving the task `Completed` despite zero durable work. `ToolCallSummary` now carries an `is_read_only` classification (single source of truth in `zeph_common::tool_classification`, re-exported by `zeph-tools`). Since `READONLY_TOOLS` and `QUARANTINE_DENIED` are not complementary (`web_scrape`, `fetch`, `load_skill`, `invoke_skill` are in both), the heuristic also counts quarantine-denied calls via `zeph_common::quarantine::is_quarantine_denied` regardless of their read/write classification, closing a blind spot where a blocked `fetch` alongside a successful `read` would otherwise go undetected.

- **#6396** — the spawn-path `Completed -> Failed` correction was status-only: it never canceled already-unblocked dependents or recomputed `GraphStatus`, unlike the `RunInline` path's `handle_failed_outcome`. `DagScheduler::propagate_corrected_task_failure` now propagates the correction. For `Retry`/`Ask` strategies and for `Abort` with `recovery.state_injection` configured, generic `dag::propagate_failure` would resurrect or pause the already-corrected task — silently undoing the fix and re-triggering `RegionHealth` double-counting on redispatch — so those cases route through a new `dag::propagate_failure_forced_terminal` that always applies terminal Abort-style behavior instead.

Dependents that already reached a terminal status before the correction landed are not retroactively unwound — a deliberate, documented remaining limitation shared with the `RunInline` path.

## Test plan

- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — full workspace green (14136/14136 post-rebase)
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`)
- [x] `cargo test --doc --workspace`
- [x] `gitleaks protect --staged --no-banner --redact`
- [x] New regression tests: mixed-trace classification (partial write success, blocked fetch/invoke_skill alongside successful reads), `Retry`/`Ask`/`Abort`-with-recovery forced-terminal propagation, already-completed-dependent limitation lock-in, `RunInline`-path end-to-end coverage for the second `is_read_only` call site
- [x] `.local/testing/coverage-status.md` and `.local/testing/playbooks/orchestration-plan.md` updated in place (main repo root, per project convention)

Closes #6397
Closes #6396