### PR TITLE
fix(core,acp): reset owner_key/is_guest_context staleness, thread ACP identity into cross-thread store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   genuinely non-terminating for its prompt shape regardless of timeout — live root-cause
   confirmation is still pending (#6379 remains open).
 
+- `zeph-core`/`zeph-acp`: two follow-ups from the cross-thread store `owner_key` work
+  (spec-080, #6389/PR #6416). `session.owner_key`/`is_guest_context` were set only in the
+  `LoopEvent::Message` arm and reset only at `Agent::end_turn`, so a fast-path
+  slash-command dispatch that exits the loop iteration via `DispatchFlow::Continue`/`Break`
+  before reaching `end_turn` could leave a stale value (e.g. a previous sender's derived
+  `owner_key`) in place for the next `LoopEvent` — a scheduled task, autonomous tick, or a
+  different sender's fast-path message. Both scalars are now reset unconditionally at the
+  top of every `Agent::run` loop iteration, closing the gap for all dispatch paths (#6418).
+  Separately, ACP dispatch never threaded its already-authenticated per-connection identity
+  into the cross-thread store, collapsing every ACP session to the shared `"local"` bucket
+  like the single-user CLI/TUI/Telegram paths — despite ACP having the strongest per-caller
+  identity of any dispatch path. All three `ChannelMessage` construction sites in the ACP
+  agent (`do_prompt`, `/clear`, `/review`) now carry that identity as `owner_key` (#6419).
+
 - `zeph-session`: `AdvisoryLock::acquire`'s `WOULDBLOCK` path gave operators only a bare
   "another session is already active" message with no way to tell whether the lock's holder
   was still running (#6378). The holder's PID is now written into the sibling lock file

--- a/crates/zeph-acp/src/agent/mod.rs
+++ b/crates/zeph-acp/src/agent/mod.rs
@@ -1616,7 +1616,10 @@ impl ZephAcpAgentState {
                 attachments,
                 is_guest_context: false,
                 is_from_bot: false,
-                owner_key: None,
+                // #6419: thread the connection's authenticated identity (#5868) into the
+                // cross-thread store owner key (#6389), instead of falling back to the
+                // shared DEFAULT_OWNER_KEY="local" bucket used by CLI/TUI/Telegram.
+                owner_key: Some(self.owner_key.clone()),
             })
             .await
             .map_err(|_| acp::Error::internal_error().data("agent channel closed"))?;
@@ -2571,7 +2574,8 @@ impl ZephAcpAgentState {
                         attachments: vec![],
                         is_guest_context: false,
                         is_from_bot: false,
-                        owner_key: None,
+                        // #6419: see do_prompt above.
+                        owner_key: Some(self.owner_key.clone()),
                     });
                 }
                 "Session history cleared.".to_owned()
@@ -2636,7 +2640,8 @@ impl ZephAcpAgentState {
                 attachments: vec![],
                 is_guest_context: false,
                 is_from_bot: false,
-                owner_key: None,
+                // #6419: see do_prompt above.
+                owner_key: Some(self.owner_key.clone()),
             })
             .is_err()
         {
@@ -4324,6 +4329,96 @@ mod slash_command_wiring_tests {
         assert_eq!(
             reply, "Fetched 2 models.",
             "must report the live list_models_remote() count from the resolved active provider"
+        );
+    }
+}
+
+/// Regression tests for #6419: ACP already derives a real per-connection identity
+/// (`ZephAcpAgentState::owner_key`, #5868) used to scope persisted ACP session
+/// list/load/resume access. Before this fix, that identity was never threaded into the
+/// `ChannelMessage.owner_key` sent to the agent loop, so every ACP turn silently fell back to
+/// the shared `DEFAULT_OWNER_KEY = "local"` cross-thread-store bucket (#6389) — the same bucket
+/// CLI/TUI/Telegram use — even though ACP already has a stronger per-caller identity available.
+#[cfg(test)]
+mod owner_key_threading_tests {
+    use std::sync::Arc;
+
+    use parking_lot::RwLock;
+    use zeph_core::channel::{Channel as _, LoopbackChannel};
+    use zeph_llm::any::AnyProvider;
+
+    use super::*;
+
+    /// Builds an agent with the given connection `owner_key` and one registered session,
+    /// returning the `LoopbackChannel` half so the test can `recv()` whatever `ChannelMessage`
+    /// the handler under test forwards to `input_tx`.
+    fn make_agent_with_owner_key(
+        owner_key: &str,
+    ) -> (ZephAcpAgent, acp::schema::v1::SessionId, LoopbackChannel) {
+        let spawner: AgentSpawner = Arc::new(|_ch, _ctx, _sc| Box::pin(async {}));
+        let agent = ZephAcpAgent::new(spawner, 4, 1800, None).with_owner_key(owner_key);
+        let session_id = acp::schema::v1::SessionId::new("owner-key-test".to_owned());
+
+        let (channel, handle) = LoopbackChannel::pair(4);
+        let provider_override = Arc::new(RwLock::new(None::<AnyProvider>));
+        let (notify_tx, notify_rx) = mpsc::channel(4);
+        let entry = ZephAcpAgent::make_session_entry(
+            handle,
+            "test-model".to_owned(),
+            std::path::PathBuf::from("."),
+            None,
+            provider_override,
+            SessionConfigSeed {
+                thinking_enabled: false,
+                auto_approve_level: "suggest".to_owned(),
+                temperature_preset: zeph_config::AcpTemperaturePreset::default(),
+            },
+            notify_tx,
+            notify_rx,
+        );
+        agent.sessions.lock().insert(session_id.clone(), entry);
+        (agent, session_id, channel)
+    }
+
+    #[tokio::test]
+    async fn review_command_threads_connection_owner_key_into_channel_message() {
+        let (agent, session_id, mut channel) = make_agent_with_owner_key("acp:alice");
+
+        agent
+            .handle_review_command(&session_id, "")
+            .expect("/review must succeed");
+
+        let msg = channel
+            .recv()
+            .await
+            .expect("recv must not error")
+            .expect("handle_review_command must forward a ChannelMessage");
+        assert_eq!(
+            msg.owner_key.as_deref(),
+            Some("acp:alice"),
+            "/review must carry the connection's owner_key, not fall back to None/local"
+        );
+    }
+
+    #[tokio::test]
+    async fn clear_command_threads_connection_owner_key_into_channel_message() {
+        let (agent, session_id, mut channel) = make_agent_with_owner_key("acp:bob");
+
+        agent
+            .handle_slash_command(&session_id, "/clear")
+            .await
+            .expect("/clear must succeed");
+
+        let msg = channel
+            .recv()
+            .await
+            .expect("recv must not error")
+            .expect("/clear must forward a sentinel ChannelMessage");
+        assert_eq!(msg.text, "/clear");
+        assert_eq!(
+            msg.owner_key.as_deref(),
+            Some("acp:bob"),
+            "/clear sentinel must carry the connection's owner_key, not fall back to None/local"
         );
     }
 }

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -425,6 +425,17 @@ impl<C: Channel> Agent<C> {
         self.maybe_start_heuristic_promotion();
 
         loop {
+            // #6418: reset per-turn cross-thread identity state unconditionally at the top of
+            // every iteration, rather than relying solely on `Agent::end_turn` (which only runs
+            // after `process_user_message` completes). A fast-path slash-command dispatch, or any
+            // non-`Message` `LoopEvent`, can `continue`/`break` out of this loop before ever
+            // reaching `end_turn` — without this reset that would leave the previous iteration's
+            // `owner_key`/`is_guest_context` stale for whatever runs next (a different sender's
+            // message, a scheduled task, an autonomous tick, ...). The `LoopEvent::Message` arm
+            // below overwrites both with the real per-message values for this iteration only.
+            self.services.session.is_guest_context = false;
+            state::persistence::DEFAULT_OWNER_KEY.clone_into(&mut self.services.session.owner_key);
+
             self.apply_provider_override();
             self.check_tool_refresh().await;
             self.process_pending_elicitations().await;
@@ -1105,11 +1116,12 @@ impl<C: Channel> Agent<C> {
         self.services.session.current_turn_intent = None;
         // Clear guest context flag: each turn is independently classified.
         self.services.session.is_guest_context = false;
-        // Reset the cross-thread store owner key (#6389) at turn end, same as
-        // is_guest_context above. Like is_guest_context, this reset can be skipped on a
-        // fast-path dispatch (e.g. a slash command) that exits before reaching end_turn,
-        // leaving a stale value for whatever runs next — a pre-existing gap shared with
-        // is_guest_context, not new to this field.
+        // Reset the cross-thread store owner key (#6389) at turn end, same as is_guest_context
+        // above. Both resets are redundant with the unconditional per-iteration reset at the top
+        // of the `run()` loop (#6418) — that loop-top reset is what actually closes the
+        // fast-path-dispatch staleness gap (a slash command or non-Message LoopEvent can
+        // `continue`/`break` before ever reaching end_turn); these two lines are kept as
+        // defense-in-depth for the normal end-of-turn path.
         state::persistence::DEFAULT_OWNER_KEY.clone_into(&mut self.services.session.owner_key);
         // Cancel all in-flight speculative handles at turn boundary.
         if let Some(ref engine) = self.services.speculation_engine {

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -2120,6 +2120,64 @@ mod tests {
         assert!(out.contains("root cause identified"));
     }
 
+    #[tokio::test]
+    async fn cross_thread_store_scoped_by_owner_key_not_shared_across_owners() {
+        // #6418 acceptance criterion: prove `CommandHandoffContext::owner_key` is
+        // load-bearing on `persist_handoff_update`/`append_shared_state_block` — a write
+        // made under one owner_key must not be visible to a different owner_key's read,
+        // and must be visible to a read under the SAME owner_key. This is the isolation
+        // #6389 added to the cross-thread store; #6418 guarantees the session-level
+        // owner_key that feeds this context can never leak stale across a fast-path
+        // dispatch (loop-top reset in `Agent::run`).
+        let memory = std::sync::Arc::new(test_memory().await);
+        let sanitizer = test_sanitizer();
+        let store_config = zeph_config::CrossThreadStoreConfig {
+            enabled: true,
+            max_value_bytes: 65536,
+            search_provider: None,
+        };
+        let ctx_alice = CommandHandoffContext {
+            command_enabled: true,
+            store_config: store_config.clone(),
+            memory: Some(memory.clone()),
+            sanitizer: sanitizer.clone(),
+            owner_key: "gateway:alice".to_owned(),
+        };
+        let ctx_local = CommandHandoffContext {
+            command_enabled: true,
+            store_config,
+            memory: Some(memory.clone()),
+            sanitizer,
+            owner_key: crate::agent::state::persistence::DEFAULT_OWNER_KEY.to_owned(),
+        };
+
+        let graph_id = zeph_orchestration::GraphId::new();
+        let namespace = format!("orch/{graph_id}");
+        memory
+            .sqlite()
+            .store_put(
+                ctx_alice.owner_key.as_str(),
+                &namespace,
+                "finding",
+                "alice-only secret",
+                65536,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let prompt = "task".to_string();
+        let out_local =
+            append_shared_state_block(prompt.clone(), &ctx_local, graph_id.clone()).await;
+        assert_eq!(
+            out_local, prompt,
+            "a different owner_key must not observe another owner's store write"
+        );
+
+        let out_alice = append_shared_state_block(prompt.clone(), &ctx_alice, graph_id).await;
+        assert!(out_alice.contains("alice-only secret"));
+    }
+
     // ── AC-8 spawn/inline trace parity + S1 fail-closed-on-partial-read regression
     //    (spec 009 § Verifier Tool-Call Grounding) ──────────────────────────────
 

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -918,14 +918,18 @@ pub(crate) struct SessionState {
     pub(crate) is_guest_context: bool,
     /// Cross-thread store owner key for the current turn (spec-080 §10 OQ-1, GitHub #6389).
     ///
-    /// Set from `ChannelMessage::owner_key` when a `LoopEvent::Message` is dispatched
-    /// (falls back to [`persistence::DEFAULT_OWNER_KEY`] when the originating channel
-    /// leaves it unset — CLI/TUI/Telegram) and reset to the default at [`Agent::end_turn`],
-    /// same as `is_guest_context` above — including that reset's same pre-existing gap: a
-    /// fast-path dispatch that exits before reaching `end_turn` can leave a stale value for
-    /// whatever runs next. Read by `/store` (`agent_access_impl.rs`) and the Command-handoff
-    /// store writes/reads (`scheduler_loop.rs`).
+    /// Set from `ChannelMessage::owner_key` when a `LoopEvent::Message` is dispatched (falls back
+    /// to [`persistence::DEFAULT_OWNER_KEY`] when the originating channel leaves it unset —
+    /// CLI/TUI/Telegram). Reset to the default unconditionally at the top of every iteration of
+    /// [`Agent::run`]'s main loop (#6418), and again at [`Agent::end_turn`] as defense-in-depth
+    /// for the normal end-of-turn path — same as `is_guest_context` above. The loop-top reset is
+    /// what guarantees no stale value survives into a `LoopEvent` triggered by a different
+    /// sender/channel or a non-`Message` event (scheduled task, autonomous tick, ...), even when a
+    /// fast-path slash-command dispatch `continue`s/`break`s before ever reaching `end_turn`. Read
+    /// by `/store` (`agent_access_impl.rs`) and the Command-handoff store writes/reads
+    /// (`scheduler_loop.rs`).
     ///
+    /// [`Agent::run`]: crate::agent::Agent::run
     /// [`Agent::end_turn`]: crate::agent::Agent::end_turn
     pub(crate) owner_key: String,
     /// Active durable execution context for the P1 agent-loop adapter (spec-064 §P1, #5452).

--- a/crates/zeph-core/src/agent/tests/agent_tests/mod.rs
+++ b/crates/zeph-core/src/agent/tests/agent_tests/mod.rs
@@ -14,6 +14,7 @@ mod lifecycle_tests;
 mod metrics_summary_tests;
 mod model_help_status_exit_tests;
 mod orchestration_persistence_tests;
+mod owner_key_tests;
 mod skill_fallback_tests;
 mod skill_prompt_bloat_tests;
 mod subagent_command_tests;

--- a/crates/zeph-core/src/agent/tests/agent_tests/owner_key_tests.rs
+++ b/crates/zeph-core/src/agent/tests/agent_tests/owner_key_tests.rs
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Regression tests for #6418: `SessionState.owner_key` must never carry a stale value from
+//! one `LoopEvent` into the next, even when a fast-path slash-command dispatch (or any
+//! non-`Message` `LoopEvent`) exits the `Agent::run` loop iteration before ever reaching
+//! `process_user_message`/`end_turn`.
+
+#[allow(unused_imports)]
+use super::*;
+
+use std::collections::VecDeque;
+
+/// Channel that yields a fixed queue of full [`ChannelMessage`]s (including `owner_key`) one
+/// at a time via `recv()`. Deliberately does NOT override `try_recv()` — it keeps the
+/// [`Channel`] trait's `None` default — so `Agent::drain_channel`'s opportunistic pre-drain
+/// never intercepts these messages before `next_event()`'s `channel.recv()` branch sets
+/// `session.owner_key` from `ChannelMessage::owner_key` (the `Some(LoopEvent::Message(msg))`
+/// arm in `agent/mod.rs`). A channel that overrides `try_recv()` (like `MockChannel`) would
+/// route these through the message-queue fast path instead, which never touches `owner_key`
+/// at all, making the set/reset behavior this file tests unobservable.
+struct OwnerKeyChannel {
+    inbox: VecDeque<ChannelMessage>,
+    sent: Arc<Mutex<Vec<String>>>,
+}
+
+impl OwnerKeyChannel {
+    fn new(messages: Vec<ChannelMessage>) -> (Self, Arc<Mutex<Vec<String>>>) {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        (
+            Self {
+                inbox: messages.into(),
+                sent: Arc::clone(&sent),
+            },
+            sent,
+        )
+    }
+}
+
+impl Channel for OwnerKeyChannel {
+    async fn recv(&mut self) -> Result<Option<ChannelMessage>, crate::channel::ChannelError> {
+        Ok(self.inbox.pop_front())
+    }
+
+    async fn send(&mut self, text: &str) -> Result<(), crate::channel::ChannelError> {
+        self.sent.lock().unwrap().push(text.to_owned());
+        Ok(())
+    }
+
+    async fn send_chunk(&mut self, chunk: &str) -> Result<(), crate::channel::ChannelError> {
+        self.sent.lock().unwrap().push(chunk.to_owned());
+        Ok(())
+    }
+
+    async fn flush_chunks(&mut self) -> Result<(), crate::channel::ChannelError> {
+        Ok(())
+    }
+}
+
+fn owner_key_message(text: &str, owner_key: Option<&str>) -> ChannelMessage {
+    ChannelMessage {
+        text: text.to_owned(),
+        attachments: vec![],
+        is_guest_context: false,
+        is_from_bot: false,
+        owner_key: owner_key.map(str::to_owned),
+    }
+}
+
+/// A normal (non-slash) turn sets `session.owner_key` from the inbound
+/// `ChannelMessage.owner_key`, and `Agent::end_turn` resets it back to `DEFAULT_OWNER_KEY`
+/// once the turn completes — proven here by inspecting session state after `run()` exits with
+/// no further messages pending.
+#[tokio::test]
+async fn owner_key_reset_to_default_after_normal_turn_completes() {
+    let provider = mock_provider(vec!["ok".to_owned()]);
+    let (channel, _sent) = OwnerKeyChannel::new(vec![owner_key_message(
+        "hello agent",
+        Some("gateway:alice"),
+    )]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+    agent.run().await.expect("agent run failed");
+
+    assert_eq!(
+        agent.services.session.owner_key,
+        crate::agent::state::persistence::DEFAULT_OWNER_KEY,
+        "owner_key must be reset to the default once the normal turn (Message -> \
+         process_user_message -> end_turn) completes and no further LoopEvent is pending"
+    );
+}
+
+/// #6418 regression: a fast-path slash-command dispatch (session/debug registry
+/// `DispatchFlow::Continue`) exits the loop iteration WITHOUT ever reaching
+/// `process_user_message`/`end_turn`. Before the fix, `session.owner_key` — set from that
+/// message's `ChannelMessage.owner_key` — would remain stale forever once the channel closed
+/// (no further `Message` event to overwrite it). The unconditional per-iteration reset at the
+/// top of `Agent::run`'s loop closes this gap.
+///
+/// `mock_provider(vec![])` (zero canned responses) doubles as a self-check: if `/help` ever
+/// regressed into reaching `process_user_message`, the empty response queue would surface as a
+/// hard failure here instead of silently passing.
+#[tokio::test]
+async fn owner_key_not_stale_after_fastpath_slash_command_bypasses_end_turn() {
+    let provider = mock_provider(vec![]);
+    let (channel, _sent) =
+        OwnerKeyChannel::new(vec![owner_key_message("/help", Some("gateway:alice"))]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+    agent.run().await.expect("agent run failed");
+
+    assert_eq!(
+        agent.services.session.owner_key,
+        crate::agent::state::persistence::DEFAULT_OWNER_KEY,
+        "a fast-path slash-command dispatch that skips end_turn must not leave a stale \
+         owner_key once the channel closes"
+    );
+}


### PR DESCRIPTION
## Summary

Two follow-ups from the cross-thread store `owner_key` work (spec-080, #6389 / PR #6416):

- `session.owner_key`/`is_guest_context` were set only in the `LoopEvent::Message` arm of the agent loop and reset only at `Agent::end_turn`. A fast-path slash-command dispatch that exits the loop iteration via `DispatchFlow::Continue`/`Break` before reaching `end_turn` could leave a stale value in place for the next `LoopEvent` (a scheduled task, autonomous tick, or a different sender's fast-path message). Both scalars are now reset unconditionally at the top of every `Agent::run` loop iteration, closing the gap uniformly across CLI/TUI/Telegram/gateway/A2A/ACP. `end_turn`'s existing reset is kept as defense-in-depth.
- ACP dispatch never threaded its already-authenticated per-connection identity into the cross-thread store, collapsing every ACP session to the shared `"local"` bucket like the single-user CLI/TUI/Telegram paths, despite ACP having the strongest per-caller identity of any dispatch path. All three `ChannelMessage` construction sites in the ACP agent (`do_prompt`, `/clear`, `/review`) now carry that identity as `owner_key`.

## Review notes

- impl-critic verified the reset placement is provably correct (nothing reads `session.owner_key`/`is_guest_context` between the reset and the point where they're set for the current iteration) and traced all ACP entry points to confirm the three `ChannelMessage` sites cover every path that reaches the cross-thread store.
- A related, narrower gap was found and confirmed out of scope: `QueuedMessage` has no `owner_key`/`is_guest_context` fields, so a `ChannelMessage` queued mid-turn silently loses its owner_key at `drain_channel`. Confirmed unreachable today (every channel that can carry a real owner_key routes through `recv()`, not `try_recv()`) and fail-safe in direction (falls back to the shared default bucket, never misattributes to another tenant). Worth a follow-up issue, not a blocker here.
- Reviewer independently ran the full CI-matching check suite (fmt, clippy `--profile ci`, nextest, rustdoc gate) after rebase — all green.

## Test plan

- [x] New regression test proving the fast-path staleness bug (verified load-bearing by reverting the fix and confirming the test fails)
- [x] Two-turn `Agent` integration test asserting `owner_key` set/reset through a real turn
- [x] `scheduler_loop.rs` test proving `persist_handoff_update`/`append_shared_state_block` are load-bearing on `owner_key`
- [x] ACP owner_key-threading tests for `/clear` and `/review`
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (14222 passed)
- [x] rustdoc gate (`RUSTFLAGS=-D warnings`, `--deny rustdoc::broken_intra_doc_links`)

Closes #6418
Closes #6419