### PR TITLE
fix(subagent,core): reap panicked sub-agents via join_handle, scrub PII in sub-agent debug dumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   through the same dump pipeline as top-level calls. Covers both the standalone `/agent`
   spawn path and `/agent resume`, which previously dropped the sink by passing `None` for
   `spawn_context`.
+- `zeph-core`/`zeph-subagent`: sub-agent-executed LLM-call debug dumps (#6391) only received
+  the baseline `scrub_content`/`redact_binary_blobs` pass, skipping the optional extra
+  `PiiFilter.scrub()` layer that top-level dumps get when `[classifiers]`/PII filtering is
+  enabled — an inconsistent PII-redaction posture between top-level and sub-agent-executed
+  dumps, though not a secret-leak risk since baseline scrubbing still applied (#6407). Added
+  `zeph-sanitizer`'s `PiiFilter` (`Clone`, now cheap since compiled `Regex` values are
+  `Arc`-backed) and `zeph-core`'s new `PiiScrubbingDumpSink`, which wraps `DebugDumper` and
+  applies the same `PiiFilter` scrub top-level dumps get before delegating; `build_spawn_context`
+  now threads a cloned `PiiFilter` handle into the sub-agent `DebugDumpSink` this way.
 - `src/channel.rs`: `impl Channel for AppChannel` forwarded most `Channel` trait methods via
   `dispatch_app_channel!` but never overrode `elicit()` or `send_context_estimate()`, so both
   calls fell through to the trait's default methods instead of reaching `AnyChannel`/`TuiChannel`'s

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `Arc`-backed) and `zeph-core`'s new `PiiScrubbingDumpSink`, which wraps `DebugDumper` and
   applies the same `PiiFilter` scrub top-level dumps get before delegating; `build_spawn_context`
   now threads a cloned `PiiFilter` handle into the sub-agent `DebugDumpSink` this way.
+- `zeph-subagent`/`zeph-core`: `collect_finished_subagents()` determined reapability purely
+  from `status_rx`'s terminal state, so a sub-agent task that exited via a panic inside
+  `run_agent_loop` — without ever publishing a terminal `SubAgentStatus` — left its handle
+  frozen in the last observed `Working` value forever, reproducing the same zombie-sidebar-entry
+  symptom as #6381 through a path #6406 did not close (#6408). Added
+  `zeph_common::task_supervisor::BlockingHandle::is_finished` and
+  `SubAgentManager::is_task_finished`, an independent runtime-level terminal signal now checked
+  alongside `status_rx` state. Also fixed a related bug in `SubAgentManager::collect()`: it
+  early-returned via `?` on a panicked `join_handle`, skipping the fleet `mark_terminal` call and
+  the final `TranscriptMeta` write for panicked tasks; the double-`Result` is now flattened so
+  both still run.
 - `src/channel.rs`: `impl Channel for AppChannel` forwarded most `Channel` trait methods via
   `dispatch_app_channel!` but never overrode `elicit()` or `send_context_estimate()`, so both
   calls fell through to the trait's default methods instead of reaching `AnyChannel`/`TuiChannel`'s

--- a/crates/zeph-common/src/task_supervisor.rs
+++ b/crates/zeph-common/src/task_supervisor.rs
@@ -225,6 +225,18 @@ impl<R> BlockingHandle<R> {
     pub fn abort(&self) {
         self.abort.abort();
     }
+
+    /// Non-blocking, non-consuming check for whether the task has finished.
+    ///
+    /// Unlike [`try_join`][Self::try_join], this does not consume `self` or retrieve the
+    /// result — it only reports completion, including a panicked or aborted task. Useful
+    /// for reap sweeps that must detect a task exit even when the task's own
+    /// application-level status channel never got a chance to publish a terminal value
+    /// before exiting (e.g. a panic partway through the task body).
+    #[must_use]
+    pub fn is_finished(&self) -> bool {
+        self.abort.is_finished()
+    }
 }
 
 /// Point-in-time state of a supervised task.

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -2715,6 +2715,115 @@ mod tests {
         );
     }
 
+    /// Regression test for issue #6408: a sub-agent handle that is genuinely still running —
+    /// `status_rx` still reports `Working` AND the backstop `join_handle.is_finished()` check
+    /// is `false` — must survive `collect_finished_subagents()`. This is the negative side of
+    /// the OR-condition the fix introduced: the previous test proves the backstop reaps a
+    /// finished-but-status-stuck handle, this one proves it does not also reap a handle that
+    /// has neither signal set, which would turn the backstop into an over-eager reaper.
+    #[tokio::test]
+    async fn collect_finished_subagents_keeps_still_running_handle() {
+        use crate::agent::agent_tests::*;
+        use zeph_subagent::def::{SkillFilter, SubAgentPermissions, ToolPolicy};
+        use zeph_subagent::hooks::SubagentHooks;
+        use zeph_subagent::{
+            PermissionGrants, SubAgentDef, SubAgentHandle, SubAgentManager, SubAgentState,
+            SubAgentStatus,
+        };
+
+        let provider = mock_provider(vec!["unused".into()]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+
+        let def = SubAgentDef {
+            name: "worker".into(),
+            description: "A worker bot".into(),
+            model: None,
+            tools: ToolPolicy::InheritAll,
+            disallowed_tools: vec![],
+            permissions: SubAgentPermissions::default(),
+            skills: SkillFilter::default(),
+            system_prompt: "You are a worker.".into(),
+            hooks: SubagentHooks::default(),
+            memory: None,
+            source: None,
+            file_path: None,
+        };
+
+        // Simulate a background task that is genuinely still in progress: it awaits a
+        // never-resolving future, so `join_handle.is_finished()` stays `false` for the
+        // lifetime of the test — unlike the panic test above, where the task exits.
+        let supervisor =
+            zeph_common::TaskSupervisor::new(tokio_util::sync::CancellationToken::new());
+        let join_handle: zeph_common::task_supervisor::BlockingHandle<
+            Result<String, zeph_subagent::SubAgentError>,
+        > = supervisor.spawn_oneshot_classified(
+            std::sync::Arc::from("still-running-test-agent"),
+            || std::future::pending(),
+            Result::is_ok,
+        );
+        assert!(
+            !join_handle.is_finished(),
+            "precondition: the still-running background task must not have finished"
+        );
+
+        let (status_tx, status_rx) = tokio::sync::watch::channel(SubAgentStatus {
+            state: SubAgentState::Working,
+            last_message: None,
+            turns_used: 0,
+            started_at: std::time::Instant::now(),
+        });
+
+        let (_pending_secret_tx, pending_secret_rx) = tokio::sync::mpsc::channel(1);
+        let (secret_tx, _secret_rx) = tokio::sync::mpsc::channel(1);
+
+        let task_id = "still-running-agent".to_string();
+        let sa_handle = SubAgentHandle {
+            id: task_id.clone(),
+            def: def.clone(),
+            task_id: task_id.clone(),
+            state: SubAgentState::Working,
+            join_handle: Some(join_handle),
+            cancel: tokio_util::sync::CancellationToken::new(),
+            status_rx,
+            grants: PermissionGrants::default(),
+            pending_secret_rx,
+            secret_tx,
+            started_at_str: String::new(),
+            transcript_dir: None,
+            mcp_tool_names: Vec::new(),
+        };
+
+        let mut mgr = SubAgentManager::new(4);
+        mgr.definitions_mut().push(def);
+        mgr.insert_handle_for_test(task_id.clone(), sa_handle);
+        agent.services.orchestration.subagent_manager = Some(mgr);
+
+        agent.collect_finished_subagents().await;
+
+        assert_eq!(
+            agent
+                .services
+                .orchestration
+                .subagent_manager
+                .as_ref()
+                .unwrap()
+                .statuses()
+                .iter()
+                .find(|(id, _)| id == &task_id)
+                .map(|(_, s)| s.state),
+            Some(SubAgentState::Working),
+            "a handle whose task is still running (status_rx == Working and \
+             join_handle.is_finished() == false) must not be reaped"
+        );
+
+        // Keep `status_tx` alive for the duration of the assertions above so `status_rx`
+        // cannot spuriously observe a closed-channel state.
+        drop(status_tx);
+    }
+
     // ── #6380: spawn-path total tool-call failure must not leave a task Completed ──────
 
     /// Regression test for issue #6380 (the actual reported repro path): a `/plan`-orchestrated

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -1525,6 +1525,15 @@ impl<C: crate::channel::Channel> Agent<C> {
     /// Reap sub-agent handles that have reached a terminal state, writing their final
     /// `TranscriptMeta` sidecar and removing them from [`zeph_subagent::SubAgentManager`].
     ///
+    /// A handle is reapable when either its `status_rx` reports a terminal
+    /// [`zeph_subagent::SubAgentState`], or its background task has finished at the runtime
+    /// level per [`zeph_subagent::SubAgentManager::is_task_finished`] even though
+    /// `status_rx` is still stuck on a non-terminal value. The latter check is a
+    /// defense-in-depth backstop: a code path that exits the sub-agent's task without
+    /// publishing a terminal status first — most notably a panic inside `run_agent_loop` —
+    /// would otherwise leave the handle permanently in its last observed state (typically
+    /// `Working`), producing a permanent zombie entry in the TUI sidebar (issue #6408).
+    ///
     /// Safe to call at any point in the tick loop: [`Self::build_tool_trace_for_task`] no longer
     /// depends on handle residency, so ordering relative to `SchedulerAction::Verify` is not
     /// load-bearing here (spec 009 § Verifier Tool-Call Grounding, issue #6288). Errors are
@@ -1534,19 +1543,18 @@ impl<C: crate::channel::Channel> Agent<C> {
         let Some(mgr) = &mut self.services.orchestration.subagent_manager else {
             return;
         };
-        let finished: Vec<String> = mgr
-            .statuses()
-            .into_iter()
-            .filter_map(|(id, status)| {
-                matches!(
-                    status.state,
-                    zeph_subagent::SubAgentState::Completed
-                        | zeph_subagent::SubAgentState::Failed
-                        | zeph_subagent::SubAgentState::Canceled
-                )
-                .then_some(id)
-            })
-            .collect();
+        let mut finished = Vec::new();
+        for (id, status) in mgr.statuses() {
+            let terminal_status = matches!(
+                status.state,
+                zeph_subagent::SubAgentState::Completed
+                    | zeph_subagent::SubAgentState::Failed
+                    | zeph_subagent::SubAgentState::Canceled
+            );
+            if terminal_status || mgr.is_task_finished(&id) {
+                finished.push(id);
+            }
+        }
         for task_id in finished {
             if let Err(e) = mgr.collect(&task_id).await {
                 tracing::warn!(task_id, error = %e, "failed to collect finished orchestration sub-agent");
@@ -2580,6 +2588,130 @@ mod tests {
                 .statuses()
                 .is_empty(),
             "canceled sub-agent handle must be reaped, not leaked"
+        );
+    }
+
+    /// Regression test for issue #6408: a sub-agent whose background task exits (e.g. via a
+    /// panic inside `run_agent_loop`) without ever publishing a terminal `SubAgentState` on
+    /// `status_rx` must still be reaped by `collect_finished_subagents()`. This is detected via
+    /// `SubAgentManager::is_task_finished`, a defense-in-depth backstop independent of the
+    /// `status_rx`-based check exercised by the two tests above — before this fix, such a
+    /// handle stayed `Working` forever, producing a permanent zombie entry in the TUI sidebar.
+    #[tokio::test]
+    async fn collect_finished_subagents_reaps_handle_whose_task_finished_without_terminal_status() {
+        use crate::agent::agent_tests::*;
+        use zeph_subagent::def::{SkillFilter, SubAgentPermissions, ToolPolicy};
+        use zeph_subagent::hooks::SubagentHooks;
+        use zeph_subagent::{
+            PermissionGrants, SubAgentDef, SubAgentHandle, SubAgentManager, SubAgentState,
+            SubAgentStatus,
+        };
+
+        let provider = mock_provider(vec!["unused".into()]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+
+        let def = SubAgentDef {
+            name: "worker".into(),
+            description: "A worker bot".into(),
+            model: None,
+            tools: ToolPolicy::InheritAll,
+            disallowed_tools: vec![],
+            permissions: SubAgentPermissions::default(),
+            skills: SkillFilter::default(),
+            system_prompt: "You are a worker.".into(),
+            hooks: SubagentHooks::default(),
+            memory: None,
+            source: None,
+            file_path: None,
+        };
+
+        // Simulate the background task panicking: spawn a task under a real `TaskSupervisor`
+        // that panics, and wait for the panic to actually happen so `is_finished()` observes
+        // it — mirrors what `SubAgentManager::spawn` wires up internally for a real agent loop.
+        let supervisor =
+            zeph_common::TaskSupervisor::new(tokio_util::sync::CancellationToken::new());
+        let join_handle: zeph_common::task_supervisor::BlockingHandle<
+            Result<String, zeph_subagent::SubAgentError>,
+        > = supervisor.spawn_oneshot_classified(
+            std::sync::Arc::from("panic-test-agent"),
+            || async { panic!("simulated run_agent_loop panic before status publish") },
+            Result::is_ok,
+        );
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !join_handle.is_finished() && tokio::time::Instant::now() < deadline {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            join_handle.is_finished(),
+            "precondition: the panicking background task must have finished"
+        );
+
+        // `status_tx` is dropped without ever sending a terminal state, so `status_rx` stays
+        // stuck on the initial `Working` value forever — exactly what a real panic leaves
+        // behind (the sender lives inside the panicked task's stack).
+        let (status_tx, status_rx) = tokio::sync::watch::channel(SubAgentStatus {
+            state: SubAgentState::Working,
+            last_message: None,
+            turns_used: 0,
+            started_at: std::time::Instant::now(),
+        });
+        drop(status_tx);
+        let (_pending_secret_tx, pending_secret_rx) = tokio::sync::mpsc::channel(1);
+        let (secret_tx, _secret_rx) = tokio::sync::mpsc::channel(1);
+
+        let task_id = "panicked-agent".to_string();
+        let sa_handle = SubAgentHandle {
+            id: task_id.clone(),
+            def: def.clone(),
+            task_id: task_id.clone(),
+            state: SubAgentState::Working,
+            join_handle: Some(join_handle),
+            cancel: tokio_util::sync::CancellationToken::new(),
+            status_rx,
+            grants: PermissionGrants::default(),
+            pending_secret_rx,
+            secret_tx,
+            started_at_str: String::new(),
+            transcript_dir: None,
+            mcp_tool_names: Vec::new(),
+        };
+
+        let mut mgr = SubAgentManager::new(4);
+        mgr.definitions_mut().push(def);
+        mgr.insert_handle_for_test(task_id.clone(), sa_handle);
+        agent.services.orchestration.subagent_manager = Some(mgr);
+
+        assert_eq!(
+            agent
+                .services
+                .orchestration
+                .subagent_manager
+                .as_ref()
+                .unwrap()
+                .statuses()
+                .iter()
+                .find(|(id, _)| id == &task_id)
+                .map(|(_, s)| s.state),
+            Some(SubAgentState::Working),
+            "precondition: status_rx never left Working, as would happen after a real panic"
+        );
+
+        agent.collect_finished_subagents().await;
+
+        assert!(
+            agent
+                .services
+                .orchestration
+                .subagent_manager
+                .as_ref()
+                .unwrap()
+                .statuses()
+                .is_empty(),
+            "handle whose background task finished (e.g. panicked) must be reaped even though \
+             status_rx never reported a terminal state"
         );
     }
 

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -2761,7 +2761,7 @@ mod tests {
             Result<String, zeph_subagent::SubAgentError>,
         > = supervisor.spawn_oneshot_classified(
             std::sync::Arc::from("still-running-test-agent"),
-            || std::future::pending(),
+            std::future::pending,
             Result::is_ok,
         );
         assert!(

--- a/crates/zeph-core/src/agent/subagent_commands.rs
+++ b/crates/zeph-core/src/agent/subagent_commands.rs
@@ -751,12 +751,16 @@ impl<C: Channel> Agent<C> {
             // Threaded down so sub-agent LLM calls are captured through the same
             // `--debug-dump` pipeline as the top-level agent loop (#6391). `None` when
             // debug dumps are disabled, mirroring the top-level `debug_dumper: None` case.
-            debug_dump_sink: self
-                .runtime
-                .debug
-                .debug_dumper
-                .clone()
-                .map(|d| Arc::new(d) as Arc<dyn zeph_llm::debug_dump::DebugDumpSink>),
+            // Wrapped in `PiiScrubbingDumpSink` so sub-agent dumps get the same optional
+            // `PiiFilter` layer top-level dumps get via `write_chat_debug_dump` — the plain
+            // `DebugDumpSink` impl on `DebugDumper` only applies the baseline
+            // `scrub_content`/`redact_binary_blobs` pass (#6407).
+            debug_dump_sink: self.runtime.debug.debug_dumper.clone().map(|d| {
+                Arc::new(crate::debug_dump::PiiScrubbingDumpSink::new(
+                    d,
+                    self.services.security.pii_filter.clone(),
+                )) as Arc<dyn zeph_llm::debug_dump::DebugDumpSink>
+            }),
             // Constraint propagation (#3993): populated by orchestration layer when spawning
             // with explicit trust/tool restrictions. Top-level agent sessions leave these None.
             ..Default::default()

--- a/crates/zeph-core/src/debug_dump/mod.rs
+++ b/crates/zeph-core/src/debug_dump/mod.rs
@@ -483,7 +483,7 @@ impl zeph_llm::debug_dump::DebugDumpSink for DebugDumper {
 
 /// Wraps a [`DebugDumper`] with a [`zeph_sanitizer::pii::PiiFilter`] so sub-agent-executed LLM
 /// calls get the same optional PII-redaction layer top-level dumps receive via
-/// [`DebugState::write_chat_debug_dump`](crate::agent::state::DebugState::write_chat_debug_dump)
+/// `DebugState::write_chat_debug_dump`
 /// — the baseline `scrub_content`/`redact_binary_blobs` pass inside [`DebugDumper::dump_response`]
 /// always applies, but the extra `PiiFilter.scrub()` layer is opt-in per config and was
 /// previously only wired into the top-level path (#6407).

--- a/crates/zeph-core/src/debug_dump/mod.rs
+++ b/crates/zeph-core/src/debug_dump/mod.rs
@@ -172,10 +172,9 @@ impl DebugDumper {
 
     /// Response text extracted from a `ChatResponse`, mirroring
     /// [`DebugState::write_chat_debug_dump`](crate::agent::state::DebugState) — kept as a free
-    /// function so [`DebugDumpSink::dump_response`] can reuse it without a PII-filter dependency
-    /// (sub-agent dumps rely on the baseline `scrub_content`/`redact_binary_blobs` pass already
-    /// inside [`DebugDumper::dump_response`], skipping the optional extra `PiiFilter` layer that
-    /// top-level dumps get — see #6391).
+    /// function so both the plain [`DebugDumpSink`] impl on [`DebugDumper`] (baseline
+    /// `scrub_content`/`redact_binary_blobs` only) and [`PiiScrubbingDumpSink`] (adds the
+    /// optional `PiiFilter` layer, see #6407) can reuse it.
     pub(crate) fn chat_response_dump_text(response: &ChatResponse) -> String {
         match response {
             ChatResponse::Text(t) => t.clone(),
@@ -479,6 +478,58 @@ impl zeph_llm::debug_dump::DebugDumpSink for DebugDumper {
 
     fn dump_response(&self, id: u32, response: &ChatResponse) {
         DebugDumper::dump_response(self, id, &DebugDumper::chat_response_dump_text(response));
+    }
+}
+
+/// Wraps a [`DebugDumper`] with a [`zeph_sanitizer::pii::PiiFilter`] so sub-agent-executed LLM
+/// calls get the same optional PII-redaction layer top-level dumps receive via
+/// [`DebugState::write_chat_debug_dump`](crate::agent::state::DebugState::write_chat_debug_dump)
+/// — the baseline `scrub_content`/`redact_binary_blobs` pass inside [`DebugDumper::dump_response`]
+/// always applies, but the extra `PiiFilter.scrub()` layer is opt-in per config and was
+/// previously only wired into the top-level path (#6407).
+pub struct PiiScrubbingDumpSink {
+    inner: DebugDumper,
+    pii_filter: zeph_sanitizer::pii::PiiFilter,
+}
+
+impl PiiScrubbingDumpSink {
+    /// Wraps `inner` so every [`DebugDumpSink::dump_response`](zeph_llm::debug_dump::DebugDumpSink::dump_response)
+    /// call is scrubbed through `pii_filter` before being written to disk.
+    #[must_use]
+    pub fn new(inner: DebugDumper, pii_filter: zeph_sanitizer::pii::PiiFilter) -> Self {
+        Self { inner, pii_filter }
+    }
+}
+
+impl zeph_llm::debug_dump::DebugDumpSink for PiiScrubbingDumpSink {
+    fn is_trace_format(&self) -> bool {
+        self.inner.is_trace_format()
+    }
+
+    fn dump_request(
+        &self,
+        model_name: &str,
+        messages: &[Message],
+        tools: &[ToolDefinition],
+        provider_request: serde_json::Value,
+    ) -> u32 {
+        <DebugDumper as zeph_llm::debug_dump::DebugDumpSink>::dump_request(
+            &self.inner,
+            model_name,
+            messages,
+            tools,
+            provider_request,
+        )
+    }
+
+    fn dump_response(&self, id: u32, response: &ChatResponse) {
+        let raw = DebugDumper::chat_response_dump_text(response);
+        let text = if self.pii_filter.is_enabled() {
+            self.pii_filter.scrub(&raw).into_owned()
+        } else {
+            raw
+        };
+        self.inner.dump_response(id, &text);
     }
 }
 
@@ -1293,6 +1344,68 @@ mod tests {
         assert!(
             !content.contains("sk-abc123def456"),
             "raw secret must not reach disk: {content}"
+        );
+    }
+
+    /// #6407: sub-agent dumps (routed through the `DebugDumpSink` trait via
+    /// `PiiScrubbingDumpSink`) must get the same optional `PiiFilter` scrub top-level dumps
+    /// get via `DebugState::write_chat_debug_dump`, not just the baseline secret/JWT scrub.
+    #[tokio::test]
+    async fn pii_scrubbing_dump_sink_scrubs_pii_when_filter_enabled() {
+        use zeph_llm::debug_dump::DebugDumpSink as _;
+        use zeph_llm::provider::ChatResponse;
+        use zeph_sanitizer::pii::{PiiFilter, PiiFilterConfig};
+
+        let dir = tempdir().unwrap();
+        let dumper = DebugDumper::new(dir.path(), DumpFormat::Json).unwrap();
+        let pii_filter = PiiFilter::new(PiiFilterConfig {
+            enabled: true,
+            ..Default::default()
+        });
+        let sink = PiiScrubbingDumpSink::new(dumper, pii_filter);
+
+        sink.dump_response(
+            0,
+            &ChatResponse::Text("contact me at someone@example.com".to_owned()),
+        );
+
+        let content = read_dump_file(dir.path(), "0000-response.txt").await;
+        assert!(
+            content.contains("[PII:email]"),
+            "email must be scrubbed by the PiiFilter layer: {content}"
+        );
+        assert!(
+            !content.contains("someone@example.com"),
+            "raw email must not reach disk: {content}"
+        );
+    }
+
+    /// Mirrors the above with the filter disabled (config default: `enabled = true`, so this
+    /// exercises the explicit opt-out) — only baseline `scrub_content`/`redact_binary_blobs`
+    /// applies, matching `DebugState::write_chat_debug_dump`'s `is_enabled()` gate.
+    #[tokio::test]
+    async fn pii_scrubbing_dump_sink_skips_pii_scrub_when_filter_disabled() {
+        use zeph_llm::debug_dump::DebugDumpSink as _;
+        use zeph_llm::provider::ChatResponse;
+        use zeph_sanitizer::pii::{PiiFilter, PiiFilterConfig};
+
+        let dir = tempdir().unwrap();
+        let dumper = DebugDumper::new(dir.path(), DumpFormat::Json).unwrap();
+        let pii_filter = PiiFilter::new(PiiFilterConfig {
+            enabled: false,
+            ..Default::default()
+        });
+        let sink = PiiScrubbingDumpSink::new(dumper, pii_filter);
+
+        sink.dump_response(
+            0,
+            &ChatResponse::Text("contact me at someone@example.com".to_owned()),
+        );
+
+        let content = read_dump_file(dir.path(), "0000-response.txt").await;
+        assert!(
+            content.contains("someone@example.com"),
+            "disabled PiiFilter must not scrub email: {content}"
         );
     }
 

--- a/crates/zeph-sanitizer/src/pii.rs
+++ b/crates/zeph-sanitizer/src/pii.rs
@@ -233,11 +233,13 @@ fn detect_name_spans(text: &str) -> Vec<PiiSpan> {
 // Internal pattern record
 // ---------------------------------------------------------------------------
 
+#[derive(Clone)]
 struct PiiPattern {
     regex: Regex,
     replacement: &'static str,
 }
 
+#[derive(Clone)]
 struct CustomPiiPatternCompiled {
     regex: Regex,
     replacement: String,
@@ -336,6 +338,11 @@ pub fn redact_spans(text: &str, spans: &[PiiSpan]) -> String {
 /// Stateless PII filter. Construct once from [`PiiFilterConfig`] and store on the agent.
 ///
 /// When disabled, all methods are no-ops that return the input unchanged.
+///
+/// `Clone` is cheap: compiled `Regex` values are internally `Arc`-backed, so cloning only
+/// bumps reference counts. This lets callers hand an independent handle to a sub-agent's
+/// debug-dump sink without sharing mutable state (#6407).
+#[derive(Clone)]
 pub struct PiiFilter {
     enabled: bool,
     /// Built-in patterns selected by config flags.

--- a/crates/zeph-subagent/src/manager/collect.rs
+++ b/crates/zeph-subagent/src/manager/collect.rs
@@ -43,10 +43,16 @@ impl SubAgentManager {
 
         handle.grants.revoke_all();
 
-        let result = if let Some(jh) = handle.join_handle.take() {
-            jh.join()
-                .await
-                .map_err(|e| SubAgentError::Spawn(e.to_string()))?
+        // Flatten the outer `BlockingError` (panic/abort of the supervised task itself)
+        // into `result` rather than propagating it with `?`: an early return here would
+        // skip the fleet `mark_terminal` call and final `TranscriptMeta` write below,
+        // leaving both stuck showing the agent as still active even though it has just
+        // been removed from `self.agents` (issue #6408).
+        let result: Result<String, SubAgentError> = if let Some(jh) = handle.join_handle.take() {
+            match jh.join().await {
+                Ok(inner) => inner,
+                Err(e) => Err(SubAgentError::Spawn(e.to_string())),
+            }
         } else {
             Ok(String::new())
         };
@@ -148,6 +154,25 @@ impl SubAgentManager {
                 (h.task_id.clone(), status)
             })
             .collect()
+    }
+
+    /// Returns whether the background task backing `task_id` has finished at the runtime
+    /// level, independent of whether its `status_rx` channel ever published a terminal
+    /// [`SubAgentState`].
+    ///
+    /// A code path that exits `run_agent_loop` without sending a terminal status first —
+    /// most notably a panic — leaves `status_rx` stuck on the last observed state (typically
+    /// `Working`) forever. Callers such as `collect_finished_subagents` in `zeph-core` use
+    /// this as a defense-in-depth reap signal for that case (issue #6408).
+    ///
+    /// Returns `false` for an unknown `task_id` or a handle with no `join_handle` (already
+    /// collected, or a test-constructed handle).
+    #[must_use]
+    pub fn is_task_finished(&self, task_id: &str) -> bool {
+        self.agents
+            .get(task_id)
+            .and_then(|h| h.join_handle.as_ref())
+            .is_some_and(zeph_common::task_supervisor::BlockingHandle::is_finished)
     }
 
     /// Return the definition for a specific agent by `task_id`.

--- a/crates/zeph-subagent/src/manager/tests.rs
+++ b/crates/zeph-subagent/src/manager/tests.rs
@@ -3851,6 +3851,82 @@ async fn fleet_mark_terminal_cancelled_on_cancel() {
     );
 }
 
+// ── is_task_finished / collect() join-handle backstop (#6408) ──────────
+
+#[tokio::test]
+async fn is_task_finished_false_for_unknown_id_and_handle_without_join_handle() {
+    let mut mgr = make_manager();
+    assert!(!mgr.is_task_finished("no-such-task"));
+
+    let handle = SubAgentHandle::for_test("idle", sample_def());
+    mgr.insert_handle_for_test("idle".to_string(), handle);
+    assert!(
+        !mgr.is_task_finished("idle"),
+        "a handle with no join_handle (e.g. test-constructed) must never report finished"
+    );
+}
+
+/// Regression test for issue #6408: a background task that panics without ever publishing a
+/// terminal status must still be detected as finished via `is_task_finished`, and `collect()`
+/// must still finalize the fleet registry as `Failed` rather than losing that step to the
+/// panic — before this fix, `collect()` returned early on the join error, skipping
+/// `mark_terminal` and the final `TranscriptMeta` write.
+#[tokio::test]
+async fn collect_marks_fleet_terminal_failed_when_task_panics_without_status_update() {
+    let registry = MockFleetRegistry::new();
+    let mut mgr = make_manager_with_fleet(Arc::clone(&registry) as SharedFleetRegistry);
+    let def = sample_def();
+    mgr.definitions.push(def.clone());
+
+    let supervisor = TaskSupervisor::new(CancellationToken::new());
+    let join_handle: zeph_common::task_supervisor::BlockingHandle<Result<String, SubAgentError>> =
+        supervisor.spawn_oneshot_classified(
+            Arc::from("panic-test"),
+            || async { panic!("simulated run_agent_loop panic before status publish") },
+            Result::is_ok,
+        );
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(5);
+    while !join_handle.is_finished() && tokio::time::Instant::now() < deadline {
+        tokio::task::yield_now().await;
+    }
+    assert!(
+        join_handle.is_finished(),
+        "precondition: the panicking background task must have finished"
+    );
+
+    let task_id = "panicked".to_string();
+    let mut handle = SubAgentHandle::for_test(task_id.clone(), def);
+    handle.join_handle = Some(join_handle);
+    mgr.insert_handle_for_test(task_id.clone(), handle);
+
+    assert!(
+        mgr.is_task_finished(&task_id),
+        "join_handle already panicked and finished — must be reported as finished even though \
+         status_rx is still stuck on the initial Working value"
+    );
+
+    let result = mgr.collect(&task_id).await;
+    assert!(
+        result.is_err(),
+        "collect must surface the panic as an error"
+    );
+
+    tokio::time::timeout(
+        tokio::time::Duration::from_secs(2),
+        registry.terminal_notify.notified(),
+    )
+    .await
+    .expect("mark_terminal must still be called even though the join panicked");
+
+    let terminated = registry.terminated.lock().unwrap();
+    assert!(
+        terminated
+            .iter()
+            .any(|(id, s)| id == &task_id && *s == FleetSessionStatus::Failed),
+        "a panicked task must be marked Failed in the fleet registry, not left dangling: {terminated:?}"
+    );
+}
+
 // ── spawn_hook_task cap enforcement (#4422) ────────────────────────────
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Two P3 bug follow-ups discovered during impl-critic review of PR #6406, bundled together since both are small, independent defense-in-depth fixes from the same review cycle.

- `collect_finished_subagents()` (`crates/zeph-core/src/agent/scheduler_loop.rs`) determined reapability purely from `status_rx`'s terminal state, so a sub-agent task that exited via a panic — without ever publishing a terminal `SubAgentStatus` — left its handle frozen in the last observed `Working` state forever, reproducing the #6381 zombie-sidebar-entry symptom through a path #6406 did not close. Added `join_handle.is_finished()` as an independent terminal signal (`BlockingHandle::is_finished` in `zeph-common`, `SubAgentManager::is_task_finished` in `zeph-subagent`). Also fixed a related bug in `SubAgentManager::collect()`, which early-returned via `?` on a panicked `join_handle`, skipping the fleet `mark_terminal` call and the final `TranscriptMeta` write for panicked tasks.
- Sub-agent-executed LLM-call debug dumps (wired in #6406 via `DebugDumpSink`) received baseline `scrub_content`/`redact_binary_blobs` scrubbing but skipped the optional extra `PiiFilter.scrub()` layer that top-level dumps get when PII filtering is enabled — an inconsistent PII-redaction posture between top-level and sub-agent-executed dumps. Added `PiiScrubbingDumpSink`, wrapping `DebugDumper` with the same `PiiFilter` handle used by top-level dump construction, wired into `build_spawn_context` for both fresh spawn and `/agent resume`.

Closes #6408
Closes #6407

## Test plan

- [x] New regression tests: reap-on-panic-via-backstop, keep-alive negative path (still-running handle not reaped), PII-scrub-when-enabled, skip-when-disabled
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (14161 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` (34 doc-test suites)
- [x] `gitleaks detect` on the branch diff
- [x] Adversarial critique (rust-critic) and code review (2 rounds) both passed