### PR TITLE
chore(arch): enable workspace lints for zeph-experiments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,6 +247,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   with `ALL` (but does not by itself detect a variant missing from `ALL`). No behavior
   change for any of the 9 existing variants.
 
+- `zeph-experiments`: added `[lints] workspace = true` to `Cargo.toml` — it was the only
+  crate in the workspace missing it, silently excluding the crate from every lint declared
+  in `[workspace.lints.clippy]` (root `Cargo.toml`), not just `clippy::await_holding_lock`
+  added in #6355 (#6371). Fixed the ~11 `clippy::pedantic` violations this surfaced:
+  wrapped `SQLite`/`GoSkills`/`snake_case` identifiers in backticks across doc comments
+  (`doc_markdown`), replaced a manual `(min + max) / 2.0` midpoint with `f64::midpoint`
+  in a test helper (`manual_midpoint`), and split `Evaluator::evaluate` (126/100 lines) into
+  `collect_subject_responses` (Phase 1: subject model calls) and `score_subject_responses`
+  (Phase 2: judge scoring) private helper methods (`too_many_lines`). No behavior change.
+
 ### Fixed
 
 - `zeph-core`: the initial system prompt built at agent construction

--- a/crates/zeph-experiments/Cargo.toml
+++ b/crates/zeph-experiments/Cargo.toml
@@ -45,3 +45,6 @@ default = ["sqlite"]
 sqlite = ["zeph-memory/sqlite"]
 postgres = ["zeph-memory/postgres"]
 mock = []
+
+[lints]
+workspace = true

--- a/crates/zeph-experiments/src/engine.rs
+++ b/crates/zeph-experiments/src/engine.rs
@@ -4,7 +4,7 @@
 //! Experiment engine — core async loop for autonomous parameter tuning.
 //!
 //! [`ExperimentEngine`] orchestrates baseline evaluation, variation generation,
-//! candidate scoring, acceptance decisions, and optional SQLite persistence.
+//! candidate scoring, acceptance decisions, and optional `SQLite` persistence.
 //! Cancellation is supported via [`tokio_util::sync::CancellationToken`].
 //!
 //! # Loop Summary
@@ -14,7 +14,7 @@
 //! 3. Clone the subject provider with generation overrides from the candidate snapshot.
 //! 4. Evaluate the candidate; accept if `delta >= config.min_improvement`.
 //! 5. On acceptance, update the progressive baseline (greedy hill-climbing).
-//! 6. Optionally persist the result to SQLite.
+//! 6. Optionally persist the result to `SQLite`.
 //! 7. Repeat until: max experiments, wall-time limit, search exhaustion, or cancellation.
 //!
 //! [`VariationGenerator`]: crate::VariationGenerator

--- a/crates/zeph-experiments/src/error.rs
+++ b/crates/zeph-experiments/src/error.rs
@@ -105,7 +105,7 @@ pub enum EvalError {
         radius: f64,
     },
 
-    /// An experiment result could not be persisted to SQLite.
+    /// An experiment result could not be persisted to `SQLite`.
     #[error("experiment storage error: {0}")]
     Storage(String),
 

--- a/crates/zeph-experiments/src/evaluator.rs
+++ b/crates/zeph-experiments/src/evaluator.rs
@@ -352,7 +352,38 @@ impl Evaluator {
     pub async fn evaluate(&self, subject: &AnyProvider) -> Result<EvalReport, EvalError> {
         let cases_total = self.benchmark.cases.len();
 
-        // Phase 1: call subject model in parallel, bounded by `parallel_evals`.
+        let (subject_responses, subject_error_count) =
+            self.collect_subject_responses(subject).await?;
+
+        let (scores, mut error_count, budget_hit, total_tokens) =
+            self.score_subject_responses(&subject_responses).await;
+
+        let cases_scored = scores.len();
+        error_count += subject_error_count;
+        let is_partial = budget_hit || error_count > 0;
+
+        Ok(build_report(
+            scores,
+            cases_scored,
+            cases_total,
+            is_partial,
+            error_count,
+            total_tokens,
+        ))
+    }
+
+    /// Phase 1 of [`Self::evaluate`]: call the subject model for every benchmark case in
+    /// parallel, bounded by `parallel_evals`. Returns responses paired with their original
+    /// case index and reference, plus the count of cases skipped due to tolerated errors.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first [`EvalError`] encountered once `tolerate_subject_errors` is
+    /// `false` (the default).
+    async fn collect_subject_responses(
+        &self,
+        subject: &AnyProvider,
+    ) -> Result<(Vec<(usize, &BenchmarkCase, String)>, usize), EvalError> {
         let subject_semaphore = Arc::new(Semaphore::new(self.parallel_evals));
         let mut subject_futures: FuturesUnordered<_> = FuturesUnordered::new();
 
@@ -389,7 +420,8 @@ impl Evaluator {
 
         // Collect subject responses. When `tolerate_subject_errors` is false (default) any
         // error aborts the run immediately. When true, failed cases are excluded from Phase 2.
-        let mut indexed_responses: Vec<(usize, String)> = Vec::with_capacity(cases_total);
+        let mut indexed_responses: Vec<(usize, String)> =
+            Vec::with_capacity(self.benchmark.cases.len());
         let mut subject_error_count = 0usize;
         while let Some(result) = subject_futures.next().await {
             match result {
@@ -407,17 +439,26 @@ impl Evaluator {
         // Restore deterministic order for Phase 2 (FuturesUnordered yields in completion order).
         indexed_responses.sort_unstable_by_key(|(i, _)| *i);
 
-        let subject_responses: Vec<(usize, &BenchmarkCase, String)> = indexed_responses
+        let subject_responses = indexed_responses
             .into_iter()
             .map(|(i, response)| (i, &self.benchmark.cases[i], response))
             .collect();
 
-        // Phase 2: score responses in parallel with a per-invocation budget counter.
+        Ok((subject_responses, subject_error_count))
+    }
+
+    /// Phase 2 of [`Self::evaluate`]: score subject responses with the judge model in
+    /// parallel, enforcing the per-invocation token budget. Returns collected scores, the
+    /// judge error count, whether the budget was exhausted, and total tokens consumed.
+    async fn score_subject_responses(
+        &self,
+        subject_responses: &[(usize, &BenchmarkCase, String)],
+    ) -> (Vec<CaseScore>, usize, bool, u64) {
         let tokens_used = Arc::new(AtomicU64::new(0));
         let semaphore = Arc::new(Semaphore::new(self.parallel_evals));
         let mut futures: FuturesUnordered<_> = FuturesUnordered::new();
 
-        for (case_index, case, response) in &subject_responses {
+        for (case_index, case, response) in subject_responses {
             let judge = Arc::clone(&self.judge);
             let sem = Arc::clone(&semaphore);
             let budget = self.budget_tokens;
@@ -440,7 +481,7 @@ impl Evaluator {
                 // a reservation slot; if we are already at or above budget we roll back.
                 // The real token cost is added inside score_case_with_provider after the
                 // call completes. The reservation remains in the counter to keep the
-                // budget guard conservative — EvalReport::total_tokens is corrected by
+                // budget guard conservative — the caller's total_tokens is corrected by
                 // subtracting cases_scored (one reservation per successful call) after
                 // all futures complete, so the reported value reflects only real usage.
                 let prev = tokens_used.fetch_add(1, Ordering::AcqRel);
@@ -463,7 +504,7 @@ impl Evaluator {
             });
         }
 
-        let mut scores: Vec<CaseScore> = Vec::with_capacity(cases_total);
+        let mut scores: Vec<CaseScore> = Vec::with_capacity(subject_responses.len());
         let mut error_count = 0usize;
         let mut budget_hit = false;
 
@@ -495,23 +536,13 @@ impl Evaluator {
         }
 
         let cases_scored = scores.len();
-        error_count += subject_error_count;
-        let is_partial = budget_hit || error_count > 0;
-
         // Each successful judge call left a +1 reservation in tokens_used that was never
         // rolled back (the reservation is intentionally kept to prevent budget races).
-        // Subtract cases_scored here so EvalReport::total_tokens reflects only real usage.
+        // Subtract cases_scored here so the caller's total_tokens reflects only real usage.
         let raw_tokens = tokens_used.load(Ordering::Relaxed);
         let total_tokens = raw_tokens.saturating_sub(cases_scored as u64);
 
-        Ok(build_report(
-            scores,
-            cases_scored,
-            cases_total,
-            is_partial,
-            error_count,
-            total_tokens,
-        ))
+        (scores, error_count, budget_hit, total_tokens)
     }
 }
 

--- a/crates/zeph-experiments/src/grid.rs
+++ b/crates/zeph-experiments/src/grid.rs
@@ -138,7 +138,7 @@ mod tests {
 
     fn single_param_space(min: f64, max: f64, step: f64) -> SearchSpace {
         // default = midpoint so it satisfies min <= default <= max
-        let default = (min + max) / 2.0;
+        let default = f64::midpoint(min, max);
         SearchSpace {
             parameters: vec![
                 ParameterRange::new(ParameterKind::Temperature, min, max, Some(step), default)

--- a/crates/zeph-experiments/src/lib.rs
+++ b/crates/zeph-experiments/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! [`ExperimentEngine`] ties all three together: it evaluates a baseline, iterates over
 //! variations produced by the generator, accepts improvements (greedy hill-climbing), and
-//! optionally persists results to SQLite.
+//! optionally persists results to `SQLite`.
 //!
 //! # Quick Start
 //!

--- a/crates/zeph-experiments/src/snapshot.rs
+++ b/crates/zeph-experiments/src/snapshot.rs
@@ -61,7 +61,7 @@ pub struct ConfigSnapshot {
     pub similarity_threshold: f64,
     /// Half-life in days for temporal memory decay.
     pub temporal_decay: f64,
-    /// GoSkills group-structured injection toggle (0.0 = disabled, 1.0 = enabled).
+    /// `GoSkills` group-structured injection toggle (0.0 = disabled, 1.0 = enabled).
     pub group_structured: f64,
 }
 

--- a/crates/zeph-experiments/src/types.rs
+++ b/crates/zeph-experiments/src/types.rs
@@ -72,7 +72,7 @@ pub enum ParameterKind {
     SimilarityThreshold,
     /// Half-life in days for temporal memory decay (float).
     TemporalDecay,
-    /// GoSkills group-structured skill injection toggle (boolean: 0.0 = off, 1.0 = on).
+    /// `GoSkills` group-structured skill injection toggle (boolean: 0.0 = off, 1.0 = on).
     ///
     /// When active, this parameter overrides `skills.group_structured` in config,
     /// bidirectionally (experiment can both enable and disable the feature).
@@ -127,7 +127,7 @@ impl ParameterKind {
     /// Forces [`Self::_all_variants_exhaustive`] to be checked at compile time.
     const _ASSERT_ALL_VARIANTS_HANDLED: () = Self::_all_variants_exhaustive(Self::Temperature);
 
-    /// Return the canonical snake_case name of this parameter.
+    /// Return the canonical `snake_case` name of this parameter.
     ///
     /// The returned string matches the key used in config files and experiment
     /// storage. It is identical to the `#[serde(rename_all = "snake_case")]`
@@ -265,14 +265,14 @@ impl std::fmt::Display for VariationValue {
 /// Persisted record of a single variation trial.
 ///
 /// Each time [`ExperimentEngine`] evaluates a candidate variation, it produces an
-/// `ExperimentResult` that is stored in SQLite (when memory is configured) and
+/// `ExperimentResult` that is stored in `SQLite` (when memory is configured) and
 /// included in the [`ExperimentSessionReport`].
 ///
 /// [`ExperimentEngine`]: crate::ExperimentEngine
 /// [`ExperimentSessionReport`]: crate::engine::ExperimentSessionReport
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExperimentResult {
-    /// Row ID in the SQLite experiments table. `None` when not yet persisted.
+    /// Row ID in the `SQLite` experiments table. `None` when not yet persisted.
     pub id: Option<i64>,
     /// Session ID of the experiment session that produced this result.
     pub session_id: SessionId,
@@ -317,7 +317,7 @@ pub enum ExperimentSource {
 }
 
 impl ExperimentSource {
-    /// Return the canonical snake_case name of this source.
+    /// Return the canonical `snake_case` name of this source.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
## Summary
- Adds `[lints] workspace = true` to `crates/zeph-experiments/Cargo.toml` — it was the only crate in the workspace missing it, silently excluded from every lint in `[workspace.lints.clippy]`, including `clippy::await_holding_lock` added in #6355.
- Fixes the 12 `clippy::pedantic` violations this surfaced: 10x `doc_markdown` backtick wraps, 1x `manual_midpoint` replacement in a test-only helper, 1x `too_many_lines` split of `Evaluator::evaluate` into `collect_subject_responses` (Phase 1: subject calls) and `score_subject_responses` (Phase 2: judge scoring) — pure extraction, no behavior change.
- Updates CHANGELOG.md.

Closes #6371

## Test plan
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — one unrelated pre-existing flake in `zeph-llm::model_cache` root-caused and filed separately as #6432 (PID-recycling temp-dir collision, untouched by this diff)
- [x] Adversarial critique of the `evaluate` split (arithmetic/control-flow/TOCTOU-comment parity) — approved
- [x] Test-coverage validation of the split — confirmed existing tests transitively cover both new phases, no coverage gap

Also surfaced and filed as a separate follow-up: #6431 (`zeph-memory`'s `mock_semantic_memory()` hardcodes `SqliteStore`, breaks `postgres`-only nextest runs — pre-existing, unrelated to this diff).