### PR TITLE
fix(llm): gate OpenAI/Compatible supports_vision on model capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   CLI or TUI display surface (#6390). `/plan status` now lists any rejected handoffs by task
   id/title/reason, and the TUI plan view's task row shows a `[handoff rejected: ...]` title
   suffix, mirroring the existing failed-task error suffix.
+- `zeph-llm`: `OpenAiProvider::supports_vision()` (and `CompatibleProvider`, which delegates to
+  it) unconditionally returned `true` regardless of the configured model's actual capability
+  (#6411, same defect class as #6377/#6410). This caused images to be attached and sent to
+  text-only models such as `gpt-3.5-turbo` (`type = "openai"`) or arbitrary text-only
+  `type = "compatible"` endpoints. Unlike Ollama, there is no standardized capability-discovery
+  endpoint for arbitrary `OpenAI`-compatible servers, so `supports_vision()` now resolves via an
+  explicit `vision` override (new `OpenAiConfig`/`CompatibleConfig` field and
+  `OpenAiProvider::with_vision`/`CompatibleProvider::with_vision` builder, also exposed as a new
+  `vision` field on `[[llm.providers]]` entries) falling back to a built-in model-name prefix
+  table for well-known `OpenAI` vision families (`gpt-4o`, `gpt-4-turbo`, `gpt-4.1`, `gpt-5`,
+  vision-capable `o`+digit reasoning models, explicitly excluding text-only reasoning variants
+  like `o1-mini`/`o1-preview`/`o3-mini`). Fails safe to `false` for any unrecognised model name —
+  the prefix table cannot identify arbitrary `compatible` endpoint model names at all, so an
+  explicit `vision = true` override is the documented way to enable images for those.
 - `zeph-core`: the sanitizer's ML-backed injection and PII classifier calls
   (`ContentSanitizer::classify_injection`/`detect_pii`) were never recorded in the TUI
   metrics panel (#6382). The shared `Arc<ClassifierMetrics>` ring buffer they record into was

--- a/book/src/advanced/multimodal.md
+++ b/book/src/advanced/multimodal.md
@@ -114,7 +114,8 @@ Pipeline: Image attachment → MessagePart::Image → LLM provider (base64) → 
 | Provider | Vision | Notes |
 |----------|--------|-------|
 | Claude | Yes | Anthropic image content block |
-| OpenAI | Yes | image_url data-URI |
+| OpenAI | Conditional | Auto-detected from the model name, or set explicitly via `vision` |
+| Compatible | Conditional | Model-name auto-detection rarely applies (third-party names); set `vision` explicitly |
 | Ollama | Conditional | Only when `vision_model` is configured, or the main model is confirmed vision-capable |
 | Candle | No | Text-only |
 
@@ -137,6 +138,35 @@ vision_model = "llava:13b"
 Alternatively, set `model` directly to a vision-capable model (e.g. `llava:13b`,
 `qwen2.5vl`, `llama3.2-vision`) and Zeph detects the capability automatically — no
 `vision_model` override needed.
+
+### OpenAI / Compatible Vision Override
+
+`type = "openai"` and `type = "compatible"` providers auto-detect vision support from a
+built-in model-name prefix table (`gpt-4o`, `gpt-4-turbo`, `gpt-4.1`, `gpt-5`, `o`+digit
+reasoning models — all match; `gpt-3.5*` and anything unrecognised do not). Unlike Ollama,
+there is no standardized capability-discovery endpoint for arbitrary `OpenAI`-compatible
+servers, so this table is the only automatic signal available, and it fails safe to `false`
+for any model name it cannot identify — which is the common case for third-party
+`compatible` endpoints (Together AI, local vLLM, etc.), since their model names carry no
+`OpenAI` naming convention.
+
+Set `vision` explicitly to override the auto-detected value in either direction:
+
+```toml
+[[llm.providers]]
+name = "local-vlm"
+type = "compatible"
+base_url = "http://localhost:8000/v1"
+model = "llava-onevision"
+vision = true   # the prefix table cannot recognise this model name
+```
+
+```toml
+[[llm.providers]]
+type = "openai"
+model = "gpt-4o"
+vision = false  # force images off even for a recognised vision model
+```
 
 ### Sending Images
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -109,6 +109,7 @@ embedding_model = "qwen3-embedding"
 # max_tokens = 4096
 # embedding_model = "text-embedding-3-small"
 # reasoning_effort = "medium"           # low, medium, high (for o-series models)
+# vision = true                         # override auto-detected vision capability (default: auto-detect via model-name prefix)
 
 # Google Gemini
 # [[llm.providers]]
@@ -127,6 +128,7 @@ embedding_model = "qwen3-embedding"
 # base_url = "https://api.groq.com/openai/v1"
 # model = "llama-3.3-70b-versatile"
 # max_tokens = 4096
+# vision = false                        # override auto-detected vision capability; unrecognised model names default to false
 
 # GonkaGate — OpenAI-compatible decentralized inference gateway (USD billing).
 # Sign up at https://gonkagate.com/en/register, create an API key, then:

--- a/crates/zeph-agent-persistence/src/session_sink.rs
+++ b/crates/zeph-agent-persistence/src/session_sink.rs
@@ -390,6 +390,7 @@ mod tests {
             reasoning_effort: None,
             context_window: None,
             completion_tokens_param: None,
+            vision: None,
         });
         let request = provider.debug_request_json(&messages, &tools, false);
 

--- a/crates/zeph-config/src/providers/entry.rs
+++ b/crates/zeph-config/src/providers/entry.rs
@@ -138,6 +138,16 @@ pub struct ProviderEntry {
     // --- Vision ---
     #[serde(default)]
     pub vision_model: Option<String>,
+    /// Explicit vision-capability override for `type = "openai"` / `type = "compatible"`
+    /// providers.
+    ///
+    /// `None` (default) auto-detects via the built-in `OpenAI` model-name prefix table
+    /// (e.g. `gpt-4o` → capable, `gpt-3.5-turbo` → not capable), which fails safe to `false`
+    /// for any unrecognised model name — the common case for arbitrary `compatible` endpoints.
+    /// Set explicitly to override the auto-detected value in either direction. Ignored by
+    /// other provider types.
+    #[serde(default)]
+    pub vision: Option<bool>,
 
     // --- Gonka-specific ---
     /// Gonka network node pool. Required (non-empty) when `type = "gonka"`.
@@ -222,6 +232,7 @@ impl Default for ProviderEntry {
             api_key: None,
             candle: None,
             vision_model: None,
+            vision: None,
             gonka_nodes: Vec::new(),
             gonka_chain_prefix: None,
             cocoon_client_url: None,
@@ -258,6 +269,7 @@ impl std::fmt::Debug for ProviderEntry {
             .field("api_key", &self.api_key.as_ref().map(|_| "[REDACTED]"))
             .field("candle", &self.candle)
             .field("vision_model", &self.vision_model)
+            .field("vision", &self.vision)
             .field("gonka_nodes", &self.gonka_nodes)
             .field("gonka_chain_prefix", &self.gonka_chain_prefix)
             .field("cocoon_client_url", &self.cocoon_client_url)

--- a/crates/zeph-core/src/debug_dump/mod.rs
+++ b/crates/zeph-core/src/debug_dump/mod.rs
@@ -1919,6 +1919,7 @@ mod tests {
             reasoning_effort: None,
             context_window: None,
             completion_tokens_param: None,
+            vision: None,
         });
         let gemini = zeph_llm::gemini::GeminiProvider::new(
             "test-key".to_owned(),

--- a/crates/zeph-core/src/provider_factory.rs
+++ b/crates/zeph-core/src/provider_factory.rs
@@ -349,6 +349,7 @@ fn build_openai_provider(
             reasoning_effort: entry.reasoning_effort.clone(),
             context_window: None,
             completion_tokens_param: None,
+            vision: entry.vision,
         })
         .with_provider_name(entry.effective_name())
         .with_client(llm_client(config.timeouts.llm_request_timeout_secs))
@@ -437,6 +438,7 @@ fn build_compatible_provider(
         max_tokens,
         embedding_model: entry.embedding_model.clone(),
         completion_tokens_param: None,
+        vision: entry.vision,
     })
     .with_output_schema_forwarding(
         config.mcp.forward_output_schema,

--- a/crates/zeph-llm/src/any.rs
+++ b/crates/zeph-llm/src/any.rs
@@ -1072,6 +1072,7 @@ mod tests {
                 reasoning_effort: None,
                 context_window: None,
                 completion_tokens_param: None,
+                vision: None,
             },
         ));
         assert_eq!(provider.name(), "openai");
@@ -1089,6 +1090,7 @@ mod tests {
                 reasoning_effort: None,
                 context_window: None,
                 completion_tokens_param: None,
+                vision: None,
             },
         ));
         assert!(provider.supports_streaming());
@@ -1106,6 +1108,7 @@ mod tests {
                 reasoning_effort: None,
                 context_window: None,
                 completion_tokens_param: None,
+                vision: None,
             },
         ));
         assert!(with_embed.supports_embeddings());
@@ -1120,6 +1123,7 @@ mod tests {
                 reasoning_effort: None,
                 context_window: None,
                 completion_tokens_param: None,
+                vision: None,
             },
         ));
         assert!(!without_embed.supports_embeddings());
@@ -1137,6 +1141,7 @@ mod tests {
                 reasoning_effort: None,
                 context_window: None,
                 completion_tokens_param: None,
+                vision: None,
             },
         ));
         let debug = format!("{provider:?}");
@@ -1175,6 +1180,7 @@ mod tests {
                 reasoning_effort: None,
                 context_window: None,
                 completion_tokens_param: None,
+                vision: None,
             },
         ));
         assert!(provider.supports_structured_output());
@@ -1197,7 +1203,7 @@ mod tests {
     }
 
     #[test]
-    fn any_openai_supports_vision() {
+    fn any_openai_supports_vision_true_for_vision_model() {
         let provider = AnyProvider::OpenAi(crate::openai::OpenAiProvider::new(
             crate::openai::OpenAiConfig {
                 api_key: "key".into(),
@@ -1208,9 +1214,29 @@ mod tests {
                 reasoning_effort: None,
                 context_window: None,
                 completion_tokens_param: None,
+                vision: None,
             },
         ));
         assert!(provider.supports_vision());
+    }
+
+    #[test]
+    fn any_openai_supports_vision_false_for_gpt35() {
+        // #6411: a text-only model must not be reported as vision-capable.
+        let provider = AnyProvider::OpenAi(crate::openai::OpenAiProvider::new(
+            crate::openai::OpenAiConfig {
+                api_key: "key".into(),
+                base_url: "https://api.openai.com/v1".into(),
+                model: "gpt-3.5-turbo".into(),
+                max_tokens: 1024,
+                embedding_model: None,
+                reasoning_effort: None,
+                context_window: None,
+                completion_tokens_param: None,
+                vision: None,
+            },
+        ));
+        assert!(!provider.supports_vision());
     }
 
     #[test]
@@ -1370,6 +1396,7 @@ mod tests {
             reasoning_effort: None,
             context_window: None,
             completion_tokens_param: None,
+            vision: None,
         })
     }
 
@@ -1382,6 +1409,7 @@ mod tests {
             max_tokens: 1024,
             embedding_model: None,
             completion_tokens_param: None,
+            vision: None,
         })
     }
 

--- a/crates/zeph-llm/src/cocoon/provider.rs
+++ b/crates/zeph-llm/src/cocoon/provider.rs
@@ -181,6 +181,7 @@ impl CocoonProvider {
             reasoning_effort: None,
             context_window: None,
             completion_tokens_param: None,
+            vision: None,
         });
         Self {
             inner,

--- a/crates/zeph-llm/src/compatible.rs
+++ b/crates/zeph-llm/src/compatible.rs
@@ -47,6 +47,7 @@ use crate::provider::{
 ///     max_tokens: 4096,
 ///     embedding_model: None,
 ///     completion_tokens_param: None,
+///     vision: None,
 /// };
 /// let provider = CompatibleProvider::new(cfg);
 /// ```
@@ -70,6 +71,13 @@ pub struct CompatibleConfig {
     /// prefix table. Set explicitly for models the table does not recognise (e.g. fine-tuned
     /// reasoning models whose names do not start with `o` + digit).
     pub completion_tokens_param: Option<CompletionTokensParam>,
+    /// Explicit vision-capability override.
+    ///
+    /// `OpenAiProvider`'s built-in model-name prefix table cannot recognise arbitrary
+    /// `compatible` endpoint model names (Together AI, local vLLM, etc.), so it fails safe
+    /// to `false` for all of them. Set this when the endpoint's configured model actually
+    /// accepts image input.
+    pub vision: Option<bool>,
 }
 
 impl fmt::Debug for CompatibleConfig {
@@ -82,6 +90,7 @@ impl fmt::Debug for CompatibleConfig {
             .field("max_tokens", &self.max_tokens)
             .field("embedding_model", &self.embedding_model)
             .field("completion_tokens_param", &self.completion_tokens_param)
+            .field("vision", &self.vision)
             .finish()
     }
 }
@@ -110,6 +119,7 @@ impl CompatibleProvider {
             reasoning_effort: None,
             context_window: None,
             completion_tokens_param: cfg.completion_tokens_param,
+            vision: cfg.vision,
         });
         Self {
             inner,
@@ -181,12 +191,45 @@ impl CompatibleProvider {
     ///     max_tokens: 4096,
     ///     embedding_model: None,
     ///     completion_tokens_param: None,
+    ///     vision: None,
     /// })
     /// .with_completion_tokens_param(CompletionTokensParam::MaxCompletionTokens);
     /// ```
     #[must_use]
     pub fn with_completion_tokens_param(mut self, param: CompletionTokensParam) -> Self {
         self.inner = self.inner.with_completion_tokens_param(param);
+        self
+    }
+
+    /// Override the vision-capability value reported by [`LlmProvider::supports_vision`].
+    ///
+    /// Delegates to the inner [`OpenAiProvider`]. Use this for `compatible` endpoints whose
+    /// model name is not covered by `OpenAiProvider`'s built-in prefix table — which is the
+    /// common case, since third-party model names carry no `OpenAI` naming convention and the
+    /// table therefore fails safe to `false` for them.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_llm::compatible::{CompatibleConfig, CompatibleProvider};
+    /// use zeph_llm::provider::LlmProvider;
+    ///
+    /// let provider = CompatibleProvider::new(CompatibleConfig {
+    ///     provider_name: "local-vlm".into(),
+    ///     api_key: "key".into(),
+    ///     base_url: "http://localhost:8000/v1".into(),
+    ///     model: "llava-onevision".into(),
+    ///     max_tokens: 4096,
+    ///     embedding_model: None,
+    ///     completion_tokens_param: None,
+    ///     vision: None,
+    /// })
+    /// .with_vision(true);
+    /// assert!(provider.supports_vision());
+    /// ```
+    #[must_use]
+    pub fn with_vision(mut self, supported: bool) -> Self {
+        self.inner = self.inner.with_vision(supported);
         self
     }
 
@@ -361,6 +404,7 @@ mod tests {
             max_tokens: 4096,
             embedding_model: None,
             completion_tokens_param: None,
+            vision: None,
         })
     }
 
@@ -381,6 +425,7 @@ mod tests {
             max_tokens: 4096,
             embedding_model: None,
             completion_tokens_param: None,
+            vision: None,
         });
         assert_eq!(p.context_window(), Some(128_000));
     }
@@ -396,6 +441,7 @@ mod tests {
             max_tokens: 4096,
             embedding_model: None,
             completion_tokens_param: None,
+            vision: None,
         });
         // OpenAiProvider returns Some(128_000) as fallback for unrecognised models.
         assert!(p.context_window().is_some());
@@ -421,6 +467,7 @@ mod tests {
             max_tokens: 100,
             embedding_model: Some("embed-model".into()),
             completion_tokens_param: None,
+            vision: None,
         });
         assert!(p.supports_embeddings());
     }
@@ -449,6 +496,7 @@ mod tests {
             max_tokens: 100,
             embedding_model: None,
             completion_tokens_param: None,
+            vision: None,
         });
         let msgs = vec![Message::from_legacy(crate::provider::Role::User, "hello")];
         assert!(p.chat(&msgs).await.is_err());
@@ -499,8 +547,49 @@ mod tests {
 
     #[test]
     fn supports_vision_delegates_to_inner() {
-        // OpenAiProvider always returns true for supports_vision.
-        assert!(test_provider().supports_vision());
+        // #6411: test_provider() uses model "llama-3.3-70b", which matches no OpenAI
+        // vision prefix — OpenAiProvider's fail-safe default must be false, not true.
+        assert!(!test_provider().supports_vision());
+    }
+
+    #[test]
+    fn supports_vision_with_vision_override_delegates_to_inner() {
+        // with_vision(true) must override the prefix-table default even for a model
+        // name the table cannot recognise.
+        let p = test_provider().with_vision(true);
+        assert!(p.supports_vision());
+    }
+
+    #[test]
+    fn supports_vision_config_field_true_forwards_to_inner() {
+        // Distinct code path from with_vision(): CompatibleConfig::vision must be forwarded
+        // into the inner OpenAiConfig by CompatibleProvider::new, not just by the builder.
+        let p = CompatibleProvider::new(CompatibleConfig {
+            provider_name: "test".into(),
+            api_key: "key".into(),
+            base_url: "http://localhost".into(),
+            model: "llama-3.3-70b".into(),
+            max_tokens: 100,
+            embedding_model: None,
+            completion_tokens_param: None,
+            vision: Some(true),
+        });
+        assert!(p.supports_vision());
+    }
+
+    #[test]
+    fn supports_vision_config_field_false_forwards_to_inner() {
+        let p = CompatibleProvider::new(CompatibleConfig {
+            provider_name: "test".into(),
+            api_key: "key".into(),
+            base_url: "http://localhost".into(),
+            model: "llama-3.3-70b".into(),
+            max_tokens: 100,
+            embedding_model: None,
+            completion_tokens_param: None,
+            vision: Some(false),
+        });
+        assert!(!p.supports_vision());
     }
 
     #[test]
@@ -524,6 +613,7 @@ mod tests {
             max_tokens: 4096,
             embedding_model: None,
             completion_tokens_param: None,
+            vision: None,
         };
         let dbg = format!("{cfg:?}");
         assert!(!dbg.contains("sk-SUPERSECRET"));

--- a/crates/zeph-llm/src/gonka/provider.rs
+++ b/crates/zeph-llm/src/gonka/provider.rs
@@ -199,6 +199,7 @@ impl GonkaProvider {
             reasoning_effort: None,
             context_window: None,
             completion_tokens_param: None,
+            vision: None,
         });
         // HTTP client timeout is generous to avoid double-timeout with tokio::time::timeout.
         let client = crate::http::llm_client(cfg.timeout.as_secs().saturating_add(30));

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -58,6 +58,7 @@ use serde::{Deserialize, Serialize};
 ///     reasoning_effort: None,
 ///     context_window: None,
 ///     completion_tokens_param: Some(CompletionTokensParam::MaxCompletionTokens),
+///     vision: None,
 /// };
 /// let provider = OpenAiProvider::new(cfg);
 /// ```
@@ -88,6 +89,7 @@ pub enum CompletionTokensParam {
 ///     reasoning_effort: None,
 ///     context_window: None,
 ///     completion_tokens_param: None,
+///     vision: None,
 /// };
 /// let provider = OpenAiProvider::new(cfg);
 /// ```
@@ -119,6 +121,13 @@ pub struct OpenAiConfig {
     /// prefix table. Set explicitly for models the table does not recognise (e.g. fine-tuned
     /// reasoning models whose names do not start with `o` + digit).
     pub completion_tokens_param: Option<CompletionTokensParam>,
+    /// Explicit vision-capability override.
+    ///
+    /// When set, this value is returned by [`LlmProvider::supports_vision`] instead of the
+    /// built-in prefix-match table. Use this for models the table does not recognise (e.g.
+    /// arbitrary `type = "compatible"` endpoints, whose model names carry no `OpenAI` naming
+    /// convention) or to force a known table entry off.
+    pub vision: Option<bool>,
 }
 
 impl fmt::Debug for OpenAiConfig {
@@ -132,6 +141,7 @@ impl fmt::Debug for OpenAiConfig {
             .field("reasoning_effort", &self.reasoning_effort)
             .field("context_window", &self.context_window)
             .field("completion_tokens_param", &self.completion_tokens_param)
+            .field("vision", &self.vision)
             .finish()
     }
 }
@@ -155,6 +165,7 @@ const MAX_RETRIES: u32 = 3;
 /// - [`with_generation_overrides`](Self::with_generation_overrides)
 /// - [`with_status_tx`](Self::with_status_tx)
 /// - [`with_context_window`](Self::with_context_window)
+/// - [`with_vision`](Self::with_vision)
 pub struct OpenAiProvider {
     client: reqwest::Client,
     api_key: String,
@@ -179,6 +190,9 @@ pub struct OpenAiProvider {
     /// Override which token-limit field to use. `None` means infer from the model name prefix
     /// table via [`CompletionTokens::for_model`].
     completion_tokens_override: Option<CompletionTokensParam>,
+    /// Explicit vision-capability override set via [`OpenAiConfig::vision`] or
+    /// [`OpenAiProvider::with_vision`]. Takes precedence over the prefix-match table.
+    vision_override: Option<bool>,
     /// Name reported by [`LlmProvider::name`]. Defaults to `"openai"`; set the TOML-configured
     /// `name` via [`with_provider_name`](Self::with_provider_name) so that router reputation
     /// tracking and provider selection can distinguish between multiple configured `OpenAI`
@@ -210,6 +224,7 @@ impl fmt::Debug for OpenAiProvider {
                 "completion_tokens_override",
                 &self.completion_tokens_override,
             )
+            .field("vision_override", &self.vision_override)
             .field("provider_name", &self.provider_name)
             .finish()
     }
@@ -233,6 +248,7 @@ impl Clone for OpenAiProvider {
             max_tool_description_bytes: self.max_tool_description_bytes,
             context_window_override: self.context_window_override,
             completion_tokens_override: self.completion_tokens_override,
+            vision_override: self.vision_override,
             provider_name: self.provider_name.clone(),
         }
     }
@@ -262,6 +278,7 @@ impl OpenAiProvider {
             max_tool_description_bytes: usize::MAX,
             context_window_override: cfg.context_window.map(|v| v as usize),
             completion_tokens_override: cfg.completion_tokens_param,
+            vision_override: cfg.vision,
             provider_name: "openai".to_owned(),
         }
     }
@@ -336,6 +353,7 @@ impl OpenAiProvider {
     ///     reasoning_effort: None,
     ///     context_window: None,
     ///     completion_tokens_param: None,
+    ///     vision: None,
     /// })
     /// .with_context_window(200_000);
     /// assert_eq!(provider.context_window(), Some(200_000));
@@ -366,12 +384,47 @@ impl OpenAiProvider {
     ///     reasoning_effort: None,
     ///     context_window: None,
     ///     completion_tokens_param: None,
+    ///     vision: None,
     /// })
     /// .with_completion_tokens_param(CompletionTokensParam::MaxCompletionTokens);
     /// ```
     #[must_use]
     pub fn with_completion_tokens_param(mut self, param: CompletionTokensParam) -> Self {
         self.completion_tokens_override = Some(param);
+        self
+    }
+
+    /// Override the vision-capability value reported by [`LlmProvider::supports_vision`].
+    ///
+    /// Use this for models the built-in prefix table does not recognise — most commonly
+    /// arbitrary `type = "compatible"` endpoints, whose model names carry no `OpenAI` naming
+    /// convention and therefore fail safe to `false`. Also usable to force a known table
+    /// entry off. Mirrors the config-level [`OpenAiConfig::vision`] field but can also be
+    /// set after construction.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_llm::openai::{OpenAiConfig, OpenAiProvider};
+    /// use zeph_llm::provider::LlmProvider;
+    ///
+    /// let provider = OpenAiProvider::new(OpenAiConfig {
+    ///     api_key: "k".into(),
+    ///     base_url: "http://localhost:8000/v1".into(),
+    ///     model: "my-local-vision-model".into(),
+    ///     max_tokens: 4096,
+    ///     embedding_model: None,
+    ///     reasoning_effort: None,
+    ///     context_window: None,
+    ///     completion_tokens_param: None,
+    ///     vision: None,
+    /// })
+    /// .with_vision(true);
+    /// assert!(provider.supports_vision());
+    /// ```
+    #[must_use]
+    pub fn with_vision(mut self, supported: bool) -> Self {
+        self.vision_override = Some(supported);
         self
     }
 
@@ -395,6 +448,7 @@ impl OpenAiProvider {
     ///     reasoning_effort: None,
     ///     context_window: None,
     ///     completion_tokens_param: None,
+    ///     vision: None,
     /// });
     /// provider.set_reasoning_effort(Some("high".into()));
     /// ```
@@ -1007,8 +1061,21 @@ impl LlmProvider for OpenAiProvider {
         serde_json::from_str::<T>(content).map_err(|e| LlmError::StructuredParse(e.to_string()))
     }
 
+    /// Returns whether the configured model accepts image input.
+    ///
+    /// Resolution order:
+    /// 1. Explicit override set via [`OpenAiConfig::vision`] or [`Self::with_vision`].
+    /// 2. Built-in prefix table for well-known vision-capable `OpenAI` model families.
+    /// 3. `false` for any unrecognised model — unlike [`Self::context_window`], there is no
+    ///    default-guess fallback here. An arbitrary `type = "compatible"` endpoint (Together AI,
+    ///    local vLLM, etc.) has a model name with no `OpenAI` naming convention to match against,
+    ///    so assuming vision support would risk silently sending an image the model cannot
+    ///    process (same fail-safe philosophy as `OllamaProvider::supports_vision`, #6377/#6411).
     fn supports_vision(&self) -> bool {
-        true
+        if let Some(supported) = self.vision_override {
+            return supported;
+        }
+        model_supports_vision(&self.model)
     }
 
     fn supports_tool_use(&self) -> bool {
@@ -1659,6 +1726,38 @@ impl CompletionTokens {
 fn starts_with_o_digit(model: &str) -> bool {
     let mut chars = model.chars();
     chars.next() == Some('o') && chars.next().is_some_and(|c| c.is_ascii_digit())
+}
+
+/// Built-in prefix table of `OpenAI` model families known to accept image input.
+///
+/// Not exhaustive by design (#6411): fine-tunes and newly-released variants may be missed,
+/// in which case [`OpenAiConfig::vision`] / [`OpenAiProvider::with_vision`] is the documented
+/// escape hatch. `gpt-3.5*` deliberately does not match — it is text-only.
+///
+/// Unlike [`CompletionTokens::for_model`], vision support is not uniform across the whole
+/// `o`+digit reasoning family: `o1-mini`, `o1-preview`, and `o3-mini` are text-only, while
+/// `o1`, `o3`, and `o4-mini` accept images. Reusing [`starts_with_o_digit`] wholesale here
+/// would reintroduce the #6411 bug for those three text-only variants, so they are excluded
+/// explicitly before falling back to the shared prefix check.
+fn model_supports_vision(model: &str) -> bool {
+    if model.starts_with("gpt-4o")
+        || model.starts_with("gpt-4-turbo")
+        || model.starts_with("gpt-4-vision")
+        || model.starts_with("gpt-4.1")
+        || model.starts_with("gpt-5")
+    {
+        return true;
+    }
+    if is_text_only_o_series(model) {
+        return false;
+    }
+    starts_with_o_digit(model)
+}
+
+/// `o`+digit reasoning models confirmed text-only (no image input), unlike the rest of the
+/// `o`-series family. See [`model_supports_vision`] for why this exclusion exists.
+fn is_text_only_o_series(model: &str) -> bool {
+    model.starts_with("o1-mini") || model.starts_with("o1-preview") || model.starts_with("o3-mini")
 }
 
 #[derive(Serialize)]

--- a/crates/zeph-llm/src/openai/tests.rs
+++ b/crates/zeph-llm/src/openai/tests.rs
@@ -33,6 +33,7 @@ fn test_provider() -> OpenAiProvider {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     })
 }
 
@@ -47,6 +48,7 @@ fn context_window_gpt4o() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     assert_eq!(p.context_window(), Some(128_000));
 }
@@ -67,6 +69,7 @@ fn context_window_unknown_falls_back_to_128k() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     assert_eq!(p.context_window(), Some(128_000));
 }
@@ -82,6 +85,7 @@ fn context_window_override_takes_precedence() {
         reasoning_effort: None,
         context_window: Some(256_000),
         completion_tokens_param: None,
+        vision: None,
     });
     assert_eq!(p.context_window(), Some(256_000));
 }
@@ -97,9 +101,211 @@ fn context_window_override_via_builder() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     })
     .with_context_window(200_000);
     assert_eq!(p.context_window(), Some(200_000));
+}
+
+// --- #6411: supports_vision must not be hardcoded true ---
+
+#[test]
+fn supports_vision_true_for_known_vision_model() {
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "gpt-4o".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+        context_window: None,
+        completion_tokens_param: None,
+        vision: None,
+    });
+    assert!(p.supports_vision());
+}
+
+#[test]
+fn supports_vision_false_for_gpt35() {
+    // The exact repro case from #6411: a text-only model must not be treated as vision-capable.
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "gpt-3.5-turbo".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+        context_window: None,
+        completion_tokens_param: None,
+        vision: None,
+    });
+    assert!(!p.supports_vision());
+}
+
+#[test]
+fn supports_vision_false_for_unknown_model() {
+    // Fail-safe default: an unrecognised model name (e.g. an arbitrary `compatible` endpoint
+    // model) must not be assumed vision-capable.
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "custom-model".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+        context_window: None,
+        completion_tokens_param: None,
+        vision: None,
+    });
+    assert!(!p.supports_vision());
+}
+
+#[test]
+fn supports_vision_false_for_o1_mini() {
+    // Regression: o1-mini is text-only, but naively reusing starts_with_o_digit (correct for
+    // the completion-tokens axis) would misreport it as vision-capable, reintroducing #6411.
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "o1-mini".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+        context_window: None,
+        completion_tokens_param: None,
+        vision: None,
+    });
+    assert!(!p.supports_vision());
+}
+
+#[test]
+fn supports_vision_false_for_o1_preview() {
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "o1-preview".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+        context_window: None,
+        completion_tokens_param: None,
+        vision: None,
+    });
+    assert!(!p.supports_vision());
+}
+
+#[test]
+fn supports_vision_false_for_o3_mini() {
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "o3-mini".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+        context_window: None,
+        completion_tokens_param: None,
+        vision: None,
+    });
+    assert!(!p.supports_vision());
+}
+
+#[test]
+fn supports_vision_true_for_o1() {
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "o1".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+        context_window: None,
+        completion_tokens_param: None,
+        vision: None,
+    });
+    assert!(p.supports_vision());
+}
+
+#[test]
+fn supports_vision_true_for_o3() {
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "o3".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+        context_window: None,
+        completion_tokens_param: None,
+        vision: None,
+    });
+    assert!(p.supports_vision());
+}
+
+#[test]
+fn supports_vision_true_for_o4_mini() {
+    // o4-mini is a multimodal reasoning model, unlike o1-mini/o3-mini which are text-only.
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "o4-mini".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+        context_window: None,
+        completion_tokens_param: None,
+        vision: None,
+    });
+    assert!(p.supports_vision());
+}
+
+#[test]
+fn supports_vision_true_with_explicit_override_on_text_model() {
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "gpt-3.5-turbo".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+        context_window: None,
+        completion_tokens_param: None,
+        vision: Some(true),
+    });
+    assert!(p.supports_vision());
+}
+
+#[test]
+fn supports_vision_false_with_explicit_override_on_vision_model() {
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "gpt-4o".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+        context_window: None,
+        completion_tokens_param: None,
+        vision: Some(false),
+    });
+    assert!(!p.supports_vision());
+}
+
+#[test]
+fn supports_vision_override_via_builder() {
+    let p = OpenAiProvider::new(OpenAiConfig {
+        api_key: "k".into(),
+        base_url: "https://api.openai.com/v1".into(),
+        model: "gpt-3.5-turbo".into(),
+        max_tokens: 1024,
+        embedding_model: None,
+        reasoning_effort: None,
+        context_window: None,
+        completion_tokens_param: None,
+        vision: None,
+    })
+    .with_vision(true);
+    assert!(p.supports_vision());
 }
 
 fn test_provider_no_embed() -> OpenAiProvider {
@@ -112,6 +318,7 @@ fn test_provider_no_embed() -> OpenAiProvider {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     })
 }
 
@@ -137,6 +344,7 @@ fn new_with_reasoning_effort() {
         reasoning_effort: Some("high".into()),
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     assert_eq!(p.reasoning_effort.as_deref(), Some("high"));
 }
@@ -284,6 +492,7 @@ fn debug_request_json_plain_includes_flat_reasoning_effort() {
         reasoning_effort: Some("medium".into()),
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     let messages = vec![Message::from_legacy(Role::User, "hi")];
     let json = p.debug_request_json(&messages, &[], false).to_string();
@@ -302,6 +511,7 @@ fn debug_request_json_tools_includes_flat_reasoning_effort() {
         reasoning_effort: Some("high".into()),
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     let messages = vec![Message::from_legacy(Role::User, "hi")];
     let tools = vec![ToolDefinition {
@@ -330,6 +540,7 @@ fn debug_request_json_vision_includes_flat_reasoning_effort() {
         reasoning_effort: Some("low".into()),
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     let messages = vec![Message::from_parts(
         Role::User,
@@ -508,6 +719,7 @@ async fn chat_unreachable_endpoint_errors() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     let messages = vec![Message {
         role: Role::User,
@@ -529,6 +741,7 @@ async fn stream_unreachable_endpoint_errors() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     let messages = vec![Message {
         role: Role::User,
@@ -550,6 +763,7 @@ async fn embed_unreachable_endpoint_errors() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     assert!(p.embed("test").await.is_err());
 }
@@ -578,6 +792,7 @@ fn base_url_strips_trailing_slash() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     assert_eq!(p.base_url, "https://api.openai.com/v1");
 }
@@ -626,6 +841,7 @@ async fn integration_openai_chat() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
 
     let messages = vec![Message {
@@ -652,6 +868,7 @@ async fn integration_openai_chat_stream() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
 
     let messages = vec![Message {
@@ -685,6 +902,7 @@ fn context_window_o1() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     assert_eq!(p.context_window(), Some(200_000));
 }
@@ -700,6 +918,7 @@ fn context_window_o1_mini() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     assert_eq!(p.context_window(), Some(200_000));
 }
@@ -715,6 +934,7 @@ fn context_window_o3() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     assert_eq!(p.context_window(), Some(200_000));
 }
@@ -730,6 +950,7 @@ fn context_window_o3_mini() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     assert_eq!(p.context_window(), Some(200_000));
 }
@@ -745,6 +966,7 @@ fn context_window_o4_mini() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     assert_eq!(p.context_window(), Some(200_000));
 }
@@ -760,6 +982,7 @@ fn context_window_gpt35() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     assert_eq!(p.context_window(), Some(16_385));
 }
@@ -775,6 +998,7 @@ fn context_window_gpt4_turbo() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     assert_eq!(p.context_window(), Some(128_000));
 }
@@ -792,6 +1016,7 @@ async fn integration_openai_embed() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
 
     let embedding = provider.embed("Hello world").await.unwrap();
@@ -1204,6 +1429,7 @@ fn cache_slug_openai() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     assert_eq!(p.cache_slug(), "api_openai_com");
 }
@@ -1219,6 +1445,7 @@ fn cache_slug_custom_host() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     assert_eq!(p.cache_slug(), "my_llm_example_com");
 }
@@ -1234,6 +1461,7 @@ fn cache_slug_localhost_with_port() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     assert_eq!(p.cache_slug(), "localhost");
 }
@@ -1338,6 +1566,7 @@ async fn list_models_remote_http_error_propagates() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     let result = p.list_models_remote().await;
     assert!(result.is_err());
@@ -1371,6 +1600,7 @@ async fn chat_happy_path_wiremock() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     let messages = vec![Message {
         role: Role::User,
@@ -1418,6 +1648,7 @@ async fn chat_with_tools_handles_null_assistant_content() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     let messages = vec![Message {
         role: Role::User,
@@ -1479,6 +1710,7 @@ async fn chat_with_tools_reasoning_effort_400_enriches_message() {
         reasoning_effort: Some("high".into()),
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     let messages = vec![Message {
         role: Role::User,
@@ -1542,6 +1774,7 @@ async fn chat_with_tools_reasoning_effort_none_400_passes_through_raw_message() 
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     let messages = vec![Message {
         role: Role::User,
@@ -1599,6 +1832,7 @@ async fn chat_429_rate_limit_propagates() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     let messages = vec![Message {
         role: Role::User,
@@ -1633,6 +1867,7 @@ async fn chat_401_auth_error_propagates() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     let messages = vec![Message {
         role: Role::User,
@@ -1667,6 +1902,7 @@ async fn chat_500_server_error_propagates() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     let messages = vec![Message {
         role: Role::User,
@@ -1748,6 +1984,7 @@ async fn chat_with_tools_retries_on_429_then_succeeds() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     let messages = vec![Message {
         role: Role::User,
@@ -1788,6 +2025,7 @@ fn with_generation_overrides_stores_overrides() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     assert!(provider.generation_overrides.is_none());
     let overrides = GenerationOverrides {
@@ -1954,6 +2192,7 @@ async fn embed_batch_empty_returns_empty_without_network() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     let result = p.embed_batch(&[]).await.unwrap();
     assert!(result.is_empty());
@@ -2129,6 +2368,7 @@ fn completion_tokens_override_forces_max_completion_tokens_for_legacy_model() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: Some(CompletionTokensParam::MaxCompletionTokens),
+        vision: None,
     });
     let json = serde_json::to_string(&p.completion_tokens()).unwrap();
     assert!(json.contains("\"max_completion_tokens\":1024"));
@@ -2147,6 +2387,7 @@ fn completion_tokens_override_forces_max_tokens_for_o_series_model() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: Some(CompletionTokensParam::MaxTokens),
+        vision: None,
     });
     let json = serde_json::to_string(&p.completion_tokens()).unwrap();
     assert!(json.contains("\"max_tokens\":512"));
@@ -2165,6 +2406,7 @@ fn completion_tokens_override_none_falls_back_to_prefix_table() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     let json = serde_json::to_string(&p_legacy.completion_tokens()).unwrap();
     assert!(json.contains("\"max_tokens\":256"));
@@ -2178,6 +2420,7 @@ fn completion_tokens_override_none_falls_back_to_prefix_table() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     let json = serde_json::to_string(&p_o.completion_tokens()).unwrap();
     assert!(json.contains("\"max_completion_tokens\":256"));
@@ -2194,6 +2437,7 @@ fn with_completion_tokens_param_builder_sets_override() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     })
     .with_completion_tokens_param(CompletionTokensParam::MaxCompletionTokens);
     let json = serde_json::to_string(&p.completion_tokens()).unwrap();
@@ -2213,6 +2457,7 @@ fn set_reasoning_effort_applies_value() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     assert!(p.reasoning_effort.is_none(), "starts without effort");
     p.set_reasoning_effort(Some("high".into()));
@@ -2230,6 +2475,7 @@ fn set_reasoning_effort_clears_value() {
         reasoning_effort: Some("medium".into()),
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     p.set_reasoning_effort(None);
     assert!(p.reasoning_effort.is_none());
@@ -2247,6 +2493,7 @@ fn any_provider_set_reasoning_effort_delegates_to_openai() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     let mut any = AnyProvider::OpenAi(inner);
     any.set_reasoning_effort(Some("high".into()));
@@ -2280,6 +2527,7 @@ fn set_reasoning_effort_rejects_invalid_value() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     });
     p.set_reasoning_effort(Some("ultra".into()));
     assert!(
@@ -2299,6 +2547,7 @@ fn openai_config_debug_redacts_api_key() {
         reasoning_effort: None,
         context_window: None,
         completion_tokens_param: None,
+        vision: None,
     };
     let dbg = format!("{cfg:?}");
     assert!(!dbg.contains("sk-SUPERSECRET"));

--- a/crates/zeph-llm/tests/gonka_live.rs
+++ b/crates/zeph-llm/tests/gonka_live.rs
@@ -124,6 +124,7 @@ mod compatible_live {
             max_tokens: 16,
             embedding_model: None,
             completion_tokens_param: None,
+            vision: None,
         });
 
         let messages = vec![Message::from_legacy(

--- a/crates/zeph-skills/src/bin/miner.rs
+++ b/crates/zeph-skills/src/bin/miner.rs
@@ -226,6 +226,7 @@ fn build_provider(config: &zeph_config::Config, name: &str) -> anyhow::Result<An
                 reasoning_effort: None,
                 context_window: None,
                 completion_tokens_param: None,
+                vision: None,
             }))
         }
         zeph_config::ProviderKind::Ollama => {

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -2420,6 +2420,7 @@ fn build_acp_provider_factory(
                             reasoning_effort: reasoning_effort.clone(),
                             context_window: None,
                             completion_tokens_param: None,
+                            vision: None,
                         }),
                     )));
                 }
@@ -2440,6 +2441,7 @@ fn build_acp_provider_factory(
                                 max_tokens: *max_tokens,
                                 embedding_model: embed.clone(),
                                 completion_tokens_param: None,
+                                vision: None,
                             },
                         ),
                     )));


### PR DESCRIPTION
## Summary

- `OpenAiProvider::supports_vision()` unconditionally returned `true` regardless of the configured model, so a text-only model (e.g. `gpt-3.5-turbo`, or an arbitrary text-only `type = "compatible"` endpoint) would have images attached and sent, typically failing with a 400. `CompatibleProvider` inherited the same bug via delegation.
- `supports_vision()` now resolves via an explicit `vision` override (new `OpenAiConfig`/`CompatibleConfig` field, `with_vision` builders, and a new `vision` field on `[[llm.providers]]` entries) falling back to a built-in model-name prefix table for well-known OpenAI vision families (`gpt-4o`, `gpt-4-turbo`, `gpt-4-vision`, `gpt-4.1`, `gpt-5`, vision-capable `o`-series), explicitly excluding text-only reasoning variants (`o1-mini`, `o1-preview`, `o3-mini`). Unrecognised model names fail safe to `false` — this is also the default for arbitrary `compatible` endpoints unless `vision = true` is set explicitly.
- Same defect class as #6377, already fixed for Ollama in #6410.

Closes #6411

## Test plan

- [x] Full local check suite: `cargo +nightly fmt --check`, `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`, `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (14217 passed, 0 failed, 35 skipped; one unrelated concurrency test flake confirmed non-reproducing on re-run), rustdoc gate with `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links"` — all clean.
- [x] `cargo test --doc --workspace` — all 32 crates pass, including new `with_vision` doctests on `OpenAiProvider`/`CompatibleProvider`.
- [x] Per-crate rustdoc check for touched crates (`zeph-llm`, `zeph-config`) — clean.
- [x] New unit tests cover: known-vision-model auto-detect, `gpt-3.5*` false, unrecognised-model fail-safe false, explicit override in both directions, text-only `o`-series exclusion (`o1-mini`/`o1-preview`/`o3-mini`), `CompatibleConfig.vision` config-field forwarding (distinct from the `.with_vision()` builder path).
- [x] LLM serialization gate: live round-trip against a real `gpt-4o-mini` OpenAI provider confirmed the request reaches the server and is rejected only with `429` (rate-limited, a known pre-existing test-account constraint, unrelated to this change) — never a `400`/`422`, confirming the request payload is well-formed. Verified in source that `400` responses are routed through a distinct error path (`map_error_response` → `LlmError::ApiError`) never conflated with the `429`/`503` retry loop that was actually hit.
- [x] Adversarial critique (impl-critic) and independent test-coverage validation (tester) both ran; one significant finding (o-series text-only false positive) was fixed and re-verified before code review approval.