### PR TITLE
feat(orchestration): make whole-plan verify timeout independently configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 ### Fixed
 
+- `zeph-orchestration`: `PlanVerifier::verify_plan()` (whole-plan grounding, spec 009) shared
+  the same `orchestration.verifier_timeout_secs` budget as per-task `verify()`, and consistently
+  exhausted it against slower local Ollama models even when per-task verification on the same
+  run/provider returned promptly — silently fail-opening whole-plan verification on essentially
+  every attempt (#6379). Added `orchestration.whole_plan_verifier_timeout_secs` (`0` = fall back
+  to `verifier_timeout_secs`, mirrors `[orchestration.ensemble].member_timeout_secs`) so an
+  operator can give `verify_plan()` a separate, longer budget. **Default behavior is unchanged**:
+  the default is `0`, which resolves to the same `verifier_timeout_secs` (120s) that is already
+  failing, so out-of-the-box #6379's live symptom is not resolved by this change alone — a
+  non-zero value must be set explicitly. Also added `tracing::debug!` prompt-size/tool-trace
+  diagnostics in both `verify()` and `verify_plan()`, needed because it is not yet confirmed
+  whether a longer budget actually fixes the symptom or whether the whole-plan LLM call is
+  genuinely non-terminating for its prompt shape regardless of timeout — live root-cause
+  confirmation is still pending (#6379 remains open).
+
 - `zeph-session`: `AdvisoryLock::acquire`'s `WOULDBLOCK` path gave operators only a bare
   "another session is already active" message with no way to tell whether the lock's holder
   was still running (#6378). The holder's PID is now written into the sibling lock file

--- a/config/default.toml
+++ b/config/default.toml
@@ -1191,6 +1191,9 @@ verify_completeness = false
 # timeout here causes fail-open on essentially every verification and silently skips the
 # tool-call grounding safety net (spec 009, #6278/#6287) — see #6366.
 # verifier_timeout_secs = 120
+# Timeout in seconds for the whole-plan verify_plan() LLM call; 0 = fall back to
+# verifier_timeout_secs. Default: 0. See #6379.
+# whole_plan_verifier_timeout_secs = 0
 
 # ORCH-style deterministic verifier ensemble-merge (arXiv:2602.01797), opt-in, default off.
 # See specs/073-orch-ensemble-merge/spec.md.

--- a/crates/zeph-config/src/experiment.rs
+++ b/crates/zeph-config/src/experiment.rs
@@ -567,6 +567,15 @@ pub struct OrchestrationConfig {
     #[serde(default = "default_verifier_timeout_secs")]
     pub verifier_timeout_secs: u64,
 
+    /// Timeout in seconds for the whole-plan `verify_plan()` LLM call. `0` = fall back to
+    /// `verifier_timeout_secs`. Default: `0`.
+    ///
+    /// `verify_plan()` runs once per plan (after all tasks complete) whereas per-task
+    /// `verify()` runs many times per plan — a shared timeout budget forces both to the same
+    /// value even though they are invoked at structurally different points. See #6379.
+    #[serde(default)]
+    pub whole_plan_verifier_timeout_secs: u64,
+
     /// ORCH-style deterministic verifier ensemble-merge configuration. Default: disabled.
     /// See `specs/073-orch-ensemble-merge/spec.md`.
     #[serde(default)]
@@ -633,6 +642,7 @@ impl Default for OrchestrationConfig {
             aggregator_timeout_secs: default_aggregator_timeout_secs(),
             planner_timeout_secs: default_planner_timeout_secs(),
             verifier_timeout_secs: default_verifier_timeout_secs(),
+            whole_plan_verifier_timeout_secs: 0,
             ensemble: EnsembleConfig::default(),
             default_idle_timeout_secs: None,
             command: CommandConfig::default(),
@@ -1013,5 +1023,24 @@ mod tests {
         // #6366: the previous 30s default reliably timed out PlanVerifier::verify() against
         // 20B+ local Ollama models, causing fail-open to silently skip ground().
         assert_eq!(OrchestrationConfig::default().verifier_timeout_secs, 120);
+    }
+
+    #[test]
+    fn orchestration_config_default_whole_plan_verifier_timeout_secs_is_0() {
+        // #6379: 0 = fall back to verifier_timeout_secs, mirrors EnsembleConfig::member_timeout_secs.
+        assert_eq!(
+            OrchestrationConfig::default().whole_plan_verifier_timeout_secs,
+            0
+        );
+    }
+
+    #[test]
+    fn orchestration_config_whole_plan_verifier_timeout_secs_toml_roundtrip() {
+        let toml_in = "enabled = true\nwhole_plan_verifier_timeout_secs = 300\n";
+        let cfg: OrchestrationConfig = toml::from_str(toml_in).expect("deserialize");
+        assert_eq!(cfg.whole_plan_verifier_timeout_secs, 300);
+        let serialized = toml::to_string(&cfg).expect("serialize");
+        let cfg2: OrchestrationConfig = toml::from_str(&serialized).expect("re-deserialize");
+        assert_eq!(cfg2.whole_plan_verifier_timeout_secs, 300);
     }
 }

--- a/crates/zeph-config/src/migrate/features.rs
+++ b/crates/zeph-config/src/migrate/features.rs
@@ -968,6 +968,60 @@ pub fn migrate_orchestration_command_config(
     })
 }
 
+/// Step 93 — add a `whole_plan_verifier_timeout_secs` advisory comment under `[orchestration]`,
+/// if absent (#6379).
+///
+/// `OrchestrationConfig::whole_plan_verifier_timeout_secs` has `#[serde(default)]` (`0` = fall
+/// back to `verifier_timeout_secs`) so existing configs parse without changes even without this
+/// step — this exists purely for discoverability on config upgrade, mirroring
+/// [`migrate_orchestration_idle_timeout`].
+///
+/// # Errors
+///
+/// Returns [`MigrateError`] if `toml_src` fails to parse as TOML.
+pub fn migrate_orchestration_whole_plan_verifier_timeout(
+    toml_src: &str,
+) -> Result<MigrationResult, MigrateError> {
+    if toml_src.contains("whole_plan_verifier_timeout_secs") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    if !section_header_present(toml_src, "orchestration") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "\n# Timeout in seconds for the whole-plan verify_plan() LLM call; 0 = fall \
+        back to verifier_timeout_secs. Default: 0 (#6379)\n\
+        # whole_plan_verifier_timeout_secs = 0\n";
+    let output = insert_after_section(toml_src, "orchestration", comment);
+    // Defensive: the guards above already guarantee `[orchestration]` is present and
+    // `insert_after_section` always inserts non-empty content when reached, so this is
+    // currently unreachable — kept for the same reason as `migrate_orchestration_idle_timeout`
+    // (#5945: a future change to either guard must not silently regress into reporting a
+    // change that didn't happen).
+    if output == toml_src {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    Ok(MigrationResult {
+        output,
+        changed_count: 1,
+        sections_changed: vec!["orchestration.whole_plan_verifier_timeout_secs".to_owned()],
+    })
+}
+
 /// Step 78 — add a commented-out `[skills.registry]` section with defaults if absent
 /// (spec-045, #5869).
 ///

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -26,8 +26,9 @@ pub use features::{
     migrate_knowledge_config, migrate_magic_docs_config, migrate_microcompact_config,
     migrate_orchestration_asset_sensitivity, migrate_orchestration_command_config,
     migrate_orchestration_ensemble, migrate_orchestration_idle_timeout,
-    migrate_orchestration_persistence, migrate_skill_trust_require_check, migrate_skills_registry,
-    migrate_tui_delights, migrate_tui_mouse, migrate_tui_theme_config, migrate_tui_theme_defaults,
+    migrate_orchestration_persistence, migrate_orchestration_whole_plan_verifier_timeout,
+    migrate_skill_trust_require_check, migrate_skills_registry, migrate_tui_delights,
+    migrate_tui_mouse, migrate_tui_theme_config, migrate_tui_theme_defaults,
 };
 pub use infra::*;
 /// Advisory `GonkaGate` migration is crate-internal (registered via the [`MIGRATIONS`] registry).
@@ -616,22 +617,23 @@ use steps::{
     MigrateMemoryRetrievalQueryBias, MigrateMemoryStoreConfig, MigrateMemoryTypeAwareCompose,
     MigrateMicrocompactConfig, MigrateNliConfig, MigrateOrchestrationAssetSensitivity,
     MigrateOrchestrationCommandConfig, MigrateOrchestrationEnsemble,
-    MigrateOrchestrationIdleTimeout, MigrateOrchestrationPersistence, MigrateOrchestratorProvider,
-    MigrateOtelFilter, MigrateOverflowMaxPerCallOverride, MigratePiiFilterNames,
-    MigratePlannerModelToProvider, MigratePolicyProviderAndUtilityWindow,
-    MigrateProviderMaxConcurrent, MigrateQdrantApiKey, MigrateQdrantTimeoutSecs,
-    MigrateQualityConfig, MigrateSandboxConfig, MigrateSandboxEgressFilter, MigrateSchedulerDaemon,
-    MigrateSecretMaskingConfig, MigrateServeConfig, MigrateSessionPersistProviderOverrides,
-    MigrateSessionPersistenceConfig, MigrateSessionProviderPersistence, MigrateSessionRecapConfig,
-    MigrateShadowSentinelConfig, MigrateShellCheckpointsConfig, MigrateShellTransactional,
-    MigrateSkillTrustRequireCheck, MigrateSkillsRegistry, MigrateSttToProvider,
-    MigrateSupervisorConfig, MigrateTelemetryConfig, MigrateToolsCompressionConfig,
-    MigrateTraceMetadata, MigrateTuiDelights, MigrateTuiMouse, MigrateTuiThemeConfig,
-    MigrateTuiThemeDefaults, MigrateUtilityHighGainTools, MigrateVigilConfig,
-    MigrateWorktreeConfig, MigrateWorktreeGitTimeout, MigrateWorktreeQuotaFields,
+    MigrateOrchestrationIdleTimeout, MigrateOrchestrationPersistence,
+    MigrateOrchestrationWholePlanVerifierTimeout, MigrateOrchestratorProvider, MigrateOtelFilter,
+    MigrateOverflowMaxPerCallOverride, MigratePiiFilterNames, MigratePlannerModelToProvider,
+    MigratePolicyProviderAndUtilityWindow, MigrateProviderMaxConcurrent, MigrateQdrantApiKey,
+    MigrateQdrantTimeoutSecs, MigrateQualityConfig, MigrateSandboxConfig,
+    MigrateSandboxEgressFilter, MigrateSchedulerDaemon, MigrateSecretMaskingConfig,
+    MigrateServeConfig, MigrateSessionPersistProviderOverrides, MigrateSessionPersistenceConfig,
+    MigrateSessionProviderPersistence, MigrateSessionRecapConfig, MigrateShadowSentinelConfig,
+    MigrateShellCheckpointsConfig, MigrateShellTransactional, MigrateSkillTrustRequireCheck,
+    MigrateSkillsRegistry, MigrateSttToProvider, MigrateSupervisorConfig, MigrateTelemetryConfig,
+    MigrateToolsCompressionConfig, MigrateTraceMetadata, MigrateTuiDelights, MigrateTuiMouse,
+    MigrateTuiThemeConfig, MigrateTuiThemeDefaults, MigrateUtilityHighGainTools,
+    MigrateVigilConfig, MigrateWorktreeConfig, MigrateWorktreeGitTimeout,
+    MigrateWorktreeQuotaFields,
 };
 
-/// Ordered registry of all sequential migration steps (steps 1–92).
+/// Ordered registry of all sequential migration steps (steps 1–93).
 ///
 /// Each entry wraps the corresponding free function and is evaluated lazily at first access.
 /// The ordering is chronological; the dispatch loop in `src/commands/migrate.rs` iterates
@@ -811,6 +813,9 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             // Step 92 — add [memory.store] advisory block for the generic cross-thread
             // key-value store (spec-080, #6363)
             Box::new(MigrateMemoryStoreConfig),
+            // Step 93 — add whole_plan_verifier_timeout_secs advisory comment under
+            // [orchestration] (#6379)
+            Box::new(MigrateOrchestrationWholePlanVerifierTimeout),
         ]
     });
 

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -64,7 +64,8 @@
 //! `[tools.overflow]` (#3079);
 //! step 91 adds a commented `[orchestration.command]` advisory block for Command-style
 //! dynamic task handoff (spec-080, #6363); step 92 adds a commented `[memory.store]`
-//! advisory block for the generic cross-thread key-value store (spec-080, #6363).
+//! advisory block for the generic cross-thread key-value store (spec-080, #6363); step 93
+//! adds a `whole_plan_verifier_timeout_secs` advisory comment under `[orchestration]` (#6379).
 //!
 //! Each struct is a zero-size type that delegates to the corresponding free function in
 //! `super`. They exist solely to satisfy the object-safe [`super::Migration`] trait so the
@@ -93,7 +94,8 @@ use super::{
     migrate_orchestration_asset_sensitivity, migrate_orchestration_command_config,
     migrate_orchestration_ensemble, migrate_orchestration_idle_timeout,
     migrate_orchestration_orchestrator_provider, migrate_orchestration_persistence,
-    migrate_otel_filter, migrate_overflow_max_per_call_override, migrate_pii_filter_names,
+    migrate_orchestration_whole_plan_verifier_timeout, migrate_otel_filter,
+    migrate_overflow_max_per_call_override, migrate_pii_filter_names,
     migrate_planner_model_to_provider, migrate_policy_provider_and_utility_window,
     migrate_provider_max_concurrent, migrate_qdrant_api_key, migrate_qdrant_timeout_secs,
     migrate_quality_config, migrate_sandbox_config, migrate_sandbox_egress_filter,
@@ -1163,5 +1165,18 @@ impl Migration for MigrateMemoryStoreConfig {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_memory_store_config(toml_src)
+    }
+}
+
+/// Step 93 — adds a `whole_plan_verifier_timeout_secs` advisory comment under
+/// `[orchestration]` (#6379).
+pub(super) struct MigrateOrchestrationWholePlanVerifierTimeout;
+impl Migration for MigrateOrchestrationWholePlanVerifierTimeout {
+    fn name(&self) -> &'static str {
+        "migrate_orchestration_whole_plan_verifier_timeout"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_orchestration_whole_plan_verifier_timeout(toml_src)
     }
 }

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -9,8 +9,8 @@ use super::*;
 fn migrations_registry_has_all_steps() {
     assert_eq!(
         MIGRATIONS.len(),
-        92,
-        "MIGRATIONS registry must contain all 92 sequential steps"
+        93,
+        "MIGRATIONS registry must contain all 93 sequential steps"
     );
     for m in MIGRATIONS.iter() {
         assert!(
@@ -1183,6 +1183,49 @@ fn step_88_idempotent_on_commented_output() {
     assert_eq!(second.output, first.output);
 }
 
+// ── Step 93 — migrate_orchestration_whole_plan_verifier_timeout (#6379) ──
+
+#[test]
+fn step_93_injects_whole_plan_verifier_timeout_when_orchestration_present() {
+    let src = "[orchestration]\nenabled = true\n";
+    let result = migrate_orchestration_whole_plan_verifier_timeout(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert!(
+        result.output.contains("whole_plan_verifier_timeout_secs"),
+        "advisory comment must be injected"
+    );
+    assert_eq!(
+        result.sections_changed,
+        vec!["orchestration.whole_plan_verifier_timeout_secs"]
+    );
+}
+
+#[test]
+fn step_93_noop_when_no_orchestration_section() {
+    let src = "[agent]\nname = \"zeph\"\n";
+    let result = migrate_orchestration_whole_plan_verifier_timeout(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn step_93_noop_when_key_already_present() {
+    let src = "[orchestration]\nwhole_plan_verifier_timeout_secs = 300\n";
+    let result = migrate_orchestration_whole_plan_verifier_timeout(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn step_93_idempotent_on_commented_output() {
+    let base = "[orchestration]\nenabled = true\n";
+    let first = migrate_orchestration_whole_plan_verifier_timeout(base).unwrap();
+    assert_eq!(first.changed_count, 1);
+    let second = migrate_orchestration_whole_plan_verifier_timeout(&first.output).unwrap();
+    assert_eq!(second.changed_count, 0, "second run must not double-append");
+    assert_eq!(second.output, first.output);
+}
+
 // ── Step 90 — migrate_overflow_max_per_call_override (#3079) ──────────────
 
 #[test]
@@ -1970,7 +2013,7 @@ fn migrate_focus_auto_consolidate_noop_when_only_commented_section() {
 
 #[test]
 fn registry_has_fifty_entries() {
-    assert_eq!(MIGRATIONS.len(), 92);
+    assert_eq!(MIGRATIONS.len(), 93);
 }
 
 #[test]
@@ -2102,6 +2145,7 @@ fn registry_preserves_order_matches_dispatch() {
         "migrate_overflow_max_per_call_override",
         "migrate_orchestration_command_config",
         "migrate_memory_store_config",
+        "migrate_orchestration_whole_plan_verifier_timeout",
     ];
     let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
     assert_eq!(actual, expected);

--- a/crates/zeph-orchestration/src/scheduler/mod.rs
+++ b/crates/zeph-orchestration/src/scheduler/mod.rs
@@ -941,6 +941,7 @@ mod tests {
             aggregator_timeout_secs: 60,
             planner_timeout_secs: 120,
             verifier_timeout_secs: 30,
+            whole_plan_verifier_timeout_secs: 0,
             ensemble: Default::default(),
             default_idle_timeout_secs: None,
             command: Default::default(),

--- a/crates/zeph-orchestration/src/verifier.rs
+++ b/crates/zeph-orchestration/src/verifier.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tracing::{error, warn};
+use tracing::{debug, error, warn};
 use zeph_config::OrchestrationConfig;
 
 use zeph_common::OutputSanitizer;
@@ -176,8 +176,13 @@ pub struct PlanVerifier<P: LlmProvider> {
     /// Constructed with `spotlight_untrusted = false` so delimiters do not confuse
     /// the verification LLM (RISK-5): truncation and injection detection still apply.
     sanitizer: Arc<dyn OutputSanitizer>,
-    /// Maximum time to wait for each verifier LLM call before returning fail-open.
+    /// Maximum time to wait for each per-task verifier LLM call before returning fail-open.
     timeout: Duration,
+    /// Maximum time to wait for the whole-plan `verify_plan()` LLM call before returning
+    /// fail-open. Independently configurable from `timeout` (see
+    /// `OrchestrationConfig::whole_plan_verifier_timeout_secs`, #6379) since `verify_plan()`
+    /// runs once per plan rather than many times, and may warrant a different budget.
+    whole_plan_timeout: Duration,
     /// Total times grounding overrode an LLM `complete: true` verdict to `false` (spec 009 §
     /// Verifier Tool-Call Grounding, Observability — "Override metric + log").
     grounding_overrides_total: u64,
@@ -190,18 +195,27 @@ pub struct PlanVerifier<P: LlmProvider> {
 impl<P: LlmProvider> PlanVerifier<P> {
     /// Create a new `PlanVerifier` from a provider, sanitizer, and orchestration config.
     ///
-    /// The timeout is taken from `config.verifier_timeout_secs`.
+    /// The per-task timeout is taken from `config.verifier_timeout_secs`. The whole-plan
+    /// timeout is taken from `config.whole_plan_verifier_timeout_secs` when non-zero,
+    /// otherwise it falls back to `config.verifier_timeout_secs` (mirrors
+    /// `EnsembleConfig::member_timeout_secs`'s `0 = fallback` convention).
     #[must_use]
     pub fn new(
         provider: P,
         sanitizer: Arc<dyn OutputSanitizer>,
         config: &OrchestrationConfig,
     ) -> Self {
+        let whole_plan_secs = if config.whole_plan_verifier_timeout_secs > 0 {
+            config.whole_plan_verifier_timeout_secs
+        } else {
+            config.verifier_timeout_secs
+        };
         Self {
             provider,
             consecutive_failures: 0,
             sanitizer,
             timeout: Duration::from_secs(config.verifier_timeout_secs),
+            whole_plan_timeout: Duration::from_secs(whole_plan_secs),
             grounding_overrides_total: 0,
             grounding_narrative_empty_claims_total: 0,
         }
@@ -247,6 +261,14 @@ impl<P: LlmProvider> PlanVerifier<P> {
         tool_trace: Option<&[ToolCallSummary]>,
     ) -> VerificationResult {
         let messages = build_verify_prompt(task, output, tool_trace, &self.sanitizer);
+
+        debug!(
+            task_id = %task.id,
+            prompt_chars = messages.iter().map(|m| m.to_llm_content().len()).sum::<usize>(),
+            tool_trace_entries = tool_trace.map_or(0, <[_]>::len),
+            timeout_secs = self.timeout.as_secs(),
+            "PlanVerifier: per-task verify prompt built"
+        );
 
         let result = tokio::time::timeout(
             self.timeout,
@@ -483,8 +505,18 @@ impl<P: LlmProvider> PlanVerifier<P> {
         let messages =
             build_verify_plan_prompt(goal, aggregated_output, tool_trace, &self.sanitizer);
 
+        debug!(
+            prompt_chars = messages
+                .iter()
+                .map(|m| m.to_llm_content().len())
+                .sum::<usize>(),
+            tool_trace_entries = tool_trace.map_or(0, <[_]>::len),
+            timeout_secs = self.whole_plan_timeout.as_secs(),
+            "PlanVerifier: whole-plan verify prompt built"
+        );
+
         let result = tokio::time::timeout(
-            self.timeout,
+            self.whole_plan_timeout,
             self.provider.chat_typed::<VerifyResponse>(&messages),
         )
         .await;
@@ -517,13 +549,13 @@ impl<P: LlmProvider> PlanVerifier<P> {
                 if self.consecutive_failures >= 3 {
                     error!(
                         consecutive_failures = self.consecutive_failures,
-                        timeout_secs = self.timeout.as_secs(),
+                        timeout_secs = self.whole_plan_timeout.as_secs(),
                         "PlanVerifier: 3+ consecutive LLM failures in whole-plan verify — \
                          check verify_provider configuration; plan treated as complete (fail-open)"
                     );
                 } else {
                     warn!(
-                        timeout_secs = self.timeout.as_secs(),
+                        timeout_secs = self.whole_plan_timeout.as_secs(),
                         "PlanVerifier: whole-plan LLM call timed out, treating plan as complete \
                          (fail-open)"
                     );
@@ -1527,8 +1559,9 @@ mod tests {
     fn slow_verifier() -> PlanVerifier<SlowMockProvider> {
         let config = OrchestrationConfig::default();
         let mut v = PlanVerifier::new(SlowMockProvider, test_sanitizer(), &config);
-        // Override timeout to 50ms so tests complete quickly.
+        // Override both timeouts to 50ms so tests complete quickly.
         v.timeout = Duration::from_millis(50);
+        v.whole_plan_timeout = Duration::from_millis(50);
         v
     }
 
@@ -1633,6 +1666,90 @@ mod tests {
             3,
             "three consecutive verify_plan() timeouts must accumulate to 3 — the threshold \
              the error! escalation arm checks"
+        );
+    }
+
+    #[test]
+    fn whole_plan_timeout_falls_back_to_verifier_timeout_when_zero() {
+        let config = OrchestrationConfig {
+            verifier_timeout_secs: 77,
+            whole_plan_verifier_timeout_secs: 0,
+            ..Default::default()
+        };
+        let verifier = PlanVerifier::new(SlowMockProvider, test_sanitizer(), &config);
+        assert_eq!(verifier.timeout, Duration::from_secs(77));
+        assert_eq!(
+            verifier.whole_plan_timeout,
+            Duration::from_secs(77),
+            "0 must fall back to verifier_timeout_secs"
+        );
+    }
+
+    #[test]
+    fn whole_plan_timeout_independent_when_nonzero() {
+        let config = OrchestrationConfig {
+            verifier_timeout_secs: 200,
+            whole_plan_verifier_timeout_secs: 5,
+            ..Default::default()
+        };
+        let verifier = PlanVerifier::new(SlowMockProvider, test_sanitizer(), &config);
+        assert_eq!(verifier.timeout, Duration::from_secs(200));
+        assert_eq!(
+            verifier.whole_plan_timeout,
+            Duration::from_secs(5),
+            "non-zero whole_plan_verifier_timeout_secs must not be overridden by \
+             verifier_timeout_secs"
+        );
+    }
+
+    #[tokio::test]
+    async fn verify_plan_honors_whole_plan_timeout_independently_of_verifier_timeout() {
+        // verifier_timeout_secs is large (would never trip within the test's lifetime);
+        // whole_plan_verifier_timeout_secs is short, so verify_plan() must still fail-open
+        // promptly rather than waiting on the per-task budget.
+        let config = OrchestrationConfig {
+            verifier_timeout_secs: 3600,
+            whole_plan_verifier_timeout_secs: 1,
+            ..Default::default()
+        };
+        let mut verifier = PlanVerifier::new(SlowMockProvider, test_sanitizer(), &config);
+
+        let start = std::time::Instant::now();
+        let result = verifier.verify_plan("goal", "output", None).await;
+        let elapsed = start.elapsed();
+
+        assert!(result.complete, "timeout must be fail-open (complete=true)");
+        assert!(
+            elapsed < Duration::from_secs(10),
+            "verify_plan() must respect the short whole_plan_verifier_timeout_secs budget \
+             instead of the much longer verifier_timeout_secs, elapsed={elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn verify_honors_verifier_timeout_independently_of_whole_plan_timeout() {
+        // Mirror of verify_plan_honors_whole_plan_timeout_independently_of_verifier_timeout,
+        // with the budgets swapped: verify() must use self.timeout, not self.whole_plan_timeout.
+        // whole_plan_verifier_timeout_secs is large (would never trip within the test's
+        // lifetime); verifier_timeout_secs is short, so verify() must still fail-open promptly
+        // rather than waiting on the whole-plan budget.
+        let config = OrchestrationConfig {
+            verifier_timeout_secs: 1,
+            whole_plan_verifier_timeout_secs: 3600,
+            ..Default::default()
+        };
+        let mut verifier = PlanVerifier::new(SlowMockProvider, test_sanitizer(), &config);
+        let task = TaskNode::new(0, "t", "d");
+
+        let start = std::time::Instant::now();
+        let result = verifier.verify(&task, "output", None).await;
+        let elapsed = start.elapsed();
+
+        assert!(result.complete, "timeout must be fail-open (complete=true)");
+        assert!(
+            elapsed < Duration::from_secs(10),
+            "verify() must respect the short verifier_timeout_secs budget instead of the much \
+             longer whole_plan_verifier_timeout_secs, elapsed={elapsed:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

- `verify_plan()` (whole-plan grounding) shared `orchestration.verifier_timeout_secs` with per-task `verify()`. Live testing (ci-1402/1403/1404) observed it consistently exhausting the full 120s budget and fail-opening (`complete=true, confidence=0.0, gaps=0`) while per-task `verify()` on the same run/provider returned promptly.
- Adds `whole_plan_verifier_timeout_secs` (`0` = fall back to `verifier_timeout_secs`, mirrors `EnsembleConfig::member_timeout_secs`), wired into a new `PlanVerifier::whole_plan_timeout` field used by `verify_plan()`'s timeout call and both its timeout-path log fields.
- Adds `tracing::debug!` prompt-size/tool-trace-entry diagnostics to both `verify()` and `verify_plan()` right before their LLM calls, so a future live session can tell a prompt-size effect apart from a genuine model-latency/hang issue — root-cause analysis found the whole-plan prompt is not obviously larger than a per-task prompt in the 2-task repro case, so a longer timeout alone is an unproven fix.
- Adds config migration Step 93 (advisory comment under `[orchestration]`).

**Scope note:** default behavior is unchanged (`0` still resolves to the same 120s), so this does not resolve the live symptom out-of-the-box on its own — it closes the config/spec gap that prevented giving `verify_plan()` a different budget at all, and adds the instrumentation needed to determine and confirm the actual fix in a follow-up live-verification session.

Refs #6379

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (14211 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] New unit tests: config default/round-trip, `PlanVerifier` fallback/independence (construction-level + behavioral via `SlowMockProvider`), 4 migration Step 93 tests
- [x] `CHANGELOG.md` updated (`[Unreleased] > Fixed`)
- [ ] Live LLM round-trip verification (out of scope for this session; tracked via updated `.local/testing/coverage-status.md` "Whole-plan verifier grounding" row, left `Partial`)