### PR TITLE
fix(experiments): skip postgres-only mock test without ZEPH_TEST_POSTGRES_URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 ### Fixed
 
+- `zeph-experiments`: `engine::tests::engine_persists_results_to_sqlite` `.unwrap()`ed
+  `mock_semantic_memory()` unconditionally, so a `postgres`-only build
+  (`--no-default-features --features postgres`) without a live Postgres reachable via
+  `ZEPH_TEST_POSTGRES_URL` failed the test instead of skipping it — the panic itself was
+  already fixed in #6436 (a clear `MemoryError::Other` naming the missing env var), but the
+  test still had no way to opt out (#6437). The test is now `#[ignore]`d under
+  `cfg(all(feature = "postgres", not(feature = "sqlite")))`, mirroring the
+  `#[ignore = "requires Docker"]` convention in `crates/zeph-db/tests/postgres_integration.rs`;
+  it still runs unconditionally under the default `sqlite` feature set and can be run manually
+  against a live Postgres instance with `--ignored`.
+
 - `zeph-core`: `/history` re-scanned the entire message vector on every call —
   `MessageAccessImpl::transcript_len` was O(total non-system messages) unconditionally, and
   `transcript_page`'s `.skip(start)` ran on top of a `.filter()`, so it walked from index 0 even

--- a/crates/zeph-experiments/src/engine.rs
+++ b/crates/zeph-experiments/src/engine.rs
@@ -805,6 +805,16 @@ mod tests {
 
     #[cfg(test)]
     #[tokio::test]
+    // Under a postgres-only build (`--no-default-features --features postgres`),
+    // `mock_semantic_memory` needs a live Postgres reachable via
+    // `ZEPH_TEST_POSTGRES_URL` (see crates/zeph-memory/src/testing.rs) — there is no
+    // in-process equivalent to SQLite's `:memory:`. Mirrors the `#[ignore = "requires
+    // Docker"]` convention in crates/zeph-db/tests/postgres_integration.rs: skipped by
+    // default, run explicitly with `--ignored` once a Postgres instance is available.
+    #[cfg_attr(
+        all(feature = "postgres", not(feature = "sqlite")),
+        ignore = "requires ZEPH_TEST_POSTGRES_URL"
+    )]
     async fn engine_persists_results_to_sqlite() {
         use zeph_memory::testing::mock_semantic_memory;
 


### PR DESCRIPTION
## Summary
- `engine::tests::engine_persists_results_to_sqlite` in `zeph-experiments` unwrapped `mock_semantic_memory()` unconditionally, so a `postgres`-only build (`--no-default-features --features "postgres,mock"`) without a live Postgres reachable via `ZEPH_TEST_POSTGRES_URL` still failed the test after #6436 turned the panic into a clear error.
- The test is now `#[ignore]`d under `cfg(all(feature = "postgres", not(feature = "sqlite")))`, matching `mock_store()`'s own failing-condition gate exactly, and mirroring the `#[ignore = "requires Docker"]` convention used by `crates/zeph-db/tests/postgres_integration.rs`.
- Runs unconditionally, unchanged, under the default `sqlite` feature set. Can still be run explicitly against a live Postgres with `--ignored` in a postgres-only build.

Closes #6437

## Test plan
- [x] `cargo nextest run -p zeph-experiments --no-default-features --features "postgres,mock"` — 136 passed, 1 skipped (no `ZEPH_TEST_POSTGRES_URL`/Docker), clean.
- [x] `cargo nextest run -p zeph-experiments` (default/sqlite) — no regression, test still runs.
- [x] `cargo +nightly fmt --check` — clean.
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean.
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — clean (2 unrelated pre-existing `zeph-core` fs-watcher timing flakes, both pass in isolation).
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean.
- [x] `gitleaks protect --staged` — clean.