### PR TITLE
fix(core,config): cap sub-agent skill-body token budget on default empty include

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   identity of any dispatch path. All three `ChannelMessage` construction sites in the ACP
   agent (`do_prompt`, `/clear`, `/review`) now carry that identity as `owner_key` (#6419).
 
+- Sub-agent definitions with the default (empty) `skills.include` filter inherit every skill
+  in the registry, and — unlike the main agent's per-turn skill matcher — their bodies are
+  injected once, unranked, into the sub-agent's one-shot spawn-time system prompt with no cap
+  (#6421). A large skill set could silently blow the turn-1 context budget. `filtered_skills_for`
+  now accumulates skill bodies against a new `[skills] subagent_skill_token_budget` config
+  field (default `12000` tokens) in registry order, always including at least the first skill,
+  and appends a `[skill budget: N/M skills included, ...]` marker plus a `tracing::warn!` when
+  any skills are left out, so the truncation is visible in the prompt and transcript instead of
+  silent. The cap applies only to this empty-include case — a sub-agent with an explicit,
+  hand-curated `skills.include` list is never truncated, since the operator opted into that
+  specific set on purpose.
+
 - `zeph-session`: `AdvisoryLock::acquire`'s `WOULDBLOCK` path gave operators only a bare
   "another session is already active" message with no way to tell whether the lock's holder
   was still running (#6378). The holder's PID is now written into the sibling lock file

--- a/book/src/advanced/sub-agents.md
+++ b/book/src/advanced/sub-agents.md
@@ -217,6 +217,8 @@ Report findings as a structured list with severity (critical/warning/info).
 
 If neither `tools.allow` nor `tools.deny` is specified, the sub-agent inherits all tools from the main agent.
 
+Matched skill bodies are capped by `[skills] subagent_skill_token_budget` (default `12000` tokens, config-wide, not per-agent) — applies only when `skills.include` is empty; an explicit, hand-curated `include` list is never capped — see [Skill Filtering](#skill-filtering) below.
+
 ### `permission_mode` Values
 
 | Value | Description |
@@ -503,6 +505,14 @@ skills:
 
 - Empty `include` = all skills pass (unless excluded)
 - `exclude` always takes precedence over `include`
+- Matched skill bodies are injected once into the sub-agent's system prompt at spawn time. When
+  `include` is **empty** (the "inherit everything" default), bodies are also capped at
+  `[skills] subagent_skill_token_budget` tokens (default `12000`): bodies are greedily packed in
+  registry order — an over-budget skill is skipped, not a hard stop, so a smaller skill later in
+  the order can still fit — and a `[skill budget: N/M skills included, ...]` marker is appended
+  so the truncation is visible in both the prompt and the transcript rather than silent (#6421).
+  When `include` is **non-empty** (an explicit, hand-curated list), the budget does not apply —
+  all matched bodies are injected uncapped, since the operator opted into that specific set.
 
 ## Security Model
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -184,6 +184,12 @@ embedding_model = "qwen3-embedding"
 # paths = ["/absolute/path/to/skills"]
 # Maximum number of skills to inject into context per query (embedding-based selection)
 max_active_skills = 5
+# Token budget for skill bodies injected into a sub-agent's one-shot system prompt at spawn
+# time. Sub-agents with an empty skills.include filter inherit every skill in the registry;
+# bodies are greedily packed in registry order up to this budget (an over-budget skill is
+# skipped, not a hard stop — a smaller skill later in the order can still fit), and a
+# truncation marker is appended for any skills left out (#6421).
+subagent_skill_token_budget = 12000
 # Prompt mode: "full" (inject full SKILL.md), "compact" (name+description only), "auto" (compact if budget < 8192)
 # prompt_mode = "auto"
 # Minimum score delta for skill disambiguation (0.0-1.0)

--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -50,6 +50,20 @@ fn default_max_active_skills() -> NonZeroUsize {
     NonZeroUsize::new(5).expect("5 is non-zero")
 }
 
+/// Default value for [`SkillsConfig::subagent_skill_token_budget`].
+///
+/// Exposed as `pub` (unlike this file's other `default_*` helpers) so `zeph-core` can source
+/// its `SkillState` construction-time default from the same constant instead of duplicating
+/// the literal, which would otherwise be free to drift from the config default over time.
+///
+/// # Panics
+///
+/// Never panics in practice — `12_000` is a non-zero literal.
+#[must_use]
+pub fn default_subagent_skill_token_budget() -> NonZeroUsize {
+    NonZeroUsize::new(12_000).expect("12000 is non-zero")
+}
+
 fn default_index_watch() -> bool {
     // Default off: watcher watches ALL files recursively and bypasses gitignore
     // filtering at the OS level. Projects with large .local/ or target/ directories
@@ -351,6 +365,7 @@ impl Default for RegistryConfig {
 /// max_active_skills = 5
 /// disambiguation_threshold = 0.20
 /// hybrid_search = true
+/// subagent_skill_token_budget = 12000
 /// ```
 #[allow(clippy::struct_excessive_bools)] // config struct — boolean flags are idiomatic for TOML-deserialized configuration
 #[derive(Debug, Deserialize, Serialize)]
@@ -495,6 +510,37 @@ pub struct SkillsConfig {
     /// Default: `0.50`.
     #[serde(default = "default_support_similarity_threshold")]
     pub support_similarity_threshold: f32,
+
+    /// Token budget for skill bodies injected into a sub-agent's one-shot system prompt.
+    ///
+    /// Sub-agent definitions with an empty `skills.include` filter inherit every skill in
+    /// the registry (documented, intentional — see [`crate::SkillFilter`]). Unlike the main
+    /// agent's per-turn skill matcher, a sub-agent's skill bodies are injected once, at spawn
+    /// time, with no relevance ranking and no later opportunity to trim: an unbounded include
+    /// set can silently blow the turn-1 context budget (#6421). This budget applies **only** to
+    /// that empty-`include` case — a definition with an explicit, hand-curated `include` list is
+    /// never capped, since the operator opted into that specific set on purpose. Skill bodies are
+    /// greedily packed in registry order (alphabetical by skill directory, not relevance-ranked)
+    /// up to the budget — an over-budget skill is skipped, not a hard stop, so a smaller skill
+    /// later in the order can still fit — and any skills left out are surfaced via a visible
+    /// truncation marker rather than silently dropped.
+    ///
+    /// Default: `12000` tokens.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::num::NonZeroUsize;
+    /// use zeph_config::Config;
+    ///
+    /// let config = Config::default();
+    /// assert_eq!(
+    ///     config.skills.subagent_skill_token_budget,
+    ///     NonZeroUsize::new(12_000).unwrap()
+    /// );
+    /// ```
+    #[serde(default = "default_subagent_skill_token_budget")]
+    pub subagent_skill_token_budget: NonZeroUsize,
 }
 
 fn default_generation_timeout_ms() -> u64 {

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -143,7 +143,7 @@ pub use features::{
     IndexConfig, ProactiveExplorationConfig, RegistryBackendKind, RegistryConfig,
     ScheduledTaskConfig, ScheduledTaskKind, SchedulerConfig, SchedulerDaemonConfig,
     SchedulerSecurityConfig, SkillEvaluationConfig, SkillMiningConfig, SkillPromptMode,
-    SkillsConfig, TraceConfig, VaultBackend, VaultConfig,
+    SkillsConfig, TraceConfig, VaultBackend, VaultConfig, default_subagent_skill_token_budget,
 };
 pub use fidelity::FidelityConfig;
 pub use hooks::{FileChangedConfig, HooksConfig};

--- a/crates/zeph-config/src/root.rs
+++ b/crates/zeph-config/src/root.rs
@@ -274,6 +274,7 @@ impl Default for Config {
                 semantic_scan_provider: crate::providers::ProviderName::default(),
                 group_structured: false,
                 support_similarity_threshold: 0.50,
+                subagent_skill_token_budget: NonZeroUsize::new(12_000).expect("12000 is non-zero"),
             },
             memory: MemoryConfig {
                 sqlite_path: default_sqlite_path_field(),

--- a/crates/zeph-core/config/default.toml
+++ b/crates/zeph-core/config/default.toml
@@ -170,6 +170,8 @@ max_tokens = 4096
 # paths = ["/absolute/path/to/skills"]
 # Maximum number of skills to inject into context per query (embedding-based selection)
 max_active_skills = 5
+# Token budget for skill bodies injected into a sub-agent's one-shot system prompt at spawn time
+subagent_skill_token_budget = 12000
 # Prompt mode: "full" (inject full SKILL.md), "compact" (name+description only), "auto" (compact if budget < 8192)
 # prompt_mode = "auto"
 # Minimum score delta for skill disambiguation (0.0-1.0)

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -2674,6 +2674,7 @@ impl<C: Channel> Agent<C> {
             debug_config: _debug_config,
             server_compaction,
             budget_hint_enabled,
+            subagent_skill_token_budget,
             secrets,
             recap,
             loop_min_interval_secs,
@@ -2745,6 +2746,7 @@ impl<C: Channel> Agent<C> {
         self.services.memory.persistence.store_config = store_config;
         self.wire_graph_persistence();
         self.runtime.config.budget_hint_enabled = budget_hint_enabled;
+        self.services.skill.subagent_skill_token_budget = subagent_skill_token_budget;
         self.runtime.config.recap_config = recap;
         self.runtime.config.loop_min_interval_secs = loop_min_interval_secs;
         self.runtime.config.mcp_media = mcp_media;

--- a/crates/zeph-core/src/agent/config_reload.rs
+++ b/crates/zeph-core/src/agent/config_reload.rs
@@ -31,6 +31,8 @@ impl<C: Channel> Agent<C> {
         self.services.memory.compaction.summarization_threshold =
             config.memory.summarization_threshold;
         self.services.skill.max_active_skills = config.skills.max_active_skills.get();
+        self.services.skill.subagent_skill_token_budget =
+            config.skills.subagent_skill_token_budget.get();
         self.services.skill.disambiguation_threshold = config.skills.disambiguation_threshold;
         self.services.skill.min_injection_score = config.skills.min_injection_score;
         self.services.skill.cosine_weight = config.skills.cosine_weight.clamp(0.0, 1.0);

--- a/crates/zeph-core/src/agent/session_config.rs
+++ b/crates/zeph-core/src/agent/session_config.rs
@@ -116,6 +116,10 @@ pub struct AgentSessionConfig {
     /// Inject `<budget>` XML into the volatile system prompt section (#2267).
     pub budget_hint_enabled: bool,
 
+    /// Token budget for skill bodies injected into a sub-agent's one-shot system prompt
+    /// at spawn time (#6421). See `SkillsConfig::subagent_skill_token_budget`.
+    pub subagent_skill_token_budget: usize,
+
     /// Session recap settings (#3064).
     pub recap: zeph_config::RecapConfig,
 
@@ -204,6 +208,7 @@ impl AgentSessionConfig {
             debug_config: config.debug.clone(),
             server_compaction: config.llm.providers.iter().any(|e| e.server_compaction),
             budget_hint_enabled: config.agent.budget_hint_enabled,
+            subagent_skill_token_budget: config.skills.subagent_skill_token_budget.get(),
             secrets: config
                 .secrets
                 .custom
@@ -234,6 +239,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn from_config_maps_all_fields() {
         let config = Config::default();
         let budget = 100_000;
@@ -332,6 +338,10 @@ mod tests {
         assert_eq!(
             sc.fidelity_config.is_some(),
             config.memory.fidelity.is_some()
+        );
+        assert_eq!(
+            sc.subagent_skill_token_budget,
+            config.skills.subagent_skill_token_budget.get()
         );
     }
 }

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -94,6 +94,9 @@ pub(crate) struct SkillState {
     pub(crate) trust_config: crate::config::TrustConfig,
     pub(crate) matcher: Option<SkillMatcherBackend>,
     pub(crate) max_active_skills: usize,
+    /// Token budget for skill bodies injected into a sub-agent's one-shot system prompt at
+    /// spawn time. Mirrors `SkillsConfig::subagent_skill_token_budget` (#6421).
+    pub(crate) subagent_skill_token_budget: usize,
     pub(crate) disambiguation_threshold: f32,
     pub(crate) min_injection_score: f32,
     pub(crate) embedding_model: String,
@@ -1414,6 +1417,7 @@ impl SkillState {
             trust_config: crate::config::TrustConfig::default(),
             matcher,
             max_active_skills,
+            subagent_skill_token_budget: zeph_config::default_subagent_skill_token_budget().get(),
             disambiguation_threshold: 0.20,
             min_injection_score: 0.20,
             embedding_model: String::new(),

--- a/crates/zeph-core/src/agent/subagent_commands.rs
+++ b/crates/zeph-core/src/agent/subagent_commands.rs
@@ -701,24 +701,86 @@ impl<C: Channel> Agent<C> {
             .await;
         Some(result)
     }
+    /// Resolve the skill bodies to inject into a freshly spawned (or resumed) sub-agent's
+    /// one-shot system prompt.
+    ///
+    /// A sub-agent definition with an empty `skills.include` filter inherits every skill in
+    /// the registry (documented, intentional — see [`zeph_config::SkillFilter`]). Unlike the
+    /// main agent's per-turn skill matcher, these bodies are injected once, at spawn time, with
+    /// no relevance ranking and no later opportunity to trim — an unbounded include set can
+    /// silently blow the turn-1 context budget (#6421).
+    ///
+    /// The `subagent_skill_token_budget` cap applies **only** to that empty-include case. A
+    /// definition with an explicit, hand-curated `skills.include` list is never capped here —
+    /// the operator opted into that specific set on purpose, and applying the same budget would
+    /// silently regress configs that were never broken; #6421 is about the *default* (empty)
+    /// case only.
+    ///
+    /// When capped, bodies are accumulated in the order [`zeph_subagent::filter_skills`] returns
+    /// them — the registry's directory-walk order, i.e. alphabetical by skill directory name,
+    /// **not** relevance-ranked. A task-critical skill whose directory happens to sort late is
+    /// systematically the first cut on every default-include spawn; operators who hit this can
+    /// curate `include` explicitly or raise the budget. Accumulation is a greedy best-fit, not a
+    /// hard prefix cut: an over-budget skill is skipped (not a stopping point), so a smaller
+    /// skill later in the order can still be packed in afterward. The first skill is always
+    /// included even if it alone exceeds the budget, so a single oversized skill never starves
+    /// the whole set. Any skills left out are surfaced via a synthetic marker entry rather than
+    /// silently dropped.
     pub(super) fn filtered_skills_for(&self, agent_name: &str) -> Option<Vec<String>> {
         let mgr = self.services.orchestration.subagent_manager.as_ref()?;
         let def = mgr.definitions().iter().find(|d| d.name == agent_name)?;
         let reg = self.services.skill.registry.read();
-        match zeph_subagent::filter_skills(&reg, &def.skills) {
-            Ok(skills) => {
-                let bodies: Vec<String> = skills.into_iter().map(|s| s.body.clone()).collect();
-                if bodies.is_empty() {
-                    None
-                } else {
-                    Some(bodies)
-                }
-            }
+        let skills = match zeph_subagent::filter_skills(&reg, &def.skills) {
+            Ok(skills) => skills,
             Err(e) => {
                 tracing::warn!(error = %e, "skill filtering failed for sub-agent");
-                None
+                return None;
             }
+        };
+        if skills.is_empty() {
+            return None;
         }
+
+        // #6421 scope: only the empty-include "inherit everything" case is capped. An explicit,
+        // hand-curated include list is trusted as-is (see doc comment above).
+        if !def.skills.include.is_empty() {
+            return Some(skills.into_iter().map(|s| s.body).collect());
+        }
+
+        let total = skills.len();
+        let budget = self.services.skill.subagent_skill_token_budget;
+        let counter = &self.runtime.metrics.token_counter;
+
+        let mut bodies: Vec<String> = Vec::with_capacity(total);
+        let mut running_tokens = 0usize;
+        let mut omitted_names: Vec<&str> = Vec::new();
+
+        for skill in &skills {
+            let skill_tokens = counter.count_tokens(&skill.body);
+            if !bodies.is_empty() && running_tokens + skill_tokens > budget {
+                omitted_names.push(skill.meta.name.as_str());
+                continue;
+            }
+            running_tokens += skill_tokens;
+            bodies.push(skill.body.clone());
+        }
+
+        if !omitted_names.is_empty() {
+            let included = bodies.len();
+            tracing::warn!(
+                agent_name,
+                included,
+                total,
+                budget_tokens = budget,
+                "sub-agent skill body budget exceeded; truncated skill set"
+            );
+            bodies.push(format!(
+                "[skill budget: {included}/{total} skills included, budget={budget} tokens — omitted: {}]",
+                omitted_names.join(", ")
+            ));
+        }
+
+        Some(bodies)
     }
     /// Build a `SpawnContext` from current agent state for sub-agent spawning.
     pub(super) fn build_spawn_context(
@@ -1633,5 +1695,226 @@ mod tests {
         // proves the wiring produces a working `Arc<dyn DebugDumpSink>`, not just `Some(_)`.
         let id = sink.dump_request("mock", &[], &[], serde_json::Value::Null);
         sink.dump_response(id, &zeph_llm::provider::ChatResponse::Text("ok".into()));
+    }
+
+    // ── filtered_skills_for token-budget cap (#6421) ─────────────────────────
+
+    /// Builds a `SkillRegistry` with `count` skills on disk, each named `skill-N` with a body
+    /// made of `words_per_skill` repeated words — enough real text that `TokenCounter` charges
+    /// a nontrivial, predictable-in-sign (if not exact) token count per skill.
+    ///
+    /// Returns the backing `TempDir` alongside the registry: skill bodies are loaded lazily
+    /// from disk on first access (`SkillRegistry::skill`/`body`), so the caller must keep the
+    /// directory alive for as long as the registry is used, not just during `load`.
+    fn registry_with_skills(
+        count: usize,
+        words_per_skill: usize,
+    ) -> (SkillRegistry, tempfile::TempDir) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        for i in 0..count {
+            let skill_dir = temp_dir.path().join(format!("skill-{i}"));
+            std::fs::create_dir(&skill_dir).unwrap();
+            let body = "lorem ".repeat(words_per_skill);
+            std::fs::write(
+                skill_dir.join("SKILL.md"),
+                format!("---\nname: skill-{i}\ndescription: Test skill {i}\n---\n{body}"),
+            )
+            .unwrap();
+        }
+        let registry = SkillRegistry::load(&[temp_dir.path().to_path_buf()]);
+        (registry, temp_dir)
+    }
+
+    fn agent_with_skill_registry_and_def(
+        registry: SkillRegistry,
+        def: zeph_subagent::SubAgentDef,
+    ) -> Agent<MockChannel> {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+        let mut mgr = zeph_subagent::SubAgentManager::new(4);
+        mgr.definitions_mut().push(def);
+        agent.services.orchestration.subagent_manager = Some(mgr);
+        agent
+    }
+
+    fn agent_with_skill_registry_and_helper_def(registry: SkillRegistry) -> Agent<MockChannel> {
+        agent_with_skill_registry_and_def(registry, subagent_def("helper"))
+    }
+
+    #[test]
+    fn filtered_skills_for_under_budget_returns_all_bodies_no_marker() {
+        // Default `SkillFilter` (empty include/exclude) inherits every registry skill —
+        // the #6421 scenario — but the budget here is generous enough that nothing is cut.
+        let (registry, _temp_dir) = registry_with_skills(3, 20);
+        let mut agent = agent_with_skill_registry_and_helper_def(registry);
+        agent.services.skill.subagent_skill_token_budget = 1_000_000;
+
+        let bodies = agent
+            .filtered_skills_for("helper")
+            .expect("3 skills with a huge budget must return Some");
+
+        assert_eq!(
+            bodies.len(),
+            3,
+            "no truncation marker expected when everything fits under budget"
+        );
+        for body in &bodies {
+            assert!(
+                body.contains("lorem"),
+                "every returned entry must be a real skill body, not a marker: {body}"
+            );
+        }
+    }
+
+    #[test]
+    fn filtered_skills_for_over_budget_truncates_with_marker() {
+        // 5 skills, each with a large body; a tiny budget forces truncation well before the
+        // full set is accumulated.
+        let (registry, _temp_dir) = registry_with_skills(5, 500);
+        let mut agent = agent_with_skill_registry_and_helper_def(registry);
+        agent.services.skill.subagent_skill_token_budget = 10;
+
+        let bodies = agent
+            .filtered_skills_for("helper")
+            .expect("at least the first skill must always be included");
+
+        let marker_count = bodies
+            .iter()
+            .filter(|b| b.starts_with("[skill budget:"))
+            .count();
+        assert_eq!(
+            marker_count, 1,
+            "exactly one truncation marker entry must be appended, got bodies: {bodies:?}"
+        );
+        let marker = bodies
+            .iter()
+            .find(|b| b.starts_with("[skill budget:"))
+            .unwrap();
+        let included = bodies.len() - 1;
+        assert!(
+            included < 5,
+            "budget=10 tokens must not fit all 5 large skills, included={included}"
+        );
+        assert!(
+            included >= 1,
+            "the first skill must always be included even when it alone exceeds the budget, \
+             got included={included}"
+        );
+        assert!(
+            bodies[0].contains("lorem"),
+            "the always-included first entry must be a real skill body, not the marker: {}",
+            bodies[0]
+        );
+        assert!(
+            marker.contains(&format!("{included}/5 skills included")),
+            "marker must report the correct included/total count: {marker}"
+        );
+        assert!(
+            marker.contains("budget=10 tokens"),
+            "marker must report the configured budget: {marker}"
+        );
+    }
+
+    #[test]
+    fn filtered_skills_for_mid_budget_greedily_fills_multiple_fitting_skills() {
+        // 5 identical-body skills so each costs exactly the same token count T (computed via the
+        // same TokenCounter the fix uses). A budget of `2*T + 1` fits skill-0 and skill-1 exactly
+        // (running total 2T <= budget) but not a 3rd (3T > budget) — this exercises the greedy
+        // `running_tokens + skill_tokens > budget` accumulation for a *fitting* 2nd skill, not
+        // just the always-included first one (S2: the over-budget test alone never reaches this
+        // arithmetic since its budget is too small to fit even a 2nd skill).
+        let (registry, _temp_dir) = registry_with_skills(5, 500);
+        let single_body = "lorem ".repeat(500);
+        let per_skill_tokens = zeph_memory::TokenCounter::new().count_tokens(&single_body);
+        assert!(
+            per_skill_tokens > 1,
+            "test setup: per-skill token count must be large enough for 2*T+1 to exclude a 3rd \
+             skill, got {per_skill_tokens}"
+        );
+
+        let mut agent = agent_with_skill_registry_and_helper_def(registry);
+        agent.services.skill.subagent_skill_token_budget = 2 * per_skill_tokens + 1;
+
+        let bodies = agent
+            .filtered_skills_for("helper")
+            .expect("at least the first skill must always be included");
+
+        let marker = bodies
+            .iter()
+            .find(|b| b.starts_with("[skill budget:"))
+            .unwrap_or_else(|| panic!("expected a truncation marker, got bodies: {bodies:?}"));
+        let included = bodies.len() - 1;
+        assert_eq!(
+            included, 2,
+            "budget=2*T+1 must fit exactly 2 of the 5 identical-cost skills, got {included}"
+        );
+        assert!(
+            marker.contains("2/5 skills included"),
+            "marker must report the correct included/total count: {marker}"
+        );
+        // Registry order is alphabetical by skill directory name (skill-0..skill-4), so the
+        // 2 included skills are skill-0/skill-1 and the 3 omitted are skill-2/3/4 — assert the
+        // marker's omitted-name list matches exactly, not just the count (closes Gap 3).
+        let omitted_segment = marker
+            .split("omitted: ")
+            .nth(1)
+            .and_then(|s| s.strip_suffix(']'))
+            .unwrap_or_else(|| panic!("marker missing 'omitted: ...]' segment: {marker}"));
+        let mut omitted_names: Vec<&str> = omitted_segment.split(", ").collect();
+        omitted_names.sort_unstable();
+        assert_eq!(
+            omitted_names,
+            vec!["skill-2", "skill-3", "skill-4"],
+            "marker must name exactly the 3 truncated skills, got marker: {marker}"
+        );
+    }
+
+    #[test]
+    fn filtered_skills_for_explicit_include_is_never_capped() {
+        // S1 (scope decision): the budget cap applies only to the empty-include "inherit
+        // everything" case #6421 is about. A definition with an explicit, hand-curated
+        // `skills.include` list must be returned uncapped even when its total size would
+        // otherwise exceed the configured budget — the operator opted into that set on purpose.
+        use zeph_subagent::def::{SkillFilter, SubAgentPermissions, ToolPolicy};
+        use zeph_subagent::hooks::SubagentHooks;
+
+        let (registry, _temp_dir) = registry_with_skills(5, 500);
+        let def = zeph_subagent::SubAgentDef {
+            name: "curated".to_owned(),
+            description: "A curated helper".into(),
+            model: None,
+            tools: ToolPolicy::InheritAll,
+            disallowed_tools: vec![],
+            permissions: SubAgentPermissions::default(),
+            skills: SkillFilter {
+                include: vec!["skill-*".to_owned()],
+                exclude: vec![],
+            },
+            system_prompt: "You are helpful.".into(),
+            hooks: SubagentHooks::default(),
+            memory: None,
+            source: None,
+            file_path: None,
+        };
+        let mut agent = agent_with_skill_registry_and_def(registry, def);
+        // Budget far too small to fit all 5 skills — would definitely truncate the empty-include
+        // path, but must have zero effect here.
+        agent.services.skill.subagent_skill_token_budget = 10;
+
+        let bodies = agent
+            .filtered_skills_for("curated")
+            .expect("explicit include must still match all 5 skill-* skills");
+
+        assert_eq!(
+            bodies.len(),
+            5,
+            "explicit include list must never be truncated by the budget, got: {bodies:?}"
+        );
+        assert!(
+            bodies.iter().all(|b| b.contains("lorem")),
+            "every entry must be a real skill body, not a truncation marker: {bodies:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Sub-agent definitions with the default (empty) `skills.include` filter inherit every skill in the registry, and — unlike the main agent's per-turn skill matcher — their bodies were injected once, unranked, into the sub-agent's one-shot spawn-time system prompt with **no cap**. A large skill set could silently blow the turn-1 context budget (~55-60K tokens for this repo's own 31 default skills), and unlike the sibling construction-time blob fixed in #6413, this one actually reaches the LLM on every spawn.
- `filtered_skills_for` now accumulates skill bodies against a new `[skills] subagent_skill_token_budget` config field (default `12000` tokens) in registry order, always including at least the first skill, and appends a `[skill budget: N/M skills included, ...]` marker plus a `tracing::warn!` when any skills are omitted — so the truncation is visible in the prompt and transcript instead of silent.
- The cap applies **only** to the empty-include case — a sub-agent with an explicit, hand-curated `skills.include` list is never truncated, since the operator opted into that specific set on purpose.

Closes #6421

## Test plan

- [x] 4 new unit tests in `crates/zeph-core/src/agent/subagent_commands.rs`: under-budget (no marker), over-budget with a mid-range budget (partial fill, exact omitted-name assertions), first-skill-force-include invariant, explicit-include-is-never-capped
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` clean, 0 warnings
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 14205 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` clean
- [x] `cargo test --doc -p zeph-config` — new field's doctest passes
- [x] `.local/testing/playbooks/subagent-context.md` Scenario 10 added (live-session validation still pending a CI cycle, tracked in coverage-status.md as `Untested`)