### PR TITLE
test(core): cover build_user_message vision-capability gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -664,6 +664,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing
 
+- **zeph-core**: added direct unit test coverage for `Agent::build_user_message`'s
+  vision-capability gate (#6412), which previously had no test exercising either branch.
+  `build_user_message_attaches_image_when_provider_vision_capable` drives a vision-capable
+  mock provider through `build_user_message` and asserts the returned `Message` carries both
+  the text part and the image part; `build_user_message_drops_image_when_provider_not_vision_capable`
+  drives the same call against a non-vision-capable provider and asserts the image is dropped
+  while `content` still carries the plain text, matching the existing `handle_image_command_*`
+  and `resolve_message_*` coverage already present in `image_attachment_tests.rs`. No
+  production code changed.
+
 - **zeph-orchestration** / **zeph-subagent**: closed three coverage gaps in the idle-timeout
   progress plumbing (#6245) flagged during review: direct unit tests for `effective_idle_timeout()`'s
   global-fallback branch (mirroring the existing `effective_run_timeout()` tests), a direct

--- a/crates/zeph-core/src/agent/tests/agent_tests/image_attachment_tests.rs
+++ b/crates/zeph-core/src/agent/tests/agent_tests/image_attachment_tests.rs
@@ -3,6 +3,7 @@
 
 #[allow(unused_imports)]
 use super::*;
+use std::assert_matches;
 
 #[test]
 fn detect_image_mime_jpeg() {
@@ -131,6 +132,56 @@ fn handle_image_command_parent_dir_traversal_is_rejected() {
     let result = agent.handle_image_as_string("../../etc/passwd");
     assert!(agent.msg.pending_image_parts.is_empty());
     assert!(result.contains("path traversal") && result.contains("not allowed"));
+}
+
+fn sample_image_part() -> zeph_llm::provider::MessagePart {
+    zeph_llm::provider::MessagePart::Image(Box::new(zeph_llm::provider::ImageData {
+        data: vec![1, 2, 3, 4],
+        mime_type: "image/png".into(),
+    }))
+}
+
+#[test]
+fn build_user_message_attaches_image_when_provider_vision_capable() {
+    let provider = mock_provider_with_vision(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+    let msg = agent.build_user_message("look at this", vec![sample_image_part()]);
+
+    assert_eq!(msg.role, Role::User);
+    assert_eq!(
+        msg.parts.len(),
+        2,
+        "a vision-capable provider must attach the image alongside the text part, got {:?}",
+        msg.parts
+    );
+    assert_matches!(
+        &msg.parts[0],
+        zeph_llm::provider::MessagePart::Text { text } if text == "look at this"
+    );
+    assert_matches!(&msg.parts[1], zeph_llm::provider::MessagePart::Image(_));
+}
+
+#[test]
+fn build_user_message_drops_image_when_provider_not_vision_capable() {
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+    let msg = agent.build_user_message("look at this", vec![sample_image_part()]);
+
+    assert_eq!(msg.role, Role::User);
+    assert_eq!(msg.content, "look at this");
+    assert!(
+        msg.parts.is_empty(),
+        "a non-vision-capable provider must not attach images, got {:?}",
+        msg.parts
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Adds direct unit test coverage for `build_user_message`'s `LlmProvider::supports_vision()` branch, mirroring the existing `emit_media_parts` test pair used for the sibling MCP-media-passthrough gate.
- Test-only change; no production code modified.

Closes #6412

## Test plan
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 14290 passed, 0 failed (includes both new tests)
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `gitleaks protect --staged`