### PR TITLE
fix(scheduler): stamp user_added provenance on CLI writes and fix periodic hydration prompt loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   it still runs unconditionally under the default `sqlite` feature set and can be run manually
   against a live Postgres instance with `--ignored`.
 
+- `zeph-scheduler`: two related gaps deferred from #6361/#6441's review cycle (#6442). CLI-added
+  scheduled jobs (`zeph schedule add`, both the periodic-cron and `--run-at` one-shot paths) were
+  persisted via `JobStore::insert_job` without ever binding the `provenance` column, so the
+  stored value fell back to the column's DB default instead of reflecting their genuine CLI/user
+  origin. `insert_job` now stamps `provenance = "user_added"` (`TaskProvenance::UserAdded`) on
+  every row it writes. `Scheduler::init()` hydration already force-downgrades every out-of-process
+  row to `TaskProvenance::External` regardless of the stored label (#6114 hardening), so this has
+  no effect on runtime trust decisions — it only fixes the value surfaced by direct inspection
+  (DB dumps). Separately, `Scheduler::init()`'s periodic-job hydration arm rebuilt the
+  reconstructed task's config as `serde_json::Value::Null`, discarding the CLI-supplied prompt
+  stored in `task_data` — the same defect class #6441 had already fixed for the one-shot
+  hydration arm (#6361 C1). A CLI-added periodic `kind="custom"` job now correctly rebuilds
+  `{"task": task_data}` on hydration, mirroring the one-shot fix. **Behavior change**: any
+  existing periodic custom job that was silently firing the generic fallback prompt instead of
+  its real stored prompt will start firing its real prompt on the next restart after upgrading.
+
 - `zeph-core`: `/history` re-scanned the entire message vector on every call —
   `MessageAccessImpl::transcript_len` was O(total non-system messages) unconditionally, and
   `transcript_page`'s `.skip(start)` ran on top of a `.filter()`, so it walked from index 0 even

--- a/crates/zeph-scheduler/src/scheduler.rs
+++ b/crates/zeph-scheduler/src/scheduler.rs
@@ -405,22 +405,22 @@ impl Scheduler {
             // above; control-channel adds live in `self.tasks` for their whole session and are
             // never hydrated in the same session that created them). The `provenance` column is
             // writer-controllable (direct SQL / out-of-process CLI), so it cannot be trusted as
-            // read — force the most restrictive tier regardless of the stored label. This hardens
-            // a latent trust-model gap (defense-in-depth); it does not patch an active bypass,
-            // since this (periodic) branch's own config stays `Value::Null` below, which never
-            // reaches a provenance-gated decision point today.
-            //
-            // TODO(critic): periodic hydration also drops task_data→config; same class as the
-            // #6361 oneshot fix (see the sibling `"oneshot"` branch above, which rebuilds
-            // `{"task": task_data}` instead of passing `Value::Null`). A CLI-added *periodic*
-            // custom task would likewise lose its prompt on restart. Pre-existing, out of scope
-            // for #6361 — left as-is pending a scoped follow-up.
+            // read — force the most restrictive tier regardless of the stored label.
             let hydrated_provenance = TaskProvenance::External;
+            // #6442: rebuild the custom-task config shape ({"task": "<prompt>"}, see
+            // handlers.rs/TaskHandler::execute) from the stored task_data column, mirroring the
+            // sibling oneshot arm's #6361 C1 fix above. Passing Value::Null here silently
+            // discarded a CLI-added periodic custom task's prompt on every restart.
+            let config = if job.task_data.is_empty() {
+                serde_json::Value::Null
+            } else {
+                serde_json::json!({ "task": job.task_data })
+            };
             match ScheduledTask::periodic_with_provenance(
                 job.name.clone(),
                 cron_expr.as_ref(),
                 crate::task::TaskKind::from_str_kind(&job.kind),
-                serde_json::Value::Null,
+                config,
                 hydrated_provenance,
             ) {
                 Ok(task) => {
@@ -1677,6 +1677,83 @@ mod tests {
         let injected = prompt_rx
             .try_recv()
             .expect("hydrated custom oneshot must inject a prompt on tick()");
+        assert!(
+            injected.contains(real_prompt),
+            "injected prompt must contain the user's real prompt '{real_prompt}', got: {injected}"
+        );
+        assert!(
+            !injected.contains("check status"),
+            "injected prompt must NOT be the generic fallback, got: {injected}"
+        );
+    }
+
+    /// `init()` hydrates a CLI-added `kind="custom"` periodic row with its REAL prompt, not the
+    /// generic fallback.
+    ///
+    /// Regression test for #6442: the periodic hydration arm originally passed
+    /// `serde_json::Value::Null` as the reconstructed task's config, discarding
+    /// `job.task_data` — the same defect class #6361 C1 fixed for the sibling oneshot arm
+    /// above. A CLI-added periodic `kind="custom"` job lost its real prompt and would fire
+    /// the generic "check status" fallback after every restart.
+    #[tokio::test]
+    async fn init_hydrates_cli_added_periodic_custom_job_with_real_prompt() {
+        let pool = test_pool().await;
+        let store = JobStore::new(pool.clone());
+        store.init().await.unwrap();
+
+        let real_prompt = "generate the weekly report";
+        // Mirrors the CLI write path exactly (`handle_schedule_add`'s cron branch):
+        // `store.insert_job(&job_name, &cron_expr, &kind, "periodic", None, &sanitized_prompt)`.
+        store
+            .insert_job(
+                "cli-custom-periodic",
+                "0 * * * * *",
+                "custom",
+                "periodic",
+                None,
+                real_prompt,
+            )
+            .await
+            .unwrap();
+
+        let store2 = JobStore::new(pool.clone());
+        let (_tx, rx) = watch::channel(false);
+        let (mut scheduler, _msg_tx) = Scheduler::new(store2, rx);
+        let (prompt_tx, mut prompt_rx) = tokio::sync::mpsc::channel(8);
+        // Periodic custom tasks are dispatched via a registered `CustomTaskHandler` (unlike
+        // oneshot, which also has a no-handler-registered fallback keyed on `custom_task_tx`
+        // — see the `tick()` OneShot branch), so the handler must be registered explicitly.
+        scheduler.register_handler(
+            &TaskKind::Custom("custom".into()),
+            Box::new(crate::handlers::CustomTaskHandler::new(prompt_tx)),
+        );
+
+        scheduler.init().await.unwrap();
+
+        let task = scheduler
+            .tasks
+            .iter()
+            .find(|t| t.name == "cli-custom-periodic")
+            .expect("hydrated custom periodic job must appear in tasks after init()");
+        assert_eq!(
+            task.config.get("task").and_then(|v| v.as_str()),
+            Some(real_prompt),
+            "hydrated task config must carry the real prompt from task_data, not Value::Null"
+        );
+
+        // init() only computes a future next_run; force the task overdue so tick() fires it.
+        let past = Utc::now() - Duration::hours(1);
+        scheduler
+            .store
+            .set_next_run("cli-custom-periodic", &past.to_rfc3339())
+            .await
+            .unwrap();
+
+        scheduler.tick().await;
+
+        let injected = prompt_rx
+            .try_recv()
+            .expect("hydrated periodic custom task must inject a prompt on tick()");
         assert!(
             injected.contains(real_prompt),
             "injected prompt must contain the user's real prompt '{real_prompt}', got: {injected}"

--- a/crates/zeph-scheduler/src/store.rs
+++ b/crates/zeph-scheduler/src/store.rs
@@ -241,6 +241,15 @@ impl JobStore {
 
     /// Insert a new job. Returns [`SchedulerError::DuplicateJob`] if a job with this name exists.
     ///
+    /// This is the CLI write path (`zeph schedule add`, both the cron and `--run-at` forms), so
+    /// the row is stored with [`crate::task::TaskProvenance::UserAdded`] provenance — reflecting
+    /// its genuine CLI/user origin — rather than relying on the `provenance` column's DB default.
+    /// `Scheduler::init()` hydration still force-downgrades out-of-process rows to
+    /// [`crate::task::TaskProvenance::External`] regardless of the stored value (#6114), so this
+    /// does not change runtime trust decisions; it keeps the stored label accurate for direct
+    /// inspection (e.g. a raw DB dump) — `zeph schedule list`/`show` do not currently surface
+    /// `provenance`.
+    ///
     /// # Errors
     ///
     /// Returns [`SchedulerError::DuplicateJob`] on unique constraint violation,
@@ -256,8 +265,8 @@ impl JobStore {
         task_data: &str,
     ) -> Result<(), SchedulerError> {
         let result = zeph_db::query(sql!(
-            "INSERT INTO scheduled_jobs (name, cron_expr, kind, task_mode, run_at, task_data)
-             VALUES (?, ?, ?, ?, ?, ?)"
+            "INSERT INTO scheduled_jobs (name, cron_expr, kind, task_mode, run_at, task_data, provenance)
+             VALUES (?, ?, ?, ?, ?, ?, ?)"
         ))
         .bind(name)
         .bind(cron_expr)
@@ -265,6 +274,7 @@ impl JobStore {
         .bind(task_mode)
         .bind(run_at)
         .bind(task_data)
+        .bind(crate::task::TaskProvenance::UserAdded.as_str())
         .execute(&self.pool)
         .await;
         match result {
@@ -854,6 +864,33 @@ mod tests {
             .await
             .unwrap();
         assert!(store.job_exists("new_job").await.unwrap());
+    }
+
+    /// `insert_job` is the CLI write path (`zeph schedule add`), so it must stamp
+    /// `provenance = "user_added"` rather than falling through to the `scheduled_jobs.provenance`
+    /// column's schema default. Regression test for #6442.
+    #[tokio::test]
+    async fn insert_job_stores_user_added_provenance() {
+        let pool = test_pool().await;
+        let store = JobStore::new(pool);
+        store.init().await.unwrap();
+        store
+            .insert_job(
+                "cli_added_job",
+                "0 * * * * *",
+                "custom",
+                "periodic",
+                None,
+                "run daily report",
+            )
+            .await
+            .unwrap();
+        let jobs = store.list_jobs_full().await.unwrap();
+        let job = jobs.iter().find(|j| j.name == "cli_added_job").unwrap();
+        assert_eq!(
+            job.provenance, "user_added",
+            "insert_job (the CLI write path) must stamp provenance = user_added, not the DB default"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- `JobStore::insert_job` now binds `provenance = TaskProvenance::UserAdded` instead of falling through to the `scheduled_jobs.provenance` column's `static` DB default, so CLI-added jobs (both the cron `add` path and the `--run-at` one-shot path added in #6441) are stored with a label reflecting their genuine CLI/user origin. `Scheduler::init()` hydration still force-downgrades every out-of-process row to `TaskProvenance::External` regardless of the stored value (#6114 hardening), so this only fixes direct-inspection accuracy (e.g. a raw DB dump) — not runtime trust decisions.
- `Scheduler::init()`'s periodic hydration arm now rebuilds the reconstructed task's config from `task_data` (`{"task": ...}` when non-empty, else `Value::Null`) instead of discarding it as `Value::Null`, mirroring the sibling one-shot arm's #6361/#6441 fix. A CLI-added periodic `kind="custom"` job now correctly hydrates with its real stored prompt instead of firing the generic fallback.
- **Behavior change**: any existing periodic custom job that was silently firing the generic fallback prompt will start firing its real stored prompt on the next restart after upgrading.

Closes #6442

## Test plan
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 14341 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] `gitleaks protect --staged --no-banner --redact` — no leaks
- [x] New regression test `insert_job_stores_user_added_provenance` (`store.rs`) — asserts CLI-added jobs persist `provenance = "user_added"`
- [x] New regression test `init_hydrates_cli_added_periodic_custom_job_with_real_prompt` (`scheduler.rs`) — drives a real `CustomTaskHandler` through `tick()` and asserts the injected prompt is the real stored prompt, not the generic fallback
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] `.local/testing/coverage-status.md` (main repo root) amended in place for the existing `zeph-scheduler` row