### PR TITLE
fix: close spec-080 Command-handoff verification, rejection-visibility, and owner_key gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,11 +58,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     both, defaulting to No.
   - `zeph-orchestration` gained no new production dependency on `zeph-memory` — all store
     I/O lives in `zeph-core`, per the spec's binding layering invariant.
-  - Known limitations tracked as follow-ups: gateway/A2A dispatch paths do not yet thread a
-    real per-caller `owner_key` into the store (#6389); a rejected Command handoff's
+  - Known limitations tracked as follow-ups: a rejected Command handoff's
     `TaskNode.handoff_rejected` marker is persisted and logged but has no dedicated
     TUI/CLI display surface yet (#6390); a Command-handoff outcome skips the
     `SchedulerAction::Verify` completeness check ordinary `Completed` outcomes get (#6394).
+- **Cross-thread store: real per-caller `owner_key` for gateway/A2A dispatch** (spec-080 §10
+  OQ-1, #6389): `ChannelMessage` gains an `owner_key: Option<String>` field, set per-turn on
+  `SessionState.owner_key` (mirroring the existing `is_guest_context` per-turn propagation,
+  reset at `end_turn`) and read by both the `/store` slash command and the Command-handoff
+  store write/read (`scheduler_loop.rs`). The gateway webhook forwarder derives
+  `gateway:{sender}` from `WebhookPayload.sender`; the A2A task processor derives
+  `a2a:{context_id}` (or `a2a:default` when absent) from the A2A protocol's own
+  conversation-scoping `Message.context_id`. Two distinct gateway/A2A callers sharing one
+  bearer token now land in distinct cross-thread store buckets instead of both collapsing
+  into `"local"`. This is a defense-in-depth partition, not a hard tenant boundary — the
+  bearer token remains the sole authentication gate on both paths, unchanged by this key.
+  CLI/TUI/Telegram/ACP behavior is unchanged (still `DEFAULT_OWNER_KEY = "local"`).
 - **MCP image passthrough — config/CLI/TUI surface** (spec-072 P3, #6241): completes the
   opt-in MCP image passthrough feature (#6331) with the remaining integration points.
   - `--init`: the MCP remote-server wizard now asks "Enable image passthrough for this
@@ -177,6 +188,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   array — `Bootstrap::build_provider` now probes and caches this alongside its existing
   context-window auto-detection. Fails safe to `false` (no vision) if the model info fetch fails
   or the server predates the `capabilities` field, matching the trait's documented default.
+- `zeph-orchestration`: a Command-style dynamic task handoff outcome (`TaskOutcome::Handoff`,
+  spec-080) never emitted `SchedulerAction::Verify` or `SchedulerAction::CheckToolOutcome`,
+  so a handoff node's "I'm done, go to X" claim skipped both the completeness-check/replan
+  pass and the deterministic all-tool-calls-failed check (#6380/#6397) that an ordinary
+  `Completed` node gets (#6394). `TaskOutcome::Handoff` now carries `tool_trace` like
+  `Completed` does; `handle_handoff_outcome` branches to the existing failure path before
+  any Handoff side effect when the synchronously-known trace shows total tool-call failure,
+  and otherwise emits `CheckToolOutcome` unconditionally plus `Verify` when
+  `verify_completeness` is enabled — reusing the same post-hoc correction chain the spawn
+  dispatch path already uses for `Completed`, with no new double-counting risk.
+- `zeph-core`/`zeph-tui`: `TaskNode.handoff_rejected` (spec-080) — set when a Command
+  handoff's `goto` target is rejected at consume time — was persisted and logged but had no
+  CLI or TUI display surface (#6390). `/plan status` now lists any rejected handoffs by task
+  id/title/reason, and the TUI plan view's task row shows a `[handoff rejected: ...]` title
+  suffix, mirroring the existing failed-task error suffix.
 - `zeph-core`: the sanitizer's ML-backed injection and PII classifier calls
   (`ContentSanitizer::classify_injection`/`detect_pii`) were never recorded in the TUI
   metrics panel (#6382). The shared `Arc<ClassifierMetrics>` ring buffer they record into was

--- a/crates/zeph-acp/src/agent/mod.rs
+++ b/crates/zeph-acp/src/agent/mod.rs
@@ -1616,6 +1616,7 @@ impl ZephAcpAgentState {
                 attachments,
                 is_guest_context: false,
                 is_from_bot: false,
+                owner_key: None,
             })
             .await
             .map_err(|_| acp::Error::internal_error().data("agent channel closed"))?;
@@ -2570,6 +2571,7 @@ impl ZephAcpAgentState {
                         attachments: vec![],
                         is_guest_context: false,
                         is_from_bot: false,
+                        owner_key: None,
                     });
                 }
                 "Session history cleared.".to_owned()
@@ -2634,6 +2636,7 @@ impl ZephAcpAgentState {
                 attachments: vec![],
                 is_guest_context: false,
                 is_from_bot: false,
+                owner_key: None,
             })
             .is_err()
         {

--- a/crates/zeph-bench/src/channel.rs
+++ b/crates/zeph-bench/src/channel.rs
@@ -297,6 +297,7 @@ impl zeph_core::channel::Channel for BenchmarkChannel {
                     attachments: vec![],
                     is_guest_context: false,
                     is_from_bot: false,
+                    owner_key: None,
                 }))
             }
             None => Ok(None),

--- a/crates/zeph-channels/src/cli.rs
+++ b/crates/zeph-channels/src/cli.rs
@@ -209,6 +209,7 @@ async fn process_line(
         attachments,
         is_guest_context: false,
         is_from_bot: false,
+        owner_key: None,
     }))
 }
 
@@ -1002,6 +1003,7 @@ mod tests {
             attachments: vec![],
             is_guest_context: false,
             is_from_bot: false,
+            owner_key: None,
         })
         .await
         .unwrap();

--- a/crates/zeph-channels/src/discord/mod.rs
+++ b/crates/zeph-channels/src/discord/mod.rs
@@ -251,6 +251,7 @@ impl Channel for DiscordChannel {
                 attachments: vec![],
                 is_guest_context: false,
                 is_from_bot: false,
+                owner_key: None,
             });
         }
     }
@@ -282,6 +283,7 @@ impl Channel for DiscordChannel {
                 attachments: vec![],
                 is_guest_context: false,
                 is_from_bot: false,
+                owner_key: None,
             }));
         }
     }

--- a/crates/zeph-channels/src/json_cli.rs
+++ b/crates/zeph-channels/src/json_cli.rs
@@ -108,6 +108,7 @@ impl Channel for JsonCliChannel {
                         attachments: Vec::new(),
                         is_guest_context: false,
                         is_from_bot: false,
+                        owner_key: None,
                     }));
                 }
                 Some(None) | None => return Ok(None), // EOF
@@ -138,6 +139,7 @@ impl Channel for JsonCliChannel {
                             attachments: Vec::new(),
                             is_guest_context: false,
                             is_from_bot: false,
+                            owner_key: None,
                         })
                     }
                 }

--- a/crates/zeph-channels/src/slack/mod.rs
+++ b/crates/zeph-channels/src/slack/mod.rs
@@ -254,6 +254,7 @@ impl Channel for SlackChannel {
             attachments: vec![],
             is_guest_context: false,
             is_from_bot: false,
+            owner_key: None,
         })
     }
 
@@ -291,6 +292,7 @@ impl Channel for SlackChannel {
             attachments,
             is_guest_context: false,
             is_from_bot: false,
+            owner_key: None,
         }))
     }
 

--- a/crates/zeph-channels/src/telegram.rs
+++ b/crates/zeph-channels/src/telegram.rs
@@ -1101,6 +1101,7 @@ impl Channel for TelegramChannel {
                 attachments: incoming.attachments,
                 is_guest_context: is_guest,
                 is_from_bot: incoming.is_from_bot,
+                owner_key: None,
             }
         })
     }
@@ -1150,6 +1151,7 @@ impl Channel for TelegramChannel {
                             attachments: vec![],
                             is_guest_context: false,
                             is_from_bot: false,
+                            owner_key: None,
                         }));
                     }
                     "/skills" => {
@@ -1158,6 +1160,7 @@ impl Channel for TelegramChannel {
                             attachments: vec![],
                             is_guest_context: false,
                             is_from_bot: false,
+                            owner_key: None,
                         }));
                     }
                     _ => {}
@@ -1169,6 +1172,7 @@ impl Channel for TelegramChannel {
                 attachments: incoming.attachments,
                 is_guest_context: is_guest,
                 is_from_bot: incoming.is_from_bot,
+                owner_key: None,
             }));
         }
     }

--- a/crates/zeph-core/src/agent/agent_access_impl.rs
+++ b/crates/zeph-core/src/agent/agent_access_impl.rs
@@ -861,7 +861,7 @@ impl<C: Channel + Send + 'static> AgentAccess for Agent<C> {
                     return Ok("Memory not configured.".to_owned());
                 };
 
-                let owner_key = super::state::persistence::DEFAULT_OWNER_KEY;
+                let owner_key = self.services.session.owner_key.as_str();
                 let mut parts = args.split_whitespace();
                 let Some(sub) = parts.next() else {
                     return Ok(USAGE.to_owned());

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -436,6 +436,7 @@ impl<C: Channel> Agent<C> {
                         attachments: queued.raw_attachments,
                         is_guest_context: false,
                         is_from_bot: false,
+                        owner_key: None,
                     };
                     self.resolve_message(msg).await
                 }
@@ -475,6 +476,7 @@ impl<C: Channel> Agent<C> {
                             attachments: Vec::new(),
                             is_guest_context: false,
                             is_from_bot: false,
+                            owner_key: None,
                         };
                         self.drain_channel();
                         self.resolve_message(msg).await
@@ -489,6 +491,7 @@ impl<C: Channel> Agent<C> {
                             attachments: Vec::new(),
                             is_guest_context: false,
                             is_from_bot: false,
+                            owner_key: None,
                         };
                         self.drain_channel();
                         self.resolve_message(msg).await
@@ -509,6 +512,10 @@ impl<C: Channel> Agent<C> {
                     }
                     Some(LoopEvent::Message(msg)) => {
                         self.services.session.is_guest_context = msg.is_guest_context;
+                        self.services.session.owner_key = msg
+                            .owner_key
+                            .clone()
+                            .unwrap_or_else(|| state::persistence::DEFAULT_OWNER_KEY.to_owned());
                         self.drain_channel();
                         self.resolve_message(msg).await
                     }
@@ -1092,6 +1099,12 @@ impl<C: Channel> Agent<C> {
         self.services.session.current_turn_intent = None;
         // Clear guest context flag: each turn is independently classified.
         self.services.session.is_guest_context = false;
+        // Reset the cross-thread store owner key (#6389) at turn end, same as
+        // is_guest_context above. Like is_guest_context, this reset can be skipped on a
+        // fast-path dispatch (e.g. a slash command) that exits before reaching end_turn,
+        // leaving a stale value for whatever runs next — a pre-existing gap shared with
+        // is_guest_context, not new to this field.
+        state::persistence::DEFAULT_OWNER_KEY.clone_into(&mut self.services.session.owner_key);
         // Cancel all in-flight speculative handles at turn boundary.
         if let Some(ref engine) = self.services.speculation_engine {
             let metrics = engine.end_turn();

--- a/crates/zeph-core/src/agent/plan.rs
+++ b/crates/zeph-core/src/agent/plan.rs
@@ -26,6 +26,50 @@ pub(super) fn format_plan_summary(graph: &zeph_orchestration::TaskGraph) -> Stri
     out
 }
 
+/// Render the `/plan status` message for an active graph: a status-specific summary line,
+/// plus (issue #6390) any Command-handoff `goto` rejections recorded on
+/// `TaskNode::handoff_rejected` (spec-080) — previously persisted and logged but not
+/// surfaced on any CLI/TUI display, leaving an operator to log-dive or query graph state
+/// manually to notice a dropped routing intent. The task itself stays `Completed` with its
+/// real output preserved; this section only surfaces that the *extra* routing never fired.
+pub(super) fn format_plan_status(graph: &zeph_orchestration::TaskGraph) -> String {
+    use zeph_orchestration::GraphStatus;
+
+    let base = match graph.status {
+        GraphStatus::Created => {
+            "A plan is awaiting confirmation. Type `/plan confirm` to execute or `/plan cancel` to abort."
+        }
+        GraphStatus::Running => "Plan is currently running.",
+        GraphStatus::Paused => {
+            "Plan is paused. Use `/plan resume` to continue or `/plan cancel` to abort."
+        }
+        GraphStatus::Failed => {
+            "Plan failed. Use `/plan retry` to retry or `/plan cancel` to discard."
+        }
+        GraphStatus::Completed => "Plan completed successfully.",
+        GraphStatus::Canceled => "Plan was canceled.",
+        _ => "Plan is in an unknown state.",
+    };
+
+    let rejected: Vec<String> = graph
+        .tasks
+        .iter()
+        .filter_map(|t| {
+            t.handoff_rejected
+                .as_deref()
+                .map(|reason| format!("  - Task {} \"{}\": {reason}", t.id, t.title))
+        })
+        .collect();
+    if rejected.is_empty() {
+        base.to_owned()
+    } else {
+        format!(
+            "{base}\n\nRejected Command handoff(s):\n{}",
+            rejected.join("\n")
+        )
+    }
+}
+
 pub(super) fn collect_and_truncate_task_outputs(
     graph: &zeph_orchestration::TaskGraph,
     max_tokens: u32,
@@ -1216,26 +1260,10 @@ impl<C: crate::channel::Channel> Agent<C> {
     }
 
     pub(super) fn handle_plan_status_as_string(&mut self, _graph_id: Option<&str>) -> String {
-        use zeph_orchestration::GraphStatus;
         let Some(ref graph) = self.services.orchestration.pending_graph else {
             return "No active plan.".to_owned();
         };
-        match graph.status {
-            GraphStatus::Created => {
-                "A plan is awaiting confirmation. Type `/plan confirm` to execute or `/plan cancel` to abort."
-            }
-            GraphStatus::Running => "Plan is currently running.",
-            GraphStatus::Paused => {
-                "Plan is paused. Use `/plan resume` to continue or `/plan cancel` to abort."
-            }
-            GraphStatus::Failed => {
-                "Plan failed. Use `/plan retry` to retry or `/plan cancel` to discard."
-            }
-            GraphStatus::Completed => "Plan completed successfully.",
-            GraphStatus::Canceled => "Plan was canceled.",
-            _ => "Plan is in an unknown state.",
-        }
-        .to_owned()
+        format_plan_status(graph)
     }
 
     pub(super) fn handle_plan_list_as_string(&mut self) -> String {
@@ -1550,6 +1578,47 @@ mod tests {
             orchestration: false,
             ..zeph_config::DurableConfig::default()
         }
+    }
+
+    // #6390: format_plan_status surfaces TaskNode::handoff_rejected (spec-080) — this was
+    // persisted and logged but had no CLI/TUI display surface before this fix.
+    #[test]
+    fn format_plan_status_no_rejections_is_base_message_only() {
+        use zeph_orchestration::TaskGraph;
+        let graph = TaskGraph::new("goal");
+        let msg = format_plan_status(&graph);
+        assert!(!msg.contains("Rejected Command handoff"));
+    }
+
+    #[test]
+    fn format_plan_status_includes_rejected_handoff_with_task_id_and_title() {
+        use zeph_orchestration::{TaskGraph, TaskNode};
+        let mut graph = TaskGraph::new("goal");
+        let mut task = TaskNode::new(0, "Router", "d");
+        task.handoff_rejected = Some("goto target already completed".to_string());
+        graph.tasks.push(task);
+
+        let msg = format_plan_status(&graph);
+        assert!(msg.contains("Rejected Command handoff(s):"));
+        assert!(msg.contains("Task 0"));
+        assert!(msg.contains("Router"));
+        assert!(msg.contains("goto target already completed"));
+    }
+
+    #[test]
+    fn format_plan_status_lists_multiple_rejected_handoffs() {
+        use zeph_orchestration::{TaskGraph, TaskNode};
+        let mut graph = TaskGraph::new("goal");
+        let mut t0 = TaskNode::new(0, "A", "d");
+        t0.handoff_rejected = Some("reason A".to_string());
+        let mut t1 = TaskNode::new(1, "B", "d");
+        t1.handoff_rejected = Some("reason B".to_string());
+        graph.tasks.push(t0);
+        graph.tasks.push(t1);
+
+        let msg = format_plan_status(&graph);
+        assert!(msg.contains("reason A"));
+        assert!(msg.contains("reason B"));
     }
 
     // FR-DE-13 AC: when durable is absent, disabled, or orchestration=false → no-op.

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -11,7 +11,6 @@ use zeph_llm::provider::LlmProvider;
 use super::Agent;
 use super::error;
 use super::shutdown_signal;
-use super::state::persistence::DEFAULT_OWNER_KEY;
 use super::tool_execution;
 
 /// Upper bound on a single cross-thread-store I/O call from the Command-handoff seam
@@ -152,16 +151,21 @@ pub(super) struct CommandHandoffContext {
     pub(super) store_config: zeph_config::CrossThreadStoreConfig,
     pub(super) memory: Option<Arc<zeph_memory::semantic::SemanticMemory>>,
     pub(super) sanitizer: zeph_sanitizer::ContentSanitizer,
+    /// Cross-thread store owner key for the dispatching turn (spec-080 §10 OQ-1, GitHub
+    /// #6389) — `DEFAULT_OWNER_KEY` for CLI/TUI/Telegram, a gateway/A2A-derived key when
+    /// the graph run was triggered from one of those dispatch paths.
+    pub(super) owner_key: String,
 }
 
 /// Determine whether a completed task's raw `output` is an ordinary completion or a
 /// Command-style dynamic handoff (spec-080 §5.2): parse, sanitizer-scan, and persist the
 /// `update` payload into the cross-thread store, all inline.
 ///
-/// `tool_trace` is threaded through unchanged into `TaskOutcome::Completed` when no handoff
-/// is attempted — `None` on the spawn path (the real trace is resolved later, at the
-/// `SchedulerAction::Verify` handler, from the sub-agent transcript), `Some(trace)` on the
-/// `RunInline` path (already collected in-loop).
+/// `tool_trace` is threaded through unchanged into whichever terminal outcome this function
+/// returns — `TaskOutcome::Completed` when no handoff is attempted, or `TaskOutcome::Handoff`
+/// on a successful Command parse (issue #6394) — `None` on the spawn path (the real trace is
+/// resolved later, at the `SchedulerAction::CheckToolOutcome`/`Verify` handlers, from the
+/// sub-agent transcript), `Some(trace)` on the `RunInline` path (already collected in-loop).
 ///
 /// A malformed, sanitizer-rejected, or unpersistable handoff attempt produces a loud
 /// `TaskOutcome::Failed` — never a silent fallback to `Completed` (FR-B-009, spec-080 §6
@@ -260,6 +264,7 @@ pub(super) async fn determine_task_outcome(
     TaskOutcome::Handoff {
         output,
         goto: command.goto,
+        tool_trace,
     }
 }
 
@@ -332,7 +337,7 @@ async fn persist_handoff_update(
 ) -> Result<(), String> {
     for (key, value) in update {
         let write = memory.sqlite().store_put(
-            DEFAULT_OWNER_KEY,
+            ctx.owner_key.as_str(),
             namespace,
             key,
             value,
@@ -396,7 +401,7 @@ pub(super) async fn append_shared_state_block(
     let namespace_prefix = format!("orch/{graph_id}");
     let read = memory
         .sqlite()
-        .store_list(DEFAULT_OWNER_KEY, &namespace_prefix, 0);
+        .store_list(ctx.owner_key.as_str(), &namespace_prefix, 0);
     let items = match tokio::time::timeout(STORE_IO_TIMEOUT, read).await {
         Ok(Ok(items)) => items,
         Ok(Err(e)) => {
@@ -450,6 +455,7 @@ impl<C: crate::channel::Channel> Agent<C> {
             store_config: self.services.memory.persistence.store_config.clone(),
             memory: self.services.memory.persistence.memory.clone(),
             sanitizer: self.services.security.sanitizer.clone(),
+            owner_key: self.services.session.owner_key.clone(),
         }
     }
 
@@ -1741,6 +1747,7 @@ mod tests {
             },
             memory: Some(std::sync::Arc::new(test_memory().await)),
             sanitizer: test_sanitizer(),
+            owner_key: crate::agent::state::persistence::DEFAULT_OWNER_KEY.to_owned(),
         }
     }
 

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -916,6 +916,18 @@ pub(crate) struct SessionState {
     /// When `true`, the agent prompt includes a brief guest-context annotation, and the response
     /// is delivered via `answerGuestQuery` instead of `sendMessage`.
     pub(crate) is_guest_context: bool,
+    /// Cross-thread store owner key for the current turn (spec-080 §10 OQ-1, GitHub #6389).
+    ///
+    /// Set from `ChannelMessage::owner_key` when a `LoopEvent::Message` is dispatched
+    /// (falls back to [`persistence::DEFAULT_OWNER_KEY`] when the originating channel
+    /// leaves it unset — CLI/TUI/Telegram) and reset to the default at [`Agent::end_turn`],
+    /// same as `is_guest_context` above — including that reset's same pre-existing gap: a
+    /// fast-path dispatch that exits before reaching `end_turn` can leave a stale value for
+    /// whatever runs next. Read by `/store` (`agent_access_impl.rs`) and the Command-handoff
+    /// store writes/reads (`scheduler_loop.rs`).
+    ///
+    /// [`Agent::end_turn`]: crate::agent::Agent::end_turn
+    pub(crate) owner_key: String,
     /// Active durable execution context for the P1 agent-loop adapter (spec-064 §P1, #5452).
     ///
     /// `Some` when `[durable] enabled = true` and `agent_turns = true`. The context is opened
@@ -1363,6 +1375,7 @@ impl SessionState {
             policy_config: None,
             hooks_config: HooksConfigSnapshot::default(),
             is_guest_context: false,
+            owner_key: persistence::DEFAULT_OWNER_KEY.to_owned(),
             durable_ctx: None,
             durable_subagent: false,
             durable_turn_replayed: false,

--- a/crates/zeph-core/src/agent/state/tests.rs
+++ b/crates/zeph-core/src/agent/state/tests.rs
@@ -71,6 +71,7 @@ fn make_session_state() -> SessionState {
         hooks_config: HooksConfigSnapshot::default(),
         last_assistant_at: None,
         is_guest_context: false,
+        owner_key: super::persistence::DEFAULT_OWNER_KEY.to_owned(),
         caveman_active: false,
         durable_ctx: None,
         durable_subagent: false,

--- a/crates/zeph-core/src/agent/tests/agent_tests/common.rs
+++ b/crates/zeph-core/src/agent/tests/agent_tests/common.rs
@@ -179,6 +179,7 @@ impl Channel for MockChannel {
                 attachments: vec![],
                 is_guest_context: false,
                 is_from_bot: false,
+                owner_key: None,
             }))
         }
     }
@@ -193,6 +194,7 @@ impl Channel for MockChannel {
                 attachments: vec![],
                 is_guest_context: false,
                 is_from_bot: false,
+                owner_key: None,
             })
         }
     }

--- a/crates/zeph-core/src/agent/tests/agent_tests/image_attachment_tests.rs
+++ b/crates/zeph-core/src/agent/tests/agent_tests/image_attachment_tests.rs
@@ -43,6 +43,7 @@ async fn resolve_message_extracts_image_attachment() {
         }],
         is_guest_context: false,
         is_from_bot: false,
+        owner_key: None,
     };
     let (text, parts) = agent.resolve_message(msg).await;
     assert_eq!(text, "look at this");
@@ -73,6 +74,7 @@ async fn resolve_message_drops_oversized_image() {
         }],
         is_guest_context: false,
         is_from_bot: false,
+        owner_key: None,
     };
     let (text, parts) = agent.resolve_message(msg).await;
     assert_eq!(text, "big image");

--- a/crates/zeph-core/src/agent/tests/agent_tests/metrics_summary_tests.rs
+++ b/crates/zeph-core/src/agent/tests/agent_tests/metrics_summary_tests.rs
@@ -575,6 +575,7 @@ mod resolve_message_tests {
             attachments: vec![],
             is_guest_context: false,
             is_from_bot: false,
+            owner_key: None,
         };
         assert_eq!(agent.resolve_message(msg).await.0, "hello");
     }
@@ -587,6 +588,7 @@ mod resolve_message_tests {
             attachments: vec![audio_attachment(b"audio-data")],
             is_guest_context: false,
             is_from_bot: false,
+            owner_key: None,
         };
         assert_eq!(agent.resolve_message(msg).await.0, "hello");
     }
@@ -599,6 +601,7 @@ mod resolve_message_tests {
             attachments: vec![audio_attachment(b"audio-data")],
             is_guest_context: false,
             is_from_bot: false,
+            owner_key: None,
         };
         let (result, _) = agent.resolve_message(msg).await;
         assert!(result.contains("[transcribed audio]"));
@@ -614,6 +617,7 @@ mod resolve_message_tests {
             attachments: vec![audio_attachment(b"audio-data")],
             is_guest_context: false,
             is_from_bot: false,
+            owner_key: None,
         };
         let (result, _) = agent.resolve_message(msg).await;
         assert_eq!(result, "transcribed text");
@@ -627,6 +631,7 @@ mod resolve_message_tests {
             attachments: vec![audio_attachment(b"audio-data")],
             is_guest_context: false,
             is_from_bot: false,
+            owner_key: None,
         };
         assert_eq!(agent.resolve_message(msg).await.0, "original");
     }
@@ -643,6 +648,7 @@ mod resolve_message_tests {
             ],
             is_guest_context: false,
             is_from_bot: false,
+            owner_key: None,
         };
         let (result, _) = agent.resolve_message(msg).await;
         assert_eq!(result, "chunk\nchunk\nchunk");
@@ -661,6 +667,7 @@ mod resolve_message_tests {
             }],
             is_guest_context: false,
             is_from_bot: false,
+            owner_key: None,
         };
         assert_eq!(agent.resolve_message(msg).await.0, "original");
     }

--- a/crates/zeph-core/src/channel.rs
+++ b/crates/zeph-core/src/channel.rs
@@ -203,6 +203,13 @@ pub struct ChannelMessage {
     pub is_guest_context: bool,
     /// `true` when the sender is a Telegram bot (`from.is_bot = true`).
     pub is_from_bot: bool,
+    /// Cross-thread store owner key (spec-080 §10 OQ-1, GitHub #6389) derived by the
+    /// originating dispatch path from its own caller identity — the gateway webhook
+    /// forwarder derives it from `WebhookPayload.sender`, the A2A task processor from
+    /// `Message.context_id`. `None` for CLI/TUI/Telegram, which intentionally collapse to
+    /// the default local owner bucket (single-user deployment model, unchanged by this
+    /// field).
+    pub owner_key: Option<String>,
 }
 
 /// Upper bound on [`Channel::send_status_best_effort`]. Status sends are a UX nicety, not a
@@ -839,6 +846,7 @@ mod tests {
             attachments: vec![],
             is_guest_context: false,
             is_from_bot: false,
+            owner_key: None,
         };
         assert_eq!(msg.text, "hello");
         assert!(msg.attachments.is_empty());
@@ -1037,6 +1045,7 @@ mod tests {
             attachments: vec![],
             is_guest_context: false,
             is_from_bot: false,
+            owner_key: None,
         };
         let cloned = msg.clone();
         assert_eq!(cloned.text, "test");
@@ -1049,6 +1058,7 @@ mod tests {
             attachments: vec![],
             is_guest_context: false,
             is_from_bot: false,
+            owner_key: None,
         };
         let debug = format!("{msg:?}");
         assert!(debug.contains("debug"));
@@ -1083,6 +1093,7 @@ mod tests {
             }],
             is_guest_context: false,
             is_from_bot: false,
+            owner_key: None,
         };
         assert_eq!(msg.attachments.len(), 1);
         assert_eq!(msg.attachments[0].kind, AttachmentKind::Audio);
@@ -1140,6 +1151,7 @@ mod tests {
                 attachments: vec![],
                 is_guest_context: false,
                 is_from_bot: false,
+                owner_key: None,
             })
             .await
             .unwrap();

--- a/crates/zeph-core/src/metrics.rs
+++ b/crates/zeph-core/src/metrics.rs
@@ -72,6 +72,13 @@ pub struct TaskSnapshotRow {
     pub duration_ms: u64,
     /// Truncated error message (first 80 chars) when the task failed.
     pub error: Option<String>,
+    /// Truncated rejection reason (first 80 chars) when this task emitted a Command-style
+    /// handoff (spec-080) whose `goto` was rejected by `dag::try_handoff` — mirrors
+    /// `TaskNode::handoff_rejected` (issue #6390). The task itself stays `Completed`
+    /// (its own output is preserved); this field surfaces that the *extra* routing intent
+    /// was dropped, which previously had no display surface — only logs and the
+    /// persisted-but-unsurfaced graph field.
+    pub handoff_rejected: Option<String>,
 }
 
 /// Lightweight snapshot of a `TaskGraph` for TUI display.
@@ -713,6 +720,18 @@ fn strip_ctrl(s: &str) -> String {
     out
 }
 
+/// Strip control chars, then truncate at 80 chars with an ellipsis (SEC-P6-01) — shared by
+/// every free-text field surfaced from task-graph content (`error`, `handoff_rejected`).
+fn strip_and_truncate_80(s: &str) -> String {
+    let s = strip_ctrl(s);
+    if s.len() > 80 {
+        let end = s.floor_char_boundary(79);
+        format!("{}…", &s[..end])
+    } else {
+        s
+    }
+}
+
 /// Convert a live `TaskGraph` into a lightweight snapshot for TUI display.
 impl From<&zeph_orchestration::TaskGraph> for TaskGraphSnapshot {
     fn from(graph: &zeph_orchestration::TaskGraph) -> Self {
@@ -728,16 +747,10 @@ impl From<&zeph_orchestration::TaskGraph> for TaskGraphSnapshot {
                         if r.output.is_empty() {
                             None
                         } else {
-                            // Strip control chars, then truncate at 80 chars (SEC-P6-01).
-                            let s = strip_ctrl(&r.output);
-                            if s.len() > 80 {
-                                let end = s.floor_char_boundary(79);
-                                Some(format!("{}…", &s[..end]))
-                            } else {
-                                Some(s)
-                            }
+                            Some(strip_and_truncate_80(&r.output))
                         }
                     });
+                let handoff_rejected = t.handoff_rejected.as_deref().map(strip_and_truncate_80);
                 let duration_ms = t.result.as_ref().map_or(0, |r| r.duration_ms);
                 TaskSnapshotRow {
                     id: t.id.as_u32(),
@@ -746,6 +759,7 @@ impl From<&zeph_orchestration::TaskGraph> for TaskGraphSnapshot {
                     agent: t.assigned_agent.as_deref().map(strip_ctrl),
                     duration_ms,
                     error,
+                    handoff_rejected,
                 }
             })
             .collect();
@@ -1254,6 +1268,34 @@ mod tests {
             !snap.tasks[0].title.contains('\x00'),
             "title must not contain null byte"
         );
+    }
+
+    // #6390: handoff_rejected is mapped, stripped, and truncated the same way error is.
+    #[test]
+    fn task_graph_snapshot_maps_handoff_rejected() {
+        use zeph_orchestration::{TaskGraph, TaskNode, TaskStatus};
+
+        let mut graph = TaskGraph::new("goal");
+        let mut task = TaskNode::new(0, "Router", "d");
+        task.status = TaskStatus::Completed;
+        task.handoff_rejected = Some("goto target already completed\x00".to_string());
+        graph.tasks.push(task);
+
+        let snap = TaskGraphSnapshot::from(&graph);
+        let rejected = snap.tasks[0].handoff_rejected.as_ref().unwrap();
+        assert!(rejected.contains("goto target already completed"));
+        assert!(!rejected.contains('\x00'), "control chars must be stripped");
+    }
+
+    #[test]
+    fn task_graph_snapshot_handoff_rejected_none_by_default() {
+        use zeph_orchestration::{TaskGraph, TaskNode};
+
+        let mut graph = TaskGraph::new("goal");
+        graph.tasks.push(TaskNode::new(0, "Router", "d"));
+
+        let snap = TaskGraphSnapshot::from(&graph);
+        assert!(snap.tasks[0].handoff_rejected.is_none());
     }
 
     #[test]

--- a/crates/zeph-core/src/serve.rs
+++ b/crates/zeph-core/src/serve.rs
@@ -326,6 +326,7 @@ impl SessionActor {
                                     attachments: Vec::new(),
                                     is_guest_context: false,
                                     is_from_bot: false,
+                                    owner_key: None,
                                 };
                                 tracing::debug!("session actor: forwarding prompt to agent channel");
                                 let _ = tx.send(msg).await;

--- a/crates/zeph-core/src/testing.rs
+++ b/crates/zeph-core/src/testing.rs
@@ -83,6 +83,7 @@ impl Channel for MockChannel {
                 attachments: vec![],
                 is_guest_context: false,
                 is_from_bot: false,
+                owner_key: None,
             }))
         }
     }
@@ -97,6 +98,7 @@ impl Channel for MockChannel {
                 attachments: vec![],
                 is_guest_context: false,
                 is_from_bot: false,
+                owner_key: None,
             })
         }
     }

--- a/crates/zeph-core/tests/turn_lifecycle.rs
+++ b/crates/zeph-core/tests/turn_lifecycle.rs
@@ -55,6 +55,7 @@ impl Channel for TestChannel {
                 attachments: vec![],
                 is_guest_context: false,
                 is_from_bot: false,
+                owner_key: None,
             }))
         }
     }
@@ -68,6 +69,7 @@ impl Channel for TestChannel {
                 attachments: vec![],
                 is_guest_context: false,
                 is_from_bot: false,
+                owner_key: None,
             })
         }
     }

--- a/crates/zeph-orchestration/src/dag.rs
+++ b/crates/zeph-orchestration/src/dag.rs
@@ -695,6 +695,62 @@ fn skip_subtree(graph: &mut TaskGraph, seed: TaskId, rev_adj: &[Vec<TaskId>]) ->
     to_cancel
 }
 
+/// Cancel any `commanded_from`-linked Command-handoff target of `source` that has not yet
+/// started (`Pending`/`Ready`), for use when `source` is corrected `Completed -> Failed`
+/// post-hoc (issue #6394, code-review Finding 1, 2026-07-17).
+///
+/// [`try_handoff`] links its activated target via `commanded_from`, never `depends_on` —
+/// that is the whole point of runtime-chosen routing, distinct from the plan's static
+/// edges. [`propagate_failure`]/[`propagate_failure_forced_terminal`] walk `rev_adj`, which
+/// is built strictly from `depends_on`, so neither can ever reach a `commanded_from` target.
+/// Without this function, a target already activated by a since-corrected spawn-path source
+/// (see `DagScheduler::propagate_corrected_task_failure`, whose post-hoc correction can only
+/// run *after* `try_handoff` already activated the target — the `RunInline` path branches
+/// out before activation ever happens, so this gap is spawn-path-only) would run against
+/// state its source never legitimately produced, defeating #6394's "routing intent is
+/// abandoned along with the rest of the outcome" goal for exactly the failure class
+/// #6395/#6397 exist to catch.
+///
+/// Deliberately scoped to `Pending`/`Ready` targets only — cancelling a target already
+/// `Running` (or terminal) is the pre-existing, accepted "already-unblocked work is not
+/// unwound" limitation `propagate_corrected_task_failure`'s doc comment describes for
+/// ordinary `depends_on` dependents; a live sub-agent run is a materially different (and
+/// separately risky) thing to interrupt than a `Pending`/`Ready` node that has not started
+/// any work yet, so it stays out of this fix's scope.
+///
+/// Also skips the target's own transitive `depends_on` subtree via [`skip_subtree`] — a
+/// `Pending` dependent of a now-`Skipped` target would otherwise strand forever waiting for
+/// a `Completed` that will never come, the same reasoning [`resolve_dormant_after_terminal`]
+/// already applies to an un-triggered `route_to` fallback. Returns the `Running` task IDs
+/// found in that subtree walk for the caller to cancel (the target itself is never
+/// `Running`, by the guard above).
+pub(crate) fn cancel_dangling_commanded_targets(
+    graph: &mut TaskGraph,
+    source: TaskId,
+    rev_adj: &[Vec<TaskId>],
+) -> Vec<TaskId> {
+    let targets: Vec<TaskId> = graph
+        .tasks
+        .iter()
+        .filter(|t| t.commanded_from == Some(source))
+        .filter(|t| matches!(t.status, TaskStatus::Pending | TaskStatus::Ready))
+        .map(|t| t.id)
+        .collect();
+
+    let mut to_cancel = Vec::new();
+    for target in targets {
+        tracing::warn!(
+            source = %source,
+            target = %target,
+            "orchestration.dag.cancel_dangling_commanded_targets: skipping Command-handoff \
+             target whose source was corrected Completed -> Failed post-hoc (#6394)"
+        );
+        graph.tasks[target.index()].status = TaskStatus::Skipped;
+        to_cancel.extend(skip_subtree(graph, target, rev_adj));
+    }
+    to_cancel
+}
+
 /// Resolve every still-[`TaskStatus::Dormant`] `route_to` fallback whose source has
 /// terminalized without rerouting.
 ///

--- a/crates/zeph-orchestration/src/scheduler/mod.rs
+++ b/crates/zeph-orchestration/src/scheduler/mod.rs
@@ -106,6 +106,10 @@ pub enum SchedulerAction {
     },
     /// Request verification of a completed task's output (emitted when `verify_completeness=true`).
     ///
+    /// Emitted for both `TaskOutcome::Completed` and — since issue #6394 —
+    /// `TaskOutcome::Handoff`, so a Command-handoff node's completeness claim is
+    /// replan-checked the same as an ordinary `Completed` node's.
+    ///
     /// The task remains `Completed` during verification. Downstream tasks are unblocked
     /// immediately — verification is best-effort and does not gate dispatch. The caller
     /// should run [`PlanVerifier::verify`], optionally [`PlanVerifier::replan`], and then
@@ -126,7 +130,10 @@ pub enum SchedulerAction {
     },
     /// Request a deterministic tool-outcome check for a just-completed task (issue #6380).
     ///
-    /// Emitted **unconditionally** from `tick()` for every `Completed` task — unlike
+    /// Emitted **unconditionally** from `tick()` for every `Completed` task, and — since
+    /// issue #6394 — for every `Handoff` task too, since a Command-handoff node's "I'm
+    /// done" claim is held to the same deterministic tool-outcome bar as an ordinary
+    /// `Completed` node. Unlike
     /// [`SchedulerAction::Verify`], this is not gated behind `verify_completeness`: the
     /// check is a cheap, deterministic scan over already-known or fetchable tool-call
     /// outcomes (no LLM call), so it is safe to always run. It exists because task
@@ -204,6 +211,11 @@ pub enum TaskOutcome {
         /// Routing target, already resolved from the parsed `HandoffCommand` and
         /// sanitizer-scanned by zeph-core.
         goto: super::command::TaskRef,
+        /// Real tool-call trace collected in-loop, `RunInline` dispatch path only. `None`
+        /// for the spawn dispatch path — resolved from the sub-agent transcript at
+        /// `SchedulerAction::CheckToolOutcome`/`SchedulerAction::Verify` handling time
+        /// instead, same resolution contract as `Completed::tool_trace` (issue #6394).
+        tool_trace: Option<Vec<crate::verifier::ToolCallSummary>>,
     },
 }
 

--- a/crates/zeph-orchestration/src/scheduler/tick/mod.rs
+++ b/crates/zeph-orchestration/src/scheduler/tick/mod.rs
@@ -23,6 +23,15 @@ struct CompletedTaskData {
     tool_trace: Option<Vec<crate::verifier::ToolCallSummary>>,
 }
 
+/// Bundles the fields carried by `TaskOutcome::Handoff` (issue #6394 added `tool_trace`,
+/// pushing the parameter count over clippy's `too_many_arguments` threshold) — mirrors
+/// `CompletedTaskData`'s role for `handle_completed_outcome`.
+struct HandoffTaskData {
+    output: String,
+    goto: TaskRef,
+    tool_trace: Option<Vec<crate::verifier::ToolCallSummary>>,
+}
+
 /// `true` when a call counts toward the "did this task do work that matters" judgment used
 /// by `all_tool_calls_failed` — i.e. it is *not* a call the heuristic should silently
 /// ignore even if it succeeded.
@@ -597,13 +606,20 @@ impl DagScheduler {
                 },
             ),
             TaskOutcome::Failed { error } => self.handle_failed_outcome(task_id, &error),
-            TaskOutcome::Handoff { output, goto } => self.handle_handoff_outcome(
+            TaskOutcome::Handoff {
+                output,
+                goto,
+                tool_trace,
+            } => self.handle_handoff_outcome(
                 task_id,
                 agent_handle_id,
                 agent_def_name,
                 duration_ms,
-                output,
-                &goto,
+                HandoffTaskData {
+                    output,
+                    goto,
+                    tool_trace,
+                },
             ),
         }
     }
@@ -862,30 +878,71 @@ impl DagScheduler {
     /// remains readable by any node that later reads `<shared-state>` in this graph, it
     /// is simply not the entry that was supposed to signal a completed handoff step.
     ///
-    /// # Known gap: no completeness verification (M2, review finding)
+    /// # Completeness verification parity with `Completed` (issue #6394)
     ///
-    /// Unlike [`Self::handle_completed_outcome`], this method never emits
-    /// `SchedulerAction::Verify` — a Command-handoff node's "I'm done" claim skips the
-    /// completeness-check/replan pass an ordinary `Completed` node gets. Identified during
-    /// code review as a real, non-blocking design gap (the feature is opt-in and
-    /// default-off) and deliberately deferred rather than expanding this PR's scope
-    /// further: fixing it needs `TaskOutcome::Handoff` to carry `tool_trace` first (it
-    /// doesn't today, unlike `Completed`), plus a decision on whether `Verify`'s
-    /// replan/`inject_tasks` side effects are sound for a node that already named its own
-    /// next hop. Tracked as GitHub #6394.
+    /// Like [`Self::handle_completed_outcome`], this method (a) branches out to
+    /// [`Self::handle_failed_outcome`] *before* any Completed/Handoff side effect runs
+    /// when the synchronously-known `RunInline` trace (`tool_trace: Some`) shows every
+    /// tool call failed or was policy-blocked (#6380/#6397) — a Command-handoff node's
+    /// "I'm done, go to X" claim is exactly as bogus as an ordinary node's in that case,
+    /// so the routing intent is abandoned along with the rest of the outcome, and (b)
+    /// unconditionally emits `SchedulerAction::CheckToolOutcome`, plus
+    /// `SchedulerAction::Verify` when `verify_completeness` is enabled, once the node has
+    /// been marked `Completed` and the handoff attempt (accepted or rejected) has run. The
+    /// spawn dispatch path (`tool_trace: None`) is corrected post-hoc through the same
+    /// `CheckToolOutcome` → [`Self::correct_completed_to_failed_if_all_tool_calls_failed`]
+    /// → [`Self::propagate_corrected_task_failure`] chain `Completed` already uses; no
+    /// Handoff-specific correction path was added; a status flip only ever touches
+    /// `TaskStatus`/`TaskResult::output` for this `task_id`, so it carries no risk of
+    /// double-recording this node in `cascade_detector` (see
+    /// `correct_completed_to_failed_if_all_tool_calls_failed`'s doc comment for the full
+    /// double-count analysis, which applies here unchanged).
+    ///
+    /// If a post-hoc correction later flips this node to `Failed`, a `goto` target
+    /// `try_handoff` below already activated is linked by `commanded_from`, not
+    /// `depends_on` (that is the whole point of runtime-chosen routing) — so it is *not*
+    /// reachable by `propagate_failure`/`propagate_failure_forced_terminal`'s ordinary
+    /// `depends_on`-walking cancellation. This is a wider gap than the accepted
+    /// "already-unblocked work is not unwound" limitation `propagate_corrected_task_failure`
+    /// documents for ordinary dependents, since it applies even to a target that has not
+    /// started at all (`Pending`/`Ready`), not just already-`Running`/terminal ones — a
+    /// cost-free cancellation was being skipped, not a genuinely-in-flight one (code
+    /// review Finding 1, 2026-07-17). `propagate_corrected_task_failure` therefore calls
+    /// `dag::cancel_dangling_commanded_targets` to close this specifically for
+    /// `Pending`/`Ready` targets; an already-`Running` or terminal target remains the
+    /// pre-existing, accepted limitation.
     fn handle_handoff_outcome(
         &mut self,
         task_id: TaskId,
         agent_handle_id: String,
         agent_def_name: Option<String>,
         duration_ms: u64,
-        output: String,
-        goto: &TaskRef,
+        handoff: HandoffTaskData,
     ) -> Vec<SchedulerAction> {
+        let HandoffTaskData {
+            output,
+            goto,
+            tool_trace,
+        } = handoff;
+
+        // #6394: mirrors handle_completed_outcome's early branch-out — runs before any
+        // Completed/Handoff side effect (cascade record_outcome, try_handoff activation),
+        // so there is no double-count risk here, same reasoning as the Completed path.
+        if let Some(trace) = tool_trace.as_ref()
+            && all_tool_calls_failed(trace)
+        {
+            let error = format!(
+                "all {} tool call(s) in this task failed or were policy-blocked; \
+                 narration: {output}",
+                trace.len()
+            );
+            return self.handle_failed_outcome(task_id, &error);
+        }
+
         self.graph_dirty = true;
         self.graph.tasks[task_id.index()].status = TaskStatus::Completed;
         self.graph.tasks[task_id.index()].result = Some(TaskResult {
-            output,
+            output: output.clone(),
             artifacts: Vec::new(),
             duration_ms,
             agent_id: Some(agent_handle_id),
@@ -898,7 +955,7 @@ impl DagScheduler {
             detector.record_outcome(task_id, true, &self.graph);
         }
 
-        match dag::try_handoff(&mut self.graph, task_id, goto, self.max_handoffs) {
+        match dag::try_handoff(&mut self.graph, task_id, &goto, self.max_handoffs) {
             Ok(target) => {
                 tracing::info!(
                     task_id = %task_id,
@@ -930,7 +987,22 @@ impl DagScheduler {
             }
         }
 
-        Vec::new()
+        // #6394: same completeness-check treatment as handle_completed_outcome — always
+        // request the deterministic tool-outcome check, and Verify when enabled, so a
+        // Command-handoff node's "I'm done" claim does not skip the checks an ordinary
+        // Completed node gets.
+        let mut actions = vec![SchedulerAction::CheckToolOutcome {
+            task_id,
+            tool_trace: tool_trace.clone(),
+        }];
+        if self.verify_completeness {
+            actions.push(SchedulerAction::Verify {
+                task_id,
+                output,
+                tool_trace,
+            });
+        }
+        actions
     }
 
     /// Propagate a just-applied
@@ -997,16 +1069,30 @@ impl DagScheduler {
     /// `record_outcome`; `try_recover` un-fails the task entirely), which is exactly what the
     /// special-cases prevent.
     ///
+    /// # Command-handoff targets (issue #6394, code review Finding 1, 2026-07-17)
+    ///
+    /// If `task_id` had already emitted a `Handoff` outcome whose `try_handoff` activated a
+    /// `goto` target before this correction landed, that target is linked via
+    /// `commanded_from`, not `depends_on` — invisible to `dag::propagate_failure`/
+    /// `propagate_failure_forced_terminal` above, which only walk `depends_on`-derived
+    /// `rev_adj`. This method closes that gap by additionally calling
+    /// `dag::cancel_dangling_commanded_targets`, which cancels the target (and its own
+    /// `depends_on` subtree) when it is still `Pending`/`Ready` — see that function's doc
+    /// comment for why an already-`Running`/terminal target stays out of scope (folded into
+    /// the "Remaining limitation" below rather than a separate hazard).
+    ///
     /// # Remaining limitation
     ///
-    /// Dependents that already reached a terminal status (most commonly `Completed`, having
-    /// already consumed this task's now-invalidated output) before this correction landed
-    /// are **not** retroactively unwound — neither propagation function's cancellation/skip
-    /// logic affects dependents already past `Pending`/`Ready`/`Running`. This mirrors the
+    /// Dependents (ordinary `depends_on` ones, and now `commanded_from` Command-handoff
+    /// targets too) that already reached `Running` or a terminal status (most commonly
+    /// `Completed`, having already consumed this task's now-invalidated output) before this
+    /// correction landed are **not** retroactively unwound — none of the cancellation/skip
+    /// logic above affects anything already past `Pending`/`Ready`. This mirrors the
     /// `RunInline` path's own limitation (a `Completed` dependent is never revisited there
-    /// either) and is intentionally out of scope here — fully unwinding already-finished
-    /// downstream work would require re-running or invalidating those tasks, a materially
-    /// larger change than restoring propagation parity.
+    /// either) and is intentionally out of scope here — fully unwinding already-finished or
+    /// already-running downstream work would require cancelling a live sub-agent or
+    /// re-running/invalidating those tasks, a materially larger and separately risky change
+    /// than restoring propagation parity for not-yet-started work.
     pub fn propagate_corrected_task_failure(&mut self, task_id: TaskId) -> Vec<SchedulerAction> {
         let task = &self.graph.tasks[task_id.index()];
         let effective_strategy = task
@@ -1029,11 +1115,22 @@ impl DagScheduler {
                 effective_strategy,
                 zeph_config::FailureStrategy::Retry | zeph_config::FailureStrategy::Ask
             ) || (effective_strategy == zeph_config::FailureStrategy::Abort && has_state_injection);
-        let cancel_ids = if needs_forced_terminal {
+        let mut cancel_ids = if needs_forced_terminal {
             dag::propagate_failure_forced_terminal(&mut self.graph, task_id)
         } else {
             dag::propagate_failure(&mut self.graph, task_id, &self.topology.rev_adj)
         };
+        // Finding 1 (code review, 2026-07-17): a Command-handoff target this task already
+        // activated via `try_handoff` before the correction landed is linked by
+        // `commanded_from`, not `depends_on` — neither `propagate_failure` call above can
+        // reach it. Cancel it here if it hasn't started yet (see
+        // `dag::cancel_dangling_commanded_targets`'s doc comment for the full rationale and
+        // why `Running`/terminal targets are deliberately out of scope).
+        cancel_ids.extend(dag::cancel_dangling_commanded_targets(
+            &mut self.graph,
+            task_id,
+            &self.topology.rev_adj,
+        ));
         let mut actions = Vec::new();
 
         for cancel_task_id in cancel_ids {

--- a/crates/zeph-orchestration/src/scheduler/tick/tests.rs
+++ b/crates/zeph-orchestration/src/scheduler/tick/tests.rs
@@ -145,6 +145,7 @@ fn test_handoff_event_marks_source_completed_and_activates_target() {
         outcome: TaskOutcome::Handoff {
             output: "handing off".to_string(),
             goto: TaskRef::ById(TaskId(1)),
+            tool_trace: None,
         },
     });
 
@@ -204,10 +205,11 @@ fn test_handoff_event_rejection_leaves_source_completed_not_failed() {
         outcome: TaskOutcome::Handoff {
             output: "handing off".to_string(),
             goto: TaskRef::ById(TaskId(1)),
+            tool_trace: None,
         },
     });
 
-    scheduler.tick();
+    let actions = scheduler.tick();
 
     assert_eq!(
         scheduler.graph.tasks[0].status,
@@ -222,6 +224,179 @@ fn test_handoff_event_rejection_leaves_source_completed_not_failed() {
         scheduler.graph.tasks[0].handoff_rejected.is_some(),
         "critic finding C1: a rejected handoff must be recorded as a graph-visible, \
          persisted signal, not just a log line"
+    );
+    // Tester Gap 2 (2026-07-17): the CheckToolOutcome/Verify action-emission block runs
+    // unconditionally after the try_handoff match (both Ok and Err arms fall through to
+    // the same trailing code, tick/mod.rs) -- prove that on the actual returned actions,
+    // not just by code inspection, so a rejected handoff still gets the same completeness
+    // treatment as an accepted one.
+    assert!(
+        actions.iter().any(|a| matches!(
+            a,
+            SchedulerAction::CheckToolOutcome { task_id, .. } if *task_id == TaskId(0)
+        )),
+        "CheckToolOutcome must still be emitted for a rejected handoff's own task_id: \
+         {actions:?}"
+    );
+}
+
+#[test]
+fn test_handoff_event_emits_check_tool_outcome_action() {
+    // #6394: a Handoff outcome must get the same deterministic tool-outcome check an
+    // ordinary Completed outcome gets — unconditionally, not gated on verify_completeness.
+    let graph = graph_from_nodes(vec![make_node(0, &[]), make_node(1, &[])]);
+    let mut scheduler = make_scheduler(graph);
+
+    scheduler.graph.tasks[0].status = TaskStatus::Running;
+    scheduler.running.insert(
+        TaskId(0),
+        RunningTask {
+            agent_handle_id: "handle-0".to_string(),
+            agent_def_name: "worker".to_string(),
+            started_at: std::time::Instant::now(),
+            admission_permit: None,
+            last_progress_at: None,
+        },
+    );
+
+    scheduler.buffered_events.push_back(TaskEvent {
+        task_id: TaskId(0),
+        agent_handle_id: "handle-0".to_string(),
+        outcome: TaskOutcome::Handoff {
+            output: "handing off".to_string(),
+            goto: TaskRef::ById(TaskId(1)),
+            tool_trace: None,
+        },
+    });
+
+    let actions = scheduler.tick();
+
+    let has_check = actions.iter().any(|a| {
+        matches!(
+            a,
+            SchedulerAction::CheckToolOutcome { task_id, .. } if *task_id == TaskId(0)
+        )
+    });
+    assert!(
+        has_check,
+        "a Handoff outcome must emit CheckToolOutcome for its own task_id (#6394)"
+    );
+    // Tester Gap 1 (2026-07-17): `make_scheduler`/`make_config` default
+    // `verify_completeness` to `false` — prove the flag actually suppresses `Verify` for
+    // the Handoff outcome too, not just that the enabled case (separately tested below)
+    // emits it.
+    assert!(
+        !actions
+            .iter()
+            .any(|a| matches!(a, SchedulerAction::Verify { .. })),
+        "Verify must NOT be emitted when verify_completeness is disabled (#6394): {actions:?}"
+    );
+}
+
+#[test]
+fn test_handoff_event_emits_verify_action_when_verify_completeness_enabled() {
+    // #6394: with verify_completeness enabled, a Handoff outcome must also emit Verify,
+    // mirroring handle_completed_outcome, carrying the handoff node's own output.
+    let graph = graph_from_nodes(vec![make_node(0, &[]), make_node(1, &[])]);
+    let mut config = make_config();
+    config.verify_completeness = true;
+    let defs = vec![make_def("worker")];
+    let mut scheduler =
+        DagScheduler::new(graph, &config, Box::new(FirstRouter), defs, None).unwrap();
+
+    scheduler.graph.tasks[0].status = TaskStatus::Running;
+    scheduler.running.insert(
+        TaskId(0),
+        RunningTask {
+            agent_handle_id: "handle-0".to_string(),
+            agent_def_name: "worker".to_string(),
+            started_at: std::time::Instant::now(),
+            admission_permit: None,
+            last_progress_at: None,
+        },
+    );
+
+    scheduler.buffered_events.push_back(TaskEvent {
+        task_id: TaskId(0),
+        agent_handle_id: "handle-0".to_string(),
+        outcome: TaskOutcome::Handoff {
+            output: "handing off".to_string(),
+            goto: TaskRef::ById(TaskId(1)),
+            tool_trace: None,
+        },
+    });
+
+    let actions = scheduler.tick();
+
+    let verify_output = actions.iter().find_map(|a| match a {
+        SchedulerAction::Verify {
+            task_id, output, ..
+        } if *task_id == TaskId(0) => Some(output.clone()),
+        _ => None,
+    });
+    assert_eq!(
+        verify_output.as_deref(),
+        Some("handing off"),
+        "Verify must be emitted for the handoff node and carry its own output (#6394)"
+    );
+}
+
+#[test]
+fn test_handoff_event_all_tools_failed_marks_task_failed_not_handoff() {
+    // #6394/#6380/#6397 parity: a Command-handoff node whose synchronously-known
+    // (RunInline) tool trace shows every call failed or was policy-blocked must not be
+    // allowed to route anywhere — the "I'm done, go to X" claim is bogus, so it is routed
+    // to handle_failed_outcome before any Handoff side effect (cascade record,
+    // try_handoff activation) runs, mirroring handle_completed_outcome's early branch.
+    let graph = graph_from_nodes(vec![make_node(0, &[]), make_node(1, &[])]);
+    let mut scheduler = make_scheduler(graph);
+
+    scheduler.graph.tasks[0].status = TaskStatus::Running;
+    scheduler.running.insert(
+        TaskId(0),
+        RunningTask {
+            agent_handle_id: "handle-0".to_string(),
+            agent_def_name: "worker".to_string(),
+            started_at: std::time::Instant::now(),
+            admission_permit: None,
+            last_progress_at: None,
+        },
+    );
+
+    scheduler.buffered_events.push_back(TaskEvent {
+        task_id: TaskId(0),
+        agent_handle_id: "handle-0".to_string(),
+        outcome: TaskOutcome::Handoff {
+            output: "claiming completion".to_string(),
+            goto: TaskRef::ById(TaskId(1)),
+            tool_trace: Some(vec![ToolCallSummary {
+                tool: "write".to_string(),
+                args_summary: None,
+                ok: false,
+                is_read_only: false,
+            }]),
+        },
+    });
+
+    scheduler.tick();
+
+    assert_eq!(
+        scheduler.graph.tasks[0].status,
+        TaskStatus::Failed,
+        "a Handoff outcome with an all-failed tool trace must be Failed, not Completed"
+    );
+    assert!(
+        scheduler.graph.tasks[1].commanded_from.is_none(),
+        "try_handoff must never run when the handoff node itself is corrected to Failed"
+    );
+    assert_eq!(
+        scheduler.graph.handoff_count, 0,
+        "no handoff budget must be consumed when the outcome is corrected to Failed"
+    );
+    assert!(
+        scheduler.graph.tasks[0].handoff_rejected.is_none(),
+        "handoff_rejected is a try_handoff-rejection signal, not used for the \
+         all-tool-calls-failed short-circuit"
     );
 }
 
@@ -2992,6 +3167,110 @@ fn propagate_corrected_task_failure_cancels_running_dependent_and_fails_graph() 
     assert!(
         !scheduler.running.contains_key(&TaskId(1)),
         "the canceled dependent must be removed from the running map"
+    );
+}
+
+#[test]
+fn propagate_corrected_task_failure_cancels_pending_commanded_from_target() {
+    // Finding 1 (code review, 2026-07-17): a Command-handoff target `try_handoff` already
+    // activated (linked via `commanded_from`, not `depends_on` -- the whole point of
+    // runtime-chosen routing) before a spawn-path source is corrected Completed -> Failed
+    // must be cancelled too, or it runs against state its source never legitimately
+    // produced. Three-task graph: 0 is the corrected source, 1 is its handoff target (no
+    // depends_on edge back to 0), 2 depends on 1 -- proves both the direct target and its
+    // own transitive depends_on subtree get skipped (mirrors
+    // `resolve_dormant_after_terminal`'s reasoning for an un-triggered route_to fallback).
+    let graph = graph_from_nodes(vec![
+        make_node(0, &[]),
+        make_node(1, &[]),
+        make_node(2, &[1]),
+    ]);
+    let mut scheduler = make_scheduler(graph);
+
+    scheduler.graph.tasks[0].status = TaskStatus::Completed;
+    scheduler.graph.tasks[0].result = Some(TaskResult {
+        output: "claimed done, handed off".to_string(),
+        artifacts: vec![],
+        duration_ms: 10,
+        agent_id: Some("agent-0".to_string()),
+        agent_def: Some("worker".to_string()),
+    });
+    // Simulate try_handoff's post-activation state: target 1 is Ready, commanded_from
+    // links back to source 0, with no depends_on edge.
+    scheduler.graph.tasks[1].status = TaskStatus::Ready;
+    scheduler.graph.tasks[1].commanded_from = Some(TaskId(0));
+
+    let trace = vec![ToolCallSummary {
+        tool: "write".to_string(),
+        args_summary: None,
+        ok: false,
+        is_read_only: false,
+    }];
+    let corrected =
+        scheduler.correct_completed_to_failed_if_all_tool_calls_failed(TaskId(0), Some(&trace));
+    assert!(corrected, "test precondition: task 0 must be corrected");
+
+    let _ = scheduler.propagate_corrected_task_failure(TaskId(0));
+
+    assert_eq!(
+        scheduler.graph.tasks[1].status,
+        TaskStatus::Skipped,
+        "a Pending/Ready commanded_from target must be cancelled when its source is \
+         corrected to Failed post-hoc"
+    );
+    assert_eq!(
+        scheduler.graph.tasks[2].status,
+        TaskStatus::Skipped,
+        "a depends_on dependent of the cancelled commanded_from target must also be \
+         skipped, or it would strand in Pending forever"
+    );
+}
+
+#[test]
+fn propagate_corrected_task_failure_leaves_running_commanded_from_target_untouched() {
+    // Deliberate scope boundary (Finding 1's fix): an already-Running commanded_from
+    // target is the pre-existing, accepted "already-unblocked work is not unwound"
+    // limitation, same as an ordinary Running depends_on dependent -- must not be
+    // cancelled/skipped by this fix. Uses a per-task Skip failure strategy on the source
+    // (rather than the default Abort) so the assertion isolates this fix's own behavior
+    // from Abort's unrelated "cancel every Running task in the graph" global effect.
+    let graph = graph_from_nodes(vec![make_node(0, &[]), make_node(1, &[])]);
+    let mut scheduler = make_scheduler(graph);
+
+    scheduler.graph.tasks[0].status = TaskStatus::Completed;
+    scheduler.graph.tasks[0].failure_strategy = Some(zeph_config::FailureStrategy::Skip);
+    scheduler.graph.tasks[0].result = Some(TaskResult {
+        output: "claimed done, handed off".to_string(),
+        artifacts: vec![],
+        duration_ms: 10,
+        agent_id: Some("agent-0".to_string()),
+        agent_def: Some("worker".to_string()),
+    });
+    scheduler.graph.tasks[1].commanded_from = Some(TaskId(0));
+    make_running_task(&mut scheduler, TaskId(1), "h1");
+
+    let trace = vec![ToolCallSummary {
+        tool: "write".to_string(),
+        args_summary: None,
+        ok: false,
+        is_read_only: false,
+    }];
+    let corrected =
+        scheduler.correct_completed_to_failed_if_all_tool_calls_failed(TaskId(0), Some(&trace));
+    assert!(corrected, "test precondition: task 0 must be corrected");
+
+    let actions = scheduler.propagate_corrected_task_failure(TaskId(0));
+
+    assert_eq!(
+        scheduler.graph.tasks[1].status,
+        TaskStatus::Running,
+        "an already-Running commanded_from target is out of this fix's scope"
+    );
+    assert!(
+        !actions.iter().any(
+            |a| matches!(a, SchedulerAction::Cancel { agent_handle_id } if agent_handle_id == "h1")
+        ),
+        "a Running commanded_from target must not be cancelled by this fix: {actions:?}"
     );
 }
 

--- a/crates/zeph-tui/src/channel.rs
+++ b/crates/zeph-tui/src/channel.rs
@@ -134,6 +134,7 @@ impl Channel for TuiChannel {
                     attachments: vec![],
                     is_guest_context: false,
                     is_from_bot: false,
+                    owner_key: None,
                 }))
             }
             None => Ok(None),
@@ -148,6 +149,7 @@ impl Channel for TuiChannel {
                 attachments: vec![],
                 is_guest_context: false,
                 is_from_bot: false,
+                owner_key: None,
             }
         })
     }

--- a/crates/zeph-tui/src/widgets/plan_view.rs
+++ b/crates/zeph-tui/src/widgets/plan_view.rs
@@ -59,6 +59,15 @@ fn build_task_row(task: &crate::metrics::TaskSnapshotRow, tick: u8, ascii: bool)
         } else {
             title_display
         }
+    } else if let Some(ref rejected) = task.handoff_rejected {
+        // spec-080/#6390: a Command-handoff `goto` rejection itself does not change the
+        // node's own status (it stays completed with its real output) — surface it as a
+        // title suffix regardless of status, mirroring the failed-error suffix above. A
+        // *later*, independent post-hoc correction (#6394's CheckToolOutcome) can still
+        // flip that same node to `failed` afterward, which is exactly why this branch is
+        // reached only when the `status == "failed"` arm above didn't already match —
+        // see the precedence test below for that now-reachable combination.
+        format!("{title_display} [handoff rejected: {rejected}]")
     } else {
         title_display
     };
@@ -221,6 +230,7 @@ mod tests {
                     agent: None,
                     duration_ms: 0,
                     error: None,
+                    handoff_rejected: None,
                 })
                 .collect(),
             completed_at: None,
@@ -343,6 +353,50 @@ mod tests {
         assert!(rendered.contains("Step 2"));
         assert!(rendered.contains("Step 3"));
         assert!(rendered.contains("Step 4"));
+    }
+
+    #[test]
+    fn handoff_rejected_task_shows_suffix_in_title() {
+        // #6390: a rejected Command handoff has no dedicated display surface today —
+        // it must render as a title suffix even though the task itself stays "completed".
+        let mut snap = make_snapshot("running", vec![("Router Task", "completed")]);
+        snap.tasks[0].handoff_rejected = Some("goto target already completed".to_owned());
+        let metrics = MetricsSnapshot {
+            orchestration_graph: Some(snap),
+            ..MetricsSnapshot::default()
+        };
+        let rendered = render_to_buffer(&metrics);
+        assert!(
+            rendered.contains("handoff rejected"),
+            "expected rejection suffix in rendered output, got: {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn failed_task_error_suffix_takes_precedence_over_handoff_rejected() {
+        // Both fields CAN be set on the same node in practice: `try_handoff` sets
+        // `handoff_rejected` on a still-`Completed` node (spec-080), and issue #6394's
+        // post-hoc `CheckToolOutcome` correction can independently flip that same node's
+        // status to `failed` afterward (code review Finding 3, 2026-07-17) — so this is
+        // not a hypothetical precedence rule, it is a reachable state. The failed-error
+        // branch stays the first match so a genuinely failed task's error is never masked.
+        // Note this creates a deliberate CLI/TUI display divergence: `format_plan_status`
+        // (zeph-core/agent/plan.rs) lists `handoff_rejected` for every task regardless of
+        // status, so the CLI still surfaces the rejection reason in this state — only the
+        // TUI title suffix drops it in favor of the (more actionable) failure reason.
+        let mut snap = make_snapshot("running", vec![("Router Task", "failed")]);
+        snap.tasks[0].error = Some("boom".to_owned());
+        snap.tasks[0].handoff_rejected = Some("goto target already completed".to_owned());
+        let metrics = MetricsSnapshot {
+            orchestration_graph: Some(snap),
+            ..MetricsSnapshot::default()
+        };
+        let rendered = render_to_buffer(&metrics);
+        assert!(
+            rendered.contains("[boom]"),
+            "expected error suffix, got: {rendered:?}"
+        );
+        assert!(!rendered.contains("handoff rejected"));
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -205,6 +205,27 @@ pub(crate) struct AgentTaskProcessor {
     pub(crate) drain_timeout: std::time::Duration,
 }
 
+/// Derives a cross-thread store owner key (spec-080 §10 OQ-1, GitHub #6389) from an A2A
+/// message's `context_id` — the A2A protocol's own conversation-scoping identifier ("shared
+/// with other tasks in the same session"), `crates/zeph-a2a/src/types.rs` — so distinct A2A
+/// callers/sessions land in distinct store buckets instead of every A2A message collapsing
+/// into the shared `"local"` bucket alongside the CLI/TUI operator.
+///
+/// Like the gateway's `sender`-derived key, `context_id` is client-supplied within a single
+/// shared bearer token (`AuthIdentity` has no per-caller id) — a defense-in-depth partition
+/// against accidental cross-caller collisions, not a hard tenant boundary; the bearer token
+/// remains the only real authentication gate on this path. A message with no `context_id`
+/// still gets a distinct `a2a:default` bucket rather than falling back to `"local"`, so A2A
+/// traffic never blends into the single-user CLI/TUI bucket. Capped at 256 chars to bound the
+/// value written into `owner_key` (a `cross_thread_store` primary-key column), mirroring the
+/// length limit the gateway already enforces on `sender` (`WebhookPayload::validate`).
+fn a2a_owner_key(message: &zeph_a2a::Message) -> String {
+    match &message.context_id {
+        Some(cid) => format!("a2a:{}", cid.chars().take(256).collect::<String>()),
+        None => "a2a:default".to_owned(),
+    }
+}
+
 impl zeph_a2a::TaskProcessor for AgentTaskProcessor {
     fn process(
         &self,
@@ -230,6 +251,7 @@ impl zeph_a2a::TaskProcessor for AgentTaskProcessor {
                     zeph_core::ContentSource::new(zeph_core::ContentSourceKind::A2aMessage),
                 )
                 .body;
+            let owner_key = a2a_owner_key(&message);
             let mut handle = handle.lock().await;
 
             handle
@@ -239,6 +261,7 @@ impl zeph_a2a::TaskProcessor for AgentTaskProcessor {
                     attachments: vec![],
                     is_guest_context: false,
                     is_from_bot: false,
+                    owner_key: Some(owner_key),
                 })
                 .await
                 .map_err(|_| zeph_a2a::A2aError::Server("agent channel closed".to_owned()))?;
@@ -2631,5 +2654,40 @@ mod tests {
         assert!(card.capabilities.audio);
         assert!(card.capabilities.files);
         assert!(card.capabilities.streaming);
+    }
+
+    // --- a2a_owner_key (#6389) ---
+
+    /// #6389 regression: distinct `context_id`s must derive distinct owner keys, so two A2A
+    /// callers/sessions sharing one bearer token land in distinct cross-thread store buckets
+    /// instead of both collapsing into `"local"`.
+    #[test]
+    fn a2a_owner_key_distinct_per_context_id() {
+        let mut alice = zeph_a2a::Message::user_text("hi");
+        alice.context_id = Some("alice-session".into());
+        let mut bob = zeph_a2a::Message::user_text("hi");
+        bob.context_id = Some("bob-session".into());
+
+        assert_ne!(a2a_owner_key(&alice), a2a_owner_key(&bob));
+        assert_eq!(a2a_owner_key(&alice), "a2a:alice-session");
+    }
+
+    /// A message with no `context_id` still gets a distinct, non-`"local"` bucket rather than
+    /// silently falling back to the CLI/TUI default.
+    #[test]
+    fn a2a_owner_key_missing_context_id_uses_distinct_default() {
+        let message = zeph_a2a::Message::user_text("hi");
+        assert_eq!(a2a_owner_key(&message), "a2a:default");
+        assert_ne!(a2a_owner_key(&message), "local");
+    }
+
+    /// A `context_id` longer than 256 chars must be truncated, bounding the value written
+    /// into the `cross_thread_store` `owner_key` primary-key column.
+    #[test]
+    fn a2a_owner_key_truncates_long_context_id() {
+        let mut message = zeph_a2a::Message::user_text("hi");
+        message.context_id = Some("x".repeat(500));
+        let key = a2a_owner_key(&message);
+        assert_eq!(key, format!("a2a:{}", "x".repeat(256)));
     }
 }

--- a/src/gateway_spawn.rs
+++ b/src/gateway_spawn.rs
@@ -206,6 +206,25 @@ impl<C: zeph_core::channel::Channel> zeph_core::channel::Channel for GatewayChan
 /// gateway bearer token proves the sender knows the shared secret, not that the content is safe
 /// (#5432). Returns when `webhook_rx` is closed or `agent_input_tx`'s receiver has been dropped
 /// (agent shutdown).
+/// Derives a cross-thread store owner key (spec-080 §10 OQ-1, GitHub #6389) from a webhook
+/// payload's `sender` field, so distinct gateway callers land in distinct store buckets
+/// instead of every gateway message collapsing into the shared `"local"` bucket alongside
+/// the CLI/TUI operator.
+///
+/// `sender` is unauthenticated free text within a single shared bearer token (NFR-SEC-02) —
+/// any caller holding the gateway token can claim any `sender` value, so this is a
+/// defense-in-depth partition against accidental cross-sender collisions, not a hard tenant
+/// boundary; the bearer token itself remains the only real authentication gate on this path
+/// (unchanged by this key). `sender` is already control-character-stripped and
+/// length-validated (`WebhookPayload::validate`, <=256 bytes) by `webhook_handler` before
+/// `WebhookMessage` is constructed, so no further sanitization is needed here. The
+/// `gateway:` prefix keeps this namespace disjoint from the A2A-derived and default `"local"`
+/// buckets even if the raw sender text happens to collide with either.
+#[cfg(feature = "gateway")]
+fn gateway_owner_key(sender: &str) -> String {
+    format!("gateway:{sender}")
+}
+
 #[cfg(feature = "gateway")]
 async fn forward_webhooks(
     sanitizer: zeph_core::ContentSanitizer,
@@ -230,6 +249,7 @@ async fn forward_webhooks(
             attachments: vec![],
             is_guest_context: false,
             is_from_bot: false,
+            owner_key: Some(gateway_owner_key(&payload.sender)),
         };
         if agent_input_tx.send(msg).await.is_err() {
             tracing::debug!("gateway: agent input channel closed, stopping webhook forwarder");
@@ -365,6 +385,7 @@ mod tests {
             attachments: vec![],
             is_guest_context: false,
             is_from_bot: false,
+            owner_key: None,
         };
         webhook_tx.try_send(msg).unwrap();
 
@@ -389,6 +410,7 @@ mod tests {
             attachments: vec![],
             is_guest_context: false,
             is_from_bot: false,
+            owner_key: None,
         };
         webhook_tx.send(msg).await.unwrap();
 
@@ -427,6 +449,7 @@ mod tests {
                 attachments: vec![],
                 is_guest_context: false,
                 is_from_bot: false,
+                owner_key: None,
             }))
         }
 
@@ -469,6 +492,7 @@ mod tests {
                 attachments: vec![],
                 is_guest_context: false,
                 is_from_bot: false,
+                owner_key: None,
             })
             .await
             .unwrap();
@@ -500,6 +524,7 @@ mod tests {
                 attachments: vec![],
                 is_guest_context: false,
                 is_from_bot: false,
+                owner_key: None,
             })
             .await
             .unwrap();
@@ -701,5 +726,67 @@ mod tests {
             forwarder.is_ok(),
             "forward_webhooks must return promptly once agent_input_tx is closed"
         );
+    }
+
+    /// #6389 regression: `gateway_owner_key` must derive distinct keys for distinct senders,
+    /// so two gateway callers sharing one bearer token land in distinct cross-thread store
+    /// buckets instead of both collapsing into `"local"`.
+    #[test]
+    fn gateway_owner_key_distinct_per_sender() {
+        assert_ne!(gateway_owner_key("alice"), gateway_owner_key("bob"));
+        assert_eq!(gateway_owner_key("alice"), gateway_owner_key("alice"));
+    }
+
+    /// The derived key must never equal the `"local"` bucket CLI/TUI/Telegram use, even for
+    /// a sender literally named `"local"` — the `gateway:` prefix keeps the namespaces
+    /// disjoint.
+    #[test]
+    fn gateway_owner_key_never_collides_with_default_local() {
+        assert_ne!(gateway_owner_key("local"), "local");
+        assert_eq!(gateway_owner_key("local"), "gateway:local");
+    }
+
+    /// #6389 end-to-end: two webhook payloads with different `sender` values must produce
+    /// `ChannelMessage`s with distinct, non-`None` `owner_key`s once forwarded through the
+    /// real `forward_webhooks` function `spawn_gateway_server` spawns.
+    #[tokio::test]
+    async fn forward_webhooks_threads_distinct_owner_key_per_sender() {
+        let sanitizer =
+            zeph_core::ContentSanitizer::new(&zeph_core::ContentIsolationConfig::default());
+        let (webhook_tx, webhook_rx) =
+            tokio::sync::mpsc::channel::<zeph_gateway::WebhookMessage>(4);
+        let (agent_input_tx, mut agent_input_rx) = tokio::sync::mpsc::channel::<ChannelMessage>(4);
+
+        let forwarder = tokio::spawn(forward_webhooks(sanitizer, webhook_rx, agent_input_tx));
+
+        webhook_tx
+            .send(zeph_gateway::WebhookMessage {
+                sender: "alice".into(),
+                channel: "discord".into(),
+                body: "hi from alice".into(),
+            })
+            .await
+            .unwrap();
+        webhook_tx
+            .send(zeph_gateway::WebhookMessage {
+                sender: "bob".into(),
+                channel: "discord".into(),
+                body: "hi from bob".into(),
+            })
+            .await
+            .unwrap();
+        drop(webhook_tx);
+
+        let alice_msg = agent_input_rx
+            .recv()
+            .await
+            .expect("alice message forwarded");
+        let bob_msg = agent_input_rx.recv().await.expect("bob message forwarded");
+
+        assert_eq!(alice_msg.owner_key.as_deref(), Some("gateway:alice"));
+        assert_eq!(bob_msg.owner_key.as_deref(), Some("gateway:bob"));
+        assert_ne!(alice_msg.owner_key, bob_msg.owner_key);
+
+        forwarder.await.unwrap();
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -117,6 +117,7 @@ impl Channel for MockChannel {
             attachments: vec![],
             is_guest_context: false,
             is_from_bot: false,
+            owner_key: None,
         }))
     }
 
@@ -148,6 +149,7 @@ impl Channel for ConfirmMockChannel {
             attachments: vec![],
             is_guest_context: false,
             is_from_bot: false,
+            owner_key: None,
         }))
     }
 
@@ -2568,6 +2570,7 @@ mod self_learning {
                 attachments: vec![],
                 is_guest_context: false,
                 is_from_bot: false,
+                owner_key: None,
             }))
         }
 

--- a/tests/performance_agent_integration.rs
+++ b/tests/performance_agent_integration.rs
@@ -69,6 +69,7 @@ impl Channel for MockChannel {
             attachments: vec![],
             is_guest_context: false,
             is_from_bot: false,
+            owner_key: None,
         }))
     }
 


### PR DESCRIPTION
## Summary

Three follow-ups to spec-080 (cross-thread store + Command-style dynamic task handoff, PR #6363), combined into one PR as independent, unblocked, same-epic gap-closing changes.

- **#6394** — `TaskOutcome::Handoff` now carries `tool_trace` and gets the same completeness-verification treatment `Completed` outcomes already had: `handle_handoff_outcome` emits `SchedulerAction::CheckToolOutcome` unconditionally and `SchedulerAction::Verify` when `verify_completeness` is enabled. This also fixes a spawn-path gap found during this PR's own review: a `commanded_from`-linked `goto` target kept running after its source was post-hoc corrected to `Failed`, since `propagate_corrected_task_failure` only walked `depends_on`-derived edges — closed via new `dag::cancel_dangling_commanded_targets`, scoped to `Pending`/`Ready` targets only.
- **#6390** — `TaskNode.handoff_rejected` is now surfaced in `/plan status` (CLI) and the TUI plan view's task row, instead of only being logged.
- **#6389** — `ChannelMessage` gains an `owner_key` field, threaded per-turn through `SessionState` (mirrors the existing `is_guest_context` pattern) and read by `/store` and Command-handoff store I/O. Gateway and A2A dispatch paths now derive a real per-caller key (`gateway:{sender}`, `a2a:{context_id}`) instead of collapsing to the shared `"local"` sentinel. CLI/TUI/Telegram/Discord/Slack/JSON-CLI are unchanged.

## Review notes

This PR went through a full two-round team-develop cycle: adversarial critique found 2 P2 findings and 1 P3 in the first pass; code review independently re-verified both P2s against the actual code before deciding severity, escalated the phantom-successor finding (#6394 spawn path) to merge-blocking after determining the correction chain that triggers it runs by default (not gated behind `verify_completeness` as initially assumed), and approved on re-review after the fix landed.

Known accepted, tracked-as-follow-up gaps (not fixed in this PR, documented in code comments and CHANGELOG.md):
- `owner_key`/`is_guest_context` can go stale across a fast-path slash-command dispatch that skips `end_turn` — pre-existing pattern, not a new hazard, no auth bypass (independently confirmed by security review).
- ACP sessions do not yet thread `owner_key` into the cross-thread store (only session-listing does).

Closes #6394
Closes #6390
Closes #6389

## Test plan

- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 14173 passed, 0 failed, 35 skipped
- [x] `cargo +nightly fmt --check` — clean
- [x] Rustdoc gate — clean
- [x] New unit/regression tests for all three issues, including the phantom-successor fix (`propagate_corrected_task_failure_cancels_pending_commanded_from_target`, `propagate_corrected_task_failure_leaves_running_commanded_from_target_untouched`)
- [x] CHANGELOG.md updated
- [x] `.local/testing/playbooks/orchestration.md` and `.local/testing/coverage-status.md` updated (main repo) with live-testing scenarios for a future CI cycle
- [ ] Not yet live-tested against a real LLM session — structural/unit coverage only this cycle