### PR TITLE
fix(subagent): publish terminal status on LLM timeout and capture debug dumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   The flash-style patch was only applied in the `MessageGroup::Grouped` render arm; the
   `Single` arm now applies the same `patch_flash_style` check, so a lone tool completion
   flashes identically to a grouped one.
+- `zeph-subagent`: a sub-agent LLM-call timeout inside `call_provider_with_status`
+  (`agent_loop.rs`) early-returned without publishing a terminal status, unlike the sibling
+  provider-error arm — `status_tx`/`status_rx` stayed frozen at the last `Working` value
+  forever, so `collect_finished_subagents()` never reaped the handle and the TUI agents
+  sidebar showed a zombie WORKING entry with an ever-climbing elapsed counter (#6381). Same
+  defect class as #6257's setup-phase fix, now closed for the per-turn LLM-call path too: the
+  timeout arm now sends `SubAgentStatus { state: Failed, .. }` before returning.
+- `zeph-subagent`: sub-agent-executed task turns (including orchestration-dispatched ones)
+  wrote no `--debug-dump` files, since `zeph-subagent`'s LLM-call path had no equivalent of
+  the top-level agent loop's request/response dump interceptor (#6391). Added
+  `zeph_llm::debug_dump::DebugDumpSink`, a cross-crate trait implemented by `zeph-core`'s
+  `DebugDumper` and threaded down via `SpawnContext`/`AgentLoopArgs` (same plumbing shape as
+  the existing `progress_at` idle-timeout heartbeat), so sub-agent LLM calls are now captured
+  through the same dump pipeline as top-level calls. Covers both the standalone `/agent`
+  spawn path and `/agent resume`, which previously dropped the sink by passing `None` for
+  `spawn_context`.
 - `src/channel.rs`: `impl Channel for AppChannel` forwarded most `Channel` trait methods via
   `dispatch_app_channel!` but never overrode `elicit()` or `send_context_estimate()`, so both
   calls fell through to the trait's default methods instead of reaching `AnyChannel`/`TuiChannel`'s

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -1163,19 +1163,7 @@ impl DebugState {
         let Some((d, id)) = self.debug_dumper.as_ref().zip(dump_id) else {
             return;
         };
-        let raw = match result {
-            zeph_llm::provider::ChatResponse::Text(t) => t.clone(),
-            zeph_llm::provider::ChatResponse::ToolUse {
-                text, tool_calls, ..
-            } => {
-                let calls = serde_json::to_string_pretty(tool_calls).unwrap_or_default();
-                format!(
-                    "{}\n\n---TOOL_CALLS---\n{calls}",
-                    text.as_deref().unwrap_or("")
-                )
-            }
-            _ => String::new(),
-        };
+        let raw = crate::debug_dump::DebugDumper::chat_response_dump_text(result);
         let text = if pii_filter.is_enabled() {
             pii_filter.scrub(&raw).into_owned()
         } else {

--- a/crates/zeph-core/src/agent/subagent_commands.rs
+++ b/crates/zeph-core/src/agent/subagent_commands.rs
@@ -650,9 +650,26 @@ impl<C: Channel> Agent<C> {
         let skills = self.filtered_skills_for(&def_name);
         let provider = self.provider.clone();
         let tool_executor = Arc::clone(&self.tool_executor);
+        // Built before borrowing `subagent_manager` mutably below (build_spawn_context takes
+        // `&self`). Previously this call site passed `None`, which meant resumed sub-agents
+        // never got a `debug_dump_sink` — their LLM calls went uncaptured by `--debug-dump`
+        // even though fresh spawns correctly wired it (#6391). `resume()` only reads
+        // `max_trust_level`/`inherited_tool_allowlist`/`network_denied`/`debug_dump_sink` off
+        // `spawn_context` (see `manager/spawn.rs::resume`) — the first three are already at
+        // `build_spawn_context`'s top-level defaults (`None`/`None`/`false`, identical to what
+        // `None` produced here), so this only changes `debug_dump_sink` for this call site.
+        let spawn_ctx = self.build_spawn_context(&cfg);
         let mgr = self.services.orchestration.subagent_manager.as_mut()?;
         let (task_id, _) = match mgr
-            .resume(id, prompt, provider, tool_executor, skills, &cfg, None)
+            .resume(
+                id,
+                prompt,
+                provider,
+                tool_executor,
+                skills,
+                &cfg,
+                Some(&spawn_ctx),
+            )
             .await
         {
             Ok(pair) => pair,
@@ -731,6 +748,15 @@ impl<C: Channel> Agent<C> {
             orchestrator_name: Some("zeph".to_owned()),
             orchestrator_role: Some("orchestrator".to_owned()),
             session_mcp_servers: Vec::new(),
+            // Threaded down so sub-agent LLM calls are captured through the same
+            // `--debug-dump` pipeline as the top-level agent loop (#6391). `None` when
+            // debug dumps are disabled, mirroring the top-level `debug_dumper: None` case.
+            debug_dump_sink: self
+                .runtime
+                .debug
+                .debug_dumper
+                .clone()
+                .map(|d| Arc::new(d) as Arc<dyn zeph_llm::debug_dump::DebugDumpSink>),
             // Constraint propagation (#3993): populated by orchestration layer when spawning
             // with explicit trust/tool restrictions. Top-level agent sessions leave these None.
             ..Default::default()
@@ -1549,5 +1575,59 @@ mod tests {
             1,
             "exactly one real spawn must occur on the still-pending fallback path"
         );
+    }
+
+    // ── build_spawn_context: debug_dump_sink wiring (#6391) ─────────────────
+
+    #[test]
+    fn build_spawn_context_leaves_debug_dump_sink_none_without_dumper() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let agent = Agent::new(
+            provider,
+            channel,
+            registry,
+            None,
+            5,
+            MockToolExecutor::no_tools(),
+        );
+
+        let ctx = agent.build_spawn_context(&zeph_config::SubAgentConfig::default());
+        assert!(
+            ctx.debug_dump_sink.is_none(),
+            "no DebugDumper configured, so SpawnContext must carry no sink"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_spawn_context_wires_debug_dump_sink_when_dumper_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let dumper =
+            crate::debug_dump::DebugDumper::new(dir.path(), crate::debug_dump::DumpFormat::Raw)
+                .unwrap();
+
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let mut agent = Agent::new(
+            provider,
+            channel,
+            registry,
+            None,
+            5,
+            MockToolExecutor::no_tools(),
+        );
+        agent.runtime.debug.debug_dumper = Some(dumper);
+
+        let ctx = agent.build_spawn_context(&zeph_config::SubAgentConfig::default());
+        let sink = ctx
+            .debug_dump_sink
+            .expect("a configured DebugDumper must be threaded into SpawnContext");
+
+        // Exercise the sink through the trait, same as `zeph-subagent`'s agent loop would —
+        // proves the wiring produces a working `Arc<dyn DebugDumpSink>`, not just `Some(_)`.
+        let id = sink.dump_request("mock", &[], &[], serde_json::Value::Null);
+        sink.dump_response(id, &zeph_llm::provider::ChatResponse::Text("ok".into()));
     }
 }

--- a/crates/zeph-core/src/debug_dump/mod.rs
+++ b/crates/zeph-core/src/debug_dump/mod.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use base64::Engine as _;
-use zeph_llm::provider::{Message, MessagePart, Role, ToolDefinition};
+use zeph_llm::provider::{ChatResponse, Message, MessagePart, Role, ToolDefinition};
 
 use crate::redact::{redact_binary_blobs, scrub_content};
 
@@ -168,6 +168,28 @@ impl DebugDumper {
         let redacted = scrub_content(response);
         let redacted = redact_binary_blobs(&redacted);
         self.write(&format!("{id:04}-response.txt"), redacted.as_bytes());
+    }
+
+    /// Response text extracted from a `ChatResponse`, mirroring
+    /// [`DebugState::write_chat_debug_dump`](crate::agent::state::DebugState) — kept as a free
+    /// function so [`DebugDumpSink::dump_response`] can reuse it without a PII-filter dependency
+    /// (sub-agent dumps rely on the baseline `scrub_content`/`redact_binary_blobs` pass already
+    /// inside [`DebugDumper::dump_response`], skipping the optional extra `PiiFilter` layer that
+    /// top-level dumps get — see #6391).
+    pub(crate) fn chat_response_dump_text(response: &ChatResponse) -> String {
+        match response {
+            ChatResponse::Text(t) => t.clone(),
+            ChatResponse::ToolUse {
+                text, tool_calls, ..
+            } => {
+                let calls = serde_json::to_string_pretty(tool_calls).unwrap_or_default();
+                format!(
+                    "{}\n\n---TOOL_CALLS---\n{calls}",
+                    text.as_deref().unwrap_or("")
+                )
+            }
+            _ => String::new(),
+        }
     }
 
     /// Dump raw tool output before any truncation or summarization.
@@ -422,6 +444,41 @@ impl DebugDumper {
                 tracing::warn!("dump_tool_error: failed to serialize error payload: {e}");
             }
         }
+    }
+}
+
+/// Lets `zeph-subagent`'s agent loop write sub-agent LLM request/response pairs through the
+/// same [`DebugDumper`] the top-level agent loop uses, without `zeph-subagent` depending on
+/// `zeph-core` (#6391). See [`zeph_llm::debug_dump::DebugDumpSink`] for the contract.
+impl zeph_llm::debug_dump::DebugDumpSink for DebugDumper {
+    fn is_trace_format(&self) -> bool {
+        self.is_trace_format()
+    }
+
+    fn dump_request(
+        &self,
+        model_name: &str,
+        messages: &[Message],
+        tools: &[ToolDefinition],
+        provider_request: serde_json::Value,
+    ) -> u32 {
+        DebugDumper::dump_request(
+            self,
+            &RequestDebugDump {
+                model_name,
+                messages,
+                tools,
+                provider_request,
+                // Sub-agents have no `MemCoT` accumulator of their own (that state lives on
+                // the top-level `Agent`'s `services.memory.extraction`), so there is nothing
+                // to attach here.
+                memcot_state: None,
+            },
+        )
+    }
+
+    fn dump_response(&self, id: u32, response: &ChatResponse) {
+        DebugDumper::dump_response(self, id, &DebugDumper::chat_response_dump_text(response));
     }
 }
 

--- a/crates/zeph-llm/src/debug_dump.rs
+++ b/crates/zeph-llm/src/debug_dump.rs
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Cross-crate sink trait for LLM request/response debug-dump instrumentation.
+//!
+//! `zeph-core` owns the concrete debug-dump writer (`DebugDumper`) and the top-level
+//! agent loop's `--debug-dump` wiring, but `zeph-subagent` cannot depend on `zeph-core`
+//! (the dependency runs the other way). [`DebugDumpSink`] is the minimal contract that
+//! lets `zeph-core` hand a dump-writer handle down into `zeph-subagent`'s agent loop —
+//! via `SpawnContext`/`AgentLoopArgs` — so sub-agent LLM calls are captured through the
+//! same pipeline as top-level calls (#6391).
+
+use crate::provider::{ChatResponse, Message, ToolDefinition};
+
+/// Receives LLM request/response pairs for debug-dump instrumentation.
+///
+/// Implemented by `zeph-core`'s `DebugDumper`. Callers pair each [`dump_request`] with a
+/// [`dump_response`] using the returned id.
+///
+/// [`dump_request`]: DebugDumpSink::dump_request
+/// [`dump_response`]: DebugDumpSink::dump_response
+pub trait DebugDumpSink: Send + Sync {
+    /// Returns `true` when the active dump format does not need `provider_request` built
+    /// (e.g. Trace format, which records spans instead of numbered files) — callers can
+    /// skip the (non-free) request serialization in that case.
+    fn is_trace_format(&self) -> bool;
+
+    /// Dump the outgoing request. Returns an id that must be passed to [`dump_response`]
+    /// to correlate the pair.
+    ///
+    /// [`dump_response`]: DebugDumpSink::dump_response
+    fn dump_request(
+        &self,
+        model_name: &str,
+        messages: &[Message],
+        tools: &[ToolDefinition],
+        provider_request: serde_json::Value,
+    ) -> u32;
+
+    /// Dump the response paired with a prior [`dump_request`] call.
+    ///
+    /// [`dump_request`]: DebugDumpSink::dump_request
+    fn dump_response(&self, id: u32, response: &ChatResponse);
+}

--- a/crates/zeph-llm/src/lib.rs
+++ b/crates/zeph-llm/src/lib.rs
@@ -81,6 +81,7 @@ pub mod claude;
 #[cfg(feature = "cocoon")]
 pub mod cocoon;
 pub mod compatible;
+pub mod debug_dump;
 #[cfg(feature = "candle")]
 pub(crate) mod device;
 pub mod ema;

--- a/crates/zeph-subagent/src/agent_loop.rs
+++ b/crates/zeph-subagent/src/agent_loop.rs
@@ -80,6 +80,9 @@ pub(super) struct AgentLoopArgs {
     /// turn boundary. `None` for spawns not tracked by an orchestration scheduler (the
     /// standalone `/agent run`/`resume` commands), which are never idle-tracked.
     pub(super) progress_at: Option<Arc<AtomicU64>>,
+    /// Cross-crate debug-dump sink, threaded down from `SpawnContext::debug_dump_sink`
+    /// (issue #6391). `None` when debug dumps are disabled.
+    pub(super) debug_dump_sink: Option<Arc<dyn zeph_llm::debug_dump::DebugDumpSink>>,
 }
 
 /// Record a progress heartbeat, if this loop has a live handle. No-op for `None` (untracked
@@ -157,6 +160,7 @@ fn build_effective_system_prompt(
 }
 
 #[tracing::instrument(name = "subagent.agent_loop.call_provider", skip_all, err)]
+#[allow(clippy::too_many_arguments)]
 async fn call_provider_with_status(
     provider: &AnyProvider,
     messages: &[Message],
@@ -165,7 +169,20 @@ async fn call_provider_with_status(
     turns: u32,
     started_at: Instant,
     llm_timeout: std::time::Duration,
+    debug_dump_sink: Option<&dyn zeph_llm::debug_dump::DebugDumpSink>,
 ) -> Result<ChatResponse, super::error::SubAgentError> {
+    // Mirrors `zeph-core`'s `prepare_chat_debug_dump`/`write_chat_debug_dump` pair so
+    // sub-agent LLM calls are captured through the same `--debug-dump` pipeline as the
+    // top-level agent loop (#6391). `None` when debug dumps are disabled.
+    let dump_id = debug_dump_sink.map(|sink| {
+        let provider_request = if sink.is_trace_format() {
+            serde_json::Value::Null
+        } else {
+            provider.debug_request_json(messages, tool_defs, false) // lgtm[rust/cleartext-logging]
+        };
+        sink.dump_request(provider.name(), messages, tool_defs, provider_request)
+    });
+
     let llm_result =
         tokio::time::timeout(llm_timeout, provider.chat_with_tools(messages, tool_defs))
             .await
@@ -174,10 +191,26 @@ async fn call_provider_with_status(
                     timeout_secs = llm_timeout.as_secs(),
                     "sub-agent LLM call timed out"
                 );
-                super::error::SubAgentError::Llm("LLM call timed out".to_owned())
+                let timeout_err = super::error::SubAgentError::Llm("LLM call timed out".to_owned());
+                // Without this, status_tx stays frozen at its last `Working` value forever —
+                // the TUI sidebar and `collect_finished_subagents()` never see a terminal
+                // state, so the handle is never reaped (#6381, same defect class as #6257's
+                // setup-phase fix).
+                let _ = status_tx.send(SubAgentStatus {
+                    state: SubAgentState::Failed,
+                    last_message: Some(timeout_err.to_string()),
+                    turns_used: turns,
+                    started_at,
+                });
+                timeout_err
             })?;
     match llm_result {
-        Ok(r) => Ok(r),
+        Ok(r) => {
+            if let (Some(sink), Some(id)) = (debug_dump_sink, dump_id) {
+                sink.dump_response(id, &r);
+            }
+            Ok(r)
+        }
         Err(e) => {
             tracing::error!(error = %e, "sub-agent LLM call failed");
             let _ = status_tx.send(SubAgentStatus {
@@ -429,6 +462,7 @@ async fn run_turn(
     granted_secrets: &mut HashMap<String, GrantedSecret>,
     sanitizer: &ContentSanitizer,
     llm_timeout: std::time::Duration,
+    debug_dump_sink: Option<&dyn zeph_llm::debug_dump::DebugDumpSink>,
 ) -> Result<TurnOutcome, super::error::SubAgentError> {
     let response = call_provider_with_status(
         provider,
@@ -438,6 +472,7 @@ async fn run_turn(
         *turns,
         started_at,
         llm_timeout,
+        debug_dump_sink,
     )
     .await?;
 
@@ -752,7 +787,9 @@ pub(super) async fn run_agent_loop(
         content_isolation,
         llm_timeout,
         progress_at,
+        debug_dump_sink,
     } = args;
+    let debug_dump_sink = debug_dump_sink.as_deref();
 
     let sanitizer = ContentSanitizer::new(&content_isolation);
 
@@ -813,6 +850,7 @@ pub(super) async fn run_agent_loop(
             &mut granted_secrets,
             &sanitizer,
             llm_timeout,
+            debug_dump_sink,
         )
         .await?
         {

--- a/crates/zeph-subagent/src/manager/mod.rs
+++ b/crates/zeph-subagent/src/manager/mod.rs
@@ -171,6 +171,20 @@ pub struct SpawnContext {
     /// `None` (the default) for spawns not tracked by a `DagScheduler` — e.g. the standalone
     /// `/agent run` command — which are never idle-tracked.
     pub progress_at: Option<Arc<std::sync::atomic::AtomicU64>>,
+
+    /// Cross-crate debug-dump sink, threaded down so sub-agent LLM calls are captured
+    /// through the same pipeline as the top-level agent loop's `--debug-dump` output (#6391).
+    ///
+    /// Set by `zeph-core`'s `build_spawn_context` from `DebugState::debug_dumper`. `None`
+    /// when debug dumps are disabled — no sub-agent dump is written in that case, mirroring
+    /// the top-level `debug_dumper: None` behavior.
+    ///
+    /// # Caller responsibility for nested spawns
+    ///
+    /// Like [`max_trust_level`][Self::max_trust_level], this does **not** propagate
+    /// automatically — a sub-agent that spawns its own children must copy this field from
+    /// its received `SpawnContext` into the child's, or grandchild LLM calls go undumped.
+    pub debug_dump_sink: Option<Arc<dyn zeph_llm::debug_dump::DebugDumpSink>>,
 }
 
 /// Live status snapshot of a running sub-agent.

--- a/crates/zeph-subagent/src/manager/spawn.rs
+++ b/crates/zeph-subagent/src/manager/spawn.rs
@@ -738,6 +738,7 @@ impl SubAgentManager {
             content_isolation: ctx.content_isolation,
             llm_timeout: std::time::Duration::from_secs(config.llm_timeout_secs),
             progress_at: ctx.progress_at,
+            debug_dump_sink: ctx.debug_dump_sink,
         };
 
         let join_handle = self.spawn_agent_task(Arc::from(task_id.as_str()), move || async move {
@@ -1143,6 +1144,10 @@ impl SubAgentManager {
         let new_task_id_for_loop = new_task_id.clone();
         let resumed_mcp_tool_names_for_handle = resumed_mcp_tool_names.clone();
         let llm_timeout = std::time::Duration::from_secs(config.llm_timeout_secs);
+        // Cloned out of the `&SpawnContext` reference before the `move` closure below —
+        // `spawn_context` itself is borrowed for this method call only and cannot be
+        // captured by the `'static` task closure.
+        let debug_dump_sink_for_loop = spawn_context.and_then(|ctx| ctx.debug_dump_sink.clone());
         let join_handle = self.spawn_agent_task(Arc::from(new_task_id.as_str()), move || {
             run_agent_loop(AgentLoopArgs {
                 provider,
@@ -1170,6 +1175,7 @@ impl SubAgentManager {
                 // `resume()` is the standalone `/agent resume` command path, never tracked
                 // by a `DagScheduler` — no progress handle to reattach to.
                 progress_at: None,
+                debug_dump_sink: debug_dump_sink_for_loop,
             })
         });
 

--- a/crates/zeph-subagent/src/manager/tests.rs
+++ b/crates/zeph-subagent/src/manager/tests.rs
@@ -1733,6 +1733,74 @@ fn resume_with_spawn_context_applies_trust_cap_to_executor() {
 }
 
 #[test]
+fn resume_with_spawn_context_wires_debug_dump_sink_to_resumed_loop() {
+    // Regression test for #6391 (S1 follow-up): the production `/agent resume` call site
+    // (`crates/zeph-core/src/agent/subagent_commands.rs::handle_agent_resume`) used to pass
+    // `None` for `spawn_context`, so `debug_dump_sink` never reached the resumed loop even
+    // when the parent session had a real dumper configured — resumed sub-agents' LLM calls
+    // went uncaptured by `--debug-dump`. This proves `resume()`'s own plumbing (SpawnContext
+    // -> AgentLoopArgs -> call_provider_with_status) delivers the sink through to a real
+    // executed turn when `Some(ctx)` is passed, mirroring
+    // `run_agent_loop_dumps_llm_request_and_response_via_sink`'s coverage for the plain
+    // `run_agent_loop`/`spawn()` path.
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let agent_id = "d3bd0000-0000-0000-0000-000000000000";
+    write_completed_meta(tmp.path(), agent_id, "bot");
+
+    let mut mgr = make_manager();
+    mgr.definitions.push(sample_def());
+    let cfg = make_cfg_with_dir(tmp.path());
+
+    let sink = Arc::new(RecordingDumpSink::default());
+    let ctx = SpawnContext {
+        debug_dump_sink: Some(Arc::clone(&sink) as Arc<dyn zeph_llm::debug_dump::DebugDumpSink>),
+        ..SpawnContext::default()
+    };
+
+    let (new_id, _) = rt
+        .block_on(mgr.resume(
+            "d3bd0000",
+            "continue",
+            mock_provider(vec!["done"]),
+            noop_executor(),
+            None,
+            &cfg,
+            Some(&ctx),
+        ))
+        .unwrap();
+
+    // Poll until the resumed background task reaches a terminal status.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let _guard = rt.enter();
+    rt.block_on(async {
+        loop {
+            let state = mgr.agents.get(&new_id).map(|h| h.status_rx.borrow().state);
+            if !matches!(
+                state,
+                Some(SubAgentState::Working | SubAgentState::Submitted)
+            ) {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "resumed agent never reached a terminal state"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    });
+
+    assert!(
+        !sink.requests.lock().unwrap().is_empty(),
+        "the resumed loop's LLM call(s) must go through the debug_dump_sink threaded via \
+         SpawnContext, not be silently dropped as they were before the S1 fix"
+    );
+
+    rt.block_on(mgr.collect(&new_id)).unwrap();
+}
+
+#[test]
 fn def_name_for_resume_returns_def_name() {
     let rt = tokio::runtime::Runtime::new().unwrap();
 
@@ -2223,6 +2291,7 @@ fn make_agent_loop_args(
         max_history_messages: 200,
         llm_timeout: std::time::Duration::from_mins(2),
         progress_at: None,
+        debug_dump_sink: None,
     }
 }
 
@@ -2332,6 +2401,80 @@ async fn run_agent_loop_passes_tools_to_provider() {
     );
 }
 
+// ── LLM-call timeout status publish (#6381) ──────────────────────────────
+
+#[tokio::test]
+async fn run_agent_loop_publishes_failed_status_on_llm_call_timeout() {
+    // Regression test for #6381: an LLM-call timeout inside `call_provider_with_status`
+    // must publish a terminal `Failed` status before returning — otherwise `status_rx`
+    // stays frozen at `Working` forever (from `init_loop_state`'s first send), the TUI
+    // sidebar shows a zombie WORKING entry with an ever-climbing elapsed counter, and
+    // `collect_finished_subagents()` never reaps the handle. Same defect class as
+    // #6257's setup-phase fix, but for the per-turn LLM-call path instead of spawn setup.
+    let provider = AnyProvider::Mock(MockProvider::default().with_delay(500));
+    let executor = FilteredToolExecutor::new(noop_executor(), ToolPolicy::InheritAll);
+
+    let (status_tx, status_rx) = tokio::sync::watch::channel(SubAgentStatus {
+        state: SubAgentState::Working,
+        last_message: None,
+        turns_used: 0,
+        started_at: std::time::Instant::now(),
+    });
+    let (secret_request_tx, _secret_request_rx) = tokio::sync::mpsc::channel(1);
+    let (_secret_approved_tx, secret_rx) =
+        tokio::sync::mpsc::channel::<Option<crate::grants::GrantedSecret>>(1);
+
+    let args = AgentLoopArgs {
+        provider,
+        executor,
+        system_prompt: "You are a bot".into(),
+        task_prompt: "Do something".into(),
+        skills: None,
+        max_turns: 3,
+        cancel: tokio_util::sync::CancellationToken::new(),
+        status_tx,
+        started_at: std::time::Instant::now(),
+        secret_request_tx,
+        secret_rx,
+        background: false,
+        hooks: super::super::hooks::SubagentHooks::default(),
+        task_id: "test-task".into(),
+        agent_name: "test-bot".into(),
+        initial_messages: vec![],
+        transcript_writer: None,
+        spawn_depth: 0,
+        mcp_tool_names: Vec::new(),
+        content_isolation: ContentIsolationConfig::default(),
+        max_history_messages: 200,
+        // Much shorter than the mock provider's 500ms delay so the timeout branch fires
+        // deterministically instead of racing the real response.
+        llm_timeout: std::time::Duration::from_millis(30),
+        progress_at: None,
+        debug_dump_sink: None,
+    };
+
+    let result = run_agent_loop(args).await;
+    assert!(
+        result.is_err(),
+        "expected the LLM-call timeout to propagate as an error"
+    );
+
+    let status = status_rx.borrow().clone();
+    assert_eq!(
+        status.state,
+        SubAgentState::Failed,
+        "status_tx must be updated to Failed on LLM-call timeout, not left stuck at Working"
+    );
+    assert!(
+        status
+            .last_message
+            .as_deref()
+            .is_some_and(|m| m.contains("timed out")),
+        "Failed status message should mention the timeout: {:?}",
+        status.last_message
+    );
+}
+
 // ── idle-timeout progress heartbeat (#6245) ──────────────────────────────
 
 #[tokio::test]
@@ -2378,6 +2521,106 @@ async fn run_agent_loop_none_progress_handle_is_unaffected() {
     let provider = mock_provider(vec!["done"]);
     let executor = FilteredToolExecutor::new(noop_executor(), ToolPolicy::InheritAll);
     let args = make_agent_loop_args(provider, executor, 1); // progress_at: None by default
+
+    let result = run_agent_loop(args).await;
+    assert!(result.is_ok(), "loop failed: {result:?}");
+}
+
+// ── debug-dump sink wiring (#6391) ────────────────────────────────────────
+
+/// Records every `dump_request`/`dump_response` call it receives, so tests can assert
+/// sub-agent LLM calls are captured through `zeph_llm::debug_dump::DebugDumpSink` the same
+/// way the top-level agent loop's `DebugDumper` would capture them.
+#[derive(Default)]
+struct RecordingDumpSink {
+    requests: std::sync::Mutex<Vec<(String, usize, usize)>>,
+    responses: std::sync::Mutex<Vec<(u32, String)>>,
+    next_id: std::sync::atomic::AtomicU32,
+}
+
+impl zeph_llm::debug_dump::DebugDumpSink for RecordingDumpSink {
+    fn is_trace_format(&self) -> bool {
+        false
+    }
+
+    fn dump_request(
+        &self,
+        model_name: &str,
+        messages: &[zeph_llm::provider::Message],
+        tools: &[zeph_llm::provider::ToolDefinition],
+        _provider_request: serde_json::Value,
+    ) -> u32 {
+        let id = self
+            .next_id
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        self.requests
+            .lock()
+            .unwrap()
+            .push((model_name.to_owned(), messages.len(), tools.len()));
+        id
+    }
+
+    fn dump_response(&self, id: u32, response: &ChatResponse) {
+        let text = match response {
+            ChatResponse::Text(t) => t.clone(),
+            ChatResponse::ToolUse { text, .. } => text.clone().unwrap_or_default(),
+            _ => String::new(),
+        };
+        self.responses.lock().unwrap().push((id, text));
+    }
+}
+
+#[tokio::test]
+async fn run_agent_loop_dumps_llm_request_and_response_via_sink() {
+    // Regression test for #6391: sub-agent LLM calls must go through the same
+    // `DebugDumpSink` pipeline as the top-level agent loop's `--debug-dump` output, so
+    // `zeph-core` can capture sub-agent/orchestration LLM payloads via `SpawnContext`.
+    let provider = mock_provider(vec!["done"]);
+    let executor = FilteredToolExecutor::new(noop_executor(), ToolPolicy::InheritAll);
+    let sink = Arc::new(RecordingDumpSink::default());
+
+    let args = AgentLoopArgs {
+        debug_dump_sink: Some(Arc::clone(&sink) as Arc<dyn zeph_llm::debug_dump::DebugDumpSink>),
+        ..make_agent_loop_args(provider, executor, 1)
+    };
+
+    let result = run_agent_loop(args).await;
+    assert!(result.is_ok(), "loop failed: {result:?}");
+
+    let requests = sink.requests.lock().unwrap();
+    assert_eq!(
+        requests.len(),
+        1,
+        "exactly one LLM call was made, so exactly one dump_request was expected"
+    );
+    assert_eq!(
+        requests[0].0, "mock",
+        "MockProvider's default name() is \"mock\""
+    );
+    assert!(
+        requests[0].1 > 0,
+        "dumped request must include the (non-empty) message history"
+    );
+
+    let responses = sink.responses.lock().unwrap();
+    assert_eq!(responses.len(), 1, "expected exactly one dump_response");
+    assert_eq!(
+        responses[0].0, 0,
+        "response id must correlate with the request id"
+    );
+    assert_eq!(
+        responses[0].1, "done",
+        "dumped response text must match the LLM's reply"
+    );
+}
+
+#[tokio::test]
+async fn run_agent_loop_skips_dump_when_sink_is_none() {
+    // Regression guard: with no sink configured (debug dumps disabled), the loop must run
+    // to completion without attempting to call through a `None` sink.
+    let provider = mock_provider(vec!["done"]);
+    let executor = FilteredToolExecutor::new(noop_executor(), ToolPolicy::InheritAll);
+    let args = make_agent_loop_args(provider, executor, 1); // debug_dump_sink: None by default
 
     let result = run_agent_loop(args).await;
     assert!(result.is_ok(), "loop failed: {result:?}");


### PR DESCRIPTION
## Summary
- `call_provider_with_status` (crates/zeph-subagent/src/agent_loop.rs) now publishes a terminal `Failed` status via `status_tx` when the sub-agent's LLM call times out, mirroring the sibling provider-error arm. Previously the timeout branch early-returned via `?` without publishing, leaving the TUI agents sidebar permanently showing a `WORKING` zombie entry with an ever-climbing elapsed counter that is never reaped by `collect_finished_subagents()`.
- Adds a `DebugDumpSink` trait (`crates/zeph-llm/src/debug_dump.rs`) threaded through `SpawnContext`/`AgentLoopArgs` and wired at zeph-core's `build_spawn_context`, so sub-agent and orchestration-dispatched LLM calls are captured by the debug_dump interceptor the same way top-level agent loop calls already are. This includes the `/agent resume` path, which previously passed `None` for spawn context and silently dropped debug-dump capture (and other spawn-context fields) for resumed sub-agents.

## Scope notes
- Sub-agent debug dumps get the same baseline `scrub_content`/`redact_binary_blobs` scrubbing as top-level dumps (secrets, binary blobs), but skip the optional extra `PiiFilter` layer top-level dumps get when enabled. This is a deliberate, documented scope decision, not an oversight — a follow-up issue will track closing this parity gap.
- A more robust join_handle-based zombie-reaping fallback (covering a hypothetical panic in `run_agent_loop`, not just the timeout path fixed here) is out of scope for this PR — tracked as a separate follow-up.

## Test plan
- [x] New regression test for #6381: triggers the LLM-call-timeout branch specifically and asserts the terminal `Failed` status lands on `status_rx`/`SubAgentManager::statuses()`, not just that the function returns an error.
- [x] New regression tests for #6391: drive a real sub-agent LLM call end-to-end with a `RecordingDumpSink`, assert a correlated request+response dump pair is produced; verified via grep that both standalone `/agent` spawn paths and the orchestration-dispatched spawn path route through the same `build_spawn_context` wiring point.
- [x] New regression test for the resume-path fix: drives a real `resume()` call with a `RecordingDumpSink`, polls to terminal status, asserts the sink was invoked.
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 14120/14120 passed
- [x] rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`)
- [x] `gitleaks protect --staged`
- [x] `.local/testing/playbooks/subagent-llm-visibility.md` and `.local/testing/coverage-status.md` updated
- [x] `CHANGELOG.md` `[Unreleased]` updated

Closes #6381
Closes #6391