### PR TITLE
feat(durable): add zeph durable cancel command and Canceled status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`zeph durable cancel <id>`** (#6362): a new `Canceled` durable execution status and CLI
+  command for deliberately, permanently stopping a running execution. `LocalBackend::cancel_execution`
+  probes the execution's INV-15 advisory lock (SQLite/Unix) before writing: no live owner →
+  immediate cancel; a live owner (or a concurrent maintenance sweep) → refused with a `LiveOwner`
+  outcome, row untouched; a cross-process backend with no lock to probe (Postgres) → refused with
+  `LivenessUnverifiable` rather than blind-flipping a possibly-live row. The write itself reuses
+  `finalize`'s race-safe `UPDATE … WHERE status = 'running'` pattern (no read-then-write window).
+  A canceled execution is never reopened: `open_execution`/`open_execution_exclusive` now fail
+  closed with `DurableError::ExecutionCanceled` instead of un-finalizing it (INV-16′, refining
+  INV-16 in spec-064 — operator intent outranks the active-reopen heuristic it stands in for), and
+  `zeph durable resume` reports "intentionally canceled" distinctly from the generic
+  adapters-not-wired message. `zeph durable list --status canceled` and `prune`/`prune --dry-run`
+  (TTL retention, grouped with `failed`/`aborted`) both recognize the new status. Cooperative
+  cancellation of a genuinely live owner (FR-007) is explicitly deferred to a follow-up issue — see
+  `.local/specs/071-durable-run-cancel/spec.md` §2.1 for the rationale. New SQLite migration 112
+  rebuilds `durable_executions`' CHECK constraint under `-- no-transaction` + explicit
+  `BEGIN`/`COMMIT` (required so `PRAGMA foreign_keys = OFF` actually takes effect for the parent
+  table rebuild — the `PRAGMA` is a no-op inside sqlx's default per-migration transaction); the
+  matching Postgres migration is a plain constraint swap.
+
 - **Resume UX and history visibility** (spec-068 §13, #6420): resuming a non-empty prior
   conversation no longer looks like starting from scratch on display-owning channels.
   - CLI prints a neutral `↻ Resuming session (last active …) — N messages, M turns.` banner at

--- a/crates/zeph-db/migrations/postgres/112_durable_canceled_status.sql
+++ b/crates/zeph-db/migrations/postgres/112_durable_canceled_status.sql
@@ -1,0 +1,5 @@
+-- Migration 112 (#6362): add 'canceled' to durable_executions.status CHECK.
+-- Postgres allows an in-place constraint swap (unlike SQLite, no table rebuild needed).
+ALTER TABLE durable_executions DROP CONSTRAINT durable_executions_status_check;
+ALTER TABLE durable_executions ADD CONSTRAINT durable_executions_status_check
+    CHECK (status IN ('running', 'completed', 'failed', 'aborted', 'canceled'));

--- a/crates/zeph-db/migrations/sqlite/112_durable_canceled_status.sql
+++ b/crates/zeph-db/migrations/sqlite/112_durable_canceled_status.sql
@@ -1,0 +1,23 @@
+-- no-transaction
+-- Migration 112 (#6362): add 'canceled' to durable_executions.status CHECK.
+-- durable_executions is a PARENT of durable_journal/promises/timers (FK, default NO ACTION).
+-- SQLite cannot alter a CHECK in place. The rebuild must run with foreign_keys OFF, which is only
+-- possible OUTSIDE a transaction — hence `-- no-transaction`. The explicit BEGIN/COMMIT restores
+-- atomicity so a crash mid-rebuild rolls back cleanly (DROP TABLE IF EXISTS handles a prior partial).
+PRAGMA foreign_keys = OFF;
+BEGIN;
+DROP TABLE IF EXISTS durable_executions_new;
+CREATE TABLE durable_executions_new (
+    execution_id TEXT    PRIMARY KEY,
+    kind         TEXT    NOT NULL,
+    status       TEXT    NOT NULL CHECK(status IN ('running', 'completed', 'failed', 'aborted', 'canceled')),
+    created_at   INTEGER NOT NULL,
+    updated_at   INTEGER NOT NULL,
+    finalized_at INTEGER
+);
+INSERT INTO durable_executions_new SELECT * FROM durable_executions;
+DROP TABLE durable_executions;
+ALTER TABLE durable_executions_new RENAME TO durable_executions;
+CREATE INDEX idx_durable_exec_status_time ON durable_executions(status, finalized_at);
+COMMIT;
+PRAGMA foreign_keys = ON;

--- a/crates/zeph-db/tests/durable_canceled_migration.rs
+++ b/crates/zeph-db/tests/durable_canceled_migration.rs
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Regression test for migration 112 (#6362, critic finding F1): the `durable_executions` table
+//! rebuild (adding `'canceled'` to the `SQLite` CHECK constraint) must preserve every FK-linked
+//! child row in `durable_journal`/`durable_promises`/`durable_timers`.
+//!
+//! Precedent migration 054 is a false precedent for this rebuild pattern — it rebuilds a table
+//! with zero inbound foreign keys, so it never exercises the parent-drop path. `durable_executions`
+//! is the parent of three FK-children (all default `NO ACTION`), and `PRAGMA foreign_keys = OFF`
+//! is a documented `SQLite` no-op *inside a transaction* — sqlx wraps ordinary migrations in one, so
+//! a migration that forgot the `-- no-transaction` marker would pass this exact test against an
+//! empty database and then FK-violate in production the instant a child row exists. This test
+//! seeds all three child tables before running migration 112 through the real production pool
+//! config (`.foreign_keys(true)`, matching `crates/zeph-db/src/pool.rs`), which is what actually
+//! exposes that failure mode.
+
+#![cfg(all(feature = "sqlite", not(feature = "postgres")))]
+
+use std::str::FromStr as _;
+
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn migration_112_preserves_fk_linked_child_rows_across_the_rebuild() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("durable.db");
+
+    // Mirrors the real production pool config (`connect_sqlite` in `src/pool.rs`): a file-backed
+    // database with foreign key enforcement on. A `:memory:` or FK-off connection would not
+    // exercise the bug this test guards against.
+    let opts = SqliteConnectOptions::from_str(&format!("sqlite:{}?mode=rwc", db_path.display()))
+        .unwrap()
+        .create_if_missing(true)
+        .foreign_keys(true);
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(opts)
+        .await
+        .expect("failed to open file-backed sqlite pool");
+
+    let migrator = sqlx::migrate!("./migrations/sqlite");
+
+    // Apply every migration through 111 — durable_executions/journal/promises/timers all exist,
+    // but the 112 rebuild has not run yet, leaving a window to seed FK-populated data.
+    migrator
+        .run_to(111, &pool)
+        .await
+        .expect("migrations through 111 must apply cleanly");
+
+    let exec_id = "11111111-1111-1111-1111-111111111111";
+    sqlx::query(
+        "INSERT INTO durable_executions (execution_id, kind, status, created_at, updated_at, finalized_at)
+         VALUES (?, 'agent_turn', 'running', 0, 0, NULL)",
+    )
+    .bind(exec_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO durable_journal (execution_id, step_id, entry_kind, created_at)
+         VALUES (?, 0, 'test_entry', 0)",
+    )
+    .bind(exec_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let promise_id = "22222222-2222-2222-2222-222222222222";
+    sqlx::query(
+        "INSERT INTO durable_promises (promise_id, execution_id, resolver_token_hash, created_at)
+         VALUES (?, ?, ?, 0)",
+    )
+    .bind(promise_id)
+    .bind(exec_id)
+    .bind(vec![0u8; 32])
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let timer_id = "33333333-3333-3333-3333-333333333333";
+    sqlx::query(
+        "INSERT INTO durable_timers (timer_id, execution_id, due_at, created_at)
+         VALUES (?, ?, 0, 0)",
+    )
+    .bind(timer_id)
+    .bind(exec_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Run the remaining migrations (112). Under the false-precedent 054 approach this would
+    // FK-violate on the implicit `DROP TABLE durable_executions` cascading to its children.
+    migrator
+        .run(&pool)
+        .await
+        .expect("migration 112 must succeed with FK-populated child rows present");
+
+    let (exec_count,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM durable_executions WHERE execution_id = ?")
+            .bind(exec_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        exec_count, 1,
+        "durable_executions row must survive the rebuild"
+    );
+
+    let (journal_count,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM durable_journal WHERE execution_id = ?")
+            .bind(exec_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        journal_count, 1,
+        "durable_journal child row must survive with its FK intact"
+    );
+
+    let (promise_count,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM durable_promises WHERE execution_id = ?")
+            .bind(exec_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        promise_count, 1,
+        "durable_promises child row must survive with its FK intact"
+    );
+
+    let (timer_count,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM durable_timers WHERE execution_id = ?")
+            .bind(exec_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        timer_count, 1,
+        "durable_timers child row must survive with its FK intact"
+    );
+
+    // The rebuilt CHECK constraint must now accept 'canceled' — the whole point of the migration.
+    sqlx::query("UPDATE durable_executions SET status = 'canceled' WHERE execution_id = ?")
+        .bind(exec_id)
+        .execute(&pool)
+        .await
+        .expect("'canceled' must be accepted by the rebuilt CHECK constraint");
+}

--- a/crates/zeph-durable/README.md
+++ b/crates/zeph-durable/README.md
@@ -18,9 +18,12 @@ point of failure instead of restarting from scratch.
 > protocol, and `parallel()` batches), the promise/timer layer (`DurablePromise`, `DurableHandle`,
 > `DurableTimerService`), and journal retention (`DurableRetentionService`, including the
 > flock-verified crash-orphan staleness sweep) have all landed. The `zeph durable` CLI (`list` /
-> `show` / ...) and the TUI durable-execution widget are wired, and all four consuming adapters —
-> agent tool loop, orchestration (`/plan resume`), scheduler, and subagent — journal their steps
-> through `DurableContext`.
+> `show` / `inspect` / `prune` / `resume` / `cancel`) and the TUI durable-execution widget are
+> wired, and all four consuming adapters — agent tool loop, orchestration (`/plan resume`),
+> scheduler, and subagent — journal their steps through `DurableContext`. `zeph durable cancel <id>`
+> (issue [#6362](https://github.com/bug-ops/zeph/issues/6362)) durably marks a specific execution as
+> intentionally stopped via a terminal `Canceled` status, distinct from the crash-driven `Aborted`
+> state, so crash-resume sweeps never resurrect it.
 
 ## Overview
 

--- a/crates/zeph-durable/src/backend.rs
+++ b/crates/zeph-durable/src/backend.rs
@@ -39,7 +39,7 @@ pub mod execution_lock;
 pub mod local;
 
 pub use execution_lock::ExecutionLock;
-pub use local::LocalBackend;
+pub use local::{CancelOutcome, LocalBackend};
 
 /// A read-only summary of a single durable execution, for operability surfaces.
 ///
@@ -259,13 +259,28 @@ impl ExecutionBackend for DurableBackendEnum {
 /// Promise, timer, and retention dispatch.
 ///
 /// These methods back the [`DurablePromise`](crate::DurablePromise) /
-/// [`DurableTimerService`](crate::DurableTimerService) / [`DurableRetentionService`] surfaces. They
+/// [`DurableTimerService`](crate::DurableTimerService) /
+/// [`DurableRetentionService`](crate::DurableRetentionService) surfaces. They
 /// are inherent on the enum rather than on the sealed [`ExecutionBackend`] trait because they are
 /// implemented through the local backend's dedicated `durable_promises` / `durable_timers` tables; a
 /// future cross-process backend (Restate) would satisfy the same surface through its own SDK
 /// primitives, so the closed `match` here gains a new arm at that point — a compile-time prompt
 /// rather than a silent gap.
 impl DurableBackendEnum {
+    /// Cancel a `running` execution so it is never resumed. See [`LocalBackend::cancel_execution`].
+    ///
+    /// A plain in-process-callable primitive (#6362 trimmed US-002): no CLI or orchestration
+    /// coupling, just a dispatch to the active backend.
+    ///
+    /// # Errors
+    ///
+    /// Returns any [`DurableError`] [`LocalBackend::cancel_execution`] can return.
+    pub async fn cancel_execution(&self, id: ExecutionId) -> Result<CancelOutcome, DurableError> {
+        match self {
+            Self::Local(backend) => backend.cancel_execution(id).await,
+        }
+    }
+
     /// Insert a freshly-created promise row. See [`LocalBackend::insert_promise`].
     pub(crate) async fn insert_promise(
         &self,

--- a/crates/zeph-durable/src/backend/local.rs
+++ b/crates/zeph-durable/src/backend/local.rs
@@ -88,6 +88,38 @@ fn idem_key_prefix(bytes: &[u8]) -> String {
     })
 }
 
+/// Outcome of a [`LocalBackend::cancel_execution`] request (#6362).
+///
+/// `Canceled` is the only outcome that wrote to the row; every other variant is a refusal or a
+/// no-op, so a caller can always trust "did this call change the database" from the variant alone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CancelOutcome {
+    /// The execution was `running` with no live owner detected; it is now `canceled` and will
+    /// never be reopened (INV-16′).
+    Canceled,
+    /// The execution was already terminal (`completed`, `failed`, `aborted`, or already
+    /// `canceled`) — idempotent no-op, per NFR-003.
+    AlreadyTerminal {
+        /// The execution's status before (and, since no write happened, after) this call.
+        status: ExecutionStatus,
+    },
+    /// No execution exists for the given id.
+    NotFound,
+    /// Another process holds the execution's [`ExecutionLock`] (SQLite/Unix only). This may be the
+    /// execution's true owner still journaling, or a concurrent maintenance sweep/prune/cancel
+    /// transiently holding the same lock — the flock alone cannot distinguish the two, so no claim
+    /// stronger than "held" is made. The row was not touched; cooperative live-owner cancellation
+    /// (FR-007) is deferred to a follow-up issue.
+    LiveOwner {
+        /// PID of the process currently holding the lock, or `0` if it could not be determined.
+        pid: u32,
+    },
+    /// This backend cannot verify whether a live owner holds the execution (a cross-process
+    /// backend, e.g. Postgres, with no advisory-lock directory to probe). Refusing rather than
+    /// blind-flipping a possibly-live row (F3).
+    LivenessUnverifiable,
+}
+
 /// The always-compiled durable backend that journals to a dedicated `durable.db`.
 ///
 /// Construct it from a [`zeph_db::DbPool`] (or open one with [`LocalBackend::open`]), then attach an
@@ -291,6 +323,35 @@ impl LocalBackend {
         .await
     }
 
+    /// Look up a single execution's current status, without touching journal entries or payloads.
+    ///
+    /// Backs the `zeph durable resume` CLI's canceled-refusal check (FR-011): resume must report a
+    /// `canceled` execution distinctly from "no adapters wired", which requires knowing the status
+    /// before deciding which message to print.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DurableError::Storage`] if the query fails, or [`DurableError::Decode`] if the
+    /// stored status cannot be reconstructed (schema corruption — the column is `CHECK`-constrained).
+    pub async fn execution_status(
+        &self,
+        id: ExecutionId,
+    ) -> Result<Option<ExecutionStatus>, DurableError> {
+        let row: Option<(String,)> = zeph_db::query_as(sql!(
+            "SELECT status FROM durable_executions WHERE execution_id = ?"
+        ))
+        .bind(id.as_uuid().to_string())
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| DurableError::storage("execution_status", e))?;
+        row.map(|(status,)| {
+            ExecutionStatus::from_tag(&status).ok_or(DurableError::Decode {
+                context: "execution status is not a recognized CHECK-constrained value",
+            })
+        })
+        .transpose()
+    }
+
     /// Read one execution's journal entries as redaction-safe metadata, without decrypting payloads.
     ///
     /// Unlike [`read_execution`](Journal::read_execution), this never touches the cipher, so it works
@@ -346,7 +407,7 @@ impl LocalBackend {
             "SELECT COUNT(*) FROM durable_executions
              WHERE finalized_at IS NOT NULL
                AND ( (status = 'completed' AND finalized_at <= ?)
-                  OR (status IN ('failed', 'aborted') AND finalized_at <= ?) )"
+                  OR (status IN ('failed', 'aborted', 'canceled') AND finalized_at <= ?) )"
         ))
         .bind(cutoffs.completed_before_ms)
         .bind(cutoffs.failed_before_ms)
@@ -402,9 +463,10 @@ impl LocalBackend {
     /// any entry is appended, so callers open the execution first.
     ///
     /// Reopening a row previously [`finalize`](Journal::finalize)d as `completed`, `failed`, or
-    /// `aborted` un-finalizes it: status resets to `running` and `finalized_at` clears (INV-16,
-    /// #6254). A caller reopening an execution is, by definition, still using it, so the retention
-    /// sweep (gated on `finalized_at`) must not consider it prunable while it does — without this,
+    /// `aborted` un-finalizes it: status resets to `running` and `finalized_at` clears (INV-16′,
+    /// #6254). A `canceled` row is the deliberate exception — see the `canceled` branch below
+    /// (INV-16′, #6362). A caller reopening an execution is, by definition, still using it, so the
+    /// retention sweep (gated on `finalized_at`) must not consider it prunable while it does — without this,
     /// a long-lived execution finalized at one process's graceful shutdown and legitimately resumed
     /// by a later process (e.g. a per-conversation `AgentTurn` execution) would keep a stale
     /// `finalized_at` and could be pruned out from under its still-active journal. `aborted` rows
@@ -459,8 +521,9 @@ impl LocalBackend {
             }
 
             // Zero rows: either the row doesn't exist, or it exists but wasn't terminal (already
-            // `running`, no reset needed — every terminal status is covered by the UPDATE above).
-            // Distinguish the two — if a concurrent prune deleted a terminal row between any
+            // `running`, no reset needed — every terminal status is covered by the UPDATE above),
+            // or it is `canceled` — deliberately excluded from the UPDATE's IN-list (INV-16′).
+            // Distinguish the cases — if a concurrent prune deleted a terminal row between any
             // earlier observation and this check, this SELECT sees the authoritative post-delete
             // state instead of a stale belief that it's there.
             let existing: Option<(String,)> = zeph_db::query_as(sql!(
@@ -470,7 +533,10 @@ impl LocalBackend {
             .fetch_optional(&self.pool)
             .await
             .map_err(|e| DurableError::storage("open", e))?;
-            if existing.is_some() {
+            if let Some((status,)) = existing {
+                if status == "canceled" {
+                    return Err(DurableError::ExecutionCanceled { execution_id: id });
+                }
                 tracing::Span::current().record("is_resume", true);
                 return Ok(true);
             }
@@ -527,6 +593,135 @@ impl LocalBackend {
             .transpose()?;
         let is_resume = self.open_execution(id, kind).await?;
         Ok((is_resume, lock))
+    }
+
+    /// Cancel a `running` execution so it is deliberately, permanently stopped and never resumed
+    /// (#6362, FR-003/006/012/014).
+    ///
+    /// Unlike [`finalize`](Journal::finalize), which blindly flips `status` under the caller's
+    /// authority, this is the operator-facing entry point: it first tries to establish that no
+    /// live process still owns the execution, so a cancel never races a genuinely active owner's
+    /// own `finalize` into an inconsistent state.
+    ///
+    /// **Liveness probe (SQLite/Unix only).** When this backend has an on-disk `lock_dir`
+    /// (opened via [`LocalBackend::open`] against a real file), a non-blocking acquire of `id`'s
+    /// [`ExecutionLock`] distinguishes a live owner from a dead one:
+    /// - Lock held by another process → [`CancelOutcome::LiveOwner`], row untouched.
+    /// - Lock free → held across the write below (a restart cannot race in mid-window), then
+    ///   released.
+    ///
+    /// **No `lock_dir` (`:memory:` or a backend built via [`LocalBackend::new`]).** The safety
+    /// argument here rests on [`ExecutionBackend::capabilities`]'s `cross_process` flag, which
+    /// this crate only ever sets from `cfg!(feature = "postgres")` — i.e. it assumes "no
+    /// `lock_dir` on a `SQLite` build" implies "no other process can hold this row", true for
+    /// `:memory:` but **not** for a file-backed pool handed to [`LocalBackend::new`] directly
+    /// (which never derives a `lock_dir`); that programmatic path is not reachable from the CLI
+    /// (which always uses [`LocalBackend::open`]), but a future caller of `::new` on a shared file
+    /// should not assume the immediate-cancel path is probe-safe there.
+    /// - `cross_process == false` → provably single-process; proceed directly to the write.
+    /// - `cross_process == true` (Postgres) → a live owner cannot be ruled out and there is no
+    ///   flock to probe → [`CancelOutcome::LivenessUnverifiable`], row untouched (F3).
+    ///
+    /// **Write.** A conditional `UPDATE … WHERE status = 'running'` (the same single-writer-wins
+    /// pattern as `finalize`) — no read-then-write window (NFR-001). Zero rows affected then
+    /// disambiguates via a follow-up `SELECT` into [`CancelOutcome::NotFound`] or
+    /// [`CancelOutcome::AlreadyTerminal`] (idempotent for an already-`canceled` row, NFR-003).
+    ///
+    /// Span: `durable.backend.cancel`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DurableError::Storage`] if a query fails, or propagates any
+    /// [`DurableError`] other than [`DurableError::ExecutionLocked`] from the lock acquisition
+    /// (`ExecutionLocked` itself is caught and converted into [`CancelOutcome::LiveOwner`], never
+    /// surfaced as an `Err`).
+    pub async fn cancel_execution(&self, id: ExecutionId) -> Result<CancelOutcome, DurableError> {
+        let span = tracing::info_span!(
+            "durable.backend.cancel",
+            execution_id = %id.as_uuid(),
+            prior_status = tracing::field::Empty,
+            path = tracing::field::Empty,
+        );
+        async move {
+            let exec = id.as_uuid().to_string();
+
+            if let Some(lock_dir) = self.lock_dir.clone() {
+                let _lock = match ExecutionLock::acquire(&lock_dir, id) {
+                    Ok(lock) => lock,
+                    Err(DurableError::ExecutionLocked { holder_pid, .. }) => {
+                        tracing::Span::current().record("path", "live_owner_refused");
+                        return Ok(CancelOutcome::LiveOwner { pid: holder_pid });
+                    }
+                    Err(e) => return Err(e),
+                };
+                let outcome = self.cancel_write(&exec).await?;
+                tracing::Span::current().record("path", "immediate");
+                record_prior_status(outcome);
+                return Ok(outcome);
+                // `_lock` drops here, after the write commits.
+            }
+
+            if self.capabilities().cross_process {
+                tracing::Span::current().record("path", "unverifiable");
+                return Ok(CancelOutcome::LivenessUnverifiable);
+            }
+
+            tracing::Span::current().record("path", "no_lock_dir_single_process");
+            let outcome = self.cancel_write(&exec).await?;
+            record_prior_status(outcome);
+            Ok(outcome)
+        }
+        .instrument(span)
+        .await
+    }
+
+    /// The conditional terminal write behind [`cancel_execution`](Self::cancel_execution),
+    /// factored out so both the SQLite/Unix (lock-held) and single-process (no-`lock_dir`) paths
+    /// share one implementation of the race-safe `UPDATE … WHERE status = 'running'` pattern.
+    async fn cancel_write(&self, exec: &str) -> Result<CancelOutcome, DurableError> {
+        let now = now_unix_millis();
+        let mut tx = zeph_db::begin_write(&self.pool)
+            .await
+            .map_err(|e| DurableError::storage("cancel", e))?;
+        let result = zeph_db::query(sql!(
+            "UPDATE durable_executions SET status = 'canceled', finalized_at = ?, updated_at = ?
+             WHERE execution_id = ? AND status = 'running'"
+        ))
+        .bind(now)
+        .bind(now)
+        .bind(exec)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| DurableError::storage("cancel", e))?;
+        if result.rows_affected() > 0 {
+            tx.commit()
+                .await
+                .map_err(|e| DurableError::storage("cancel", e))?;
+            return Ok(CancelOutcome::Canceled);
+        }
+
+        // Zero rows: either no such execution, or it exists but was not `running`. Read the
+        // current status inside the same transaction so this reflects exactly what the UPDATE
+        // above saw — no window for a concurrent writer to change the answer in between.
+        let existing: Option<(String,)> = zeph_db::query_as(sql!(
+            "SELECT status FROM durable_executions WHERE execution_id = ?"
+        ))
+        .bind(exec)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| DurableError::storage("cancel", e))?;
+        tx.commit()
+            .await
+            .map_err(|e| DurableError::storage("cancel", e))?;
+        match existing {
+            None => Ok(CancelOutcome::NotFound),
+            Some((status,)) => {
+                let status = ExecutionStatus::from_tag(&status).ok_or(DurableError::Decode {
+                    context: "unrecognized durable_executions.status value",
+                })?;
+                Ok(CancelOutcome::AlreadyTerminal { status })
+            }
+        }
     }
 
     /// Group-commit a batch of buffered entries in a single write transaction.
@@ -1158,7 +1353,7 @@ impl LocalBackend {
             "SELECT execution_id FROM durable_executions
              WHERE finalized_at IS NOT NULL
                AND ( (status = 'completed' AND finalized_at <= ?)
-                  OR (status IN ('failed', 'aborted') AND finalized_at <= ?) )
+                  OR (status IN ('failed', 'aborted', 'canceled') AND finalized_at <= ?) )
              ORDER BY finalized_at LIMIT ?
              FOR UPDATE"
         ))
@@ -1173,7 +1368,7 @@ impl LocalBackend {
             "SELECT execution_id FROM durable_executions
              WHERE finalized_at IS NOT NULL
                AND ( (status = 'completed' AND finalized_at <= ?)
-                  OR (status IN ('failed', 'aborted') AND finalized_at <= ?) )
+                  OR (status IN ('failed', 'aborted', 'canceled') AND finalized_at <= ?) )
              ORDER BY finalized_at LIMIT ?"
         ))
         .bind(cutoffs.completed_before_ms)
@@ -1198,7 +1393,7 @@ impl LocalBackend {
              WHERE execution_id = ?
                AND finalized_at IS NOT NULL
                AND ( (status = 'completed' AND finalized_at <= ?)
-                  OR (status IN ('failed', 'aborted') AND finalized_at <= ?) )"
+                  OR (status IN ('failed', 'aborted', 'canceled') AND finalized_at <= ?) )"
         );
         let mut removed = 0u64;
         for (id,) in &ids {
@@ -1900,6 +2095,25 @@ pub(crate) fn now_unix_millis() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_or(0, |d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
+}
+
+/// Record `cancel_execution`'s `prior_status` span field for a write-path outcome.
+///
+/// `Canceled` was `running` immediately before this call (that is the only status the guarded
+/// `UPDATE` matches); `AlreadyTerminal` already carries its own prior status. `NotFound` leaves
+/// the field unset — there was no row to have had a status.
+fn record_prior_status(outcome: CancelOutcome) {
+    match outcome {
+        CancelOutcome::Canceled => {
+            tracing::Span::current().record("prior_status", "running");
+        }
+        CancelOutcome::AlreadyTerminal { status } => {
+            tracing::Span::current().record("prior_status", status.as_str());
+        }
+        CancelOutcome::NotFound
+        | CancelOutcome::LiveOwner { .. }
+        | CancelOutcome::LivenessUnverifiable => {}
+    }
 }
 
 /// The absolute `updated_at` cutoff (Unix ms) at or before which a `status='running'` row becomes
@@ -2629,6 +2843,352 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancel_execution_with_no_live_owner_cancels_immediately() {
+        // `:memory:` has `lock_dir = None` and `cross_process = false` (sqlite build), so this
+        // exercises the provably-safe single-process direct-write path (F3).
+        let backend = mem_backend(1_048_576).await;
+        let exec = ExecutionId::new();
+        backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+
+        let outcome = backend.cancel_execution(exec).await.unwrap();
+        assert_eq!(outcome, CancelOutcome::Canceled);
+
+        let (status, finalized): (String, Option<i64>) = zeph_db::query_as(sql!(
+            "SELECT status, finalized_at FROM durable_executions WHERE execution_id = ?"
+        ))
+        .bind(exec.as_uuid().to_string())
+        .fetch_one(backend.pool())
+        .await
+        .unwrap();
+        assert_eq!(status, "canceled");
+        assert!(finalized.is_some(), "a terminal status stamps finalized_at");
+    }
+
+    #[tokio::test]
+    async fn cancel_execution_with_no_live_owner_on_file_backed_pool_cancels_immediately() {
+        // The SQLite/Unix lock-probe path: no lock is held, so the probe succeeds and the write
+        // proceeds while the lock is held across it, then releases.
+        let dir = tempfile::tempdir().unwrap();
+        let backend =
+            LocalBackend::open(&dir.path().join("durable.db").to_string_lossy(), 1_048_576)
+                .await
+                .unwrap();
+        backend.init().await.unwrap();
+
+        let exec = ExecutionId::new();
+        backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+
+        let outcome = backend.cancel_execution(exec).await.unwrap();
+        assert_eq!(outcome, CancelOutcome::Canceled);
+
+        // The lock must have been released after the write: a fresh acquire succeeds.
+        let lock_dir = backend.lock_dir.clone().unwrap();
+        assert!(ExecutionLock::acquire(&lock_dir, exec).is_ok());
+    }
+
+    #[tokio::test]
+    async fn cancel_execution_refuses_a_live_owner_without_touching_the_row() {
+        // FR-006/FR-007 refusal: a live owner's held flock must short-circuit cancel to
+        // `LiveOwner`, and the row must be left completely untouched.
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("durable.db");
+        let url = db_path.to_string_lossy().into_owned();
+
+        let owner = LocalBackend::open(&url, 1_048_576).await.unwrap();
+        owner.init().await.unwrap();
+        let canceler = LocalBackend::open(&url, 1_048_576).await.unwrap();
+
+        let exec = ExecutionId::new();
+        let (_, _lock) = owner
+            .open_execution_exclusive(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+
+        let outcome = canceler.cancel_execution(exec).await.unwrap();
+        assert!(
+            matches!(outcome, CancelOutcome::LiveOwner { pid } if pid == std::process::id()),
+            "expected LiveOwner{{pid: {}}}, got {outcome:?}",
+            std::process::id()
+        );
+
+        let (status,): (String,) = zeph_db::query_as(sql!(
+            "SELECT status FROM durable_executions WHERE execution_id = ?"
+        ))
+        .bind(exec.as_uuid().to_string())
+        .fetch_one(owner.pool())
+        .await
+        .unwrap();
+        assert_eq!(status, "running", "a live-owned row must never be touched");
+    }
+
+    #[tokio::test]
+    async fn cancel_execution_is_idempotent_on_a_second_call() {
+        // NFR-003: canceling an already-canceled row is a no-op, not an error.
+        let backend = mem_backend(1_048_576).await;
+        let exec = ExecutionId::new();
+        backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            backend.cancel_execution(exec).await.unwrap(),
+            CancelOutcome::Canceled
+        );
+        let second = backend.cancel_execution(exec).await.unwrap();
+        assert_eq!(
+            second,
+            CancelOutcome::AlreadyTerminal {
+                status: ExecutionStatus::Canceled
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_execution_on_each_other_terminal_status_is_already_terminal() {
+        for status in [
+            ExecutionStatus::Completed,
+            ExecutionStatus::Failed,
+            ExecutionStatus::Aborted,
+        ] {
+            let backend = mem_backend(1_048_576).await;
+            let exec = ExecutionId::new();
+            backend
+                .open_execution(exec, ExecutionKind::AgentTurn)
+                .await
+                .unwrap();
+            backend.finalize(exec, status).await.unwrap();
+
+            let outcome = backend.cancel_execution(exec).await.unwrap();
+            assert_eq!(
+                outcome,
+                CancelOutcome::AlreadyTerminal { status },
+                "canceling a {status:?} execution must be a no-op reporting its own status"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn cancel_execution_on_unknown_id_returns_not_found() {
+        let backend = mem_backend(1_048_576).await;
+        let outcome = backend.cancel_execution(ExecutionId::new()).await.unwrap();
+        assert_eq!(outcome, CancelOutcome::NotFound);
+    }
+
+    #[tokio::test]
+    async fn cancel_execution_races_finalize_exactly_one_terminal_status_wins() {
+        // SC-003: concurrent `cancel_execution` and `finalize(Completed)` — the guarded
+        // `UPDATE ... WHERE status = 'running'` pattern shared by both means whichever commits
+        // first wins, and the loser's write is simply a no-op rather than clobbering the winner.
+        // Drives the two as genuinely concurrent tasks against a real multi-connection pool
+        // (file-backed — `:memory:` forces a single connection, per `zeph-db/src/pool.rs`'s
+        // `connect_sqlite`, which would serialize the two calls trivially and prove nothing),
+        // across many trials so both orderings are exercised without artificial delay injection —
+        // mirrors `concurrent_prune_and_reopen_never_lose_or_corrupt_the_row`'s pattern.
+        let dir = tempfile::tempdir().unwrap();
+        let db_url = dir.path().join("durable.db").to_string_lossy().into_owned();
+        let backend = Arc::new(LocalBackend::open(&db_url, 1_048_576).await.unwrap());
+        backend.init().await.unwrap();
+
+        for _ in 0..20 {
+            let exec = ExecutionId::new();
+            backend
+                .open_execution(exec, ExecutionKind::AgentTurn)
+                .await
+                .unwrap();
+
+            let cancel_backend = backend.clone();
+            let cancel = tokio::spawn(async move { cancel_backend.cancel_execution(exec).await });
+            let finalize_backend = backend.clone();
+            let finalize = tokio::spawn(async move {
+                finalize_backend
+                    .finalize(exec, ExecutionStatus::Completed)
+                    .await
+            });
+
+            let (cancel_result, finalize_result) = tokio::join!(cancel, finalize);
+            let cancel_outcome = cancel_result
+                .expect("cancel task must not panic")
+                .expect("cancel_execution must not error under a concurrent finalize");
+            finalize_result
+                .expect("finalize task must not panic")
+                .expect("finalize must not error under a concurrent cancel");
+
+            let (status,): (String,) = zeph_db::query_as(sql!(
+                "SELECT status FROM durable_executions WHERE execution_id = ?"
+            ))
+            .bind(exec.as_uuid().to_string())
+            .fetch_one(backend.pool())
+            .await
+            .unwrap();
+
+            // Whichever guarded UPDATE committed first wins; the loser's is a no-op. Both
+            // outcomes are legitimate depending on scheduling — the invariant is that exactly one
+            // terminal status is recorded, matching whichever `cancel_execution` outcome resulted.
+            match cancel_outcome {
+                CancelOutcome::Canceled => assert_eq!(
+                    status, "canceled",
+                    "cancel_execution won the race — the row must be canceled"
+                ),
+                CancelOutcome::AlreadyTerminal {
+                    status: ExecutionStatus::Completed,
+                } => assert_eq!(
+                    status, "completed",
+                    "finalize won the race — the row must be completed, and cancel's own \
+                     guarded UPDATE must have found it already non-running"
+                ),
+                other => panic!(
+                    "cancel_execution must only ever win or lose cleanly against a concurrent \
+                     finalize, got {other:?}"
+                ),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn cancel_execution_races_sweep_orphans_exactly_one_of_canceled_or_aborted_wins() {
+        // SC-004: concurrent `cancel_execution` and `sweep_orphans` on the same stale `running`
+        // row. Both probe the same INV-15 `ExecutionLock` before writing, so this race has two
+        // layers: whichever task wins the flock is the only one that ever attempts a write (the
+        // loser either gets `LiveOwner` immediately without touching the row, or skips the
+        // candidate without aborting it — INV-17's "never abort on staleness alone" rule already
+        // covers a live-held lock). Drives the two as genuinely concurrent tasks against a real
+        // multi-connection pool, across many trials so both lock-acquisition orderings are
+        // exercised — mirrors `concurrent_sweep_and_reopen_race_never_corrupts_the_row`'s pattern.
+        let dir = tempfile::tempdir().unwrap();
+        let db_url = dir.path().join("durable.db").to_string_lossy().into_owned();
+        let backend = Arc::new(LocalBackend::open(&db_url, 1_048_576).await.unwrap());
+        backend.init().await.unwrap();
+
+        let policy = RetentionPolicy {
+            stale_running_after_secs: 1,
+            prune_batch_size: 10,
+            ..RetentionPolicy::default()
+        };
+
+        for _ in 0..20 {
+            let exec = ExecutionId::new();
+            backend
+                .open_execution(exec, ExecutionKind::AgentTurn)
+                .await
+                .unwrap();
+            backdate_updated_at(&backend, exec, 0).await;
+
+            let cancel_backend = backend.clone();
+            let cancel = tokio::spawn(async move { cancel_backend.cancel_execution(exec).await });
+            let sweep_backend = backend.clone();
+            let policy_for_task = policy.clone();
+            let sweep =
+                tokio::spawn(async move { sweep_backend.sweep_orphans(&policy_for_task).await });
+
+            let (cancel_result, sweep_result) = tokio::join!(cancel, sweep);
+            let cancel_outcome = cancel_result
+                .expect("cancel task must not panic")
+                .expect("cancel_execution must not error under a concurrent sweep");
+            let aborted = sweep_result
+                .expect("sweep task must not panic")
+                .expect("sweep_orphans must not error under a concurrent cancel");
+
+            let (status,): (String,) = zeph_db::query_as(sql!(
+                "SELECT status FROM durable_executions WHERE execution_id = ?"
+            ))
+            .bind(exec.as_uuid().to_string())
+            .fetch_one(backend.pool())
+            .await
+            .unwrap();
+
+            match cancel_outcome {
+                CancelOutcome::Canceled => {
+                    assert_eq!(aborted, 0, "cancel won the lock — sweep must skip this row");
+                    assert_eq!(status, "canceled");
+                }
+                CancelOutcome::LiveOwner { .. } => {
+                    assert_eq!(aborted, 1, "sweep won the lock — it must abort this row");
+                    assert_eq!(status, "aborted");
+                }
+                other => panic!(
+                    "cancel_execution must only ever win the lock (Canceled) or lose it \
+                     (LiveOwner) against a concurrent sweep, got {other:?}"
+                ),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn open_execution_on_canceled_row_fails_closed_and_never_resumes() {
+        // INV-16′ (#6362), mirroring spec-064 scenario #13: unlike `completed`/`failed`/`aborted`,
+        // a `canceled` row is the one deliberate carve-out — reopening it must fail closed with
+        // `ExecutionCanceled` rather than un-finalizing it back to `running`.
+        let backend = mem_backend(1_048_576).await;
+        let exec = ExecutionId::new();
+        backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        let outcome = backend.cancel_execution(exec).await.unwrap();
+        assert_eq!(outcome, CancelOutcome::Canceled);
+
+        let err = backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .expect_err("reopening a canceled execution must fail closed");
+        assert!(
+            matches!(err, DurableError::ExecutionCanceled { execution_id } if execution_id == exec),
+            "expected ExecutionCanceled, got {err:?}"
+        );
+
+        let (status,): (String,) = zeph_db::query_as(sql!(
+            "SELECT status FROM durable_executions WHERE execution_id = ?"
+        ))
+        .bind(exec.as_uuid().to_string())
+        .fetch_one(backend.pool())
+        .await
+        .unwrap();
+        assert_eq!(
+            status, "canceled",
+            "the row must never be reset to running by a reopen attempt"
+        );
+    }
+
+    #[tokio::test]
+    async fn open_execution_exclusive_on_canceled_row_fails_closed_with_lock_released() {
+        // Same INV-16′ guarantee via the exclusive entry point; the flock guard must still be
+        // released normally (no lock leak) when the call returns an error.
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("durable.db");
+        let backend = LocalBackend::open(&db_path.to_string_lossy(), 1_048_576)
+            .await
+            .unwrap();
+        backend.init().await.unwrap();
+
+        let exec = ExecutionId::new();
+        backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        assert_eq!(
+            backend.cancel_execution(exec).await.unwrap(),
+            CancelOutcome::Canceled
+        );
+
+        let err = backend
+            .open_execution_exclusive(exec, ExecutionKind::AgentTurn)
+            .await
+            .expect_err("reopening a canceled execution exclusively must fail closed");
+        assert!(matches!(err, DurableError::ExecutionCanceled { .. }));
+
+        // The lock must have been released (no leak): a fresh acquire on the same id succeeds.
+        let dir2 = backend.lock_dir.clone().unwrap();
+        assert!(ExecutionLock::acquire(&dir2, exec).is_ok());
+    }
+
+    #[tokio::test]
     async fn reopen_of_a_row_deleted_out_from_under_it_starts_fresh() {
         // #6251 critic S1: simulates the tail of the prune-vs-reopen race — a concurrent prune
         // sweep deletes the row entirely before the reopen's guarded UPDATE runs. The guarded
@@ -3055,6 +3615,45 @@ mod tests {
         assert_eq!(backend.read_execution(live).await.unwrap().len(), 1);
     }
 
+    #[tokio::test]
+    async fn count_prunable_and_prune_include_canceled_executions_past_ttl() {
+        // FR-013 (#6362): a canceled row groups with failed/aborted for the retention TTL cutoff
+        // — without this, canceled rows would never be pruned and would accumulate forever.
+        let backend = mem_backend(1_048_576).await;
+        let exec = ExecutionId::new();
+        backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        assert_eq!(
+            backend.cancel_execution(exec).await.unwrap(),
+            CancelOutcome::Canceled
+        );
+        // Backdate finalized_at far into the past so it is past the failed/aborted TTL cutoff.
+        zeph_db::query(sql!(
+            "UPDATE durable_executions SET finalized_at = 1000 WHERE execution_id = ?"
+        ))
+        .bind(exec.as_uuid().to_string())
+        .execute(backend.pool())
+        .await
+        .unwrap();
+
+        let policy = RetentionPolicy {
+            ttl_failed_secs: 1,
+            prune_batch_size: 10,
+            ..RetentionPolicy::default()
+        };
+        let prunable = backend.count_prunable(&policy).await.unwrap();
+        assert_eq!(
+            prunable, 1,
+            "an aged canceled row must be counted as prunable"
+        );
+
+        let deleted = backend.prune(&policy).await.unwrap();
+        assert_eq!(deleted, 1, "an aged canceled row must actually be pruned");
+        assert!(backend.read_execution(exec).await.unwrap().is_empty());
+    }
+
     /// Backdate a `durable_executions` row's `updated_at` so it becomes a sweep candidate.
     async fn backdate_updated_at(backend: &LocalBackend, id: ExecutionId, updated_at_ms: i64) {
         zeph_db::query(sql!(
@@ -3233,6 +3832,51 @@ mod tests {
         };
         let aborted = backend.sweep_orphans(&policy).await.unwrap();
         assert_eq!(aborted, 0);
+    }
+
+    #[tokio::test]
+    async fn sweep_orphans_never_touches_a_stale_canceled_row() {
+        // FR-008 regression (#6362): `sweep_orphan_batch` only ever candidate-selects
+        // `status = 'running'` rows, so a canceled row — even a stale one — must never be
+        // resurrected or otherwise touched, across repeated sweep cycles.
+        let dir = tempfile::tempdir().unwrap();
+        let backend =
+            LocalBackend::open(&dir.path().join("durable.db").to_string_lossy(), 1_048_576)
+                .await
+                .unwrap();
+        backend.init().await.unwrap();
+
+        let exec = ExecutionId::new();
+        backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        assert_eq!(
+            backend.cancel_execution(exec).await.unwrap(),
+            CancelOutcome::Canceled
+        );
+        backdate_updated_at(&backend, exec, 0).await;
+
+        let policy = RetentionPolicy {
+            stale_running_after_secs: 1,
+            ..RetentionPolicy::default()
+        };
+        for _ in 0..3 {
+            let aborted = backend.sweep_orphans(&policy).await.unwrap();
+            assert_eq!(aborted, 0, "a canceled row must never be swept");
+        }
+
+        let (status,): (String,) = zeph_db::query_as(sql!(
+            "SELECT status FROM durable_executions WHERE execution_id = ?"
+        ))
+        .bind(exec.as_uuid().to_string())
+        .fetch_one(backend.pool())
+        .await
+        .unwrap();
+        assert_eq!(
+            status, "canceled",
+            "sweep must never resurrect a canceled row"
+        );
     }
 
     #[tokio::test]

--- a/crates/zeph-durable/src/error.rs
+++ b/crates/zeph-durable/src/error.rs
@@ -174,6 +174,16 @@ pub enum DurableError {
         /// PID of the process currently holding the lock, or `0` if it could not be determined.
         holder_pid: u32,
     },
+
+    /// [`crate::backend::LocalBackend::open_execution`] (or its exclusive variant) found the
+    /// execution's row already `canceled` (INV-16′, #6362). Unlike `completed`/`failed`/`aborted`,
+    /// a canceled row is never un-finalized and reopened — the cancellation was an explicit
+    /// operator decision that this execution must not run again.
+    #[error("execution {execution_id} was canceled and cannot be resumed")]
+    ExecutionCanceled {
+        /// The execution whose row is `canceled`.
+        execution_id: ExecutionId,
+    },
 }
 
 impl DurableError {
@@ -271,5 +281,14 @@ mod tests {
         let rendered = err.to_string();
         assert!(rendered.contains(&execution_id.to_string()));
         assert!(rendered.contains("4242"));
+    }
+
+    #[test]
+    fn execution_canceled_names_execution_and_is_metadata_only() {
+        let execution_id = ExecutionId::new();
+        let err = DurableError::ExecutionCanceled { execution_id };
+        let rendered = err.to_string();
+        assert!(rendered.contains(&execution_id.to_string()));
+        assert!(rendered.contains("canceled"));
     }
 }

--- a/crates/zeph-durable/src/journal.rs
+++ b/crates/zeph-durable/src/journal.rs
@@ -26,7 +26,7 @@ use crate::ids::{
 /// Terminal and in-flight status of a durable execution.
 ///
 /// Maps one-to-one to the `status` column `CHECK` constraint
-/// (`'running' | 'completed' | 'failed' | 'aborted'`).
+/// (`'running' | 'completed' | 'failed' | 'aborted' | 'canceled'`).
 ///
 /// # Examples
 ///
@@ -48,6 +48,9 @@ pub enum ExecutionStatus {
     Failed,
     /// The execution was discarded (e.g. after a replay divergence or step-cap abort).
     Aborted,
+    /// The execution was deliberately stopped by an operator (`zeph durable cancel`) and must
+    /// never be reopened (INV-16′) — distinct from `Aborted`, which the system may re-drive.
+    Canceled,
 }
 
 impl ExecutionStatus {
@@ -59,13 +62,14 @@ impl ExecutionStatus {
             Self::Completed => "completed",
             Self::Failed => "failed",
             Self::Aborted => "aborted",
+            Self::Canceled => "canceled",
         }
     }
 
     /// Reconstruct a status from its canonical `status`-column string.
     ///
     /// Returns `None` for an unrecognized tag. The `durable_executions.status` column carries a
-    /// `CHECK` constraint over exactly these four values, so a `None` indicates schema corruption
+    /// `CHECK` constraint over exactly these five values, so a `None` indicates schema corruption
     /// or drift rather than a routine miss; callers should fail closed.
     #[must_use]
     pub fn from_tag(tag: &str) -> Option<Self> {
@@ -74,6 +78,7 @@ impl ExecutionStatus {
             "completed" => Some(Self::Completed),
             "failed" => Some(Self::Failed),
             "aborted" => Some(Self::Aborted),
+            "canceled" => Some(Self::Canceled),
             _ => None,
         }
     }
@@ -404,10 +409,13 @@ mod tests {
             ExecutionStatus::Completed,
             ExecutionStatus::Failed,
             ExecutionStatus::Aborted,
+            ExecutionStatus::Canceled,
         ] {
             assert!(!status.as_str().is_empty());
+            assert_eq!(ExecutionStatus::from_tag(status.as_str()), Some(status));
         }
         assert!(ExecutionStatus::Running.is_running());
         assert!(!ExecutionStatus::Aborted.is_running());
+        assert!(!ExecutionStatus::Canceled.is_running());
     }
 }

--- a/crates/zeph-durable/src/lib.rs
+++ b/crates/zeph-durable/src/lib.rs
@@ -96,8 +96,8 @@ pub mod writer;
 pub use sealed::Sealed;
 
 pub use backend::{
-    BackendCapabilities, DurableBackendEnum, ExecutionBackend, ExecutionLock, ExecutionSummary,
-    LocalBackend, RedactedEntry,
+    BackendCapabilities, CancelOutcome, DurableBackendEnum, ExecutionBackend, ExecutionLock,
+    ExecutionSummary, LocalBackend, RedactedEntry,
 };
 pub use cipher::{
     CipherError, EntryKindTag, PayloadAad, PayloadCipher, ensure_payload_within_limit,

--- a/crates/zeph-tui/src/widgets/durable.rs
+++ b/crates/zeph-tui/src/widgets/durable.rs
@@ -69,6 +69,7 @@ fn status_color(status: &str) -> Color {
         "completed" => Color::DarkGray,
         "failed" => Color::Red,
         "aborted" => Color::Yellow,
+        "canceled" => Color::Magenta,
         _ => Color::White,
     }
 }
@@ -173,6 +174,7 @@ mod tests {
     fn status_color_maps_known_states() {
         assert_eq!(status_color("running"), Color::Green);
         assert_eq!(status_color("failed"), Color::Red);
+        assert_eq!(status_color("canceled"), Color::Magenta);
         assert_eq!(status_color("mystery"), Color::White);
     }
 

--- a/specs/064-durable-execution/spec.md
+++ b/specs/064-durable-execution/spec.md
@@ -199,19 +199,29 @@ binds `execution_id` (cipher.rs) and `IdempotencyKey::derive` already folds `exe
 `IdempotencyKey` collision this invariant's introduction considered was only ever possible when
 `ExecutionId` itself collided, which this lock now prevents structurally.
 
-**INV-16 — Reopening an execution un-finalizes ALL terminal statuses identically (#6254).**
+**INV-16′ — Reopening an execution un-finalizes every terminal status EXCEPT a deliberate operator
+cancel, which fails closed instead (#6254, refined #6362).**
 `open_execution`/`open_execution_exclusive`'s reopen path MUST reset `status='running'` and clear
-`finalized_at` for a row found in ANY terminal status — `completed`, `failed`, OR `aborted` — not
-just `completed`/`failed` as in the pre-#6254 behavior. The deciding fact for prunability is
-"is this execution being actively reopened right now", never "which terminal status produced the
-row". Leaving `aborted` untouched on reopen (the pre-#6254 behavior, justified at the time because
-the only `aborted` producers were rare, immediately-redriven divergence-recovery/`StepCapExceeded`
-aborts) becomes unsafe once the crash-orphan sweep (INV-17) makes `aborted` the common outcome of a
-resumable crash: a resumed execution whose row keeps `finalized_at` set is prunable out from under
-the active resume — the exact hazard the completed/failed un-finalize was built to prevent. Un-
-finalizing `aborted` on reopen is strictly safer for the pre-existing divergence-recovery case too
-(it now also protects that fresh re-drive from prune) and does not change replay-cursor
-fresh-vs-resume selection, which is independent of the `status` column.
+`finalized_at` for a row found in `completed`, `failed`, OR `aborted` — not just `completed`/
+`failed` as in the pre-#6254 behavior. The deciding fact for prunability is "is this execution
+being actively reopened right now", never "which terminal status produced the row" — for those
+three statuses. Leaving `aborted` untouched on reopen (the pre-#6254 behavior, justified at the
+time because the only `aborted` producers were rare, immediately-redriven divergence-recovery/
+`StepCapExceeded` aborts) becomes unsafe once the crash-orphan sweep (INV-17) makes `aborted` the
+common outcome of a resumable crash: a resumed execution whose row keeps `finalized_at` set is
+prunable out from under the active resume — the exact hazard the completed/failed un-finalize was
+built to prevent. Un-finalizing `aborted` on reopen is strictly safer for the pre-existing
+divergence-recovery case too (it now also protects that fresh re-drive from prune) and does not
+change replay-cursor fresh-vs-resume selection, which is independent of the `status` column.
+`canceled` (#6362, `zeph durable cancel`) is the one deliberate carve-out: the reopen-reset
+heuristic above exists as a *proxy* for "someone still wants this execution", and a `canceled` row
+records the direct, opposite signal — an explicit human decision that it must never run again.
+Operator intent outranks the proxy it stands in for, so reopen MUST NOT un-finalize a `canceled`
+row; `open_execution`/`open_execution_exclusive` instead fail closed with
+[`DurableError::ExecutionCanceled`](../../crates/zeph-durable/src/error.rs), and the row's status
+never changes. This is not a mechanical "…except canceled" exception bolted onto the "status never
+decides" language above — it is a reasoned carve-out for the one status whose entire purpose is to
+decide, permanently.
 
 **INV-17 — A crash-orphaned `running` execution is reclaimed only after its liveness is verified
 via the INV-15 advisory lock, never by staleness alone (#6254).**

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -755,7 +755,7 @@ pub(crate) enum DbCommand {
 pub(crate) enum DurableCommand {
     /// List durable executions, newest first
     List {
-        /// Filter by status: running | completed | failed | aborted
+        /// Filter by status: running | completed | failed | aborted | canceled
         #[arg(long)]
         status: Option<String>,
         /// Filter by execution kind (e.g. `agent_turn`, `dag_run`, `scheduled_job`, `subagent_session`)
@@ -801,6 +801,11 @@ pub(crate) enum DurableCommand {
     },
     /// Trigger a manual replay of a supported execution
     Resume {
+        /// Execution id (UUID)
+        id: String,
+    },
+    /// Cancel a running durable execution so it is never resumed
+    Cancel {
         /// Execution id (UUID)
         id: String,
     },

--- a/src/commands/durable.rs
+++ b/src/commands/durable.rs
@@ -16,7 +16,7 @@ use crate::bootstrap::load_config_or_default;
 use zeph_core::config::Config;
 use zeph_core::durable::XChaCha20Poly1305Cipher;
 use zeph_core::vault::AgeVaultProvider;
-use zeph_durable::{ExecutionId, Journal, LocalBackend};
+use zeph_durable::{CancelOutcome, ExecutionId, Journal, LocalBackend};
 
 use crate::cli::DurableCommand;
 
@@ -359,6 +359,18 @@ pub(crate) async fn handle_durable_command(
             let Some(backend) = open_backend(&config, false).await? else {
                 return Ok(());
             };
+            // FR-011: a canceled execution is refused distinctly, before the generic
+            // adapters-not-wired message — resuming it would contradict the operator's own
+            // deliberate `zeph durable cancel` decision (INV-16′).
+            if backend
+                .execution_status(exec)
+                .await
+                .map_err(|e| anyhow::anyhow!("failed to look up execution status: {e}"))?
+                == Some(zeph_durable::ExecutionStatus::Canceled)
+            {
+                println!("Execution {id} was intentionally canceled and will not be resumed.");
+                return Ok(());
+            }
             let entries = backend
                 .read_execution_redacted(exec)
                 .await
@@ -375,6 +387,47 @@ pub(crate) async fn handle_durable_command(
                  standalone CLI replay is not available in this build (durable adapters A1-A4).",
                 entries.len()
             );
+        }
+
+        DurableCommand::Cancel { id } => {
+            let exec = ExecutionId::parse_str(&id)
+                .map_err(|e| anyhow::anyhow!("invalid execution id '{id}': {e}"))?;
+            let Some(backend) = open_backend(&config, false).await? else {
+                return Ok(());
+            };
+            let outcome = backend
+                .cancel_execution(exec)
+                .await
+                .map_err(|e| anyhow::anyhow!("failed to cancel execution: {e}"))?;
+            match outcome {
+                CancelOutcome::Canceled => {
+                    println!("Execution {id} canceled; it will not be resumed.");
+                }
+                CancelOutcome::AlreadyTerminal { status } => {
+                    println!(
+                        "Execution {id} is already {}; nothing to cancel.",
+                        status.as_str()
+                    );
+                }
+                CancelOutcome::NotFound => {
+                    anyhow::bail!("No durable execution {id} found.");
+                }
+                CancelOutcome::LiveOwner { pid } => {
+                    anyhow::bail!(
+                        "Execution {id} is currently locked by pid {pid} (an active owner, or a \
+                         maintenance sweep/prune); live cancellation is not yet supported. If \
+                         that process is the owner, stop it (or wait for it to exit) then re-run \
+                         cancel; if it was a transient sweep, just retry shortly."
+                    );
+                }
+                CancelOutcome::LivenessUnverifiable => {
+                    anyhow::bail!(
+                        "Cannot verify whether execution {id} has a live owner on this backend \
+                         (no advisory lock available); refusing to cancel to avoid stopping a \
+                         running execution unsafely."
+                    );
+                }
+            }
         }
     }
 
@@ -929,6 +982,111 @@ mod tests {
         assert!(
             result.is_err(),
             "a declared shared database must fail closed without ZEPH_DURABLE_KEY (INV-8)"
+        );
+    }
+
+    /// Write a minimal config file (default config with `memory.sqlite_path` overridden) and
+    /// return its path, for exercising [`handle_durable_command`]'s config-file-driven entry
+    /// point rather than the lower-level `open_backend` helper directly.
+    ///
+    /// Also touches an empty durable journal file at the resolved URL — `open_backend` treats a
+    /// missing file as "durable execution has never run yet" and refuses to open it (prints a
+    /// friendly notice and returns `Ok(None)`), so a fresh temp dir must have the file pre-created
+    /// before any `open_backend`/`handle_durable_command` call, mirroring
+    /// `open_backend_reveal_succeeds_without_key_when_encrypt_payload_disabled`'s pattern above.
+    fn write_config_toml(dir: &std::path::Path) -> std::path::PathBuf {
+        let mut config = Config::default();
+        config.memory.sqlite_path = dir.join("zeph.db").to_string_lossy().into_owned();
+        let toml = toml::to_string_pretty(&config).unwrap();
+        let path = dir.join("config.toml");
+        std::fs::write(&path, toml).unwrap();
+        std::fs::write(resolve_durable_db_url(&config), []).unwrap();
+        path
+    }
+
+    /// Regression for #6362: `zeph durable cancel <id>` dispatches to `LocalBackend::cancel_execution`
+    /// and actually marks the row `canceled` in the database.
+    #[tokio::test]
+    async fn handle_durable_command_cancel_marks_a_running_execution_canceled() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = write_config_toml(dir.path());
+        let config = load_config_or_default(&config_path);
+
+        let exec = ExecutionId::new();
+        {
+            let backend = open_backend(&config, false).await.unwrap().unwrap();
+            backend
+                .open_execution(exec, zeph_durable::ExecutionKind::AgentTurn)
+                .await
+                .unwrap();
+        }
+
+        let result = handle_durable_command(
+            DurableCommand::Cancel {
+                id: exec.as_uuid().to_string(),
+            },
+            Some(&config_path),
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "canceling a running execution must succeed: {result:?}"
+        );
+
+        let backend = open_backend(&config, false).await.unwrap().unwrap();
+        let status = backend.execution_status(exec).await.unwrap();
+        assert_eq!(status, Some(zeph_durable::ExecutionStatus::Canceled));
+    }
+
+    /// Regression for #6362 (FR-004): canceling an unknown execution id must exit non-zero.
+    #[tokio::test]
+    async fn handle_durable_command_cancel_on_unknown_id_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = write_config_toml(dir.path());
+
+        let result = handle_durable_command(
+            DurableCommand::Cancel {
+                id: ExecutionId::new().as_uuid().to_string(),
+            },
+            Some(&config_path),
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "canceling an unknown execution id must exit non-zero"
+        );
+    }
+
+    /// Regression for #6362 (FR-011): `zeph durable resume` on a canceled execution must report
+    /// the distinct "intentionally canceled" message and succeed, rather than reaching the
+    /// generic "adapters not wired" message or erroring.
+    #[tokio::test]
+    async fn handle_durable_command_resume_on_canceled_execution_refuses_distinctly() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = write_config_toml(dir.path());
+        let config = load_config_or_default(&config_path);
+
+        let exec = ExecutionId::new();
+        {
+            let backend = open_backend(&config, false).await.unwrap().unwrap();
+            backend
+                .open_execution(exec, zeph_durable::ExecutionKind::AgentTurn)
+                .await
+                .unwrap();
+            let outcome = backend.cancel_execution(exec).await.unwrap();
+            assert_eq!(outcome, CancelOutcome::Canceled);
+        }
+
+        let result = handle_durable_command(
+            DurableCommand::Resume {
+                id: exec.as_uuid().to_string(),
+            },
+            Some(&config_path),
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "resume on a canceled execution must report a message and exit 0, not error: {result:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

Killing the process running a durable execution only delays its resume: the next crash-orphan sweep resumes it, since crash-resume is explicitly designed to survive process death. This adds a durable, intentional `Canceled` terminal status distinct from the crash-driven `Aborted` state, and a `zeph durable cancel <id>` command to set it.

- New `ExecutionStatus::Canceled` variant, additive (SQLite CHECK constraint extended via migration 112 on both dialects).
- `LocalBackend::cancel_execution` probes the execution's advisory lock (INV-15) before writing: no live owner → immediate cancel via the same race-safe `UPDATE ... WHERE status = 'running'` pattern `finalize` already uses; a live owner (or a concurrent maintenance sweep) → refused (`CancelOutcome::LiveOwner`), row untouched; a cross-process backend with no lock to probe (Postgres) → refused (`CancelOutcome::LivenessUnverifiable`) rather than blind-flipping a possibly-live row.
- Canceled executions are never reopened or resumed: `open_execution`/`open_execution_exclusive` fail closed with `DurableError::ExecutionCanceled` (refines INV-16 → INV-16′ in `specs/064-durable-execution/spec.md` — operator intent now outranks the active-reopen heuristic it stands in for). `zeph durable resume` reports "intentionally canceled" distinctly from the generic adapters-not-wired message.
- `zeph durable list --status canceled` and `prune`/`prune --dry-run` (TTL retention) both recognize the new status.
- SQLite migration 112 rebuilds `durable_executions`' CHECK constraint under `-- no-transaction` + explicit `BEGIN`/`COMMIT`, required so `PRAGMA foreign_keys = OFF` actually takes effect for the parent-table rebuild (the PRAGMA is a no-op inside sqlx's default per-migration transaction, which would otherwise FK-violate in production against real `durable_journal`/`durable_promises`/`durable_timers` child rows — caught in review, verified by a dedicated FK-survival integration test). The matching Postgres migration is a plain constraint swap.

Cooperative cancellation of a genuinely live owner (a durable signal the owning process observes and stops on cooperatively) is explicitly out of scope here: there is no live-owner step loop to observe it yet, since the per-kind resume adapters (agent-turn/subagent) are unwired in this build. Tracked as a follow-up issue.

Closes #6362

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 14304 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `gitleaks protect --staged --no-banner --redact` — no leaks
- [x] Dedicated FK-survival migration integration test (`crates/zeph-db/tests/durable_canceled_migration.rs`) — seeds all three FK-linked child tables, runs the real migration through a file-backed `foreign_keys(true)` pool, asserts row/FK survival
- [x] Real concurrent race tests (`tokio::spawn` + `tokio::join!`, 20 trials) for cancel-vs-finalize and cancel-vs-sweep_orphans
- [x] `cargo clippy -p zeph-durable -p zeph-db --no-default-features --features postgres` — dual-backend model respected
- [ ] Live-session `kill`-and-cancel walkthrough — not yet performed (playbook scenarios written, flagged `Partial` in coverage-status.md, recommended as a follow-up live-tester pass)