### PR TITLE
fix(serve): compute resume banner for created, reactivated, and forked sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   churn (LSP notes, focus checkpoints) would make that index itself O(n) per turn, moving cost
   onto the hotter turn loop instead of the `/history` read path.
 
+- `zeph serve`/`zeph-core`: `POST /sessions`, `POST /sessions/:id/prompt` (reactivation), and
+  `POST /sessions/:id/fork` never computed the resume-visibility banner (spec-068 §13.5, AC-24)
+  — `SessionActorHandle::claim_resume_banner()` had zero production call sites (#6425, #6426).
+  `build_agent_factory` now computes the banner from the session's already-replayed message
+  history in its async prefix (before `[session.resume] show_banner` and prior-history checks)
+  and returns it alongside the `build_agent` closure; `SessionActor::spawn` stores it on
+  `SessionActorHandle::pending_resume_banner`. `GET /sessions/:id/events` renders it exactly
+  once, subscribing to the session's output broadcast before sending so a not-yet-attached
+  client can never miss it — the same single-emission guarantee already covered by
+  `claim_resume_banner`'s existing unit test, now exercised through the real HTTP handler for
+  create, reactivate, and fork alike. A forked session's banner never shows a "last active"
+  timestamp — `ForkEngine::fork` already stamps the new child's row with the current time as
+  part of its own bookkeeping, which would otherwise read back as a misleading "last active just
+  now" on a session nobody has actually resumed yet; it matches `POST /sessions`' no-timestamp
+  banner for the same reason.
+
 - `zeph-orchestration`: `PlanVerifier::verify_plan()` (whole-plan grounding, spec 009) shared
   the same `orchestration.verifier_timeout_secs` budget as per-task `verify()`, and consistently
   exhausted it against slower local Ollama models even when per-task verification on the same

--- a/crates/zeph-core/src/serve.rs
+++ b/crates/zeph-core/src/serve.rs
@@ -149,6 +149,7 @@ impl SessionActor {
         session_id: &SessionId,
         build_agent: F,
         mailbox_capacity: usize,
+        resume_banner: Option<String>,
     ) -> (SessionActorHandle, BlockingHandle<()>)
     where
         F: FnOnce(LoopbackChannel) -> Agent<LoopbackChannel> + Send + 'static,
@@ -227,6 +228,7 @@ impl SessionActor {
                 last_active: Instant::now(),
                 cancel: session_cancel,
                 resume_banner_sent: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                pending_resume_banner: resume_banner.map(Arc::from),
             },
             blocking_handle,
         )
@@ -400,6 +402,12 @@ pub struct SessionActorHandle {
     /// paths observe the same flag. Use [`Self::claim_resume_banner`] rather than reading
     /// this directly.
     pub resume_banner_sent: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// Resume-visibility banner text, computed once at session build time (spec-068 §13.5,
+    /// AC-24) from the session's replayed history. `None` when `[session.resume] show_banner
+    /// = false` or the session had no prior history to resume. Rendered by exactly one
+    /// attach path, gated by [`Self::claim_resume_banner`] — see `GET /sessions/:id/events`
+    /// (`events_session_handler`, `src/serve/handlers.rs`) for the sole production consumer.
+    pub pending_resume_banner: Option<std::sync::Arc<str>>,
 }
 
 impl SessionActorHandle {
@@ -586,6 +594,7 @@ mod tests {
             last_active: Instant::now(),
             cancel: CancellationToken::new(),
             resume_banner_sent: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            pending_resume_banner: None,
         }
     }
 
@@ -851,6 +860,7 @@ mod tests {
                 agent
             },
             4,
+            None,
         );
 
         handle
@@ -901,6 +911,7 @@ mod tests {
                 Agent::new(provider, channel, registry, None, 5, executor)
             },
             4,
+            None,
         );
 
         // No `SessionCommand::Shutdown` sent — cancel the per-session token directly, as idle
@@ -1010,6 +1021,7 @@ mod tests {
                         )
                     },
                     4,
+                    None,
                 );
                 actors.push((handle, blocking));
             }

--- a/src/serve/agent_factory.rs
+++ b/src/serve/agent_factory.rs
@@ -60,6 +60,12 @@ const REACTIVATION_LOCK_RETRY_DELAY: std::time::Duration = std::time::Duration::
 /// `session_id`/`conversation_id` are owned, `SessionSink` is `Send + Sync`, replayed messages
 /// are plain data) — the `LoopbackChannel` and the resulting `!Send` `Agent` never leave that
 /// thread.
+///
+/// `is_fork` must be `true` only when `session_id` is a fork's freshly minted child id (i.e.
+/// its `SessionStore` row was just written by `zeph_session::ForkEngine::fork`, not by this
+/// function) — it suppresses the `last_active` lookup so the returned resume banner never shows
+/// a misleading "just now" timestamp for a session that has never actually been resumed by a
+/// caller (S1, #6425 follow-up). `create`/`reactivate` callers must pass `false`.
 #[tracing::instrument(
     name = "serve.agent_factory.build",
     skip_all,
@@ -71,7 +77,35 @@ pub(crate) async fn build_agent_factory(
     deps: ServeAgentDeps,
     session_id: zeph_common::SessionId,
     conversation_id: zeph_memory::ConversationId,
-) -> impl FnOnce(LoopbackChannel) -> Agent<LoopbackChannel> + Send + 'static {
+    is_fork: bool,
+) -> (
+    Option<String>,
+    impl FnOnce(LoopbackChannel) -> Agent<LoopbackChannel> + Send + 'static,
+) {
+    // #6425: looked up BEFORE hydrate_session_sink, which itself seeds/mutates this session's
+    // metadata row (SessionStore::create/link_conversation) — reading last_active afterward
+    // would return "just now" instead of the row's true prior updated_at on reactivation.
+    //
+    // `is_fork` short-circuits this to `None` unconditionally (S1 fix): unlike create/reactivate,
+    // a forked session's row already exists by the time we get here —
+    // `fork_session_handler` calls `zeph_session::ForkEngine::fork` first, which itself calls
+    // `store.record_fork` + `store.update_seq` (the latter sets `updated_at = NOW()`) on the new
+    // child id — so a plain `store.get` here would read back "just now" instead of `None`,
+    // rendering a misleading "(last active just now)" segment on a session that has never
+    // actually been resumed by a caller. A freshly forked session is fresh, like `create`'s, and
+    // must render the same no-timestamp banner.
+    let last_active = if deps.session_persistence_config.enabled && !is_fork {
+        let store = zeph_session::SessionStore::new(deps.memory.sqlite().pool().clone());
+        store
+            .get(session_id.as_str())
+            .await
+            .ok()
+            .flatten()
+            .map(|meta| meta.updated_at)
+    } else {
+        None
+    };
+
     let (session_sink, preloaded_messages) = if deps.session_persistence_config.enabled {
         hydrate_session_sink(
             &deps.session_persistence_config,
@@ -86,6 +120,22 @@ pub(crate) async fn build_agent_factory(
     } else {
         (None, Vec::new())
     };
+
+    // #6425 (spec-068 §13.5, AC-24): computed once, here, from the already-reconstructed
+    // message stream — zero additional I/O beyond the last_active lookup above. Rendered later
+    // by exactly one attach path via SessionActorHandle::claim_resume_banner (see
+    // events_session_handler in src/serve/handlers.rs).
+    let resume_banner = deps
+        .session_config
+        .resume
+        .show_banner
+        .then(|| {
+            zeph_core::session_resume::SessionResumeInfo::from_messages(
+                &preloaded_messages,
+                last_active.as_deref(),
+            )
+        })
+        .and_then(|info| info.banner_text());
 
     // SkillOrchestra: wire the RL routing head, if enabled (#5921). `deps.rl_head` is loaded/
     // cold-started exactly once in `crate::acp::build_shared_core` and cloned (cheap `Arc`
@@ -138,7 +188,7 @@ pub(crate) async fn build_agent_factory(
         Some((&trajectory_risk_slot, &trajectory_signal_queue)),
     );
 
-    move |channel| {
+    let build_agent = move |channel| {
         // Capture before apply_session_config consumes deps.session_config (mirrors
         // spawn_acp_agent's debug_config capture in src/acp.rs).
         let debug_config = deps.session_config.debug_config.clone();
@@ -287,7 +337,8 @@ pub(crate) async fn build_agent_factory(
             .0;
         }
         agent
-    }
+    };
+    (resume_banner, build_agent)
 }
 
 /// Wraps `tool_executor` in the per-session trust/policy/adversarial gate stack (SEC-H1 / R1):
@@ -862,7 +913,8 @@ mod tests {
             tools_enabled: true,
         };
 
-        let build_agent = Box::pin(build_agent_factory(deps, session_id.clone(), cid)).await;
+        let (_, build_agent) =
+            Box::pin(build_agent_factory(deps, session_id.clone(), cid, false)).await;
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
         let _agent = build_agent(channel);
 
@@ -879,6 +931,90 @@ mod tests {
             has_timestamped_child,
             "DebugDumper::new must create a timestamped subdirectory under the session dir"
         );
+    }
+
+    /// #6425 regression: when `[session] enabled = false`, `build_agent_factory` must skip both
+    /// the `last_active` lookup and `hydrate_session_sink` entirely (no `SessionStore`/event-log
+    /// I/O against a session that was never persisted) and still return `None` for the banner,
+    /// rather than panicking or attempting to open a nonexistent durable log. This is the one
+    /// branch of the new async-prefix banner computation not already exercised by
+    /// `hydrate_session_sink_*` (which all set `enabled: true`) or by the `enabled: true`
+    /// `build_agent_factory_wires_*` tests below.
+    #[tokio::test]
+    async fn build_agent_factory_computes_no_banner_when_persistence_disabled() {
+        let memory = make_memory().await;
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        let session_id = zeph_common::SessionId::new("no-persistence-session");
+
+        let session_config =
+            zeph_core::AgentSessionConfig::from_config(&zeph_core::config::Config::default(), 0);
+        let (condenser, token_counter) = make_test_condenser();
+
+        let deps = ServeAgentDeps {
+            provider: AnyProvider::Mock(zeph_llm::mock::MockProvider::default()),
+            embedding_provider: AnyProvider::Mock(zeph_llm::mock::MockProvider::default()),
+            registry: Arc::new(parking_lot::RwLock::new(
+                zeph_skills::registry::SkillRegistry::empty(),
+            )),
+            matcher: None,
+            max_active_skills: 5,
+            skill_disambiguation_threshold: 0.2,
+            skill_two_stage_matching: false,
+            skill_confusability_threshold: 0.0,
+            skill_group_structured: false,
+            skill_support_similarity_threshold: 0.50,
+            skill_min_injection_score: 0.20,
+            skill_generation_provider: String::new(),
+            skill_disambiguate_provider: String::new(),
+            semantic_scan: false,
+            semantic_scan_provider: String::new(),
+            trust_config: zeph_core::config::TrustConfig::default(),
+            rl_routing_enabled: false,
+            rl_learning_rate: 0.0,
+            rl_weight: 0.0,
+            rl_persist_interval: 0,
+            rl_warmup_updates: 0,
+            rl_head: None,
+            tool_executor: Arc::new(zeph_tools::SetCwdExecutor::new(vec![])),
+            capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
+            permission_policy: zeph_tools::PermissionPolicy::default(),
+            audit_logger: None,
+            policy_gate_pieces: crate::agent_setup::PolicyGatePieces::default(),
+            memory: Arc::clone(&memory),
+            history_limit: 10,
+            recall_limit: 5,
+            summarization_threshold: 1000,
+            session_config,
+            session_persistence_config: zeph_config::SessionConfig {
+                enabled: false,
+                ..Default::default()
+            },
+            resume_condenser: Arc::new(condenser),
+            resume_token_counter: Arc::new(token_counter),
+            provider_pool: Vec::new(),
+            provider_config_snapshot: zeph_core::ProviderConfigSnapshot::default(),
+            shadow_sentinel_config: zeph_config::ShadowSentinelConfig::default(),
+            shadow_sentinel_probe_provider: AnyProvider::Mock(
+                zeph_llm::mock::MockProvider::default(),
+            ),
+            trajectory_sentinel_config: zeph_config::TrajectorySentinelConfig::default(),
+            quality_pipeline: None,
+            safe_mode: false,
+            allowed_paths: vec![],
+            tools_enabled: true,
+        };
+
+        let (resume_banner, build_agent) =
+            Box::pin(build_agent_factory(deps, session_id.clone(), cid, false)).await;
+        assert!(
+            resume_banner.is_none(),
+            "no last_active lookup or history exists when persistence is disabled, so the \
+             banner must be None; got: {resume_banner:?}"
+        );
+        // Drives the closure too, proving the disabled-persistence path also builds a working
+        // agent (empty session_sink, no preloaded messages) rather than only type-checking.
+        let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
+        let _agent = build_agent(channel);
     }
 
     /// #5450 regression: `build_agent_factory` must call `Agent::with_provider_pool` so
@@ -956,7 +1092,8 @@ mod tests {
             tools_enabled: true,
         };
 
-        let build_agent = Box::pin(build_agent_factory(deps, session_id.clone(), cid)).await;
+        let (_, build_agent) =
+            Box::pin(build_agent_factory(deps, session_id.clone(), cid, false)).await;
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
         let mut agent = build_agent(channel);
 
@@ -1069,7 +1206,8 @@ mod tests {
             tools_enabled: true,
         };
 
-        let build_agent = Box::pin(build_agent_factory(deps, session_id.clone(), cid)).await;
+        let (_, build_agent) =
+            Box::pin(build_agent_factory(deps, session_id.clone(), cid, false)).await;
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
         let mut agent = build_agent(channel);
 
@@ -1171,7 +1309,8 @@ mod tests {
             tools_enabled: true,
         };
 
-        let build_agent = Box::pin(build_agent_factory(deps, session_id.clone(), cid)).await;
+        let (_, build_agent) =
+            Box::pin(build_agent_factory(deps, session_id.clone(), cid, false)).await;
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
         let mut agent = build_agent(channel);
 
@@ -1272,7 +1411,8 @@ mod tests {
             tools_enabled: true,
         };
 
-        let build_agent = Box::pin(build_agent_factory(deps, session_id.clone(), cid)).await;
+        let (_, build_agent) =
+            Box::pin(build_agent_factory(deps, session_id.clone(), cid, false)).await;
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
         let mut agent = build_agent(channel);
 
@@ -1370,7 +1510,8 @@ mod tests {
             tools_enabled: true,
         };
 
-        let build_agent = Box::pin(build_agent_factory(deps, session_id.clone(), cid)).await;
+        let (_, build_agent) =
+            Box::pin(build_agent_factory(deps, session_id.clone(), cid, false)).await;
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
         let mut agent = build_agent(channel);
 
@@ -1491,8 +1632,15 @@ mod tests {
             crate::agent_setup::PolicyGatePieces::default(),
         );
 
-        let build_agent_a = Box::pin(build_agent_factory(deps.clone(), session_id_a, cid_a)).await;
-        let build_agent_b = Box::pin(build_agent_factory(deps, session_id_b, cid_b)).await;
+        let (_, build_agent_a) = Box::pin(build_agent_factory(
+            deps.clone(),
+            session_id_a,
+            cid_a,
+            false,
+        ))
+        .await;
+        let (_, build_agent_b) =
+            Box::pin(build_agent_factory(deps, session_id_b, cid_b, false)).await;
         let (channel_a, _handle_a) = zeph_core::LoopbackChannel::pair(8);
         let (channel_b, _handle_b) = zeph_core::LoopbackChannel::pair(8);
         let agent_a = build_agent_a(channel_a);
@@ -1564,7 +1712,7 @@ mod tests {
             policy_gate_pieces,
         );
 
-        let build_agent = Box::pin(build_agent_factory(deps, session_id, cid)).await;
+        let (_, build_agent) = Box::pin(build_agent_factory(deps, session_id, cid, false)).await;
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
         let agent = build_agent(channel);
 
@@ -1734,7 +1882,7 @@ mod tests {
             ..Default::default()
         };
 
-        let build_agent = Box::pin(build_agent_factory(deps, session_id, cid)).await;
+        let (_, build_agent) = Box::pin(build_agent_factory(deps, session_id, cid, false)).await;
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
         let agent = build_agent(channel);
         let executor = agent.tool_executor_arc();
@@ -1812,7 +1960,7 @@ mod tests {
             ..Default::default()
         };
 
-        let build_agent = Box::pin(build_agent_factory(deps, session_id, cid)).await;
+        let (_, build_agent) = Box::pin(build_agent_factory(deps, session_id, cid, false)).await;
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
         let agent = build_agent(channel);
         let executor = agent.tool_executor_arc();
@@ -1875,7 +2023,7 @@ mod tests {
             crate::agent_setup::PolicyGatePieces::default(),
         );
 
-        let build_agent = Box::pin(build_agent_factory(deps, session_id, cid)).await;
+        let (_, build_agent) = Box::pin(build_agent_factory(deps, session_id, cid, false)).await;
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
         let agent = build_agent(channel);
 
@@ -1931,7 +2079,7 @@ mod tests {
             crate::agent_setup::PolicyGatePieces::default(),
         );
 
-        let build_agent = Box::pin(build_agent_factory(deps, session_id, cid)).await;
+        let (_, build_agent) = Box::pin(build_agent_factory(deps, session_id, cid, false)).await;
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
         let agent = build_agent(channel);
 
@@ -2006,7 +2154,8 @@ mod tests {
             .create_conversation()
             .await
             .unwrap();
-        let build_agent = Box::pin(build_agent_factory(serve_deps, session_id, cid)).await;
+        let (_, build_agent) =
+            Box::pin(build_agent_factory(serve_deps, session_id, cid, false)).await;
         let (channel, _handle) = zeph_core::LoopbackChannel::pair(8);
         let agent = build_agent(channel);
 

--- a/src/serve/handlers.rs
+++ b/src/serve/handlers.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use tokio_stream::StreamExt;
 use tokio_stream::wrappers::BroadcastStream;
 use zeph_common::SessionId;
-use zeph_core::serve::{SessionActor, SessionActorHandle, SessionCommand};
+use zeph_core::serve::{SessionActor, SessionActorHandle, SessionCommand, SessionOutput};
 
 use super::AppState;
 use super::agent_factory::build_agent_factory;
@@ -60,10 +60,11 @@ async fn reactivate_session(
     let meta = store.get(session_id.as_str()).await.ok().flatten()?;
     let conversation_id = meta.conversation_id.map(zeph_memory::ConversationId)?;
 
-    let build_agent = Box::pin(build_agent_factory(
+    let (resume_banner, build_agent) = Box::pin(build_agent_factory(
         state.deps.clone(),
         session_id.clone(),
         conversation_id,
+        false,
     ))
     .await;
     let (handle, _blocking_handle) = SessionActor::spawn(
@@ -72,6 +73,7 @@ async fn reactivate_session(
         session_id,
         build_agent,
         state.mailbox_capacity,
+        resume_banner,
     );
     state.registry.insert(session_id.clone(), handle.clone());
 
@@ -131,10 +133,11 @@ pub(super) async fn create_session_handler(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
-    let build_agent = Box::pin(build_agent_factory(
+    let (resume_banner, build_agent) = Box::pin(build_agent_factory(
         state.deps.clone(),
         session_id.clone(),
         conversation_id,
+        false,
     ))
     .await;
     let (handle, _blocking_handle) = SessionActor::spawn(
@@ -143,6 +146,7 @@ pub(super) async fn create_session_handler(
         &session_id,
         build_agent,
         state.mailbox_capacity,
+        resume_banner,
     );
     state.registry.insert(session_id.clone(), handle);
 
@@ -334,6 +338,12 @@ pub(super) async fn prompt_session_handler(
 /// dropped rather than the connection closed — the durable event log (when `[session] enabled =
 /// true`) is the source of truth for anything a lagged subscriber missed.
 ///
+/// Also renders the session's pending resume banner (#6425/#6426, spec-068 §13.5, AC-24), if
+/// any, exactly once across every attach — see [`zeph_core::serve::SessionActorHandle::claim_resume_banner`].
+/// The banner is sent as a plain `SessionOutput::Token`, the same variant used for streamed
+/// model output — a leading `token` event immediately after attach may therefore be the resume
+/// banner rather than actual LLM output; it always precedes the first `TurnComplete`.
+///
 /// Returns `400` if `id` is empty or contains a path separator, `..`, or a NUL byte (see
 /// [`get_session_handler`]), or `404` if the session is neither live nor durably known (or
 /// reactivation failed — see [`reactivate_session`], D-12).
@@ -353,7 +363,20 @@ pub(super) async fn events_session_handler(
         return Err(StatusCode::NOT_FOUND);
     };
 
-    let stream = BroadcastStream::new(handle.tx_out.subscribe()).filter_map(|item| match item {
+    // #6425/#6426 (spec-068 §13.5, AC-24): subscribe() MUST happen before send() — a
+    // broadcast::Receiver only observes messages sent after its own creation, so sending first
+    // would race a not-yet-subscribed client and silently drop the banner. claim_resume_banner()
+    // guarantees exactly one of any concurrent/sequential attaches to this session renders it.
+    let rx = handle.tx_out.subscribe();
+    if let Some(banner) = handle.pending_resume_banner.clone()
+        && handle.claim_resume_banner()
+    {
+        // `rx` (above) must stay alive across this send — claim_resume_banner()'s exactly-once
+        // guarantee is already burned at this point regardless of whether the send itself lands.
+        let _ = handle.tx_out.send(SessionOutput::Token(banner.to_string()));
+    }
+
+    let stream = BroadcastStream::new(rx).filter_map(|item| match item {
         Ok(output) => match Event::default().json_data(&output) {
             Ok(event) => Some(Ok(event)),
             Err(e) => {
@@ -440,10 +463,15 @@ pub(super) async fn fork_session_handler(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
-    let build_agent = Box::pin(build_agent_factory(
+    // is_fork: true — ForkEngine::fork (above) already wrote this child's SessionStore row via
+    // record_fork + update_seq (the latter sets updated_at = NOW()), so build_agent_factory must
+    // not read it back as a genuine "last active" timestamp (S1 fix, #6425 follow-up): a freshly
+    // forked session is fresh, and must render the same no-timestamp banner as a brand-new one.
+    let (resume_banner, build_agent) = Box::pin(build_agent_factory(
         state.deps.clone(),
         new_id.clone(),
         conversation_id,
+        true,
     ))
     .await;
     let (handle, _blocking_handle) = SessionActor::spawn(
@@ -452,6 +480,7 @@ pub(super) async fn fork_session_handler(
         &new_id,
         build_agent,
         state.mailbox_capacity,
+        resume_banner,
     );
     state.registry.insert(new_id.clone(), handle);
 
@@ -602,6 +631,17 @@ mod tests {
         state: &AppState,
         id: &str,
     ) -> tokio::sync::mpsc::Receiver<SessionCommand> {
+        insert_live_session_with_banner(state, id, None)
+    }
+
+    /// Same as [`insert_live_session`], but lets the caller set `pending_resume_banner` — used by
+    /// the #6425/#6426 regression tests below to exercise `events_session_handler`'s banner-claim
+    /// wiring without going through the full `build_agent_factory`/`SessionActor::spawn` pipeline.
+    fn insert_live_session_with_banner(
+        state: &AppState,
+        id: &str,
+        banner: Option<&str>,
+    ) -> tokio::sync::mpsc::Receiver<SessionCommand> {
         let (tx, rx) = tokio::sync::mpsc::channel(4);
         let (tx_out, _sub) = tokio::sync::broadcast::channel(4);
         state.registry.insert(
@@ -612,9 +652,349 @@ mod tests {
                 last_active: std::time::Instant::now(),
                 cancel: tokio_util::sync::CancellationToken::new(),
                 resume_banner_sent: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                pending_resume_banner: banner.map(std::sync::Arc::from),
             },
         );
         rx
+    }
+
+    /// `make_state`, but with `[session] enabled = true` against `data_dir` instead of the
+    /// disabled default — needed by the end-to-end resume-banner tests below, which must
+    /// actually hydrate/replay a durable event log through `build_agent_factory`.
+    async fn make_state_with_persistence(data_dir: &std::path::Path) -> AppState {
+        let mut state = make_state().await;
+        state.deps.session_persistence_config = zeph_config::SessionConfig {
+            enabled: true,
+            data_dir: data_dir.to_string_lossy().into_owned(),
+            ..Default::default()
+        };
+        state
+    }
+
+    /// Seeds `session_id`'s durable event log and `SessionStore` row directly (bypassing any
+    /// live agent turn) with one user/assistant exchange, so a subsequent `build_agent_factory`
+    /// call (via `create`/`reactivate`/`fork`) replays real prior history — mirrors
+    /// `agent_factory::tests::hydrate_session_sink_replays_prior_history_on_reactivation`, but
+    /// using the public `zeph_session`/`zeph_agent_persistence` APIs directly since
+    /// `hydrate_session_sink` itself is private to the `agent_factory` module.
+    async fn seed_session_history(
+        deps: &ServeAgentDeps,
+        session_id: &SessionId,
+        conversation_id: zeph_memory::ConversationId,
+    ) {
+        let store = zeph_session::SessionStore::new(deps.memory.sqlite().pool().clone());
+        store.create(session_id.as_str()).await.unwrap();
+        store
+            .link_conversation(session_id.as_str(), conversation_id.0)
+            .await
+            .unwrap();
+
+        let data_dir = PathBuf::from(&deps.session_persistence_config.data_dir);
+        let session_path = zeph_session::session_dir(&data_dir, session_id.as_str());
+        let log = zeph_session::SessionEventLog::open_exclusive(&session_path)
+            .await
+            .unwrap();
+        let sink =
+            zeph_agent_persistence::SessionSink::new(Arc::new(log), store, session_id.clone());
+        sink.record_message(zeph_llm::provider::Role::User, "hello", &[])
+            .await
+            .unwrap();
+        sink.record_message(zeph_llm::provider::Role::Assistant, "hi there", &[])
+            .await
+            .unwrap();
+    }
+
+    /// #6426 regression: when two attach paths (e.g. two `GET /sessions/:id/events` clients)
+    /// hit the same live session, exactly one must render the resume banner —
+    /// `claim_resume_banner()`'s single-emission guarantee, exercised through the real HTTP
+    /// handler rather than the bare primitive (`zeph_core::serve::tests::
+    /// claim_resume_banner_wins_exactly_once_across_clones` covers the primitive itself).
+    #[tokio::test]
+    async fn events_session_handler_renders_banner_exactly_once_across_two_attaches() {
+        let state = make_state().await;
+        insert_live_session_with_banner(&state, "s1", Some("resume banner text"));
+
+        let first = Box::pin(events_session_handler(
+            State(state.clone()),
+            Path("s1".to_owned()),
+        ))
+        .await
+        .unwrap();
+        let second = Box::pin(events_session_handler(
+            State(state.clone()),
+            Path("s1".to_owned()),
+        ))
+        .await
+        .unwrap();
+        // Push a distinguishing event only after BOTH attaches have subscribed (a
+        // broadcast::Receiver only observes sends issued after its own creation — the same
+        // ordering constraint the production fix relies on) so the second attach's stream has
+        // something to yield even though it must not see the banner.
+        let handle = state.registry.get(&SessionId::new("s1")).unwrap();
+        handle.tx_out.send(SessionOutput::TurnComplete).unwrap();
+
+        let first_text = first_sse_frame_text(first).await;
+        assert!(
+            first_text.contains("resume banner text"),
+            "the first attach must win the resume-banner claim and render it, got: {first_text}"
+        );
+
+        let second_text = first_sse_frame_text(second).await;
+        assert!(
+            !second_text.contains("resume banner text"),
+            "the second attach must NOT render the resume banner (already claimed), got: \
+             {second_text}"
+        );
+    }
+
+    /// Reads the first frame off an `events_session_handler` SSE response, as raw UTF-8 text,
+    /// with a bounded timeout so a stream with nothing to yield fails the test instead of
+    /// hanging. Takes `impl IntoResponse` (rather than the bare `Sse<impl Stream<...>>`) since
+    /// the underlying `KeepAliveStream` is not `Unpin`, matching `test_support.rs`'s own
+    /// `into_data_stream()` usage on a full `axum::response::Response`.
+    async fn first_sse_frame_text(sse: impl IntoResponse) -> String {
+        let mut stream = sse.into_response().into_body().into_data_stream();
+        let frame = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            futures::StreamExt::next(&mut stream),
+        )
+        .await
+        .expect("SSE frame must arrive before timeout")
+        .expect("stream must yield at least one frame")
+        .expect("frame read must not error");
+        String::from_utf8_lossy(&frame).into_owned()
+    }
+
+    /// #6425/#6426 end-to-end regression: proves the full plumbing (`build_agent_factory`
+    /// computes the banner -> `SessionActor::spawn` stores it on `SessionActorHandle` ->
+    /// `events_session_handler` renders it via `claim_resume_banner`), which previously had zero
+    /// coverage — `build_agent_factory`'s own unit tests never threaded their `resume_banner`
+    /// return value anywhere, and `events_session_handler`'s only tests used a hand-built
+    /// `SessionActorHandle` bypassing `build_agent_factory`/`SessionActor::spawn` entirely.
+    #[tokio::test]
+    async fn build_agent_factory_banner_flows_through_events_session_handler_end_to_end() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = make_state_with_persistence(dir.path()).await;
+        let session_id = SessionId::new("resume-e2e-session");
+        let cid = state
+            .deps
+            .memory
+            .sqlite()
+            .create_conversation()
+            .await
+            .unwrap();
+        seed_session_history(&state.deps, &session_id, cid).await;
+
+        let (resume_banner, build_agent) = Box::pin(build_agent_factory(
+            state.deps.clone(),
+            session_id.clone(),
+            cid,
+            false,
+        ))
+        .await;
+        let banner = resume_banner.expect(
+            "build_agent_factory must compute Some(banner) for a session with prior history \
+             and [session.resume] show_banner = true (the default)",
+        );
+        assert!(
+            banner.contains("2 messages") && banner.contains("1 turn"),
+            "banner must reflect the seeded 1 user + 1 assistant history exactly; got: {banner}"
+        );
+
+        let (handle, _blocking_handle) = SessionActor::spawn(
+            &state.supervisor,
+            &state.registry,
+            &session_id,
+            build_agent,
+            state.mailbox_capacity,
+            Some(banner.clone()),
+        );
+        state.registry.insert(session_id.clone(), handle.clone());
+
+        let sse = Box::pin(events_session_handler(
+            State(state.clone()),
+            Path(session_id.as_str().to_owned()),
+        ))
+        .await
+        .unwrap();
+        let frame_text = first_sse_frame_text(sse).await;
+        assert!(
+            frame_text.contains(&banner),
+            "GET /sessions/:id/events must render the exact banner build_agent_factory computed; \
+             got: {frame_text}"
+        );
+
+        handle.cancel.cancel();
+    }
+
+    /// #6425 fork-specific regression (debugger handoff, explicit ask): a forked session's
+    /// banner must reflect the COPIED message count from the source session, not e.g. zero or
+    /// the source's own count if fewer events were copied — proves `preloaded_messages` flows
+    /// correctly from `ForkEngine::fork`'s copy through `build_agent_factory` for the fork path
+    /// specifically, not just create/reactivate.
+    #[tokio::test]
+    async fn fork_session_handler_banner_reflects_copied_message_count() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = make_state_with_persistence(dir.path()).await;
+        let src_id = SessionId::new("fork-banner-src");
+        let cid = state
+            .deps
+            .memory
+            .sqlite()
+            .create_conversation()
+            .await
+            .unwrap();
+        seed_session_history(&state.deps, &src_id, cid).await;
+
+        let fork_response = Box::pin(fork_session_handler(
+            State(state.clone()),
+            Path(src_id.as_str().to_owned()),
+            Json(ForkRequest::default()),
+        ))
+        .await
+        .unwrap()
+        .into_response();
+        assert_eq!(fork_response.status(), StatusCode::CREATED);
+        let bytes = http_body_util::BodyExt::collect(fork_response.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            body["events_copied"], 2,
+            "fork with no at_seq must copy every seeded event"
+        );
+        let new_id = body["session_id"].as_str().unwrap().to_owned();
+
+        let sse = Box::pin(events_session_handler(State(state), Path(new_id)))
+            .await
+            .unwrap();
+        let frame_text = first_sse_frame_text(sse).await;
+        assert!(
+            frame_text.contains("2 messages") && frame_text.contains("1 turn"),
+            "the forked session's banner must reference the copied message/turn count \
+             (2 messages, 1 turn), got: {frame_text}"
+        );
+        // S1 (impl-critic finding): ForkEngine::fork already wrote the child's SessionStore row
+        // (record_fork + update_seq, the latter sets updated_at = NOW()) before
+        // build_agent_factory runs, so a naive last_active lookup would read that back as "just
+        // now" — a freshly forked session must render the same no-timestamp banner as a
+        // brand-new one (create's banner never shows a "last active" segment either).
+        assert!(
+            !frame_text.contains("last active"),
+            "a freshly forked session must NOT show a \"last active\" timestamp — it has never \
+             actually been resumed by a caller, unlike ForkEngine's internal bookkeeping write; \
+             got: {frame_text}"
+        );
+    }
+
+    /// #6425 negative-path regression: `[session.resume] show_banner = false` must make
+    /// `build_agent_factory` return `None` for the banner — even though the session has real
+    /// prior history that would otherwise produce one — and `events_session_handler` must never
+    /// send anything on that account (`claim_resume_banner` is never even reached, since
+    /// `pending_resume_banner` is `None`). Without this test, a regression that ignored
+    /// `show_banner` entirely (e.g. always computing a banner whenever history exists) would slip
+    /// through undetected, since every other banner test in this module leaves `show_banner` at
+    /// its default `true`.
+    #[tokio::test]
+    async fn build_agent_factory_computes_no_banner_when_show_banner_disabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = make_state_with_persistence(dir.path()).await;
+        state.deps.session_config.resume.show_banner = false;
+        let session_id = SessionId::new("no-banner-session");
+        let cid = state
+            .deps
+            .memory
+            .sqlite()
+            .create_conversation()
+            .await
+            .unwrap();
+        seed_session_history(&state.deps, &session_id, cid).await;
+
+        let (resume_banner, build_agent) = Box::pin(build_agent_factory(
+            state.deps.clone(),
+            session_id.clone(),
+            cid,
+            false,
+        ))
+        .await;
+        assert!(
+            resume_banner.is_none(),
+            "build_agent_factory must return None when show_banner = false, even with prior \
+             history present; got: {resume_banner:?}"
+        );
+        drop(build_agent);
+
+        // Registers a handle carrying the actual computed (None) banner — bypassing
+        // SessionActor::spawn's real Agent-building closure (which this test has no need to
+        // drive to completion) — mirrors insert_live_session_with_banner's role in the
+        // exactly-once test above.
+        insert_live_session_with_banner(&state, session_id.as_str(), resume_banner.as_deref());
+        let handle = state.registry.get(&session_id).unwrap();
+
+        let sse = Box::pin(events_session_handler(
+            State(state.clone()),
+            Path(session_id.as_str().to_owned()),
+        ))
+        .await
+        .unwrap();
+        // Push a distinguishing event only after the SSE subscribe above, so the stream has
+        // something to yield — proving the absence of a banner frame is because none was sent,
+        // not because the stream never produced any output at all.
+        handle.tx_out.send(SessionOutput::TurnComplete).unwrap();
+        let frame_text = first_sse_frame_text(sse).await;
+        assert!(
+            !frame_text.contains("resum") && !frame_text.contains("message"),
+            "no banner text may ever be sent when show_banner = false; got: {frame_text}"
+        );
+    }
+
+    /// #6425 reactivation-path regression: `reactivate_session` (not `create`/`fork`) is its own
+    /// call site into `build_agent_factory`/`SessionActor::spawn` — this proves the banner is
+    /// wired through it too, not just the other two paths already covered by
+    /// `build_agent_factory_banner_flows_through_events_session_handler_end_to_end` (create) and
+    /// `fork_session_handler_banner_reflects_copied_message_count` (fork). Simulates a session
+    /// whose actor has ended (idle eviction / process restart, D-12) by seeding durable history
+    /// and a `SessionStore` row without ever inserting a live registry entry, then calling
+    /// `events_session_handler` directly — its `get_or_reactivate` miss must invoke
+    /// `reactivate_session`, which must thread the freshly computed banner onto the newly spawned
+    /// `SessionActorHandle` exactly like the create/fork paths do.
+    #[tokio::test]
+    async fn reactivate_session_banner_reflects_prior_history() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = make_state_with_persistence(dir.path()).await;
+        let session_id = SessionId::new("reactivate-banner-session");
+        let cid = state
+            .deps
+            .memory
+            .sqlite()
+            .create_conversation()
+            .await
+            .unwrap();
+        seed_session_history(&state.deps, &session_id, cid).await;
+
+        // No live registry entry exists for session_id — the registry miss inside
+        // events_session_handler's get_or_reactivate must fall through to reactivate_session.
+        assert!(state.registry.get(&session_id).is_none());
+
+        let sse = Box::pin(events_session_handler(
+            State(state.clone()),
+            Path(session_id.as_str().to_owned()),
+        ))
+        .await
+        .unwrap();
+        let frame_text = first_sse_frame_text(sse).await;
+        assert!(
+            frame_text.contains("2 messages") && frame_text.contains("1 turn"),
+            "a reactivated session's banner must reflect its prior history (2 messages, 1 \
+             turn), got: {frame_text}"
+        );
+
+        let handle = state
+            .registry
+            .get(&session_id)
+            .expect("reactivate_session must register a live handle on success");
+        handle.cancel.cancel();
     }
 
     /// Regression test for #5474: `POST /sessions/:id/prompt` must sanitize/classify the raw HTTP

--- a/src/serve/test_support.rs
+++ b/src/serve/test_support.rs
@@ -215,6 +215,7 @@ impl ServeTestHarness {
                 last_active: std::time::Instant::now(),
                 cancel: tokio_util::sync::CancellationToken::new(),
                 resume_banner_sent: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                pending_resume_banner: None,
             },
         );
         (rx, tx_out)


### PR DESCRIPTION
## Summary

- `build_agent_factory` now computes the resume-visibility banner (spec-068 section 13.5, AC-24) from the session's already-replayed message history, in its existing async prefix, and returns it alongside the `build_agent` closure — previously nothing on this path ever called `SessionResumeInfo::from_messages`.
- `SessionActor::spawn` stores the computed banner on a new `SessionActorHandle::pending_resume_banner` field; `GET /sessions/:id/events` renders it exactly once via the existing `claim_resume_banner()` guard, subscribing to the session's output broadcast before sending so a client that hasn't attached yet can never miss it. This gives `claim_resume_banner()` its first production call site.
- A forked session's banner never shows a "last active" timestamp: `ForkEngine::fork` stamps the new child session's row with the current time as part of its own bookkeeping, which would otherwise read back as a misleading "last active just now" on a session nobody has actually resumed yet. This matches the no-timestamp banner already shown for brand-new sessions created via `POST /sessions`.
- Covers all three entry points that funnel through `build_agent_factory`: session create, session reactivate, and session fork.

Closes #6425
Closes #6426

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 14276 passed, 0 failed, 35 skipped
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — 19 passed, 0 failed
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links"`) — clean
- [x] New regression tests: exactly-once banner delivery across two concurrent/sequential attaches, end-to-end banner computation through `build_agent_factory` -> `SessionActor` -> `events_session_handler`, fork-specific banner (copied message count, no "last active" timestamp), `show_banner = false` negative path, persistence-disabled negative path, `reactivate_session`'s own path
- [x] `.local/testing/playbooks/session-resume-history.md` and `.local/testing/coverage-status.md` updated (main repo)