### PR TITLE
perf(core): make /history transcript_len/transcript_page O(1)/O(count)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 ### Fixed
 
+- `zeph-core`: `/history` re-scanned the entire message vector on every call —
+  `MessageAccessImpl::transcript_len` was O(total non-system messages) unconditionally, and
+  `transcript_page`'s `.skip(start)` ran on top of a `.filter()`, so it walked from index 0 even
+  though the common bounded-default case (`/history N`) computes `start` near the end of history.
+  Repeated `/history all` → `/history next` paging did O(total²/page_size) aggregate work (#6427,
+  follow-up from #6420). `MessageState` now maintains an incrementally-updated `non_system_count`
+  (O(1) `transcript_len`), and `transcript_page` scans from whichever end of the vector is closer
+  to the requested page, making both named hot patterns (`/history N` bounded-default and
+  `/history all`'s first page) O(count) instead of O(total). Middle-of-history pages reached via
+  a long `/history next` chain still cost up to O(min(start, total-end)) — tracking a full
+  position index of non-system ordinals was rejected since arbitrary-position System-message
+  churn (LSP notes, focus checkpoints) would make that index itself O(n) per turn, moving cost
+  onto the hotter turn loop instead of the `/history` read path.
+
 - `zeph-orchestration`: `PlanVerifier::verify_plan()` (whole-plan grounding, spec 009) shared
   the same `orchestration.verifier_timeout_secs` budget as per-task `verify()`, and consistently
   exhausted it against slower local Ollama models even when per-task verification on the same

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -235,6 +235,7 @@ impl<C: Channel> Agent<C> {
         mut messages: Vec<zeph_llm::provider::Message>,
     ) -> Self {
         self.msg.messages.append(&mut messages);
+        self.msg.recompute_non_system_count();
         self.msg.history_preloaded = true;
         self
     }

--- a/crates/zeph-core/src/agent/command_context_impls.rs
+++ b/crates/zeph-core/src/agent/command_context_impls.rs
@@ -139,6 +139,7 @@ impl MessageAccess for MessageAccessImpl<'_> {
         self.msg.pending_image_parts.clear();
         self.tool_orchestrator.clear_cache();
         self.security.user_provided_urls.write().clear();
+        self.msg.recompute_non_system_count();
     }
 
     fn queue_len(&self) -> usize {
@@ -161,22 +162,47 @@ impl MessageAccess for MessageAccessImpl<'_> {
     }
 
     fn transcript_len(&self) -> usize {
-        self.msg
-            .messages
-            .iter()
-            .filter(|m| m.role != Role::System)
-            .count()
+        self.msg.non_system_len()
     }
 
     fn transcript_page(&self, start: usize, count: usize) -> Vec<TranscriptEntry> {
-        self.msg
-            .messages
-            .iter()
-            .filter(|m| m.role != Role::System)
-            .skip(start)
-            .take(count)
-            .map(message_to_transcript_entry)
-            .collect()
+        let total = self.msg.non_system_len();
+        if count == 0 || start >= total {
+            return Vec::new();
+        }
+        let end = start.saturating_add(count).min(total);
+        // Scan from whichever end of `messages` is ordinally closer to the requested page —
+        // the bounded-default `/history N` case always asks for the tail (back_cost == 0) and
+        // `/history all`'s first page always asks for the head (front_cost == 0), so both of
+        // the common call patterns become O(count) instead of walking the full vector on every
+        // call (#6427). Middle-of-history pages from repeated `/history next` still cost up to
+        // O(min(start, total - end)), but that heavy full-history walk is explicitly the rare,
+        // user-warned-about path ("this may take a moment"), not a hot one.
+        let front_cost = start;
+        let back_cost = total - end;
+        if front_cost <= back_cost {
+            self.msg
+                .messages
+                .iter()
+                .filter(|m| m.role != Role::System)
+                .skip(start)
+                .take(end - start)
+                .map(message_to_transcript_entry)
+                .collect()
+        } else {
+            let mut page: Vec<TranscriptEntry> = self
+                .msg
+                .messages
+                .iter()
+                .rev()
+                .filter(|m| m.role != Role::System)
+                .skip(back_cost)
+                .take(end - start)
+                .map(message_to_transcript_entry)
+                .collect();
+            page.reverse();
+            page
+        }
     }
 
     fn history_cursor(&self) -> usize {
@@ -352,5 +378,251 @@ impl SessionAccess for NullSessionAccess {
 
     fn history_expand_default_lines(&self) -> usize {
         20
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::Agent;
+    use crate::agent::agent_tests::{
+        MockChannel, MockToolExecutor, create_test_registry, mock_provider,
+    };
+    use zeph_llm::provider::MessageMetadata;
+
+    fn make_agent() -> Agent<MockChannel> {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        Agent::new(provider, channel, registry, None, 5, executor)
+    }
+
+    fn msg(role: Role, content: &str) -> Message {
+        Message {
+            role,
+            content: content.to_string(),
+            parts: vec![],
+            metadata: MessageMetadata::default(),
+        }
+    }
+
+    fn access(agent: &mut Agent<MockChannel>) -> MessageAccessImpl<'_> {
+        MessageAccessImpl {
+            msg: &mut agent.msg,
+            tool_state: &mut agent.services.tool_state,
+            providers: &mut agent.runtime.providers,
+            metrics: &agent.runtime.metrics,
+            security: &mut agent.services.security,
+            tool_orchestrator: &mut agent.tool_orchestrator,
+        }
+    }
+
+    /// `TranscriptEntry` has no `PartialEq` (see `zeph-commands/src/transcript.rs`) — project
+    /// into a comparable tuple for `assert_eq!` in these tests.
+    fn comparable(entries: &[TranscriptEntry]) -> Vec<(TranscriptRole, String, Option<String>)> {
+        entries
+            .iter()
+            .map(|e| (e.role, e.content.clone(), e.tool_name.clone()))
+            .collect()
+    }
+
+    /// Reference implementation matching the pre-#6427 behavior exactly (the same filter,
+    /// skip, take chain), used to prove the optimized `transcript_page` produces identical
+    /// output for every case, including interleaved `Role::System` messages.
+    fn reference_page(messages: &[Message], start: usize, count: usize) -> Vec<TranscriptEntry> {
+        messages
+            .iter()
+            .filter(|m| m.role != Role::System)
+            .skip(start)
+            .take(count)
+            .map(message_to_transcript_entry)
+            .collect()
+    }
+
+    #[test]
+    fn transcript_len_empty_history_is_zero() {
+        let mut agent = make_agent();
+        let ctx = access(&mut agent);
+        // Fresh agent has only the system-prompt message.
+        assert_eq!(ctx.transcript_len(), 0);
+    }
+
+    #[test]
+    fn transcript_page_empty_history_returns_empty() {
+        let mut agent = make_agent();
+        let ctx = access(&mut agent);
+        assert!(ctx.transcript_page(0, 20).is_empty());
+    }
+
+    #[test]
+    fn transcript_page_count_zero_returns_empty() {
+        let mut agent = make_agent();
+        agent.push_message(msg(Role::User, "hi"));
+        let ctx = access(&mut agent);
+        assert!(ctx.transcript_page(0, 0).is_empty());
+    }
+
+    #[test]
+    fn transcript_page_start_beyond_len_returns_empty() {
+        let mut agent = make_agent();
+        agent.push_message(msg(Role::User, "hi"));
+        let ctx = access(&mut agent);
+        assert!(ctx.transcript_page(5, 3).is_empty());
+        assert!(ctx.transcript_page(1, 3).is_empty()); // start == total is also out of range
+    }
+
+    #[test]
+    fn transcript_len_and_page_ignore_system_only_history() {
+        let mut agent = make_agent();
+        agent.push_message(msg(Role::System, "extra system note"));
+        agent.push_message(msg(Role::System, "another note"));
+        let ctx = access(&mut agent);
+        assert_eq!(ctx.transcript_len(), 0);
+        assert!(ctx.transcript_page(0, 10).is_empty());
+    }
+
+    #[test]
+    fn transcript_len_counts_only_non_system_and_tracks_incrementally() {
+        let mut agent = make_agent();
+        agent.push_message(msg(Role::User, "u1"));
+        agent.push_message(msg(Role::System, "lsp note"));
+        agent.push_message(msg(Role::Assistant, "a1"));
+        agent.push_message(msg(Role::User, "u2"));
+        let ctx = access(&mut agent);
+        assert_eq!(ctx.transcript_len(), 3);
+    }
+
+    #[test]
+    fn transcript_page_bounded_default_tail_matches_reference() {
+        // Mirrors the `/history N` hot path: start = total - n (near the tail), exercising
+        // the back-scan branch.
+        let mut agent = make_agent();
+        for i in 0..30 {
+            agent.push_message(msg(Role::User, &format!("u{i}")));
+            agent.push_message(msg(Role::Assistant, &format!("a{i}")));
+        }
+        let messages = agent.msg.messages.clone();
+        let ctx = access(&mut agent);
+        let total = ctx.transcript_len();
+        let n = 20.min(total);
+        let start = total - n;
+        let expected = reference_page(&messages, start, n);
+        let actual = ctx.transcript_page(start, n);
+        assert_eq!(comparable(&actual), comparable(&expected));
+        assert_eq!(actual.len(), n);
+    }
+
+    #[test]
+    fn transcript_page_front_scan_then_next_continuation_matches_reference() {
+        // Mirrors `/history all` -> repeated `/history next`: start = 0, then start = cursor,
+        // cursor + count, ... — exercising the front-scan branch across a page boundary.
+        let mut agent = make_agent();
+        for i in 0..45 {
+            agent.push_message(msg(Role::User, &format!("u{i}")));
+        }
+        let messages = agent.msg.messages.clone();
+        let ctx = access(&mut agent);
+        let total = ctx.transcript_len();
+        let page_size = 20;
+
+        let mut cursor = 0;
+        while cursor < total {
+            let count = page_size.min(total - cursor);
+            let expected = reference_page(&messages, cursor, count);
+            let actual = ctx.transcript_page(cursor, count);
+            assert_eq!(
+                comparable(&actual),
+                comparable(&expected),
+                "mismatch at cursor={cursor}"
+            );
+            cursor += count;
+        }
+    }
+
+    #[test]
+    fn transcript_page_matches_reference_with_interleaved_system_messages() {
+        // Simulates focus checkpoints / LSP notes / knowledge blocks scattered throughout
+        // history (#6427) — the non-system counter must still yield byte-identical output to
+        // the naive filter-skip-take reference for every (start, count) pair, regardless of
+        // which end `transcript_page` chooses to scan from.
+        let mut agent = make_agent();
+        for i in 0..40 {
+            agent.push_message(msg(Role::User, &format!("u{i}")));
+            if i % 3 == 0 {
+                agent.push_message(msg(Role::System, &format!("note{i}")));
+            }
+            agent.push_message(msg(Role::Assistant, &format!("a{i}")));
+        }
+        let messages = agent.msg.messages.clone();
+        let ctx = access(&mut agent);
+        let total = ctx.transcript_len();
+        assert_eq!(
+            total,
+            messages.iter().filter(|m| m.role != Role::System).count()
+        );
+
+        for start in [0, 1, total / 2, total.saturating_sub(1), total] {
+            for count in [0, 1, 5, total] {
+                let expected = reference_page(&messages, start, count);
+                let actual = ctx.transcript_page(start, count);
+                assert_eq!(
+                    comparable(&actual),
+                    comparable(&expected),
+                    "mismatch at start={start}, count={count}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn clear_history_resets_transcript_len_to_zero() {
+        let mut agent = make_agent();
+        agent.push_message(msg(Role::User, "u1"));
+        agent.push_message(msg(Role::Assistant, "a1"));
+        let mut ctx = access(&mut agent);
+        assert_eq!(ctx.transcript_len(), 2);
+        ctx.clear_history();
+        assert_eq!(ctx.transcript_len(), 0);
+    }
+
+    /// Regression for the direct-append + recompute pattern used by `builder.rs:237`
+    /// (durable-log replay seeding) — the batch-mutation counterpart to the incremental
+    /// `push_message` path already covered above.
+    #[test]
+    fn with_preloaded_messages_recomputes_non_system_count() {
+        let agent = make_agent();
+        let preloaded = vec![
+            msg(Role::User, "u1"),
+            msg(Role::System, "focus checkpoint"),
+            msg(Role::Assistant, "a1"),
+            msg(Role::User, "u2"),
+        ];
+        let mut agent = agent.with_preloaded_messages(preloaded);
+        let expected = agent
+            .msg
+            .messages
+            .iter()
+            .filter(|m| m.role != Role::System)
+            .count();
+        let ctx = access(&mut agent);
+        assert_eq!(ctx.transcript_len(), expected);
+        assert_eq!(ctx.transcript_len(), 3);
+    }
+
+    /// Regression for the "mutation happens inside `zeph-agent-context` through a borrowed
+    /// `message_window_view()`, recompute after the call returns" pattern — the pattern used
+    /// by 9 of the 11 batch-mutation sites (`assembly.rs`'s `clear_history`/
+    /// `remove_lsp_messages`/`remove_code_context_messages`, `persistence/history.rs`,
+    /// `summarization/*.rs`). Distinct from `MessageAccessImpl::clear_history` (tested above),
+    /// which mutates `messages` directly and never goes through `ContextService`.
+    #[test]
+    fn agent_clear_history_recomputes_non_system_count() {
+        let mut agent = make_agent();
+        agent.push_message(msg(Role::User, "u1"));
+        agent.push_message(msg(Role::Assistant, "a1"));
+        assert_eq!(access(&mut agent).transcript_len(), 2);
+        agent.clear_history();
+        assert_eq!(access(&mut agent).transcript_len(), 0);
     }
 }

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -204,6 +204,10 @@ impl<C: Channel> Agent<C> {
     pub(in crate::agent) fn clear_history(&mut self) {
         let svc = zeph_agent_context::ContextService::new();
         svc.clear_history(&mut self.message_window_view());
+        // `ContextService` mutates `messages` through a borrowed view, so the non-system
+        // counter (#6427) can't be updated inline at the mutation site — recompute it here,
+        // mirroring `cached_prompt_tokens`, which the view already updates in place.
+        self.msg.recompute_non_system_count();
     }
 
     /// Remove previously injected LSP context notes from the message history.
@@ -213,11 +217,13 @@ impl<C: Channel> Agent<C> {
     pub(in crate::agent) fn remove_lsp_messages(&mut self) {
         let svc = zeph_agent_context::ContextService::new();
         svc.remove_lsp_messages(&mut self.message_window_view());
+        self.msg.recompute_non_system_count();
     }
 
     pub(in crate::agent) fn remove_code_context_messages(&mut self) {
         let svc = zeph_agent_context::ContextService::new();
         svc.remove_code_context_messages(&mut self.message_window_view());
+        self.msg.recompute_non_system_count();
     }
 
     /// Spawn a fire-and-forget background task to generate and persist a session digest for
@@ -495,6 +501,7 @@ impl<C: Channel> Agent<C> {
         // --- Apply the replayed history (same shape as `with_preloaded_messages`, D-6) ---
         let mut messages = hydrated.messages;
         self.msg.messages.append(&mut messages);
+        self.msg.recompute_non_system_count();
         self.msg.history_preloaded = true;
 
         // --- Set conversation_id from the resumed/forked session, not a freshly minted one ---
@@ -730,6 +737,9 @@ impl<C: Channel> Agent<C> {
             .await;
         let result = svc.prepare_context(query, &mut window, &mut view).await;
         self.channel.send_status_best_effort("").await;
+        // `window` mutates `messages` through a borrowed view, so the non-system counter
+        // (#6427) can't be updated inline at the mutation site — recompute it here.
+        self.msg.recompute_non_system_count();
 
         let delta =
             result.map_err(|e| super::super::error::AgentError::ContextError(format!("{e:#}")))?;

--- a/crates/zeph-core/src/agent/context/summarization/compaction.rs
+++ b/crates/zeph-core/src/agent/context/summarization/compaction.rs
@@ -41,6 +41,9 @@ impl<C: Channel> Agent<C> {
             .compact_context(&mut summ, None)
             .await
             .map_err(|e| crate::agent::error::AgentError::ContextError(format!("{e:#}")))?; // 6
+        // `summ` mutates `messages` through a borrowed view, so the non-system counter
+        // (#6427) can't be updated inline at the mutation site — recompute it here.
+        self.msg.recompute_non_system_count();
 
         if outcome.is_compacted() {
             self.update_metrics(|m| m.context_compactions += 1); // 7

--- a/crates/zeph-core/src/agent/context/summarization/deferred.rs
+++ b/crates/zeph-core/src/agent/context/summarization/deferred.rs
@@ -15,6 +15,9 @@ impl<C: Channel> Agent<C> {
         let providers = self.providers();
         let mut summ = self.summarization_view();
         svc.maybe_summarize_tool_pair(&mut summ, &providers).await;
+        // `summ` mutates `messages` through a borrowed view, so the non-system counter
+        // (#6427) can't be updated inline at the mutation site — recompute it here.
+        self.msg.recompute_non_system_count();
     }
 
     /// Batch-apply all pending deferred tool pair summaries.
@@ -24,7 +27,9 @@ impl<C: Channel> Agent<C> {
     pub(in crate::agent) fn apply_deferred_summaries(&mut self) -> usize {
         let svc = zeph_agent_context::ContextService::new();
         let mut summ = self.summarization_view();
-        svc.apply_deferred_summaries(&mut summ)
+        let applied = svc.apply_deferred_summaries(&mut summ);
+        self.msg.recompute_non_system_count();
+        applied
     }
 
     #[tracing::instrument(
@@ -36,12 +41,14 @@ impl<C: Channel> Agent<C> {
         let svc = zeph_agent_context::ContextService::new();
         let mut summ = self.summarization_view();
         svc.flush_deferred_summaries(&mut summ).await;
+        self.msg.recompute_non_system_count();
     }
 
     pub(in crate::agent) fn maybe_apply_deferred_summaries(&mut self) {
         let svc = zeph_agent_context::ContextService::new();
         let mut summ = self.summarization_view();
         svc.maybe_apply_deferred_summaries(&mut summ);
+        self.msg.recompute_non_system_count();
     }
 }
 

--- a/crates/zeph-core/src/agent/context/summarization/scheduling.rs
+++ b/crates/zeph-core/src/agent/context/summarization/scheduling.rs
@@ -37,6 +37,9 @@ impl<C: Channel> Agent<C> {
         svc.maybe_compact(&mut summ, &status)
             .await
             .map_err(|e| crate::agent::error::AgentError::ContextError(format!("{e:#}")))?;
+        // `summ` mutates `messages` through a borrowed view, so the non-system counter
+        // (#6427) can't be updated inline at the mutation site — recompute it here.
+        self.msg.recompute_non_system_count();
 
         // Update the persistent compaction badge whenever this tier actually freed tokens.
         self.emit_compaction_status_signal(tokens_before).await;
@@ -98,6 +101,7 @@ impl<C: Channel> Agent<C> {
         let svc = zeph_agent_context::ContextService::new();
         let mut summ = self.summarization_view();
         svc.maybe_soft_compact_mid_iteration(&mut summ);
+        self.msg.recompute_non_system_count();
     }
 
     /// Proactive context compression: delegates to [`ContextService::maybe_proactive_compress`].
@@ -122,6 +126,7 @@ impl<C: Channel> Agent<C> {
             .summarization_view()
             .with_compression_guidelines(guidelines);
         svc.maybe_proactive_compress(&mut summ, &status).await;
+        self.msg.recompute_non_system_count();
 
         // Update the persistent compaction badge whenever proactive compression freed tokens.
         self.emit_compaction_status_signal(tokens_before).await;

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -368,6 +368,7 @@ impl<C: Channel> Agent<C> {
                 deferred_db_summaries: Vec::new(),
                 history_preloaded: false,
                 history_cursor: 0,
+                non_system_count: 0,
             },
             context_manager: context_manager::ContextManager::new(),
             tool_orchestrator: tool_orchestrator::ToolOrchestrator::new(),
@@ -1318,7 +1319,9 @@ impl<C: Channel> Agent<C> {
 
             let user_msg = format!("Error: {e:#}");
             self.channel.send(&user_msg).await?;
-            self.msg.messages.pop();
+            if let Some(popped) = self.msg.messages.pop() {
+                self.msg.track_single_message(popped.role, false);
+            }
             self.recompute_prompt_tokens();
             self.channel.flush_chunks().await?;
             true

--- a/crates/zeph-core/src/agent/persistence/history.rs
+++ b/crates/zeph-core/src/agent/persistence/history.rs
@@ -126,6 +126,11 @@ impl<C: Channel> Agent<C> {
                 usize::try_from(count).unwrap_or(0);
         }
 
+        // `PersistenceService::load_history` mutates `messages` through a borrowed
+        // `&mut Vec<Message>` (part of `LoadHistoryParams`), so the non-system counter
+        // (#6427) can't be updated inline at the mutation site — recompute it here,
+        // mirroring the `recompute_prompt_tokens` call this already needed.
+        self.msg.recompute_non_system_count();
         self.recompute_prompt_tokens();
         Ok(())
     }

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -38,7 +38,7 @@ use tokio::sync::{Notify, mpsc, watch};
 use tokio::time::Interval;
 use tokio_util::sync::CancellationToken;
 use zeph_llm::any::AnyProvider;
-use zeph_llm::provider::Message;
+use zeph_llm::provider::{Message, Role};
 use zeph_llm::stt::SpeechToText;
 
 use crate::config::{ProviderEntry, SecurityConfig, SkillPromptMode, TimeoutConfig};
@@ -1066,6 +1066,51 @@ pub(crate) struct MessageState {
     /// `/history all`/`/history next` pagination cursor (spec-068 §13.6). `0` = not yet
     /// started or reset by a subsequent bounded `/history [N]` call.
     pub(crate) history_cursor: usize,
+    /// Count of `messages` entries with `role != Role::System` (#6427).
+    ///
+    /// Backs `MessageAccessImpl::transcript_len`/`transcript_page`
+    /// (`command_context_impls.rs`) so `/history` doesn't rescan the full vector on every
+    /// call. Every mutation site of `messages` must keep this in sync — use
+    /// [`MessageState::track_single_message`] for a per-message push/insert/remove (O(1)) or
+    /// [`MessageState::recompute_non_system_count`] after a batch mutation (O(n), but never on
+    /// the `/history` read path this field exists to speed up).
+    pub(crate) non_system_count: usize,
+}
+
+impl MessageState {
+    /// O(1) count of non-system messages — see [`Self::non_system_count`].
+    pub(crate) fn non_system_len(&self) -> usize {
+        self.non_system_count
+    }
+
+    /// Recompute [`Self::non_system_count`] from scratch after a batch mutation (append,
+    /// truncate, drain, retain, or a cross-crate mutation through a borrowed `&mut
+    /// Vec<Message>` view) where tracking the exact delta inline would be error-prone.
+    ///
+    /// O(n), but only called on structural mutation paths (history replay, compaction, focus
+    /// lifecycle, `/clear`) — never on the `/history` read path this counter exists to speed
+    /// up. Call alongside `recompute_prompt_tokens()`, which follows the same pattern for the
+    /// cached token count.
+    pub(crate) fn recompute_non_system_count(&mut self) {
+        self.non_system_count = self
+            .messages
+            .iter()
+            .filter(|m| m.role != Role::System)
+            .count();
+    }
+
+    /// Adjust [`Self::non_system_count`] for a single message added to or removed from
+    /// `messages`. `added = true` for push/insert, `false` for remove/pop.
+    pub(crate) fn track_single_message(&mut self, role: Role, added: bool) {
+        if role == Role::System {
+            return;
+        }
+        if added {
+            self.non_system_count += 1;
+        } else {
+            self.non_system_count = self.non_system_count.saturating_sub(1);
+        }
+    }
 }
 
 impl McpState {

--- a/crates/zeph-core/src/agent/state/tests.rs
+++ b/crates/zeph-core/src/agent/state/tests.rs
@@ -57,6 +57,7 @@ fn make_message_state() -> MessageState {
         deferred_db_summaries: Vec::new(),
         history_preloaded: false,
         history_cursor: 0,
+        non_system_count: 0,
     }
 }
 

--- a/crates/zeph-core/src/agent/tool_execution/focus.rs
+++ b/crates/zeph-core/src/agent/tool_execution/focus.rs
@@ -169,6 +169,7 @@ impl<C: Channel> Agent<C> {
             // skipped here.
             self.msg.messages.push(assistant_msg);
         }
+        self.msg.recompute_non_system_count();
         self.recompute_prompt_tokens();
         // C1 fix: mark compacted so maybe_compact() does not double-fire this turn.
         // cooldown=0: focus truncation does not impose post-compaction cooldown.
@@ -200,6 +201,7 @@ impl<C: Channel> Agent<C> {
                 self.msg.messages.insert(1, kb_msg);
             }
         }
+        self.msg.recompute_non_system_count();
         self.recompute_prompt_tokens();
     }
 
@@ -346,6 +348,7 @@ impl<C: Channel> Agent<C> {
                 self.msg.messages.remove(idx);
             }
         }
+        self.msg.recompute_non_system_count();
         self.rebuild_knowledge_block();
     }
 

--- a/crates/zeph-core/src/agent/tool_execution/metrics_compact.rs
+++ b/crates/zeph-core/src/agent/tool_execution/metrics_compact.rs
@@ -124,6 +124,7 @@ impl<C: Channel> Agent<C> {
                 metadata: MessageMetadata::default(),
             });
             self.msg.messages.extend(tail);
+            self.msg.recompute_non_system_count();
             self.update_metrics(|m| m.server_compaction_events += 1);
             self.channel.send_status_best_effort("").await;
         }

--- a/crates/zeph-core/src/agent/utils.rs
+++ b/crates/zeph-core/src/agent/utils.rs
@@ -302,6 +302,7 @@ impl<C: Channel> Agent<C> {
         if msg.role == zeph_llm::provider::Role::Assistant {
             self.services.session.last_assistant_at = Some(std::time::Instant::now());
         }
+        self.msg.track_single_message(msg.role, true);
         self.msg.messages.push(msg);
         // Detect MagicDoc headers in tool output after pushing the message.
         self.detect_magic_docs_in_messages();
@@ -322,6 +323,7 @@ impl<C: Channel> Agent<C> {
         if msg.role == zeph_llm::provider::Role::Assistant {
             self.services.session.last_assistant_at = Some(std::time::Instant::now());
         }
+        self.msg.track_single_message(msg.role, true);
         self.msg.messages.insert(index, msg);
         self.detect_magic_docs_in_messages();
     }
@@ -411,6 +413,7 @@ impl<C: Channel> Agent<C> {
             return;
         }
         let content = format!("{CODE_CONTEXT_PREFIX}{text}");
+        self.msg.track_single_message(Role::System, true);
         self.msg.messages.insert(
             1,
             Message::from_parts(


### PR DESCRIPTION
## Summary
- `MessageAccessImpl::transcript_len`/`transcript_page` (`crates/zeph-core/src/agent/command_context_impls.rs`), which back the `/history` command, re-scanned the entire message vector on every call — `transcript_len` was O(total non-system messages) unconditionally, and `transcript_page`'s `.skip(start)` ran on top of a `.filter()`, so it walked from index 0 even though the common bounded-default case (`/history N`) computes `start` near the end of history. Repeated `/history all` -> `/history next` paging did O(total²/page_size) aggregate work.
- `MessageState` now maintains an incrementally-updated `non_system_count` (O(1) `transcript_len`), and `transcript_page` scans from whichever end of the message vector is closer to the requested page, making both named hot patterns (`/history N` bounded-default tail read, `/history all`'s first page) O(count) instead of O(total).
- Middle-of-history pages reached via a long `/history next` chain remain up to O(min(start, total-end)) by design — documented in the `transcript_page` doc comment. A full position index of non-system ordinals was rejected: arbitrary-position `System`-message churn (LSP notes, focus checkpoints) would make that index itself O(n) per turn, moving cost onto the hotter per-turn path instead of the `/history` read path.
- Audited and updated every messages-vector mutation site in `zeph-core` (~15 production call sites across 9 files) to keep the counter in sync: single push/insert/remove/pop sites use an O(1) delta (`track_single_message`); batch mutations, and mutations that happen through a borrowed view in a foreign crate (`zeph-agent-context`, `zeph-agent-persistence`), use an O(n) full recount (`recompute_non_system_count`) mirroring the existing `recompute_prompt_tokens()` cache-invalidation pattern already used at the same call sites.

## Background

Follow-up from #6420 (resume-session history visibility, spec-068 §13.6, INV-SP-6), explicitly tracked as a known perf gap when that PR merged.

Went through the reduced performance chain: developer (root cause + fix + mutation-site audit + 10 unit tests) -> parallel validation (perf: microbenchmark confirming the O(1)/O(count) claim, 2400x-26000x speedup on `transcript_len`, 10.7x-87.6x on the bounded-default tail read, no regressions; tester: confirmed 2099 tests pass, found a real coverage gap — none of the batch-mutation sites were exercised by a test that reads `transcript_len`/`transcript_page` afterward; impl-critic: verdict `minor`, re-verified the mutation-site audit and the bidirectional-scan boundary logic independently, no blocking bugs) -> code review (one `changes_requested` round: required 2 targeted regression tests closing the coverage gap tester found, plus a zero-cost `saturating_add` hardening; approved on re-review).

Non-blocking follow-ups noted during review, not addressed in this PR:
- 5 `#[cfg(test)]`-gated context wrappers in `assembly.rs` have asymmetric recompute treatment vs their System-only siblings — dead in every real build (confirmed by direct read), so no live bug, but worth a uniformity pass if any of them are ever promoted to production.
- Cosmetic double-recompute in `focus.rs`'s `apply_compression_removals` -> `rebuild_knowledge_block` path — not worth changing unless that path proves hot.

## Test plan
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 14280/14280 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] `gitleaks protect --staged` — no leaks
- [x] 12 unit tests in `command_context_impls.rs::tests` (10 initial + 2 added during review to close a coverage gap on the batch-mutation/foreign-crate-view recompute pattern)
- [x] Standalone microbenchmark confirming the O(1)/O(count) complexity claim at 5k/20k/50k synthetic messages
- [x] `.local/testing/playbooks/session-resume-history.md` and `.local/testing/coverage-status.md` updated (main repo, not this worktree)
- [x] Reviewed by `rust-code-reviewer`: approved after one fix round (test coverage gap)

Closes #6427