### PR TITLE
fix(session): record and surface lock holder PID on contention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+### Fixed
+
+- `zeph-session`: `AdvisoryLock::acquire`'s `WOULDBLOCK` path gave operators only a bare
+  "another session is already active" message with no way to tell whether the lock's holder
+  was still running (#6378). The holder's PID is now written into the sibling lock file
+  (`events.jsonl.lock`) on acquire, and a contending `acquire` reads it back plus a liveness
+  check (`kill(pid, 0)` via the newly-promoted `zeph_common::pidfile::is_process_alive`,
+  formerly duplicated in `zeph-scheduler`), surfaced through a widened
+  `SessionError::AlreadyLocked { path, pid, pid_alive }` struct variant. A recorded-not-running
+  holder is reported as a hedged "may be stale, or may have just been re-acquired" — not
+  asserted as definitely dead, since the lock file is a permanent sentinel (never atomically
+  replaced) and a contender can observe a torn read of the *previous* holder's PID during the
+  brief window between a new holder's `flock` and its PID write. Diagnostic-only: no
+  auto-recovery or auto-unlink was introduced, since breaking a live `flock` without the
+  holder's cooperation is unsafe.
+
 ### Added
 
 - Coverage-guided fuzzing harnesses (cargo-fuzz) for SKILL.md frontmatter, skill extensions,

--- a/crates/zeph-common/Cargo.toml
+++ b/crates/zeph-common/Cargo.toml
@@ -58,9 +58,10 @@ uuid = { workspace = true, features = ["v4"] }
 zeroize = { workspace = true, features = ["alloc", "derive", "serde"] }
 # See https://github.com/bug-ops/zeph (workspace dependencies only contain versions)
 
-# Advisory `flock(2)` locking for the shared pid-file guard (`pidfile::PidLockGuard`); Unix only.
+# Advisory `flock(2)` locking and liveness checks (`kill(pid, 0)`) for the shared pid-file
+# guard (`pidfile::PidLockGuard`, `pidfile::is_process_alive`); Unix only.
 [target.'cfg(unix)'.dependencies]
-rustix = { workspace = true, features = ["fs", "std"] }
+rustix = { workspace = true, features = ["fs", "process", "std"] }
 
 [dev-dependencies]
 metrics-util = { workspace = true, features = ["debugging"] }

--- a/crates/zeph-common/src/pidfile.rs
+++ b/crates/zeph-common/src/pidfile.rs
@@ -146,6 +146,36 @@ pub fn read_pid_lenient(path: &Path) -> Option<u32> {
     std::fs::read_to_string(path).ok()?.trim().parse().ok()
 }
 
+/// Check whether a process with the given PID is currently alive.
+///
+/// Uses `kill(pid, 0)`, which sends no signal but returns an error if the process does not
+/// exist or is a zombie that cannot be signalled. Promoted here (from `zeph-scheduler`'s
+/// former private copy) so any crate diagnosing a contended [`PidLockGuard`]-style lock can
+/// check the recorded holder's liveness without depending on `zeph-scheduler`.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_common::pidfile::is_process_alive;
+///
+/// assert!(is_process_alive(std::process::id()));
+/// assert!(!is_process_alive(0));
+/// ```
+#[must_use]
+pub fn is_process_alive(pid: u32) -> bool {
+    // kill(pid, 0) returns Ok if the process exists and we have permission to signal it,
+    // Err(EPERM) if it exists but we lack permission, Err(ESRCH) if it does not exist.
+    // Both Ok and EPERM mean the process is alive.
+    let Some(rustix_pid) = rustix::process::Pid::from_raw(pid.cast_signed()) else {
+        return false;
+    };
+    match rustix::process::test_kill_process(rustix_pid) {
+        Ok(()) => true,
+        Err(e) if e == rustix::io::Errno::PERM => true,
+        Err(_) => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicU32, Ordering};

--- a/crates/zeph-scheduler/src/pidfile.rs
+++ b/crates/zeph-scheduler/src/pidfile.rs
@@ -15,6 +15,10 @@ use std::path::Path;
 
 use zeph_common::pidfile::{PidLockError, PidLockGuard, read_pid_lenient};
 
+/// Re-exported so existing `crate::pidfile::is_process_alive` call sites keep working after
+/// promotion to `zeph_common::pidfile` (shared with `zeph-session`'s `AdvisoryLock`).
+pub use zeph_common::pidfile::is_process_alive;
+
 use crate::error::SchedulerError;
 
 /// Advisory PID file backed by an `flock(2)` exclusive lock.
@@ -75,35 +79,6 @@ impl PidFile {
         } else {
             None
         }
-    }
-}
-
-/// Check whether a process with the given PID is currently alive.
-///
-/// Uses `kill(pid, 0)` which sends no signal but returns an error if the
-/// process does not exist or is a zombie that cannot be signalled.
-///
-/// # SIGNIFICANT-7 liveness guarantee
-///
-/// This check is combined with a flock attempt in [`PidFile::read_alive`] to
-/// confirm that the daemon actually holds the lock (not just that a PID file
-/// exists with a recycled PID). However, for the MVP `read_alive` only checks
-/// `kill(pid, 0)` and trusts the pidfile content.
-#[must_use]
-pub fn is_process_alive(pid: u32) -> bool {
-    // kill(pid, 0) returns Ok if the process exists and we have permission to signal it,
-    // Err(EPERM) if it exists but we lack permission, Err(ESRCH) if it does not exist.
-    // Both Ok and EPERM mean the process is alive.
-    let Some(rustix_pid) = rustix::process::Pid::from_raw(pid.cast_signed()) else {
-        return false;
-    };
-    // test_kill_process is kill(pid, 0): succeeds if process exists and we can signal it.
-    // EPERM means process exists but we lack permission — still alive.
-    // ESRCH means no such process.
-    match rustix::process::test_kill_process(rustix_pid) {
-        Ok(()) => true,
-        Err(e) if e == rustix::io::Errno::PERM => true,
-        Err(_) => false,
     }
 }
 

--- a/crates/zeph-session/src/error.rs
+++ b/crates/zeph-session/src/error.rs
@@ -38,11 +38,48 @@ pub enum SessionError {
 
     /// [`crate::log::SessionEventLog::open_exclusive`] found another process already
     /// holding the session's advisory write lock.
-    #[error("session event log at {0} is already locked by another process")]
-    AlreadyLocked(String),
+    #[error("{}", describe_already_locked(path, *pid, *pid_alive))]
+    AlreadyLocked {
+        /// Path to the contended lock file.
+        path: String,
+        /// PID of the process holding the lock, read back from the lock file's contents at
+        /// contention time. `None` if the file was empty or its contents could not be parsed
+        /// as a PID (e.g. the lock was acquired by a build predating PID recording).
+        pid: Option<u32>,
+        /// Whether `pid` was confirmed still running via a liveness check (`kill(pid, 0)`) at
+        /// contention time. `None` if `pid` is `None`, or on non-Unix targets where no
+        /// liveness check runs.
+        pid_alive: Option<bool>,
+    },
 
     /// A `UserMessage.image_refs` entry was not a bare hex string, so it was rejected before
     /// being joined into a filesystem path (#5982 follow-up, path-traversal guard).
     #[error("invalid blob hash (must be a non-empty hex string): {0:?}")]
     InvalidBlobHash(String),
+}
+
+/// Formats [`SessionError::AlreadyLocked`]'s message, distinguishing a recorded-not-running
+/// holder (#6378: the flock conflict is real, but the codebase previously gave operators
+/// nothing to verify it against) from a live or unknown one. The recorded-not-running case is
+/// hedged, not asserted as definitely stale: the lock file is a permanent sentinel that is
+/// truncated and rewritten (not atomically replaced) on each acquire, so a contender can observe
+/// the *previous* holder's now-dead PID during the brief window between a new holder's
+/// successful `flock` and its PID write — see the `WOULDBLOCK` branch in
+/// [`AdvisoryLock::acquire`](crate::log::AdvisoryLock::acquire). Never suggests auto-recovery —
+/// breaking a live flock without the holder's cooperation is unsafe, so this is diagnostic-only.
+fn describe_already_locked(path: &str, pid: Option<u32>, pid_alive: Option<bool>) -> String {
+    match (pid, pid_alive) {
+        (Some(pid), Some(false)) => format!(
+            "session event log at {path} is already locked: the recorded holder pid {pid} is \
+             not running; the lock may be stale, or may have just been re-acquired by another \
+             process — verify before removing it. Not auto-recovered because breaking a live \
+             flock without holder cooperation is unsafe"
+        ),
+        (Some(pid), _) => format!(
+            "session event log at {path} is already locked by another process (held by pid {pid})"
+        ),
+        (None, _) => format!(
+            "session event log at {path} is already locked by another process (holder pid unknown)"
+        ),
+    }
 }

--- a/crates/zeph-session/src/log.rs
+++ b/crates/zeph-session/src/log.rs
@@ -461,10 +461,15 @@ pub(crate) async fn set_permissions(path: &Path, mode: u32) -> Result<(), Sessio
 ///
 /// Backed by `flock(2)` on a sibling lock file (`events.jsonl.lock`) rather than
 /// `events.jsonl` itself, so the lock is independent of the append-mode file handle already
-/// held for writing. Mirrors `zeph-scheduler`'s `PidFile`, but — unlike a pid file — the lock
-/// file is never unlinked on drop: it is a permanent sentinel, not ephemeral process identity,
-/// and unlinking it would reopen an unlink/re-create race between the releasing and the next
-/// acquiring process.
+/// held for writing. Mirrors `zeph-scheduler`'s `PidFile`: the holder's PID is written into the
+/// file once the lock is acquired, so a contending `acquire` can read it back to tell an
+/// operator (or [`SessionError::AlreadyLocked`]'s caller) which process to check — unlike a pid
+/// file, though, the lock file is never unlinked on drop: it is a permanent sentinel, not
+/// ephemeral process identity, and unlinking it would reopen an unlink/re-create race between
+/// the releasing and the next acquiring process.
+///
+/// **Invariant**: `session_dir` MUST reside on a local filesystem. NFS/network mounts do not
+/// guarantee reliable exclusive locking with `flock(2)` (#6378).
 #[cfg(unix)]
 struct AdvisoryLock(#[allow(dead_code)] rustix::fd::OwnedFd);
 
@@ -483,11 +488,32 @@ impl AdvisoryLock {
 
         rustix::fs::flock(&fd, FlockOperation::NonBlockingLockExclusive).map_err(|e| {
             if e == rustix::io::Errno::WOULDBLOCK {
-                SessionError::AlreadyLocked(lock_path.display().to_string())
+                // The lock file is a permanent sentinel (never unlinked, never cleared on
+                // `Drop`), so between a new holder's successful `flock` above and its
+                // `ftruncate`+write below, this read can still observe the *previous* holder's
+                // PID — a dead PID here is a snapshot, not proof the current holder is gone
+                // (#6378, see `describe_already_locked`'s hedged wording).
+                let pid = zeph_common::pidfile::read_pid_lenient(&lock_path);
+                let pid_alive = pid.map(zeph_common::pidfile::is_process_alive);
+                SessionError::AlreadyLocked {
+                    path: lock_path.display().to_string(),
+                    pid,
+                    pid_alive,
+                }
             } else {
                 SessionError::Io(e.into())
             }
         })?;
+
+        // We hold the lock — record our own PID so a future contending `acquire` can diagnose
+        // us (#6378: previously the lock file was permanently empty, giving an operator nothing
+        // to verify a contended lock against). Mirrors `PidLockGuard::acquire`.
+        rustix::fs::ftruncate(&fd, 0).map_err(std::io::Error::from)?;
+        // A `u32` PID renders to at most 10 bytes — a single `write(2)` to a local regular file
+        // for a buffer this small does not return a short count in practice, so no `write_all`
+        // retry loop is needed here.
+        rustix::io::write(&fd, std::process::id().to_string().as_bytes())
+            .map_err(std::io::Error::from)?;
 
         Ok(Self(fd))
     }
@@ -753,13 +779,37 @@ mod tests {
         );
     }
 
+    /// Regression test for #6378: `AdvisoryLock::acquire` must record the holder's own PID
+    /// into the lock file's contents so a contending `acquire` can diagnose who holds it.
+    /// Before the fix the lock file was permanently empty.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_open_exclusive_writes_own_pid_into_lock_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let _log = SessionEventLog::open_exclusive(dir.path()).await.unwrap();
+
+        let lock_path = dir.path().join(LOCK_FILE_NAME);
+        let contents = tokio::fs::read_to_string(&lock_path).await.unwrap();
+        let pid: u32 = contents.trim().parse().unwrap_or_else(|e| {
+            panic!("lock file contents {contents:?} did not parse as a PID: {e}")
+        });
+        assert_eq!(pid, std::process::id());
+    }
+
+    /// Regression test for #6378: on contention, `SessionError::AlreadyLocked` must carry the
+    /// holder's PID (read back from the lock file) and a liveness verdict, not just the lock
+    /// path. This is a same-process test, so both the holder and the contender are the current
+    /// process — a genuinely alive PID is exactly what `pid_alive` must report.
     #[cfg(unix)]
     #[tokio::test]
     async fn test_open_exclusive_rejects_second_writer() {
         let dir = tempfile::tempdir().unwrap();
         let _first = SessionEventLog::open_exclusive(dir.path()).await.unwrap();
         match SessionEventLog::open_exclusive(dir.path()).await {
-            Err(SessionError::AlreadyLocked(_)) => {}
+            Err(SessionError::AlreadyLocked { pid, pid_alive, .. }) => {
+                assert_eq!(pid, Some(std::process::id()));
+                assert_eq!(pid_alive, Some(true));
+            }
             Err(e) => panic!("expected AlreadyLocked, got different error: {e}"),
             Ok(_) => panic!("expected AlreadyLocked, but second open_exclusive succeeded"),
         }

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -1329,9 +1329,10 @@ async fn open_session_log_or_notify_locked(
 ) -> Option<std::sync::Arc<zeph_session::SessionEventLog>> {
     match zeph_session::SessionEventLog::open_exclusive(session_path).await {
         Ok(log) => Some(std::sync::Arc::new(log)),
-        Err(zeph_session::SessionError::AlreadyLocked(lock_path)) => {
+        Err(zeph_session::SessionError::AlreadyLocked { path, pid, .. }) => {
             tracing::error!(
-                lock_path,
+                lock_path = %path,
+                pid,
                 "failed to open session event log for ACP session: another process \
                  already holds this session's write lock; session persistence disabled \
                  for this session"
@@ -1930,10 +1931,11 @@ async fn spawn_acp_agent(
                 // continuing here would let this ACP session race the other process's writes
                 // exactly like the reported bug.
                 Err(zeph_agent_persistence::PersistenceError::Session(
-                    zeph_session::SessionError::AlreadyLocked(lock_path),
+                    zeph_session::SessionError::AlreadyLocked { path, pid, .. },
                 )) => {
                     tracing::error!(
-                        lock_path,
+                        lock_path = %path,
+                        pid,
                         "session hydration failed: another process already holds this session's \
                          write lock; session persistence disabled for this session"
                     );

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -696,8 +696,8 @@ async fn init_session_sink(
                     Vec::new(),
                 ))
             }
-            Err(zeph_session::SessionError::AlreadyLocked(lock_path)) => Err(anyhow::anyhow!(
-                "another zeph session is already active for this conversation; lock: {lock_path}"
+            Err(e @ zeph_session::SessionError::AlreadyLocked { .. }) => Err(anyhow::anyhow!(
+                "another zeph session is already active for this conversation: {e}"
             )),
             Err(e) => {
                 tracing::warn!(error = %e, "failed to open session event log; session persistence disabled for this run");
@@ -738,9 +738,9 @@ async fn init_session_sink(
             Ok((Some(sink), hydrated.messages))
         }
         Err(zeph_agent_persistence::PersistenceError::Session(
-            zeph_session::SessionError::AlreadyLocked(lock_path),
+            e @ zeph_session::SessionError::AlreadyLocked { .. },
         )) => Err(anyhow::anyhow!(
-            "another zeph session is already active for this conversation; lock: {lock_path}"
+            "another zeph session is already active for this conversation: {e}"
         )),
         Err(e) => {
             tracing::warn!(error = %e, "session hydration failed for default continuation; session persistence disabled for this run");
@@ -779,8 +779,8 @@ async fn resume_session_sink_fallback(
                 ),
             )))
         }
-        Err(zeph_session::SessionError::AlreadyLocked(lock_path)) => Err(anyhow::anyhow!(
-            "another zeph session is already active for session '{resume_id}'; lock: {lock_path}"
+        Err(e @ zeph_session::SessionError::AlreadyLocked { .. }) => Err(anyhow::anyhow!(
+            "another zeph session is already active for session '{resume_id}': {e}"
         )),
         Err(open_err) => {
             tracing::warn!(error = %open_err, "bare session event log fallback also failed; continuing with SQLite-only history");
@@ -2003,10 +2003,10 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
                 // fallback below, which would just hit the same lock and fail identically, or
                 // (with a lockless open) silently race the other process's writes.
                 Err(zeph_agent_persistence::PersistenceError::Session(
-                    zeph_session::SessionError::AlreadyLocked(lock_path),
+                    e @ zeph_session::SessionError::AlreadyLocked { .. },
                 )) => {
                     anyhow::bail!(
-                        "another zeph session is already active for session '{resume_id}'; lock: {lock_path}"
+                        "another zeph session is already active for session '{resume_id}': {e}"
                     );
                 }
                 Err(e) => {

--- a/src/serve/agent_factory.rs
+++ b/src/serve/agent_factory.rs
@@ -529,10 +529,11 @@ async fn hydrate_session_sink(
                 return (Some(sink), hydrated.messages);
             }
             Err(zeph_agent_persistence::PersistenceError::Session(
-                zeph_session::SessionError::AlreadyLocked(lock_path),
+                zeph_session::SessionError::AlreadyLocked { path, pid, .. },
             )) if attempt < REACTIVATION_LOCK_RETRY_ATTEMPTS => {
                 tracing::debug!(
-                    lock_path,
+                    lock_path = %path,
+                    pid,
                     attempt,
                     "serve-sessions: event log still locked by a draining prior actor; retrying reactivation"
                 );
@@ -546,7 +547,7 @@ async fn hydrate_session_sink(
                 if matches!(
                     e,
                     zeph_agent_persistence::PersistenceError::Session(
-                        zeph_session::SessionError::AlreadyLocked(_)
+                        zeph_session::SessionError::AlreadyLocked { .. }
                     )
                 ) {
                     metrics::counter!("serve.session.reactivation_lock_exhausted_total")


### PR DESCRIPTION
## Summary

- `AdvisoryLock::acquire` (session event-log lock) now writes the current process's PID into the lock file on acquire, and on `WOULDBLOCK` reads back the holder's PID plus a liveness check, so `SessionError::AlreadyLocked` reports who holds the lock and whether they appear to still be running, instead of a bare, unactionable "another session is already active" message.
- The dead-PID case is intentionally hedged, not asserted: the lock file is a permanent sentinel (never atomically replaced), so a contender can observe the previous holder's PID during the brief window before a new holder rewrites it. This is diagnostic-only — no auto-unlink or auto-recovery is introduced, since breaking a live `flock` without the holder's cooperation is unsafe.
- `is_process_alive` is promoted from `zeph-scheduler` to `zeph-common` so `zeph-session` can reuse it without an upward dependency edge; `zeph-scheduler` now re-exports the promoted copy.

## Root cause

Diagnosed via dedicated debugging (see linked issue): the reported `AlreadyLocked` was a real `flock(2)` conflict against an external holder, not an in-process race. All three originally-suspected in-process hypotheses (TOCTOU in session-sink creation, a race with fleet's stale-session reconciliation, cross-DB lock-directory collision) were ruled out by tracing the code. The actual defect was architectural: the lock had zero diagnostic capability, so any external contention (orphaned process, dev-loop restart, filesystem staleness) surfaced as an unrecoverable, unverifiable startup failure.

## Test plan

- [x] New unit test: lock file content parses as `std::process::id()` after acquire
- [x] Extended existing contention test to assert the `AlreadyLocked` error's `pid`/`pid_alive` fields
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 14171 passed, 0 failed, 35 skipped
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] `.local/testing/coverage-status.md` and `.local/testing/playbooks/session-persistence.md` updated (main repo)

Closes #6378