### PR TITLE
fix(core): stop injecting unfiltered full-body skill dumps outside per-turn matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-core`: the initial system prompt built at agent construction
+  (`Agent::new_with_registry_arc`) and every skill hot-reload (`reload_skills()`) force-loaded
+  every registered skill's *full* `SKILL.md` body via `format_skills_prompt`, bypassing the
+  matcher/`disambiguation_threshold`/`max_active_skills` cap entirely — the misleading symptom
+  was the TUI/`/status` startup token gauge showing the entire skill registry's size (e.g.
+  ~100k tokens for 157 skills) before a single turn ran (#6413). Both call sites now build a
+  catalog-only listing (name + description, via `format_skills_catalog`) straight from
+  `SkillMeta` — no per-skill disk read — deferring full-body injection to the first per-turn
+  `rebuild_system_prompt(query)` call, which already applies the cap correctly. `reload_skills()`
+  also now recomputes `cached_prompt_tokens` after mutating `messages[0]`, so the gauge never
+  goes stale between a reload and the next turn. `specs/005-skills/spec.md` and
+  `specs/001-system-invariants/spec.md` §7 gained an explicit construction-time/reload-time
+  contract closing the spec gap that allowed this.
 - `zeph-config`/`zeph-core`: `[tools] enabled = false` was dead config — deserialized onto
   `ToolsConfig::enabled` but never read anywhere, so tool definitions were still built and sent
   to the LLM regardless of the setting (#6386). `ToolsConfig::enabled` is now mirrored into

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -10,10 +10,11 @@ use zeph_skills::ScoredMatch;
 use zeph_skills::group::{GroupResult, group_skills};
 use zeph_skills::loader::SkillMeta;
 use zeph_skills::prompt::{
-    format_grouped_skills_prompt, format_skills_catalog, format_skills_prompt_compact,
+    format_grouped_skills_prompt, format_skills_catalog, format_skills_prompt,
+    format_skills_prompt_compact,
 };
 
-use super::super::{Agent, Skill, format_skills_prompt};
+use super::super::{Agent, Skill};
 use crate::channel::Channel;
 use crate::context::build_system_prompt_with_instructions;
 use tracing::Instrument as _;

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -70,7 +70,7 @@ mod utils;
 pub(crate) mod vigil;
 mod worktree_commands;
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 use std::fmt::Write as _;
 use std::sync::Arc;
 
@@ -84,7 +84,7 @@ use zeph_memory::TokenCounter;
 use zeph_memory::semantic::SemanticMemory;
 use zeph_skills::loader::Skill;
 use zeph_skills::matcher::SkillMatcherBackend;
-use zeph_skills::prompt::format_skills_prompt;
+use zeph_skills::prompt::format_skills_catalog;
 use zeph_skills::registry::SkillRegistry;
 use zeph_tools::executor::{ErasedToolExecutor, ToolExecutor};
 
@@ -291,16 +291,22 @@ impl<C: Channel> Agent<C> {
         };
 
         debug_assert!(max_active_skills > 0, "max_active_skills must be > 0");
-        let all_skills: Vec<Skill> = {
+        // Catalog-only listing (name + description) — full skill bodies are injected
+        // exclusively by the per-turn `rebuild_system_prompt(query)` matcher on turn 1.
+        // Building the initial prompt from metadata alone avoids a synchronous full-body
+        // disk read of every SKILL.md at construction time (#6413).
+        let catalog_skills: Vec<Skill> = {
             let reg = registry.read();
             reg.all_meta()
-                .iter()
-                .filter_map(|m| reg.skill(&m.name).ok())
+                .into_iter()
+                .map(|m| Skill {
+                    meta: m.clone(),
+                    body: String::new(),
+                    resources: zeph_skills::resource::SkillResources::default(),
+                })
                 .collect()
         };
-        let empty_trust = HashMap::new();
-        let empty_health: HashMap<String, (f64, u32)> = HashMap::new();
-        let skills_prompt = format_skills_prompt(&all_skills, &empty_trust, &empty_health);
+        let skills_prompt = format_skills_catalog(&catalog_skills);
         let system_prompt = build_system_prompt(&skills_prompt, None);
         tracing::debug!(len = system_prompt.len(), "initial system prompt built");
         tracing::trace!(prompt = %system_prompt, "full system prompt");

--- a/crates/zeph-core/src/agent/skill_reload.rs
+++ b/crates/zeph-core/src/agent/skill_reload.rs
@@ -7,10 +7,7 @@
 //! per-skill trust scores, and reloads `instructions`/`AGENTS.md` overlays when the
 //! filesystem watcher signals a change.
 
-use std::collections::HashMap;
-use std::sync::Arc;
-
-use super::{Agent, state};
+use super::Agent;
 use crate::channel::Channel;
 use crate::context::build_system_prompt;
 use zeph_llm::provider::LlmProvider;
@@ -243,27 +240,28 @@ impl<C: Channel> Agent<C> {
         let all_meta_refs = all_meta.iter().collect::<Vec<_>>();
         self.rebuild_skill_matcher(&all_meta_refs).await;
 
-        // `reg.skill()` loads each skill's body (and resources) from disk on first access —
-        // synchronous fs I/O that must not run inline on the agent's async task.
-        let registry_arc = Arc::clone(&self.services.skill.registry);
-        let span = tracing::info_span!("skills.registry.load_bodies_blocking");
-        let all_skills: Vec<Skill> = tokio::task::spawn_blocking(move || {
-            let _enter = span.enter();
-            let reg = registry_arc.read();
-            reg.all_meta()
-                .iter()
-                .filter_map(|m| reg.skill(&m.name).ok())
-                .collect()
-        })
-        .await
-        .unwrap_or_else(|e| {
-            tracing::error!("reload_skills: spawn_blocking for skill bodies panicked: {e}");
-            Vec::new()
-        });
+        // Catalog-only listing (name + description) — full skill bodies are injected
+        // exclusively by the per-turn `rebuild_system_prompt(query)` matcher, so a reload
+        // must not force-load every skill's body from disk (#6413). Building `Skill` stubs
+        // straight from metadata (already loaded in `all_meta` above) needs no further I/O.
+        // Blocked skills are excluded, mirroring `apply_skill_trust_and_gating`'s per-turn
+        // catalog filter.
         let trust_map = self.build_skill_trust_map().await;
-        let empty_health: HashMap<String, (f64, u32)> = HashMap::new();
-        let skills_prompt =
-            state::SkillState::rebuild_prompt(&all_skills, &trust_map, &empty_health);
+        let catalog_skills: Vec<Skill> = all_meta
+            .iter()
+            .filter(|m| {
+                !matches!(
+                    trust_map.get(&m.name),
+                    Some(snap) if snap.trust_level == zeph_common::SkillTrustLevel::Blocked
+                )
+            })
+            .map(|m| Skill {
+                meta: m.clone(),
+                body: String::new(),
+                resources: zeph_skills::resource::SkillResources::default(),
+            })
+            .collect();
+        let skills_prompt = zeph_skills::prompt::format_skills_catalog(&catalog_skills);
         self.services
             .skill
             .last_skills_prompt
@@ -272,6 +270,10 @@ impl<C: Channel> Agent<C> {
         if let Some(msg) = self.msg.messages.first_mut() {
             msg.content = system_prompt;
         }
+        // The mutation above bypasses `push_message`'s incremental token accounting, so the
+        // cached prompt-token count must be recomputed explicitly or it goes stale until the
+        // next turn's `rebuild_system_prompt` overwrites it (#6413).
+        self.recompute_prompt_tokens();
 
         self.channel.send_status_best_effort("").await;
         tracing::info!(

--- a/crates/zeph-core/src/agent/state/skill.rs
+++ b/crates/zeph-core/src/agent/state/skill.rs
@@ -7,37 +7,9 @@
 //! Agent methods (`reload_skills`, `rebuild_skill_matcher`) stay on `Agent<C>` because
 //! they need the embedding provider, channel, and memory state.
 
-use std::collections::HashMap;
-
-use zeph_skills::loader::Skill;
-use zeph_skills::trust::SkillTrustLevel;
-
-use crate::skill_invoker::SkillTrustSnapshot;
-
 use super::SkillState;
 
 impl SkillState {
-    /// Rebuild the skills prompt text from the current registry + trust/health maps.
-    ///
-    /// Returns the formatted prompt string. Does NOT update `last_skills_prompt` —
-    /// the caller is responsible for storing the result.
-    ///
-    /// `GoSkills` group-structured formatting is intentionally NOT applied here: this
-    /// path is used during skill hot-reload without a per-turn query or embeddings,
-    /// so cosine similarity grouping cannot be computed. Grouping is only applied in
-    /// the per-turn context assembly path (`assembly.rs`).
-    pub(crate) fn rebuild_prompt(
-        all_skills: &[Skill],
-        trust_map: &HashMap<String, SkillTrustSnapshot>,
-        health_map: &HashMap<String, (f64, u32)>,
-    ) -> String {
-        let trust_levels: HashMap<String, SkillTrustLevel> = trust_map
-            .iter()
-            .map(|(k, v)| (k.clone(), v.trust_level))
-            .collect();
-        zeph_skills::prompt::format_skills_prompt(all_skills, &trust_levels, health_map)
-    }
-
     /// Rebuild the BM25 index from current registry metadata, if hybrid search is enabled.
     pub(crate) fn rebuild_bm25(&mut self, descs: &[&str]) {
         if self.hybrid_search {

--- a/crates/zeph-core/src/agent/tests/agent_tests/mod.rs
+++ b/crates/zeph-core/src/agent/tests/agent_tests/mod.rs
@@ -15,4 +15,5 @@ mod metrics_summary_tests;
 mod model_help_status_exit_tests;
 mod orchestration_persistence_tests;
 mod skill_fallback_tests;
+mod skill_prompt_bloat_tests;
 mod subagent_command_tests;

--- a/crates/zeph-core/src/agent/tests/agent_tests/skill_prompt_bloat_tests.rs
+++ b/crates/zeph-core/src/agent/tests/agent_tests/skill_prompt_bloat_tests.rs
@@ -1,0 +1,331 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+#[allow(unused_imports)]
+use super::*;
+
+/// Distinctive marker embedded in every test skill's *body* only (never in its
+/// description). Its presence in an assembled prompt proves the full instructions
+/// were injected; its absence proves the prompt is catalog-only (name + description).
+const BODY_MARKER: &str = "ZEPH_FULL_BODY_MARKER_6413";
+
+/// Write `count` skills to a fresh temp directory, each with a short description
+/// and a body padded with [`BODY_MARKER`] repeated many times — large enough that
+/// injecting all bodies unfiltered is trivially distinguishable from a catalog-only
+/// (name + description) listing.
+fn write_bloated_skills(dir: &std::path::Path, count: usize) {
+    for i in 0..count {
+        let skill_dir = dir.join(format!("bloated-skill-{i}"));
+        std::fs::create_dir(&skill_dir).unwrap();
+        let body = BODY_MARKER.repeat(200);
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            format!(
+                "---\nname: bloated-skill-{i}\ndescription: Test skill {i} with a bloated body\n---\n{body}"
+            ),
+        )
+        .unwrap();
+    }
+}
+
+// --- Task A: Agent::new (new_with_registry_arc) construction-time catalog fix ---
+
+/// #6413: the initial system prompt built at agent construction must list skills by
+/// name + description only (catalog), never their full `SKILL.md` bodies. Full bodies
+/// are injected exclusively by the first per-turn `rebuild_system_prompt(query)` call.
+/// Before the fix, `Agent::new_with_registry_arc` force-loaded every skill's body via
+/// `format_skills_prompt`, inflating the startup token gauge with content that gets
+/// discarded on turn 1.
+#[test]
+fn agent_new_initial_prompt_is_catalog_only_not_full_body() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let skill_count = 20;
+    write_bloated_skills(temp_dir.path(), skill_count);
+    let registry = zeph_skills::registry::SkillRegistry::load(&[temp_dir.path().to_path_buf()]);
+
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let executor = MockToolExecutor::no_tools();
+
+    let agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+    let system_prompt = &agent.msg.messages.first().unwrap().content;
+    assert!(
+        !system_prompt.contains(BODY_MARKER),
+        "initial system prompt must not contain full skill bodies before turn 1"
+    );
+    assert!(
+        system_prompt.contains("bloated-skill-0") && system_prompt.contains("bloated-skill-19"),
+        "initial system prompt must still list every skill's name in the catalog; got: \
+         {system_prompt}"
+    );
+
+    // Sanity ceiling: a catalog-only listing of 20 short name/description pairs is a few
+    // hundred tokens at most. A full-body dump of 20 skills * 200 marker repeats each would
+    // be tens of thousands of tokens — the ceiling below only holds under the fix.
+    let cached = agent.runtime.providers.cached_prompt_tokens;
+    assert!(
+        cached < 5_000,
+        "cached_prompt_tokens must reflect the small catalog listing, not {skill_count} \
+         bloated full skill bodies; got {cached}"
+    );
+}
+
+// --- Task B: reload_skills() catalog fix + cached_prompt_tokens recompute ---
+
+/// #6413: `reload_skills()` must rebuild `messages[0]` as a catalog-only listing (same
+/// contract as construction), not force-load every skill's full body. It must also
+/// recompute `cached_prompt_tokens` from the mutated message so the value never goes
+/// stale between a reload and the next turn's `rebuild_system_prompt`.
+#[tokio::test]
+async fn reload_skills_rebuilds_catalog_only_prompt_and_recomputes_tokens() {
+    let harness = QuickTestAgent::minimal("ok");
+    let mut agent = harness.agent;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let skill_count = 20;
+    write_bloated_skills(temp_dir.path(), skill_count);
+    agent.services.skill.skill_paths = vec![temp_dir.path().to_path_buf()];
+
+    // Poison the cached counter with an obviously-wrong sentinel value beforehand so a
+    // passing assertion below proves `reload_skills` actually recomputed it, rather than
+    // merely inheriting an already-small value from construction.
+    agent.runtime.providers.cached_prompt_tokens = 999_999;
+
+    agent.reload_skills().await;
+
+    let system_prompt = &agent.msg.messages.first().unwrap().content;
+    assert!(
+        !system_prompt.contains(BODY_MARKER),
+        "reloaded system prompt must not contain full skill bodies"
+    );
+    assert!(
+        system_prompt.contains("bloated-skill-0") && system_prompt.contains("bloated-skill-19"),
+        "reloaded system prompt must still list every skill's name in the catalog; got: \
+         {system_prompt}"
+    );
+
+    let cached = agent.runtime.providers.cached_prompt_tokens;
+    assert_ne!(
+        cached, 999_999,
+        "cached_prompt_tokens must be recomputed after reload_skills mutates messages[0], \
+         not left stale at the pre-reload sentinel value"
+    );
+    assert!(
+        cached < 5_000,
+        "cached_prompt_tokens must reflect the small catalog listing, not {skill_count} \
+         bloated full skill bodies; got {cached}"
+    );
+
+    let expected: u64 = agent
+        .msg
+        .messages
+        .iter()
+        .map(|m| agent.runtime.metrics.token_counter.count_message_tokens(m) as u64)
+        .sum();
+    assert_eq!(
+        cached, expected,
+        "cached_prompt_tokens must exactly match the sum over all messages, proving \
+         recompute_prompt_tokens ran rather than leaving a partially-updated value"
+    );
+}
+
+/// `last_skills_prompt` (used only for memory-recall budget token accounting, never
+/// injected into the LLM-bound system prompt) must also be catalog-only after
+/// construction — defence-in-depth against a future code path accidentally treating it
+/// as the real system prompt (#6413 Option C).
+#[test]
+fn agent_new_last_skills_prompt_is_catalog_only() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    write_bloated_skills(temp_dir.path(), 5);
+    let registry = zeph_skills::registry::SkillRegistry::load(&[temp_dir.path().to_path_buf()]);
+
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let executor = MockToolExecutor::no_tools();
+
+    let agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+    assert!(
+        !agent
+            .services
+            .skill
+            .last_skills_prompt
+            .contains(BODY_MARKER),
+        "last_skills_prompt must be seeded catalog-only at construction, not the full \
+         unfiltered registry blob"
+    );
+}
+
+// --- Edge case: 0-skill registry ---
+
+/// #6413 edge case: construction with a registry that resolves to zero skills (an empty
+/// skill directory) must not panic and must produce an empty catalog block rather than,
+/// say, an empty `<other_skills>` tag or a formatting artifact. `format_skills_catalog`
+/// special-cases `skills.is_empty()` to return `String::new()` — this exercises that path
+/// through the real `Agent::new` construction call site, not the formatter in isolation.
+#[test]
+fn agent_new_handles_zero_skill_registry_without_panic() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    // No SKILL.md files written — registry resolves to zero skills.
+    let registry = zeph_skills::registry::SkillRegistry::load(&[temp_dir.path().to_path_buf()]);
+    assert!(
+        registry.all_meta().is_empty(),
+        "precondition: registry must be empty"
+    );
+
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let executor = MockToolExecutor::no_tools();
+
+    let agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+    let system_prompt = &agent.msg.messages.first().unwrap().content;
+    assert!(
+        !system_prompt.contains("<other_skills>"),
+        "an empty catalog must not emit an empty <other_skills> block; got: {system_prompt}"
+    );
+    assert!(
+        !agent
+            .services
+            .skill
+            .last_skills_prompt
+            .contains("<other_skills>"),
+        "last_skills_prompt must also be empty (not an empty tag) for a zero-skill registry"
+    );
+}
+
+/// #6413 edge case: `reload_skills()` on a registry that reloads to zero skills (all
+/// `SKILL.md` files removed from disk) must not panic and must clear the catalog from
+/// `messages[0]`, mirroring the construction-time zero-skill behavior above.
+#[tokio::test]
+async fn reload_skills_handles_zero_skill_registry_without_panic() {
+    let harness = QuickTestAgent::minimal("ok");
+    let mut agent = harness.agent;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    // Empty directory — no SKILL.md files, so the reload resolves to zero skills.
+    agent.services.skill.skill_paths = vec![temp_dir.path().to_path_buf()];
+
+    agent.reload_skills().await;
+
+    let names: Vec<String> = agent
+        .services
+        .skill
+        .registry
+        .read()
+        .all_meta()
+        .iter()
+        .map(|m| m.name.clone())
+        .collect();
+    assert!(
+        names.is_empty(),
+        "precondition: reloaded registry must be empty"
+    );
+
+    let system_prompt = &agent.msg.messages.first().unwrap().content;
+    assert!(
+        !system_prompt.contains("<other_skills>"),
+        "an empty reloaded catalog must not emit an empty <other_skills> block; got: \
+         {system_prompt}"
+    );
+}
+
+// --- Edge case: Blocked-trust skill filtered out of the reload catalog ---
+
+/// #6413: `reload_skills()` filters out `Blocked`-trust skills from the rebuilt catalog,
+/// mirroring the per-turn `apply_skill_trust_and_gating` filter. This seeds a real trust
+/// row via a `SemanticMemory`-backed reload cycle (not a synthetic in-memory map) so the
+/// test exercises the actual `build_skill_trust_map` → `SQLite` round trip that
+/// `reload_skills()` depends on.
+#[tokio::test]
+async fn reload_skills_excludes_blocked_trust_skill_from_catalog() {
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+
+    let memory_provider = AnyProvider::Mock(MockProvider::default());
+    let memory = SemanticMemory::new(
+        ":memory:",
+        "http://127.0.0.1:1",
+        None,
+        memory_provider,
+        "test-model",
+    )
+    .await
+    .unwrap();
+    let cid = memory.sqlite().create_conversation().await.unwrap();
+
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor).with_memory(
+        std::sync::Arc::new(memory),
+        cid,
+        50,
+        5,
+        50,
+    );
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let allowed_dir = temp_dir.path().join("allowed-skill");
+    std::fs::create_dir(&allowed_dir).unwrap();
+    std::fs::write(
+        allowed_dir.join("SKILL.md"),
+        "---\nname: allowed-skill\ndescription: Not blocked\n---\nAllowed body",
+    )
+    .unwrap();
+    let blocked_dir = temp_dir.path().join("blocked-skill");
+    std::fs::create_dir(&blocked_dir).unwrap();
+    std::fs::write(
+        blocked_dir.join("SKILL.md"),
+        "---\nname: blocked-skill\ndescription: This one is blocked\n---\nBlocked body",
+    )
+    .unwrap();
+    agent.services.skill.skill_paths = vec![temp_dir.path().to_path_buf()];
+
+    // First reload seeds real trust rows (with the correct blake3 hash of each SKILL.md)
+    // via `update_trust_for_reloaded_skills`. A hand-rolled `upsert_skill_trust` call with a
+    // fake hash would be silently overwritten on the *next* reload — `update_trust_for_reloaded_skills`
+    // demotes any skill whose stored hash doesn't match the freshly computed one
+    // (`hash_mismatch_level`), which would mask the Blocked level being set below.
+    agent.reload_skills().await;
+
+    // Now flip trust to Blocked in place — `set_skill_trust_level` only updates the
+    // `trust_level` column, leaving the already-correct stored hash untouched.
+    let mem = agent.services.memory.persistence.memory.as_ref().unwrap();
+    let updated = mem
+        .sqlite()
+        .set_skill_trust_level("blocked-skill", zeph_common::SkillTrustLevel::Blocked)
+        .await
+        .unwrap();
+    assert!(
+        updated,
+        "precondition: trust row for blocked-skill must exist after first reload"
+    );
+
+    // `reload_skills()` short-circuits via `SkillRegistry::fingerprint()` (name + file
+    // size/mtime) when nothing on disk changed — the trust DB update above doesn't touch
+    // any SKILL.md, so a second reload would otherwise no-op and leave `messages[0]` as
+    // built on the first (pre-Blocked) reload. Add a third skill to force a real fingerprint
+    // change without touching `blocked-skill`'s or `allowed-skill`'s file content/hash.
+    let extra_dir = temp_dir.path().join("extra-skill");
+    std::fs::create_dir(&extra_dir).unwrap();
+    std::fs::write(
+        extra_dir.join("SKILL.md"),
+        "---\nname: extra-skill\ndescription: Forces a registry fingerprint change\n---\nExtra body",
+    )
+    .unwrap();
+
+    // Second reload: `blocked-skill`'s file hash is unchanged, so
+    // `update_trust_for_reloaded_skills` keeps the stored Blocked level, and the catalog
+    // filter in `reload_skills()` must exclude it.
+    agent.reload_skills().await;
+
+    let system_prompt = &agent.msg.messages.first().unwrap().content;
+    assert!(
+        system_prompt.contains("allowed-skill"),
+        "non-blocked skill must remain in the reload catalog; got: {system_prompt}"
+    );
+    assert!(
+        !system_prompt.contains("blocked-skill"),
+        "Blocked-trust skill must be excluded from the reload catalog; got: {system_prompt}"
+    );
+}

--- a/specs/001-system-invariants/spec.md
+++ b/specs/001-system-invariants/spec.md
@@ -135,8 +135,14 @@ The `Channel` trait (`crates/zeph-core/src/channel.rs`) is the only I/O boundary
 - Matching priority: BM25 + embedding hybrid (if enabled) → pure embedding → keyword fallback
 - `disambiguation_threshold` float gate: if top skill score < threshold, no skill is injected
 - Hot-reload via `notify` crate with 500ms debounce — file change must not block the agent loop
+- The matcher/threshold/`max_active_skills` cap applies to every system prompt build, including
+  the initial prompt at agent construction and any hot-reload rebuild that runs before the first
+  per-turn query is available — see `specs/005-skills/spec.md` § Construction-Time / Reload-Time
+  Skill Prompt Contract for the catalog-only fallback used when no query exists yet (#6413)
 
-**NEVER**: inject more than `max_active_skills` into a single turn; do not block on skill file I/O in the agent loop.
+**NEVER**: inject more than `max_active_skills` into a single turn; inject full skill bodies into
+a system prompt built without a per-turn query (construction, hot-reload); do not block on skill
+file I/O in the agent loop.
 
 ## 8. Configuration Contract
 

--- a/specs/005-skills/spec.md
+++ b/specs/005-skills/spec.md
@@ -83,6 +83,32 @@ Active skills are injected into Block 3 of the system prompt (volatile section):
 - Tool definitions from skills are merged into the main tool catalog for the turn
 - Skills can define `env` variables that are passed to the tool executor via `set_skill_env()`
 
+## Construction-Time / Reload-Time Skill Prompt Contract (#6413)
+
+Full-body skill injection (previous section) requires a per-turn `query` to run the matcher and
+apply `disambiguation_threshold` / `min_injection_score` / `max_active_skills`. Two call sites
+build (or rebuild) the system prompt *before* a query exists: agent construction
+(`Agent::new_with_registry_arc`) and skill hot-reload (`reload_skills()`). Neither has a query to
+match against, so neither may fall back to injecting every registered skill's full body — that
+would silently bypass the `max_active_skills` cap (a hard invariant everywhere else) and force a
+synchronous full-body disk read of every `SKILL.md`, both forbidden by `specs/001-system-invariants/spec.md`
+§7.
+
+Contract for both call sites:
+- Build the skill listing from **metadata only** (`SkillMeta`: name + description) — never call
+  into the registry's lazy full-body loader (`SkillRegistry::skill()`)
+- Format with the catalog formatter (name + description only, no `<instructions>` body), the same
+  formatter used for the *unmatched* remainder of skills in the per-turn path
+- `last_skills_prompt` (token-accounting cache, never itself injected into the LLM-bound prompt —
+  see `crates/zeph-core/src/agent/state/mod.rs`) is seeded/updated with this same catalog-only
+  text, not the full unfiltered registry blob
+- Full skill bodies are injected exclusively by the next `rebuild_system_prompt(query)` call, once
+  a real per-turn query exists to run the matcher against
+- Any code path that mutates `messages[0]` outside `push_message`'s incremental accounting (e.g.
+  `reload_skills()`) MUST recompute the cached prompt-token count from the mutated message
+  afterward — a stale count is a state-consistency bug even though it self-corrects on the next
+  turn's `rebuild_system_prompt`
+
 ## Self-Learning Integration
 
 `FeedbackDetector` monitors responses for implicit quality signals:
@@ -118,6 +144,9 @@ On-demand tool that fetches the full SKILL.md body for a named skill — allows 
 - `disambiguation_threshold` check runs before any skill injection; default is 0.20
 - `min_injection_score` check is a secondary gate applied after disambiguation — both thresholds must be cleared for injection; default is 0.20
 - NEVER inject a skill that fails the `min_injection_score` gate even if it clears `disambiguation_threshold`
+- The system prompt built at agent construction or by `reload_skills()` (no per-turn query
+  available) is catalog-only (name + description); NEVER force-load or inject full skill bodies
+  at these call sites — see § Construction-Time / Reload-Time Skill Prompt Contract (#6413)
 
 ---
 


### PR DESCRIPTION
## Summary

- `Agent::new_with_registry_arc` and `reload_skills()` built the initial/reloaded system prompt from the entire skill registry with full `SKILL.md` bodies, bypassing the matcher/`disambiguation_threshold`/`max_active_skills` cap entirely — the visible symptom was the TUI/`/status` startup token gauge showing ~100k tokens (full registry size) before any turn ran, contradicting the project's resource-efficiency positioning.
- Both call sites now build a catalog-only prompt (name + description via `format_skills_catalog`) straight from `SkillMeta`, with no per-skill disk read, deferring full-body injection to the first per-turn `rebuild_system_prompt(query)` call — which already applies the matching/cap correctly.
- `reload_skills()` now recomputes `cached_prompt_tokens` after mutating `messages[0]`, so the gauge never goes stale between a reload and the next turn.
- Closes the spec gap that allowed this: added a "Construction-Time / Reload-Time Skill Prompt Contract" section to `specs/005-skills/spec.md` and a cross-referenced `NEVER` clause to `specs/001-system-invariants/spec.md` §7 — all prior skill-injection invariants were framed strictly "per turn" and silent on the pre-first-turn prompt.
- Verified the subagent spawn path (`crates/zeph-subagent/src/agent_loop.rs` `run_turn`) does NOT share this defect — it resolves skills once at spawn time via a static include/exclude filter, architecturally distinct from the per-turn matcher. However, adversarial review found subagents with the *default* (empty `skills.include`) configuration force-load every registered skill's full body into their one-shot prompt — same defect class, worse magnitude since it actually reaches the LLM. Correctly scoped out of this PR; filed separately as #6421.

## Root cause investigation

Diagnosed via a dedicated diagnose-only session (debugger + live-tester + architect, no code changes) before this fix was implemented. Full evidence trail carried over into this worktree: `.local/handoff/2026-07-17T21-12-03-debug.md`, `.local/handoff/2026-07-17T21-14-58-live-tester.md`, `.local/handoff/2026-07-17T21-19-59-architect.md`.

## Test plan

- [x] 6 new regression tests in `crates/zeph-core/src/agent/tests/agent_tests/skill_prompt_bloat_tests.rs`: construction catalog-only + token ceiling, reload catalog-only + `cached_prompt_tokens` recompute proof, `last_skills_prompt` catalog-only, 0-skill registry (construction + reload), Blocked-trust skill filtered at reload
- [x] Verified tests are genuine regressions (fail against pre-fix code, not a wrong-layer bypass)
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 14182 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --features desktop,ide,server,chat,pdf,scheduler --locked` — clean
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — 40 passed
- [x] `gitleaks protect --staged` — no leaks
- [x] Rebased onto latest `origin/main`, re-ran full check suite post-rebase (no conflicts, no source touched by rebase)
- [x] Live-testing playbook updated: `.local/testing/playbooks/skills.md` (new scenario), `.local/testing/coverage-status.md` (new row)
- [x] CHANGELOG.md updated under `[Unreleased]/Fixed`

Closes #6413