### PR TITLE
fix(core,config): wire ToolsConfig::enabled into tool-def gating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-config`/`zeph-core`: `[tools] enabled = false` was dead config — deserialized onto
+  `ToolsConfig::enabled` but never read anywhere, so tool definitions were still built and sent
+  to the LLM regardless of the setting (#6386). `ToolsConfig::enabled` is now mirrored into
+  `Agent`'s `ToolState` (via a new `Agent::with_tools_enabled` builder method, wired at every
+  agent-construction site — `src/runner.rs`, `src/daemon.rs`, `src/acp.rs`, `src/serve/`) and
+  gates `process_response_native_tools`'s tool-definition construction: when `false`, no tool
+  definitions (including focus/compress_context/request_compaction) are built or sent, so the
+  model has no tools to call at all.
+- `zeph-config`: `LlmConfig::effective_embedding_model()`'s doc comment claimed the `[llm]
+  embedding_model` global fallback defaults to `"nomic-embed-text"`; the actual fallback,
+  `default_embedding_model()`, returns `"qwen3-embedding"` (#6385). Doc-only fix, no behavior
+  change.
 - `zeph-core`: the sanitizer's ML-backed injection and PII classifier calls
   (`ContentSanitizer::classify_injection`/`detect_pii`) were never recorded in the TUI
   metrics panel (#6382). The shared `Arc<ClassifierMetrics>` ring buffer they record into was

--- a/crates/zeph-config/src/providers/llm.rs
+++ b/crates/zeph-config/src/providers/llm.rs
@@ -369,7 +369,7 @@ impl LlmConfig {
     /// Resolution order:
     /// 1. `embedding_model` from the `[[llm.providers]]` entry marked `embed = true`
     /// 2. `embedding_model` from the first entry in `[[llm.providers]]`
-    /// 3. `[llm] embedding_model` global fallback (defaults to `"nomic-embed-text"`)
+    /// 3. `[llm] embedding_model` global fallback (defaults to `"qwen3-embedding"`)
     ///
     /// # Examples
     ///

--- a/crates/zeph-config/src/tools.rs
+++ b/crates/zeph-config/src/tools.rs
@@ -1403,7 +1403,8 @@ impl Default for ToolCompressionConfig {
 /// importing runtime types into this leaf crate.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ToolsConfig {
-    /// Enable all tools. Default: `true`.
+    /// Enable all tools. When `false`, no tool definitions are sent to the LLM and the model
+    /// cannot attempt any tool call. Default: `true`.
     #[serde(default = "default_true")]
     pub enabled: bool,
     /// Summarize long tool output before injection into context. Default: `true`.

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -884,6 +884,17 @@ impl<C: Channel> Agent<C> {
         self
     }
 
+    /// Set whether tool definitions are built and sent to the LLM (`config.tools.enabled`, #6386).
+    ///
+    /// When `false`, `process_response_native_tools` sends no tool definitions at all, so the
+    /// model has no tools to call. Defaults to `true` (matching `ToolsConfig::enabled`'s default)
+    /// when this builder method is never called.
+    #[must_use]
+    pub fn with_tools_enabled(mut self, enabled: bool) -> Self {
+        self.services.tool_state.tools_enabled = enabled;
+        self
+    }
+
     /// Configure channel identity for per-channel UX preference persistence (#3308, #4654).
     ///
     /// `channel_type` must match the active I/O channel name (`"cli"`, `"tui"`, `"telegram"`,

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -1362,12 +1362,18 @@ impl<C: crate::channel::Channel> Agent<C> {
         use zeph_orchestration::ToolCallSummary;
         use zeph_tools::executor::ToolCall;
 
-        let tool_defs: Vec<ToolDefinition> = self
-            .tool_executor
-            .tool_definitions_erased()
-            .iter()
-            .map(tool_execution::tool_def_to_definition)
-            .collect();
+        // `[tools] enabled = false` (#6386): omit tool definitions here too, matching
+        // `process_response_native_tools` — this is a second, independent path that sends
+        // tool defs to the LLM (scheduler `RunInline` branch).
+        let tool_defs: Vec<ToolDefinition> = if self.services.tool_state.tools_enabled {
+            self.tool_executor
+                .tool_definitions_erased()
+                .iter()
+                .map(tool_execution::tool_def_to_definition)
+                .collect()
+        } else {
+            Vec::new()
+        };
 
         tracing::debug!(
             prompt_len = prompt.len(),
@@ -2948,5 +2954,101 @@ mod tests {
             "a genuinely successful tool call must not be corrected away from Completed"
         );
         assert_eq!(status, GraphStatus::Completed);
+    }
+
+    // ---------------------------------------------------------------------------
+    // #6386: `run_inline_tool_loop` (the `RunInline` scheduler branch) is a second,
+    // independent path that builds tool definitions and sends them to the LLM — separate from
+    // `process_response_native_tools`. It must honor the same `[tools] enabled` gate. Drives
+    // `run_inline_tool_loop` directly (the real production entry point for `RunInline` tasks)
+    // via a tool-recording `MockProvider`.
+    // ---------------------------------------------------------------------------
+
+    fn inline_loop_test_tool_def() -> zeph_tools::registry::ToolDef {
+        use zeph_tools::registry::{InvocationHint, ToolDef};
+        ToolDef {
+            id: "test_tool".into(),
+            description: "a test tool".into(),
+            schema: schemars::Schema::default(),
+            invocation: InvocationHint::ToolCall,
+            output_schema: None,
+            server_id: None,
+        }
+    }
+
+    /// With `tools_enabled = false`, `run_inline_tool_loop` must send zero tool definitions to
+    /// the LLM, even though the underlying `tool_executor` has real tool definitions available.
+    #[tokio::test]
+    async fn run_inline_tool_loop_disabled_sends_no_tool_definitions() {
+        use crate::agent::agent_tests::*;
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+
+        let (mock, recorded_tools) =
+            MockProvider::with_responses(vec!["done".into()]).with_tool_recording();
+        let provider = AnyProvider::Mock(mock);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor =
+            MockToolExecutor::no_tools().with_definitions(vec![inline_loop_test_tool_def()]);
+        let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor)
+            .with_tools_enabled(false);
+
+        let outcome = agent
+            .run_inline_tool_loop("do something", 3)
+            .await
+            .expect("inline loop must succeed on a plain-text response");
+        assert_eq!(outcome.text, "done");
+
+        let calls = recorded_tools.lock().unwrap();
+        assert_eq!(
+            calls.len(),
+            1,
+            "provider must be called exactly once for a plain-text terminal response"
+        );
+        assert!(
+            calls[0].is_empty(),
+            "RunInline path must send zero tool definitions when tools_enabled=false (#6386), \
+             even though the tool_executor has definitions available; got: {:?}",
+            calls[0].iter().map(|t| &t.name).collect::<Vec<_>>()
+        );
+    }
+
+    /// Companion baseline: with the default `tools_enabled = true`, `run_inline_tool_loop`
+    /// must still forward the `tool_executor`'s definitions — proving the gate isn't inverted.
+    #[tokio::test]
+    async fn run_inline_tool_loop_enabled_sends_tool_definitions() {
+        use crate::agent::agent_tests::*;
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+
+        let (mock, recorded_tools) =
+            MockProvider::with_responses(vec!["done".into()]).with_tool_recording();
+        let provider = AnyProvider::Mock(mock);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor =
+            MockToolExecutor::no_tools().with_definitions(vec![inline_loop_test_tool_def()]);
+        // No `.with_tools_enabled(...)` call — exercises the builder's own default (true).
+        let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+
+        let outcome = agent
+            .run_inline_tool_loop("do something", 3)
+            .await
+            .expect("inline loop must succeed on a plain-text response");
+        assert_eq!(outcome.text, "done");
+
+        let calls = recorded_tools.lock().unwrap();
+        assert_eq!(
+            calls.len(),
+            1,
+            "provider must be called exactly once for a plain-text terminal response"
+        );
+        assert!(
+            calls[0].iter().any(|t| t.name.as_str() == "test_tool"),
+            "with the default tools_enabled=true, the tool_executor's definitions must reach \
+             the LLM; got: {:?}",
+            calls[0].iter().map(|t| &t.name).collect::<Vec<_>>()
+        );
     }
 }

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -829,8 +829,11 @@ pub(crate) struct CompressionState {
 }
 
 /// Groups runtime tool filtering, dependency tracking, and iteration bookkeeping.
-#[derive(Default)]
 pub(crate) struct ToolState {
+    /// `config.tools.enabled`, mirrored here so `process_response_native_tools` can gate
+    /// tool-definition construction without threading a live `Config` through `Agent<C>`.
+    /// When `false`, no tool definitions are built or sent to the LLM (#6386).
+    pub(crate) tools_enabled: bool,
     /// Dynamic tool schema filter: pre-computed tool embeddings for per-turn filtering (#2020).
     pub(crate) tool_schema_filter: Option<zeph_tools::ToolSchemaFilter>,
     /// Cached filtered tool IDs for the current user turn.
@@ -860,6 +863,24 @@ pub(crate) struct ToolState {
     /// callers treat empty the same way `FileExecutor::new` does (default to `[cwd]`), not as
     /// "allow every path".
     pub(crate) allowed_paths: Vec<std::path::PathBuf>,
+}
+
+impl Default for ToolState {
+    fn default() -> Self {
+        Self {
+            tools_enabled: true,
+            tool_schema_filter: None,
+            cached_filtered_tool_ids: None,
+            dependency_graph: None,
+            dependency_always_on: HashSet::new(),
+            completed_tool_ids: HashSet::new(),
+            current_tool_iteration: 0,
+            pattern_store: None,
+            tool_to_skill: HashMap::new(),
+            last_tool_per_skill: HashMap::new(),
+            allowed_paths: Vec::new(),
+        }
+    }
 }
 
 /// Groups per-session I/O and policy state.

--- a/crates/zeph-core/src/agent/state/tests.rs
+++ b/crates/zeph-core/src/agent/state/tests.rs
@@ -321,3 +321,24 @@ fn compression_state_construction() {
     assert!(state.current_task_goal.is_none());
     assert!(state.task_goal_user_msg_hash.is_none());
 }
+
+// ------------------------------------------------------------------
+// ToolState — tools_enabled gate (#6386)
+// ------------------------------------------------------------------
+
+/// `ToolState` previously derived `Default`, which sets `bool` fields to `false`. Adding
+/// `tools_enabled: bool` without a manual `Default` impl would have silently defaulted every
+/// construction path that skips `Agent::with_tools_enabled(true)` to "no tools ever sent" —
+/// the opposite of `ToolsConfig::enabled`'s documented default of `true`. This test pins the
+/// manual `impl Default for ToolState` (`crates/zeph-core/src/agent/state/mod.rs`) so a future
+/// refactor back to `#[derive(Default)]` fails loudly instead of shipping a silent regression.
+#[test]
+fn tool_state_default_enables_tools() {
+    use crate::agent::state::ToolState;
+    let state = ToolState::default();
+    assert!(
+        state.tools_enabled,
+        "ToolState::default().tools_enabled must be true to match ToolsConfig::enabled's \
+         documented default (#6386)"
+    );
+}

--- a/crates/zeph-core/src/agent/tool_execution/tests/sanitize_and_native_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/sanitize_and_native_tests.rs
@@ -1654,3 +1654,106 @@ async fn magic_doc_registered_when_tool_result_is_final_message_of_max_iteration
         agent.services.memory.subsystems.magic_docs.registered
     );
 }
+
+// ---------------------------------------------------------------------------
+// #6386: `[tools] enabled = false` must suppress every tool definition sent to the LLM.
+// Drives the real `process_response()` -> `process_response_native_tools()` path (not the
+// tool_defs construction block directly) via a tool-recording `MockProvider`, so these tests
+// only pass if the production gate in `process_response_native_tools` actually short-circuits
+// tool-definition construction end to end.
+// ---------------------------------------------------------------------------
+
+/// #6386: with `Agent::with_tools_enabled(false)`, zero tool definitions must reach the LLM —
+/// not even the always-on `compress_context` tool, which is otherwise pushed unconditionally
+/// whenever the gate is open.
+#[tokio::test]
+#[allow(clippy::large_futures)]
+async fn tools_disabled_gate_sends_no_tool_definitions_to_llm() {
+    use crate::agent::agent_tests::{MockChannel, MockToolExecutor, create_test_registry};
+    use zeph_llm::any::AnyProvider;
+    use zeph_llm::mock::MockProvider;
+    use zeph_llm::provider::{Message, MessageMetadata, Role};
+
+    let (mock, recorded_tools) =
+        MockProvider::with_responses(vec!["No tools available.".into()]).with_tool_recording();
+    let provider = AnyProvider::Mock(mock);
+
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor)
+        .with_tools_enabled(false);
+
+    agent.msg.messages.push(Message {
+        role: Role::User,
+        content: "list files using a tool".into(),
+        parts: vec![],
+        metadata: MessageMetadata::default(),
+    });
+
+    agent.process_response().await.unwrap();
+
+    let calls = recorded_tools.lock().unwrap();
+    assert_eq!(
+        calls.len(),
+        1,
+        "provider must be called exactly once for a plain-text terminal response"
+    );
+    assert!(
+        calls[0].is_empty(),
+        "with tools_enabled=false, zero tool definitions (not even compress_context) may be \
+         sent to the LLM; got: {:?}",
+        calls[0].iter().map(|t| &t.name).collect::<Vec<_>>()
+    );
+}
+
+/// #6386 companion baseline: the default (`tools_enabled = true`, matching
+/// `ToolsConfig::enabled`'s documented default) path must still send tool definitions —
+/// proving the gate condition isn't inverted and doesn't regress the always-on
+/// `compress_context` tool for the common case.
+#[tokio::test]
+#[allow(clippy::large_futures)]
+async fn tools_enabled_baseline_sends_tool_definitions_to_llm() {
+    use crate::agent::agent_tests::{MockChannel, MockToolExecutor, create_test_registry};
+    use zeph_llm::any::AnyProvider;
+    use zeph_llm::mock::MockProvider;
+    use zeph_llm::provider::{Message, MessageMetadata, Role};
+
+    let (mock, recorded_tools) =
+        MockProvider::with_responses(vec!["Sure, calling a tool.".into()]).with_tool_recording();
+    let provider = AnyProvider::Mock(mock);
+
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    // No `.with_tools_enabled(...)` call — exercises the builder's own default (true).
+    let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+
+    agent.msg.messages.push(Message {
+        role: Role::User,
+        content: "list files using a tool".into(),
+        parts: vec![],
+        metadata: MessageMetadata::default(),
+    });
+
+    agent.process_response().await.unwrap();
+
+    let calls = recorded_tools.lock().unwrap();
+    assert_eq!(
+        calls.len(),
+        1,
+        "provider must be called exactly once for a plain-text terminal response"
+    );
+    assert!(
+        !calls[0].is_empty(),
+        "with the default tools_enabled=true, at least the always-on compress_context tool \
+         definition must be sent; got an empty tool list"
+    );
+    assert!(
+        calls[0]
+            .iter()
+            .any(|t| t.name.as_str() == "compress_context"),
+        "the always-on compress_context tool must be present when tools are enabled; got: {:?}",
+        calls[0].iter().map(|t| &t.name).collect::<Vec<_>>()
+    );
+}

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -2955,30 +2955,36 @@ impl<C: Channel> Agent<C> {
 
         // `mut` required when context-compression is enabled to inject focus tool definitions.
         let tafc = &self.tool_orchestrator.tafc;
-        let mut tool_defs: Vec<ToolDefinition> = self
-            .tool_executor
-            .tool_definitions_erased()
-            .iter()
-            .map(|def| super::tool_def_to_definition_with_tafc(def, tafc))
-            .collect();
+        let mut tool_defs: Vec<ToolDefinition> = Vec::new();
 
-        // Inject focus tool definitions when the feature is enabled and configured (#1850).
-        if self.services.focus.config.enabled {
-            tool_defs.extend(crate::agent::focus::focus_tool_definitions());
-        }
+        // `[tools] enabled = false` (#6386): omit every tool definition so the LLM request
+        // carries no tools at all and the model cannot attempt a tool call.
+        if self.services.tool_state.tools_enabled {
+            tool_defs = self
+                .tool_executor
+                .tool_definitions_erased()
+                .iter()
+                .map(|def| super::tool_def_to_definition_with_tafc(def, tafc))
+                .collect();
 
-        // Inject compress_context tool — always available when context-compression is enabled (#2218).
-        tool_defs.push(crate::agent::focus::compress_context_tool_definition());
+            // Inject focus tool definitions when the feature is enabled and configured (#1850).
+            if self.services.focus.config.enabled {
+                tool_defs.extend(crate::agent::focus::focus_tool_definitions());
+            }
 
-        // Inject request_compaction tool when ARC agent-initiated compaction is enabled (#4020).
-        if self
-            .services
-            .memory
-            .subsystems
-            .arc_config
-            .allow_agent_compaction
-        {
-            tool_defs.push(crate::agent::focus::request_compaction_tool_definition());
+            // Inject compress_context tool — always available when context-compression is enabled (#2218).
+            tool_defs.push(crate::agent::focus::compress_context_tool_definition());
+
+            // Inject request_compaction tool when ARC agent-initiated compaction is enabled (#4020).
+            if self
+                .services
+                .memory
+                .subsystems
+                .arc_config
+                .allow_agent_compaction
+            {
+                tool_defs.push(crate::agent::focus::request_compaction_tool_definition());
+            }
         }
 
         // Pre-compute the full tool set for iterations 1+ before filtering.

--- a/crates/zeph-llm/README.md
+++ b/crates/zeph-llm/README.md
@@ -176,7 +176,7 @@ For cost-sensitive or resource-constrained deployments, the following Small Lang
 
 | Task | Recommended SLM | Notes |
 |------|----------------|-------|
-| Embeddings | `nomic-embed-text` (Ollama) | Default embedding model |
+| Embeddings | `qwen3-embedding` (Ollama) | Default embedding model |
 | Simple queries / routing | `qwen3:8b` (Ollama) | Fast, low memory footprint |
 | Summarization / compaction | `qwen3:8b` or `phi-4-mini` | Good quality at 8B scale |
 | Graph extraction | `qwen3:8b` | Structured output via JSON Schema |

--- a/crates/zeph-llm/src/mock.rs
+++ b/crates/zeph-llm/src/mock.rs
@@ -40,6 +40,9 @@ pub struct MockProvider {
     errors: Arc<Mutex<VecDeque<crate::LlmError>>>,
     /// When set, every `chat()` call appends a clone of the messages slice here.
     recorded: Option<Arc<Mutex<Vec<Vec<Message>>>>>,
+    /// When set, every `chat_with_tools()` call appends a clone of the `tools` slice here.
+    /// Set via [`MockProvider::with_tool_recording`].
+    recorded_tools: Option<Arc<Mutex<Vec<Vec<ToolDefinition>>>>>,
     /// Pre-configured `ChatResponse` sequence returned from `chat_with_tools()`.
     /// When exhausted, falls back to `ChatResponse::Text` via `chat()`.
     tool_responses: Arc<Mutex<VecDeque<ChatResponse>>>,
@@ -102,6 +105,7 @@ impl Default for MockProvider {
             delay_ms: 0,
             errors: Arc::new(Mutex::new(VecDeque::new())),
             recorded: None,
+            recorded_tools: None,
             tool_responses: Arc::new(Mutex::new(VecDeque::new())),
             tool_call_count: Arc::new(Mutex::new(0)),
             models: vec![],
@@ -233,6 +237,17 @@ impl MockProvider {
     pub fn with_recording(mut self) -> (Self, Arc<Mutex<Vec<Vec<Message>>>>) {
         let buf = Arc::new(Mutex::new(Vec::new()));
         self.recorded = Some(Arc::clone(&buf));
+        (self, buf)
+    }
+
+    /// Enable tool-definition recording. Returns the shared buffer. Each
+    /// `chat_with_tools()` call appends a clone of the `tools` slice it received, so tests
+    /// can assert on exactly what tool definitions reached the "LLM" (e.g. verifying
+    /// `[tools] enabled = false` results in zero tool definitions ever being sent, #6386).
+    #[must_use]
+    pub fn with_tool_recording(mut self) -> (Self, Arc<Mutex<Vec<Vec<ToolDefinition>>>>) {
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        self.recorded_tools = Some(Arc::clone(&buf));
         (self, buf)
     }
 
@@ -550,9 +565,14 @@ impl LlmProvider for MockProvider {
     async fn chat_with_tools(
         &self,
         messages: &[Message],
-        _tools: &[ToolDefinition],
+        tools: &[ToolDefinition],
     ) -> Result<ChatResponse, crate::LlmError> {
         *self.tool_call_count.lock().unwrap() += 1;
+        if let Some(buf) = &self.recorded_tools
+            && let Ok(mut guard) = buf.lock()
+        {
+            guard.push(tools.to_vec());
+        }
         if self.tool_chat_invalid_input {
             return Err(crate::LlmError::InvalidInput {
                 provider: self.name().to_owned(),

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -516,6 +516,10 @@ pub(crate) struct SharedAgentDeps {
     /// via `Agent::with_allowed_paths` so `/cd` is validated against the same sandbox
     /// boundary `FileExecutor`/`DiagnosticsExecutor`/`SetCwdExecutor` already enforce.
     cwd_allowed_paths: Vec<std::path::PathBuf>,
+    /// `config.tools.enabled` (#6386), wired into every session's `Agent` via
+    /// `Agent::with_tools_enabled` so `[tools] enabled = false` actually suppresses tool
+    /// definitions, matching `runner.rs`/`daemon.rs`.
+    tools_enabled: bool,
 
     // ACP-specific fields (transport-level; not agent-level)
     acp_agent_name: String,
@@ -1210,6 +1214,7 @@ async fn build_acp_deps(
             .iter()
             .map(std::path::PathBuf::from)
             .collect(),
+        tools_enabled: config.tools.enabled,
         session_config,
         session_persistence_config: config.session.clone(),
         resume_condenser: resume_condenser_built,
@@ -1413,6 +1418,7 @@ where
     channel_persist_provider_overrides: bool,
     safe_mode: bool,
     cwd_allowed_paths: Vec<PathBuf>,
+    tools_enabled: bool,
     tool_filter_config: zeph_core::config::ToolFilterConfig,
 }
 
@@ -1499,6 +1505,7 @@ where
     )
     .with_safe_mode(deps.safe_mode)
     .with_allowed_paths(deps.cwd_allowed_paths)
+    .with_tools_enabled(deps.tools_enabled)
     .maybe_init_tool_schema_filter(deps.tool_filter_config, deps.provider)
     .await
 }
@@ -1598,6 +1605,7 @@ async fn spawn_acp_agent(
     let hooks_config = d.hooks_config.clone();
     let safe_mode = d.safe_mode;
     let cwd_allowed_paths = d.cwd_allowed_paths.clone();
+    let tools_enabled = d.tools_enabled;
     let tool_filter_config = d.tool_filter_config.clone();
 
     // Cloned before `acp_ctx` is destructured into individual per-session executors below
@@ -2004,6 +2012,7 @@ async fn spawn_acp_agent(
         channel_persist_provider_overrides,
         safe_mode,
         cwd_allowed_paths,
+        tools_enabled,
         tool_filter_config,
     };
     let mut agent = Box::pin(build_acp_agent(build_params, channel)).await;
@@ -5075,6 +5084,7 @@ mod tests {
             channel_persist_provider_overrides: false,
             safe_mode: false,
             cwd_allowed_paths: Vec::new(),
+            tools_enabled: true,
             tool_filter_config: zeph_core::config::ToolFilterConfig::default(),
         };
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -457,6 +457,7 @@ where
             .map(PathBuf::from)
             .collect(),
     )
+    .with_tools_enabled(config.tools.enabled)
     .maybe_init_tool_schema_filter(config.agent.tool_filter.clone(), deps.embedding_provider)
     .await
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -380,6 +380,7 @@ where
             .map(std::path::PathBuf::from)
             .collect(),
     )
+    .with_tools_enabled(config.tools.enabled)
     .maybe_init_tool_schema_filter(config.agent.tool_filter.clone(), deps.embedding_provider)
     .await
 }

--- a/src/serve/agent_factory.rs
+++ b/src/serve/agent_factory.rs
@@ -251,7 +251,10 @@ pub(crate) async fn build_agent_factory(
         .with_safe_mode(deps.safe_mode)
         // #6032 SEC-2: sandbox `/cd` to the same allowed_paths as the file/shell/diagnostics
         // executors, matching src/runner.rs/src/acp.rs/src/daemon.rs.
-        .with_allowed_paths(deps.allowed_paths);
+        .with_allowed_paths(deps.allowed_paths)
+        // #6386: propagate `[tools] enabled` onto this session's Agent so a `false` value
+        // actually suppresses tool definitions, matching src/runner.rs/src/acp.rs/src/daemon.rs.
+        .with_tools_enabled(deps.tools_enabled);
         if !preloaded_messages.is_empty() {
             agent = agent.with_preloaded_messages(preloaded_messages);
         }
@@ -855,6 +858,7 @@ mod tests {
             quality_pipeline: None,
             safe_mode: false,
             allowed_paths: vec![],
+            tools_enabled: true,
         };
 
         let build_agent = Box::pin(build_agent_factory(deps, session_id.clone(), cid)).await;
@@ -948,6 +952,7 @@ mod tests {
             quality_pipeline: None,
             safe_mode: false,
             allowed_paths: vec![],
+            tools_enabled: true,
         };
 
         let build_agent = Box::pin(build_agent_factory(deps, session_id.clone(), cid)).await;
@@ -1060,6 +1065,7 @@ mod tests {
             quality_pipeline: None,
             safe_mode: false,
             allowed_paths: vec![],
+            tools_enabled: true,
         };
 
         let build_agent = Box::pin(build_agent_factory(deps, session_id.clone(), cid)).await;
@@ -1161,6 +1167,7 @@ mod tests {
             quality_pipeline: None,
             safe_mode: false,
             allowed_paths: vec![],
+            tools_enabled: true,
         };
 
         let build_agent = Box::pin(build_agent_factory(deps, session_id.clone(), cid)).await;
@@ -1261,6 +1268,7 @@ mod tests {
             quality_pipeline: None,
             safe_mode: false,
             allowed_paths: vec![],
+            tools_enabled: true,
         };
 
         let build_agent = Box::pin(build_agent_factory(deps, session_id.clone(), cid)).await;
@@ -1358,6 +1366,7 @@ mod tests {
             quality_pipeline: None,
             safe_mode: false,
             allowed_paths: vec![],
+            tools_enabled: true,
         };
 
         let build_agent = Box::pin(build_agent_factory(deps, session_id.clone(), cid)).await;
@@ -1438,6 +1447,7 @@ mod tests {
             quality_pipeline: None,
             safe_mode: false,
             allowed_paths: vec![],
+            tools_enabled: true,
         }
     }
 

--- a/src/serve/deps.rs
+++ b/src/serve/deps.rs
@@ -174,6 +174,10 @@ pub(crate) struct ServeAgentDeps {
     /// via `Agent::with_allowed_paths` so `/cd` is validated against the same sandbox
     /// boundary `FileExecutor`/`DiagnosticsExecutor`/`SetCwdExecutor` already enforce.
     pub(crate) allowed_paths: Vec<PathBuf>,
+    /// `config.tools.enabled` (#6386), wired into every session's `Agent` via
+    /// `Agent::with_tools_enabled` so `[tools] enabled = false` actually suppresses tool
+    /// definitions for `/sessions`-built agents, matching `runner.rs`/`daemon.rs`/`acp.rs`.
+    pub(crate) tools_enabled: bool,
 }
 
 /// Assemble [`ServeAgentDeps`] once at `zeph serve-sessions` startup, plus the resolved bearer
@@ -505,6 +509,7 @@ pub(crate) async fn assemble_serve_deps(
             .iter()
             .map(PathBuf::from)
             .collect(),
+        tools_enabled: config.tools.enabled,
     })
 }
 

--- a/src/serve/handlers.rs
+++ b/src/serve/handlers.rs
@@ -578,6 +578,7 @@ mod tests {
             quality_pipeline: None,
             safe_mode: false,
             allowed_paths: vec![],
+            tools_enabled: true,
         };
         AppState {
             registry: Arc::new(LiveSessionRegistry::new()),

--- a/src/serve/test_support.rs
+++ b/src/serve/test_support.rs
@@ -152,6 +152,7 @@ impl ServeTestHarness {
             quality_pipeline: None,
             safe_mode: false,
             allowed_paths: vec![],
+            tools_enabled: true,
         };
 
         let state = AppState {


### PR DESCRIPTION
## Summary

- `[tools] enabled = false` was deserialized into `ToolsConfig::enabled` but never consumed anywhere in `zeph-core`/`zeph-tools`/`zeph-agent-tools`, so setting it had no effect — tool definitions were still sent to the LLM and the model could still attempt tool calls.
- Added `tools_enabled: bool` to `ToolState` (manual `Default` impl defaulting `true`, since the struct previously derived `Default` which would have silently defaulted the bool to `false`), an `Agent::with_tools_enabled(bool)` builder method, and gated tool-definition construction in both production request-building paths: `Agent::process_response_native_tools` (`tier_loop.rs`) and `Agent::run_inline_tool_loop` (`scheduler_loop.rs`, the scheduler `RunInline` path — found missing by adversarial review of the first pass). Wired `.with_tools_enabled(config.tools.enabled)` at every `Agent` construction site across the workspace.
- Fixed a stale doc comment: `LlmConfig::effective_embedding_model()` claimed the global embedding-model fallback default is `"nomic-embed-text"`, but `default_embedding_model()` actually returns `"qwen3-embedding"` — corrected the doc comment and an identical stale claim in `crates/zeph-llm/README.md`.

Closes #6386
Closes #6385

## Testing

- Full CI-matching check suite (fmt, clippy `--profile ci`, nextest, rustdoc gate) green after rebase onto latest `main`: 14160/14160 tests passed.
- Added 5 regression tests exercising the real production entry points (`Agent::process_response()` and `Agent::run_inline_tool_loop()`, not internal helpers) plus a `MockProvider::with_tool_recording()` test-infra addition to assert on the `tools` argument sent to the provider.
- Live LLM round-trip verification (LLM Serialization Gate, per branching.md) against local Ollama, two scenarios:
  - `[tools] enabled = true` (baseline): real request payload carries 24 tool definitions; model attempts a tool call.
  - `[tools] enabled = false`: real request payload carries an empty tool list; model responds it has no directory-listing capability — confirming no tool defs reached the LLM. No 400/422 in either run.
- New playbook `.local/testing/playbooks/tools-enabled-gate.md` (5 scenarios covering CLI, TUI, serve-sessions/ACP, and the scheduler `RunInline` path) and a new `coverage-status.md` row.

## Adversarial review notes

An implementation-critique pass on the first draft found the `run_inline_tool_loop` scheduler path was left ungated (scheduled/cron tool calls would have bypassed the new flag entirely). Fixed in this PR and re-verified by a delta-review before code review.