### PR TITLE
fix(llm,memory): eliminate PID-recycled test flake and postgres-only mock panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   now" on a session nobody has actually resumed yet; it matches `POST /sessions`' no-timestamp
   banner for the same reason.
 
+- `zeph-llm`: `model_cache::tests::tmp_cache()` built its per-test temp directory
+  from `process::id()` plus an in-process counter, which `cargo nextest`'s
+  fresh-process-per-test model collapsed to a constant `<pid>-0` name with no
+  cleanup — a recycled PID within 24h of an earlier run could collide with a
+  leftover `test.json`, spuriously failing `missing_file_is_stale` (#6432).
+  Switched to `tempfile::TempDir`, which is both collision-proof and
+  auto-cleaned on drop.
+
+- `zeph-memory`: `testing::mock_semantic_memory()` unconditionally constructed
+  a `SqliteStore`, panicking with an opaque DB-connection error in a
+  `postgres`-only build (no `sqlite` feature compiled in) (#6431). Store
+  construction is now feature-gated: `sqlite` keeps the existing `:memory:`
+  behavior unchanged, `postgres`-only connects via `ZEPH_TEST_POSTGRES_URL`
+  and returns a clear, actionable error if that variable is unset instead of
+  panicking.
+
 - `zeph-orchestration`: `PlanVerifier::verify_plan()` (whole-plan grounding, spec 009) shared
   the same `orchestration.verifier_timeout_secs` budget as per-task `verify()`, and consistently
   exhausted it against slower local Ollama models even when per-task verification on the same

--- a/crates/zeph-llm/src/model_cache.rs
+++ b/crates/zeph-llm/src/model_cache.rs
@@ -179,30 +179,30 @@ impl ModelCache {
 
 #[cfg(test)]
 mod tests {
+    use tempfile::TempDir;
+
     use super::*;
 
-    fn tmp_cache() -> ModelCache {
-        use std::sync::atomic::{AtomicU64, Ordering};
-        static COUNTER: AtomicU64 = AtomicU64::new(0);
-        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
-        let dir = std::env::temp_dir()
-            .join("zeph-test-model-cache")
-            .join(format!("{}-{id}", std::process::id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        ModelCache {
-            path: dir.join("test.json"),
-        }
+    // Returns the TempDir guard alongside the cache: it must stay alive for the
+    // duration of the test, since dropping it removes the directory the cache
+    // file lives in.
+    fn tmp_cache() -> (ModelCache, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let cache = ModelCache {
+            path: dir.path().join("test.json"),
+        };
+        (cache, dir)
     }
 
     #[test]
     fn missing_file_is_stale() {
-        let c = tmp_cache();
+        let (c, _dir) = tmp_cache();
         assert!(c.is_stale());
     }
 
     #[tokio::test]
     async fn fresh_cache_is_not_stale() {
-        let c = tmp_cache();
+        let (c, _dir) = tmp_cache();
         let models = vec![RemoteModelInfo {
             id: "m1".into(),
             display_name: "Model 1".into(),
@@ -215,7 +215,7 @@ mod tests {
 
     #[tokio::test]
     async fn json_round_trip() {
-        let c = tmp_cache();
+        let (c, _dir) = tmp_cache();
         let models = vec![
             RemoteModelInfo {
                 id: "a".into(),
@@ -237,7 +237,7 @@ mod tests {
 
     #[test]
     fn stale_detection_on_old_timestamp() {
-        let c = tmp_cache();
+        let (c, _dir) = tmp_cache();
         // Write envelope with timestamp 2 days ago.
         let old_ts = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -255,7 +255,7 @@ mod tests {
 
     #[tokio::test]
     async fn invalidate_removes_file() {
-        let c = tmp_cache();
+        let (c, _dir) = tmp_cache();
         let models = vec![];
         c.save(&models).await.unwrap();
         assert!(c.path.exists());
@@ -272,14 +272,14 @@ mod tests {
 
     #[tokio::test]
     async fn load_async_missing_file_returns_none() {
-        let c = tmp_cache();
+        let (c, _dir) = tmp_cache();
         let result = c.load_async().await.unwrap();
         assert!(result.is_none());
     }
 
     #[tokio::test]
     async fn load_async_matches_sync_load() {
-        let c = tmp_cache();
+        let (c, _dir) = tmp_cache();
         let models = vec![RemoteModelInfo {
             id: "x1".into(),
             display_name: "X One".into(),
@@ -294,13 +294,13 @@ mod tests {
 
     #[tokio::test]
     async fn is_stale_async_missing_file_returns_true() {
-        let c = tmp_cache();
+        let (c, _dir) = tmp_cache();
         assert!(c.is_stale_async().await);
     }
 
     #[tokio::test]
     async fn is_stale_async_matches_sync_is_stale() {
-        let c = tmp_cache();
+        let (c, _dir) = tmp_cache();
         let models = vec![RemoteModelInfo {
             id: "y1".into(),
             display_name: "Y One".into(),

--- a/crates/zeph-memory/src/testing.rs
+++ b/crates/zeph-memory/src/testing.rs
@@ -4,7 +4,7 @@
 //! Test helpers for `zeph-memory`.
 //!
 //! Provides `mock_semantic_memory` — a convenience constructor that creates a
-//! fully-wired [`SemanticMemory`] backed by an in-memory `SQLite` database and
+//! fully-wired [`SemanticMemory`] backed by a relational store and
 //! [`InMemoryVectorStore`], so tests do not need a real Qdrant or filesystem.
 
 use std::sync::Arc;
@@ -22,21 +22,25 @@ use crate::token_counter::TokenCounter;
 /// Build a [`SemanticMemory`] that runs entirely in-process with no external
 /// dependencies.
 ///
-/// - `SQLite` backend: `:memory:` (in-process, no file I/O)
+/// - `SQLite` backend (feature `sqlite`): `:memory:` (in-process, no file I/O)
+/// - `PostgreSQL` backend (feature `postgres` only): connects to the URL from
+///   the `ZEPH_TEST_POSTGRES_URL` environment variable — `PostgreSQL` has no
+///   in-process equivalent to `SQLite`'s `:memory:`, so a reachable instance
+///   must be provided by the caller.
 /// - Vector backend: [`InMemoryVectorStore`] (cosine similarity search)
 /// - LLM provider: [`MockProvider`] with embedding support enabled
 ///
 /// # Errors
 ///
-/// Returns `MemoryError` if the in-memory `SQLite` cannot be initialised.
+/// Returns `MemoryError` if the backing store cannot be initialised — under
+/// the `postgres`-only build, this includes `ZEPH_TEST_POSTGRES_URL` being unset.
 pub async fn mock_semantic_memory() -> Result<Arc<SemanticMemory>, MemoryError> {
     let mut mock = MockProvider::default();
     mock.supports_embeddings = true;
     mock.embedding = vec![0.1_f32; 384];
     let provider = AnyProvider::Mock(mock);
 
-    // `:memory:` creates an in-process SQLite database — no disk I/O.
-    let sqlite = SqliteStore::with_pool_size(":memory:", 1).await?;
+    let sqlite = mock_store().await?;
     let pool = sqlite.pool().clone();
 
     // InMemoryVectorStore satisfies the VectorStore trait without Qdrant.
@@ -54,6 +58,27 @@ pub async fn mock_semantic_memory() -> Result<Arc<SemanticMemory>, MemoryError> 
         0.3,
         Arc::new(TokenCounter::new()),
     )))
+}
+
+/// `:memory:` creates an in-process `SQLite` database — no disk I/O.
+#[cfg(feature = "sqlite")]
+async fn mock_store() -> Result<SqliteStore, MemoryError> {
+    SqliteStore::with_pool_size(":memory:", 1).await
+}
+
+/// `PostgreSQL` has no `:memory:`-equivalent in-process mode, so this backend
+/// requires a reachable instance via `ZEPH_TEST_POSTGRES_URL`.
+#[cfg(all(feature = "postgres", not(feature = "sqlite")))]
+async fn mock_store() -> Result<SqliteStore, MemoryError> {
+    let url = std::env::var("ZEPH_TEST_POSTGRES_URL").map_err(|_| {
+        MemoryError::Other(
+            "mock_semantic_memory requires the ZEPH_TEST_POSTGRES_URL environment variable \
+             when built with the postgres backend and no sqlite backend"
+                .to_string(),
+        )
+    })?;
+    let pool = zeph_db::DbConfig { url, pool_size: 1 }.connect().await?;
+    SqliteStore::from_pool(pool).await
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- `zeph-llm`: `model_cache::tests::tmp_cache()` built its per-test temp directory from `process::id()` plus an in-process counter. Under `cargo nextest`'s fresh-process-per-test model, the counter always starts at 0, collapsing every test's directory to a constant `<pid>-0` name that was never cleaned up. A recycled PID within 24h of an earlier run could collide with a leftover `test.json`, spuriously failing `missing_file_is_stale`. Switched to `tempfile::TempDir`, which is collision-proof and auto-cleaned on drop.
- `zeph-memory`: `testing::mock_semantic_memory()` unconditionally constructed a `SqliteStore`, panicking with an opaque DB-connection error under a `postgres`-only build (no `sqlite` feature compiled in). Store construction is now feature-gated: `sqlite` keeps the existing `:memory:` behavior unchanged; `postgres`-only connects via `ZEPH_TEST_POSTGRES_URL` and returns a clear, actionable error if that variable is unset instead of panicking.

These are two independent, unrelated defects in different crates, bundled into one PR.

Closes #6432
Closes #6431

## Test plan

- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-llm -E 'test(model_cache)'` — 10/10 pass, repeated 3x for flakiness
- [x] `cargo build -p zeph-memory --lib --no-default-features --features "postgres,testing"` — clean
- [x] `cargo nextest run -p zeph-experiments --no-default-features --features "postgres,mock" -E 'test(engine_persists_results_to_sqlite)'` — failure mode confirmed changed from opaque DB-connection panic to clear `ZEPH_TEST_POSTGRES_URL not set` error (no Docker/Postgres available in this environment to exercise the success path)
- [x] `cargo nextest run -p zeph-memory` / `-p zeph-experiments` (default sqlite) — unaffected, pass
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 14270/14270 pass, 0 failed, no regressions
- [x] rustdoc gate (`zeph-memory`) — clean
- [x] `gitleaks protect --staged` — clean

Known accepted gap: the postgres-only success path (real `ZEPH_TEST_POSTGRES_URL` connection) is unexercised end-to-end in this environment (no Docker). The issue's stated remedy of feature-gating construction is delivered; a follow-up P3 issue will be filed to additionally skip/adapt `zeph-experiments`' postgres-only test run when the env var is unset, per the alternative remedy suggested in #6431.