### PR TITLE
fix(llm): gate Ollama supports_vision on actual model capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   embedding_model` global fallback defaults to `"nomic-embed-text"`; the actual fallback,
   `default_embedding_model()`, returns `"qwen3-embedding"` (#6385). Doc-only fix, no behavior
   change.
+- `zeph-llm`: `OllamaProvider::supports_vision()` unconditionally returned `true` regardless of
+  the configured model's actual capability (#6377). Since #6374 wired MCP-passthrough images
+  onto Ollama tool-role messages, this caused images to be attached and sent to text-only models
+  (e.g. `qwen3:8b`), typically failing the request server-side. `supports_vision()` now reports
+  `true` only when an explicit `vision_model` override is configured (images route to that model)
+  or when the main chat model has been confirmed vision-capable via `/api/show`'s `capabilities`
+  array — `Bootstrap::build_provider` now probes and caches this alongside its existing
+  context-window auto-detection. Fails safe to `false` (no vision) if the model info fetch fails
+  or the server predates the `capabilities` field, matching the trait's documented default.
 - `zeph-core`: the sanitizer's ML-backed injection and PII classifier calls
   (`ContentSanitizer::classify_injection`/`detect_pii`) were never recorded in the TUI
   metrics panel (#6382). The shared `Arc<ClassifierMetrics>` ring buffer they record into was

--- a/book/src/advanced/multimodal.md
+++ b/book/src/advanced/multimodal.md
@@ -115,18 +115,28 @@ Pipeline: Image attachment → MessagePart::Image → LLM provider (base64) → 
 |----------|--------|-------|
 | Claude | Yes | Anthropic image content block |
 | OpenAI | Yes | image_url data-URI |
-| Ollama | Yes | Optional `vision_model` routing |
+| Ollama | Conditional | Only when `vision_model` is configured, or the main model is confirmed vision-capable |
 | Candle | No | Text-only |
 
 ### Ollama Vision Model
 
-Route image requests to a dedicated model while keeping a smaller text model for regular queries:
+Ollama models vary widely in vision support — a text-only model (e.g. `qwen3:8b`) cannot
+process images, so Zeph never assumes vision support for Ollama: it checks the configured
+model's capabilities via `/api/show` at startup, and drops incoming images (with a warning)
+for any model that isn't confirmed vision-capable.
+
+Route image requests to a dedicated vision model while keeping a smaller text model for
+regular queries:
 
 ```toml
 [llm]
 model = "mistral:7b"
 vision_model = "llava:13b"
 ```
+
+Alternatively, set `model` directly to a vision-capable model (e.g. `llava:13b`,
+`qwen2.5vl`, `llama3.2-vision`) and Zeph detects the capability automatically — no
+`vision_model` override needed.
 
 ### Sending Images
 

--- a/crates/zeph-llm/src/any.rs
+++ b/crates/zeph-llm/src/any.rs
@@ -1214,12 +1214,23 @@ mod tests {
     }
 
     #[test]
-    fn any_ollama_supports_vision() {
+    fn any_ollama_supports_vision_false_by_default() {
+        // #6377: a freshly constructed Ollama provider has no confirmed vision capability
+        // and no explicit vision_model — AnyProvider delegation must not assume vision support.
         let provider = AnyProvider::Ollama(OllamaProvider::new(
             "http://localhost:11434",
             "test".into(),
             "embed".into(),
         ));
+        assert!(!provider.supports_vision());
+    }
+
+    #[test]
+    fn any_ollama_supports_vision_true_with_vision_model() {
+        let provider = AnyProvider::Ollama(
+            OllamaProvider::new("http://localhost:11434", "test".into(), "embed".into())
+                .with_vision_model("llava:13b".into()),
+        );
         assert!(provider.supports_vision());
     }
 

--- a/crates/zeph-llm/src/ollama.rs
+++ b/crates/zeph-llm/src/ollama.rs
@@ -71,6 +71,18 @@ fn ollama_reqwest_client() -> reqwest012::Client {
 pub struct ModelInfo {
     /// Context window size in tokens, if reported by the server.
     pub context_length: Option<usize>,
+    /// Capability tags reported by the server (e.g. `"completion"`, `"vision"`, `"tools"`).
+    ///
+    /// Empty when the server predates the `capabilities` field or the request failed.
+    pub capabilities: Vec<String>,
+}
+
+impl ModelInfo {
+    /// Whether the server-reported capabilities include `"vision"`.
+    #[must_use]
+    pub fn supports_vision(&self) -> bool {
+        self.capabilities.iter().any(|c| c == "vision")
+    }
 }
 
 /// [`LlmProvider`] backend backed by a local Ollama server.
@@ -89,6 +101,12 @@ pub struct OllamaProvider {
     embedding_model: String,
     context_window_size: Option<usize>,
     vision_model: Option<String>,
+    /// Whether the configured chat `model` itself has been confirmed vision-capable via
+    /// `/api/show` (see [`set_vision_capable`](Self::set_vision_capable)). Defaults to `false`
+    /// — vision support is never assumed, only confirmed, so an unqueried or unreachable
+    /// server fails safe to "no vision" rather than silently attaching images the model
+    /// cannot process (#6377).
+    vision_capable: bool,
     generation_overrides: Option<GenerationOverrides>,
     usage: UsageTracker,
     /// Name reported by [`LlmProvider::name`]. Defaults to `"ollama"`; set the TOML-configured
@@ -139,6 +157,7 @@ impl OllamaProvider {
             embedding_model,
             context_window_size: None,
             vision_model: None,
+            vision_capable: false,
             generation_overrides: None,
             usage: UsageTracker::default(),
             provider_name: "ollama".to_owned(),
@@ -183,6 +202,13 @@ impl OllamaProvider {
         self.context_window_size = Some(size);
     }
 
+    /// Record whether the configured chat `model` was confirmed vision-capable
+    /// (typically from the `capabilities` field of an `/api/show` response, see
+    /// [`fetch_model_info`](Self::fetch_model_info) and [`ModelInfo::supports_vision`]).
+    pub fn set_vision_capable(&mut self, capable: bool) {
+        self.vision_capable = capable;
+    }
+
     /// Query Ollama /api/show for model metadata.
     ///
     /// # Errors
@@ -211,6 +237,7 @@ impl OllamaProvider {
 
         Ok(ModelInfo {
             context_length: ctx,
+            capabilities: info.capabilities,
         })
     }
 
@@ -282,8 +309,16 @@ impl LlmProvider for OllamaProvider {
         self.context_window_size
     }
 
+    /// Ollama models vary widely in vision support (e.g. `llava`/`qwen2.5vl` vs. text-only
+    /// `qwen3:8b`) — unlike Claude/OpenAI/Gemini, there is no single API-wide guarantee.
+    /// Reports `true` only when an explicit [`vision_model`](Self::with_vision_model) is
+    /// configured (images route to that model, trusted by the operator to support them), or
+    /// when the main chat `model` was confirmed vision-capable via
+    /// [`fetch_model_info`](Self::fetch_model_info) + [`set_vision_capable`](Self::set_vision_capable).
+    /// Fails safe to `false` — an unqueried or unreachable server never assumes vision support
+    /// (#6377).
     fn supports_vision(&self) -> bool {
-        true
+        self.vision_model.is_some() || self.vision_capable
     }
 
     fn supports_tool_use(&self) -> bool {
@@ -1261,6 +1296,71 @@ mod tests {
         let provider = OllamaProvider::new("http://localhost:11434", "main".into(), "embed".into());
         let selected = provider.vision_model.as_deref().unwrap_or(&provider.model);
         assert_eq!(selected, "main");
+    }
+
+    // --- #6377: supports_vision must not be hardcoded true ---
+
+    #[test]
+    fn supports_vision_false_by_default() {
+        // A freshly constructed provider has neither an explicit vision_model nor a
+        // confirmed-capable main model — must fail safe to false, not assume vision support.
+        let provider =
+            OllamaProvider::new("http://localhost:11434", "qwen3:8b".into(), "embed".into());
+        assert!(!provider.supports_vision());
+    }
+
+    #[test]
+    fn supports_vision_true_with_explicit_vision_model() {
+        // An operator-configured vision_model is a trusted opt-in: images route to that
+        // model, so supports_vision must report true regardless of main model capability.
+        let provider =
+            OllamaProvider::new("http://localhost:11434", "qwen3:8b".into(), "embed".into())
+                .with_vision_model("llava:13b".into());
+        assert!(provider.supports_vision());
+    }
+
+    #[test]
+    fn supports_vision_true_after_set_vision_capable() {
+        let mut provider =
+            OllamaProvider::new("http://localhost:11434", "llava:13b".into(), "embed".into());
+        assert!(!provider.supports_vision());
+        provider.set_vision_capable(true);
+        assert!(provider.supports_vision());
+    }
+
+    #[test]
+    fn set_vision_capable_false_keeps_supports_vision_false() {
+        let mut provider =
+            OllamaProvider::new("http://localhost:11434", "qwen3:8b".into(), "embed".into());
+        provider.set_vision_capable(false);
+        assert!(!provider.supports_vision());
+    }
+
+    #[test]
+    fn model_info_supports_vision_true_when_capability_present() {
+        let info = ModelInfo {
+            context_length: Some(4096),
+            capabilities: vec!["completion".into(), "vision".into(), "tools".into()],
+        };
+        assert!(info.supports_vision());
+    }
+
+    #[test]
+    fn model_info_supports_vision_false_when_capability_absent() {
+        let info = ModelInfo {
+            context_length: Some(4096),
+            capabilities: vec!["completion".into(), "tools".into()],
+        };
+        assert!(!info.supports_vision());
+    }
+
+    #[test]
+    fn model_info_supports_vision_false_when_capabilities_empty() {
+        let info = ModelInfo {
+            context_length: None,
+            capabilities: vec![],
+        };
+        assert!(!info.supports_vision());
     }
 
     #[test]

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -369,12 +369,27 @@ impl AppBuilder {
 
         health_check(&provider).await;
 
-        if let AnyProvider::Ollama(ref mut ollama) = provider
-            && let Ok(info) = ollama.fetch_model_info().await
-            && let Some(ctx) = info.context_length
-        {
-            ollama.set_context_window(ctx);
-            tracing::info!(context_window = ctx, "detected Ollama model context window");
+        if let AnyProvider::Ollama(ref mut ollama) = provider {
+            match ollama.fetch_model_info().await {
+                Ok(info) => {
+                    if let Some(ctx) = info.context_length {
+                        ollama.set_context_window(ctx);
+                        tracing::info!(
+                            context_window = ctx,
+                            "detected Ollama model context window"
+                        );
+                    }
+                    let vision_capable = info.supports_vision();
+                    ollama.set_vision_capable(vision_capable);
+                    tracing::info!(vision_capable, "detected Ollama model vision capability");
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        %error,
+                        "failed to fetch Ollama model info; vision support assumed unavailable"
+                    );
+                }
+            }
         }
 
         if let Some(ctx) = provider.context_window()

--- a/src/bootstrap/tests.rs
+++ b/src/bootstrap/tests.rs
@@ -198,6 +198,86 @@ async fn health_check_ollama_unreachable() {
     health_check(&provider).await;
 }
 
+/// #6377: `build_provider` is the actual wiring point that probes `/api/show` and calls
+/// `set_vision_capable` — the per-field unit tests on `OllamaProvider::supports_vision()`
+/// and `ModelInfo::supports_vision()` never exercise this glue, only the pieces it calls.
+#[tokio::test]
+async fn build_provider_ollama_sets_vision_capable_from_api_show() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+    use zeph_llm::provider::LlmProvider as _;
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/show"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "capabilities": ["completion", "vision"],
+        })))
+        .mount(&server)
+        .await;
+
+    let mut config = Config::load(Path::new("/nonexistent")).unwrap();
+    config.llm.providers = vec![ProviderEntry {
+        provider_type: ProviderKind::Ollama,
+        base_url: Some(server.uri()),
+        model: Some("qwen2.5vl".into()),
+        ..ProviderEntry::default()
+    }];
+    let builder = AppBuilder {
+        config,
+        config_path: PathBuf::from("/nonexistent/config.toml"),
+        vault: Box::new(EnvVaultProvider),
+        age_vault: None,
+        qdrant_ops: None,
+        resolved_overlay: zeph_plugins::ResolvedOverlay::default(),
+        secret_registry: None,
+    };
+
+    let (provider, _tx, _rx) = builder
+        .build_provider()
+        .await
+        .expect("build_provider must succeed against the mock server");
+    assert!(
+        provider.supports_vision(),
+        "a model whose /api/show capabilities include \"vision\" must be wired through to \
+         supports_vision() == true"
+    );
+}
+
+/// #6377 fail-safe path: when `/api/show` cannot be reached at all, `vision_capable` must
+/// stay at its safe default (`false`) rather than the request failure leaving the field
+/// unset in some ambiguous state.
+#[tokio::test]
+async fn build_provider_ollama_vision_capable_false_when_api_show_unreachable() {
+    use zeph_llm::provider::LlmProvider as _;
+
+    let mut config = Config::load(Path::new("/nonexistent")).unwrap();
+    config.llm.providers = vec![ProviderEntry {
+        provider_type: ProviderKind::Ollama,
+        base_url: Some("http://127.0.0.1:1".into()),
+        model: Some("qwen3:8b".into()),
+        ..ProviderEntry::default()
+    }];
+    let builder = AppBuilder {
+        config,
+        config_path: PathBuf::from("/nonexistent/config.toml"),
+        vault: Box::new(EnvVaultProvider),
+        age_vault: None,
+        qdrant_ops: None,
+        resolved_overlay: zeph_plugins::ResolvedOverlay::default(),
+        secret_registry: None,
+    };
+
+    let (provider, _tx, _rx) = builder
+        .build_provider()
+        .await
+        .expect("build_provider must not fail just because /api/show is unreachable");
+    assert!(
+        !provider.supports_vision(),
+        "an unreachable /api/show must leave vision_capable at its safe default (false)"
+    );
+}
+
 #[tokio::test]
 async fn health_check_claude_noop() {
     let provider = AnyProvider::Claude(ClaudeProvider::new("key".into(), "model".into(), 1024));


### PR DESCRIPTION
## Summary

- `OllamaProvider::supports_vision()` unconditionally returned `true` regardless of the configured model's actual capability. Since #6374 wired MCP-passthrough images onto Ollama tool-role messages, this caused images to be attached and sent to text-only models (e.g. `qwen3:8b`), typically failing the request server-side.
- `supports_vision()` now returns `true` only when an explicit `vision_model` override is configured, or when the main chat model was confirmed vision-capable via `/api/show`'s `capabilities` array. `Bootstrap::build_provider` probes and caches this alongside its existing context-window auto-detection. Fails safe to `false` on probe error or missing capability.
- Fixed a stale test in `crates/zeph-llm/src/any.rs` that asserted the old buggy hardcoded-`true` behavior.

Closes #6377

## Test plan

- [x] `cargo nextest run -p zeph-llm` — 1081/1081 passed (7 new unit tests covering `supports_vision()`/`ModelInfo::supports_vision()`)
- [x] `cargo nextest run --workspace -E 'test(bootstrap) and package(zeph)'` — 74/74 passed, including 2 new wiremock-backed tests exercising `Bootstrap::build_provider`'s `/api/show` wiring (success + fail-safe-on-error paths)
- [x] `cargo +nightly fmt --check`, `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`, rustdoc gate — all clean
- [x] LLM serialization gate: live round-trip verified against a real local Ollama server — `fetch_model_info()`/`supports_vision()` correctly detected vision capability for `qwen2.5vl:3b` (`true`) and text-only `qwen2.5:7b` (`false`) via the real `/api/show` response shape, confirming the mocked wiremock tests match production server behavior
- [x] `CHANGELOG.md` and `book/src/advanced/multimodal.md` updated

## Follow-ups (not blocking, flagged during review)

- OpenAI/Compatible providers hardcode `supports_vision() == true` with no capability check — same defect class as this issue, but a different provider with no `/api/show`-equivalent endpoint; recommend a separate P3 issue.
- `build_user_message` (`crates/zeph-core/src/agent/mod.rs:1802`, the user-uploaded-image vision gate) has no direct test for its `supports_vision()` branch — pre-existing gap, not introduced by this PR.