### PR TITLE
feat(durable): add zeph durable rotate-key for AEAD payload key rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+### Added
+
+- `zeph-config`/`zeph-core`/`zeph`: added `zeph durable rotate-key`, a windowed rotation
+  command for the durable execution layer's AEAD payload key (`ZEPH_DURABLE_KEY`) — the
+  `XChaCha20Poly1305Cipher::with_previous` rotation window existed but was never operationally
+  wired to a CLI (#6447). `[durable]` gains `key_id: u8` (operator-controlled current-key
+  selector, default `0`) and `previous_key_id: Option<u8>` (rotation-window state, default
+  `None`); `load_durable_cipher` — the single chokepoint shared by the agent write path, the
+  scheduler-daemon write path, and the CLI/`--reveal` read path — now builds the cipher from
+  both fields, so a rotation is picked up uniformly everywhere. `rotate-key` generates a fresh
+  key, stashes the old one under a new `ZEPH_DURABLE_KEY_PREVIOUS` vault secret, and writes
+  `[durable] key_id`/`previous_key_id` back to the config file in place (via `toml_edit`,
+  preserving comments/formatting) — **config first, then vault**, so a crash between the two
+  writes fires `load_durable_cipher`'s existing fail-closed branch (loud startup error) instead
+  of silently mis-decrypting every pre-rotation payload. A partial-state detector refuses to
+  proceed if `previous_key_id` and the vault secret ever disagree, printing manual-recovery
+  guidance rather than guessing. Only one rotation window is open at a time (the cipher has a
+  single previous-key slot): opening a second window while one is open is refused, pointing at
+  `--drop-previous`. `--drop-previous` closes the window — by default it first scans
+  `durable_journal`/`durable_promises` for any payload still sealed under the previous key
+  (dialect-specific predicate: SQLite blob-compare, Postgres `get_byte`) and refuses if any
+  remain (`--force` skips the scan; scoped to this path only — it never bypasses the
+  open-window or shared-database refusals); a call with no window open is a clean no-op. On a
+  declared/detected shared database, `rotate-key` refuses unless `--ack-shared-db-drain` is
+  passed, since rotating also re-derives the control-entry HMAC key, which has no rotation
+  window of its own. `--dry-run` prints intended changes (including the shared-DB warning)
+  without writing anything. The cipher is built once at process startup (no hot-reload), so a
+  restart is required after rotating. A stale in-memory cipher hitting a rotated blob's
+  key-id now surfaces an actionable "restart to pick up the rotated key" message instead of
+  the raw `UnknownKeyId`/decode error. `zeph --init`'s existing key-replacement wizard step is
+  unchanged in behavior but now explicitly labels itself a destructive reset (no rotation
+  window, discards sealed payloads immediately) and points to `zeph durable rotate-key` for
+  the safe alternative. Added `MigrateDurableKeyRotation` (`--migrate-config` step 97) to
+  insert `key_id = 0` into an existing `[durable]` table lacking it.
+
 ### Fixed
 
 - `zeph-experiments`: `engine::tests::engine_persists_results_to_sqlite` `.unwrap()`ed

--- a/book/src/reference/security/durable-encryption.md
+++ b/book/src/reference/security/durable-encryption.md
@@ -103,16 +103,52 @@ than silently trusting it as an ordinary unverified field.
 
 ## Key rotation
 
-The `key_id` byte makes rotation possible without rewriting the journal:
+The `key_id` byte makes rotation possible without rewriting the journal.
+`zeph durable rotate-key` drives the whole procedure:
 
-1. Generate a new key and assign it the next `key_id`.
-2. Run with the new key as **current** and the old key registered as the
-   **previous** key. New entries seal under the new key; in-flight entries sealed
-   under the old key still decrypt during this window.
-3. Once all executions that used the old key have reached a terminal status
-   (drain), remove the old key.
+```bash
+# Open a window: generates a fresh ZEPH_DURABLE_KEY, stashes the old key under
+# ZEPH_DURABLE_KEY_PREVIOUS, and bumps [durable] key_id / previous_key_id in the config.
+zeph durable rotate-key
 
-If you prefer not to run a rotation window, the simpler drain-based policy is to
-**quiesce** the durable layer — let all running executions reach a terminal
-status — before swapping `ZEPH_DURABLE_KEY`. After a clean drain there are no
-entries sealed under the old key, so no previous-key window is needed.
+# Preview what would change without writing anything.
+zeph durable rotate-key --dry-run
+```
+
+New payloads seal under the new key; payloads sealed before the rotation still
+decrypt through the registered previous key. Only **one** rotation window is
+open at a time — running `rotate-key` again while a window is already open is
+refused (the cipher has a single previous-key slot; a second rotation would
+silently orphan the first previous key), so close the current window first.
+
+The cipher is built once at process startup and does not hot-reload, so **a
+restart is required** after rotating for every consumer (agent process,
+scheduler daemon, `--reveal`, the TUI durable panel) to pick up the new key.
+
+Once every execution that used the old key has reached a terminal status and
+been pruned — the default retention window is roughly 30 days; see
+`[durable.retention]` — close the window:
+
+```bash
+zeph durable rotate-key --drop-previous
+```
+
+This removes `ZEPH_DURABLE_KEY_PREVIOUS` from the vault and clears
+`previous_key_id`. By default it first scans the journal for any payload still
+sealed under the old key and refuses the drop if any remain; pass `--force` to
+skip that scan once you have independently confirmed pruning is complete.
+Payloads still sealed under the dropped key become permanently unreadable
+afterward. A call with no window open is a clean no-op.
+
+On a **shared database** (`[durable].shared_db = true`, or a `postgres://`
+journal URL), rotating also changes the derived control-entry HMAC key, which
+has no rotation window of its own — every in-flight execution's control entries
+fail closed with `ControlIntegrity` until they drain. `rotate-key` refuses on a
+shared database unless you pass `--ack-shared-db-drain`, after draining
+(finalizing/pruning) all in-flight executions first.
+
+`zeph --init`'s wizard step can also replace `ZEPH_DURABLE_KEY`, but that path
+is a **destructive reset**: it discards the old key immediately with no
+rotation window, orphaning every existing sealed payload right away. Prefer
+`zeph durable rotate-key` unless you specifically want to discard every
+existing payload and start over.

--- a/crates/zeph-config/src/durable.rs
+++ b/crates/zeph-config/src/durable.rs
@@ -97,6 +97,17 @@ pub struct DurableConfig {
     pub max_parked_promises: u32,
     /// Journal retention and compaction policy (`[durable.retention]`).
     pub retention: RetentionPolicy,
+    /// The AEAD key-id byte stamped on every payload sealed with the current
+    /// `ZEPH_DURABLE_KEY`. Bumped by `zeph durable rotate-key`; an operator-controlled
+    /// selector so rotation needs no recompile. Default `0` matches every payload sealed
+    /// before this field existed.
+    pub key_id: u8,
+    /// When set, the previous AEAD key (vault secret `ZEPH_DURABLE_KEY_PREVIOUS`) is
+    /// registered as the cipher's rotation-window read slot. `None` means no rotation
+    /// window is open. Set and cleared by `zeph durable rotate-key` / `--drop-previous` —
+    /// not intended for manual editing outside of documented crash recovery.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_key_id: Option<u8>,
 }
 
 impl Default for DurableConfig {
@@ -117,6 +128,8 @@ impl Default for DurableConfig {
             promise_poll_interval_secs: 2,
             max_parked_promises: 1000,
             retention: RetentionPolicy::default(),
+            key_id: 0,
+            previous_key_id: None,
         }
     }
 }
@@ -190,6 +203,32 @@ mod tests {
         assert_eq!(cfg.max_payload_bytes, 1_048_576);
         assert_eq!(cfg.promise_poll_interval_secs, 2);
         assert_eq!(cfg.max_parked_promises, 1000);
+        assert_eq!(cfg.key_id, 0);
+        assert_eq!(cfg.previous_key_id, None);
+    }
+
+    /// Round-trips the rotation-window pair a `zeph durable rotate-key` write produces, so the
+    /// config layer correctly deserializes both fields together (#6447).
+    #[test]
+    fn key_rotation_fields_round_trip_together() {
+        let cfg: DurableConfig = toml::from_str(
+            r"
+            key_id = 1
+            previous_key_id = 0
+            ",
+        )
+        .unwrap();
+        assert_eq!(cfg.key_id, 1);
+        assert_eq!(cfg.previous_key_id, Some(0));
+    }
+
+    /// `previous_key_id` is skipped when `None` (INV-5 style: no window means no field), so a
+    /// freshly-migrated config that never rotated stays visually unchanged (#6447).
+    #[test]
+    fn previous_key_id_is_omitted_from_serialization_when_none() {
+        let cfg = DurableConfig::default();
+        let toml = toml::to_string(&cfg).unwrap();
+        assert!(!toml.contains("previous_key_id"));
     }
 
     #[test]

--- a/crates/zeph-config/src/migrate/infra.rs
+++ b/crates/zeph-config/src/migrate/infra.rs
@@ -846,6 +846,69 @@ pub fn migrate_durable_stale_running_after_secs(
     })
 }
 
+/// Inserts an active `key_id = 0` into an existing `[durable]` table that lacks it (#6447).
+///
+/// `key_id` is the AEAD key-id selector `zeph durable rotate-key` bumps on rotation; `0` is the
+/// runtime `#[serde(default)]` value and matches every payload sealed before this field existed,
+/// so this step is a self-documentation convenience, not a correctness requirement — a config
+/// that never runs it still loads with the correct default.
+///
+/// Deliberately does **not** add `previous_key_id`: its absence means "no rotation window open",
+/// which is the correct default and must never be injected by a migration.
+///
+/// No-op when `[durable]` is absent (covered by [`migrate_durable_config`] instead) or `key_id`
+/// (active or commented) is already present.
+///
+/// # Errors
+///
+/// Returns [`MigrateError`] if the source is not valid TOML.
+pub fn migrate_durable_key_rotation(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    static DURABLE_HEADER_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+        Regex::new(r"(?m)^[ \t]*\[durable\][ \t]*(?:#[^\r\n]*)?\r?\n").expect("static pattern")
+    });
+
+    if !section_header_present(toml_src, "durable") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    // Exact-key match (not a prefix scan) so a hypothetical future `key_id_foo` key would not
+    // suppress this insertion.
+    let already_present = toml_src.lines().any(|l| {
+        let body = l.trim().trim_start_matches('#').trim();
+        body.split('=').next().unwrap_or("").trim() == "key_id"
+    });
+    if already_present || !DURABLE_HEADER_RE.is_match(toml_src) {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let insert = "key_id = 0\n";
+    let output = DURABLE_HEADER_RE
+        .replacen(toml_src, 1, |caps: &regex::Captures| {
+            format!("{}{insert}", &caps[0])
+        })
+        .into_owned();
+
+    let changed = output != toml_src;
+    let changed_count = usize::from(changed);
+    Ok(MigrationResult {
+        output,
+        changed_count,
+        sections_changed: if changed {
+            vec!["durable.key_id".to_owned()]
+        } else {
+            Vec::new()
+        },
+    })
+}
+
 /// Adds a commented-out `[security.content_isolation.nli]` section to configs that predate the
 /// SONAR NLI entailment check stage (#5438). Idempotent: no-op when the real or commented
 /// `[security.content_isolation.nli]` header is already present, so running `--migrate-config`

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -603,15 +603,15 @@ use steps::{
     MigrateAcpSubagentsConfig, MigrateAgentBudgetHint, MigrateAgentRetryToToolsRetry,
     MigrateAgentTimeReminder, MigrateAutodreamConfig, MigrateCavemanConfig,
     MigrateCocoonProviderNotice, MigrateCocoonShowBalance, MigrateCompressionPredictorConfig,
-    MigrateDatabaseUrl, MigrateDeepLinkConfig, MigrateDurableConfig, MigrateDurableSharedDb,
-    MigrateDurableStaleRunningAfterSecs, MigrateEgressConfig, MigrateEmbedProviderRename,
-    MigrateEvalModelToProvider, MigrateFidelityTimeoutDefaults, MigrateFiveSignalConfig,
-    MigrateFocusAutoConsolidateMinWindow, MigrateForgettingConfig, MigrateGoalsConfig,
-    MigrateGonkagateToGonka, MigrateHooksPermissionDeniedConfig, MigrateHooksTurnComplete,
-    MigrateKnowledgeConfig, MigrateLlmStreamLimits, MigrateMagicDocsConfig,
-    MigrateMcpElicitationConfig, MigrateMcpMaxConnectAttempts, MigrateMcpMediaConfig,
-    MigrateMcpRetryAndToolTimeout, MigrateMcpTrustLevels, MigrateMemoryGraph,
-    MigrateMemoryGraphRecallIncludeImported, MigrateMemoryHebbian,
+    MigrateDatabaseUrl, MigrateDeepLinkConfig, MigrateDurableConfig, MigrateDurableKeyRotation,
+    MigrateDurableSharedDb, MigrateDurableStaleRunningAfterSecs, MigrateEgressConfig,
+    MigrateEmbedProviderRename, MigrateEvalModelToProvider, MigrateFidelityTimeoutDefaults,
+    MigrateFiveSignalConfig, MigrateFocusAutoConsolidateMinWindow, MigrateForgettingConfig,
+    MigrateGoalsConfig, MigrateGonkagateToGonka, MigrateHooksPermissionDeniedConfig,
+    MigrateHooksTurnComplete, MigrateKnowledgeConfig, MigrateLlmStreamLimits,
+    MigrateMagicDocsConfig, MigrateMcpElicitationConfig, MigrateMcpMaxConnectAttempts,
+    MigrateMcpMediaConfig, MigrateMcpRetryAndToolTimeout, MigrateMcpTrustLevels,
+    MigrateMemoryGraph, MigrateMemoryGraphRecallIncludeImported, MigrateMemoryHebbian,
     MigrateMemoryHebbianConsolidation, MigrateMemoryHebbianSpread, MigrateMemoryPersonaConfig,
     MigrateMemoryReasoning, MigrateMemoryReasoningJudge, MigrateMemoryRetrieval,
     MigrateMemoryRetrievalQueryBias, MigrateMemoryStoreConfig, MigrateMemoryTypeAwareCompose,
@@ -826,6 +826,9 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             // Step 96 — add [tools.search] advisory block for the native query-based
             // web_search tool (spec 006-1-web-search, #6358)
             Box::new(MigrateSearchConfig),
+            // Step 97 — insert active key_id = 0 into an existing [durable] table lacking it
+            // (AEAD payload-key rotation, #6447)
+            Box::new(MigrateDurableKeyRotation),
         ]
     });
 

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -80,9 +80,9 @@ use super::{
     migrate_agent_time_reminder, migrate_autodream_config, migrate_caveman_config,
     migrate_cocoon_provider_notice, migrate_cocoon_show_balance,
     migrate_compression_predictor_config, migrate_database_url, migrate_deep_link_config,
-    migrate_durable_config, migrate_durable_shared_db, migrate_durable_stale_running_after_secs,
-    migrate_egress_config, migrate_embed_provider_rename, migrate_eval_model_to_provider,
-    migrate_fidelity_timeout_defaults, migrate_five_signal_config,
+    migrate_durable_config, migrate_durable_key_rotation, migrate_durable_shared_db,
+    migrate_durable_stale_running_after_secs, migrate_egress_config, migrate_embed_provider_rename,
+    migrate_eval_model_to_provider, migrate_fidelity_timeout_defaults, migrate_five_signal_config,
     migrate_focus_auto_consolidate_min_window, migrate_forgetting_config, migrate_goals_config,
     migrate_hooks_permission_denied_config, migrate_hooks_turn_complete_config,
     migrate_knowledge_config, migrate_llm_stream_limits, migrate_magic_docs_config,
@@ -1217,5 +1217,18 @@ impl Migration for MigrateSessionResumeConfig {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_session_resume_config(toml_src)
+    }
+}
+
+/// Step 97 — inserts an active `key_id = 0` into an existing `[durable]` table that lacks it
+/// (AEAD payload-key rotation, #6447).
+pub(super) struct MigrateDurableKeyRotation;
+impl Migration for MigrateDurableKeyRotation {
+    fn name(&self) -> &'static str {
+        "migrate_durable_key_rotation"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_durable_key_rotation(toml_src)
     }
 }

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -9,8 +9,8 @@ use super::*;
 fn migrations_registry_has_all_steps() {
     assert_eq!(
         MIGRATIONS.len(),
-        96,
-        "MIGRATIONS registry must contain all 96 sequential steps"
+        97,
+        "MIGRATIONS registry must contain all 97 sequential steps"
     );
     for m in MIGRATIONS.iter() {
         assert!(
@@ -2074,7 +2074,7 @@ fn migrate_focus_auto_consolidate_noop_when_only_commented_section() {
 
 #[test]
 fn registry_has_fifty_entries() {
-    assert_eq!(MIGRATIONS.len(), 96);
+    assert_eq!(MIGRATIONS.len(), 97);
 }
 
 #[test]
@@ -2111,6 +2111,7 @@ fn registry_is_idempotent_on_empty_input() {
 }
 
 #[test]
+#[allow(clippy::too_many_lines)] // flat, ordered list of every registered migration step name
 fn registry_preserves_order_matches_dispatch() {
     // Names must follow the documented step order (steps 1–95).
     let expected = [
@@ -2210,6 +2211,7 @@ fn registry_preserves_order_matches_dispatch() {
         "migrate_session_resume_config",
         "migrate_agent_time_reminder",
         "migrate_search_config",
+        "migrate_durable_key_rotation",
     ];
     let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
     assert_eq!(actual, expected);
@@ -4463,6 +4465,66 @@ fn step_87_idempotent_on_own_output() {
     let first = migrate_durable_stale_running_after_secs(src).expect("first migrate");
     assert_eq!(first.changed_count, 1);
     let second = migrate_durable_stale_running_after_secs(&first.output).expect("second migrate");
+    assert_eq!(second.changed_count, 0, "second run must be a no-op");
+    assert_eq!(
+        second.output, first.output,
+        "output unchanged on second run"
+    );
+}
+
+// ── migrate_durable_key_rotation tests (step 97, #6447) ──────────────────
+
+#[test]
+fn step_97_adds_active_key_id_when_durable_active_and_missing_field() {
+    let src = "[durable]\nenabled = true\nencrypt_payload = true\n";
+    let result = migrate_durable_key_rotation(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert!(result.output.contains("\nkey_id = 0\n"));
+    assert!(result.output.contains("enabled = true"));
+    assert!(result.output.contains("encrypt_payload = true"));
+    assert_eq!(result.sections_changed, vec!["durable.key_id".to_owned()]);
+}
+
+#[test]
+fn step_97_noop_when_key_id_already_present() {
+    let src = "[durable]\nenabled = true\nkey_id = 1\n";
+    let result = migrate_durable_key_rotation(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn step_97_noop_when_durable_section_absent() {
+    let src = "[agent]\nname = \"zeph\"\n";
+    let result = migrate_durable_key_rotation(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn step_97_noop_when_durable_only_commented_advisory() {
+    let src = "# [durable]\n# enabled = false\n";
+    let result = migrate_durable_key_rotation(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn step_97_never_adds_previous_key_id() {
+    let src = "[durable]\nenabled = true\n";
+    let result = migrate_durable_key_rotation(src).expect("migrate");
+    assert!(
+        !result.output.contains("previous_key_id"),
+        "absence of previous_key_id (= no rotation window open) must never be injected"
+    );
+}
+
+#[test]
+fn step_97_idempotent_on_own_output() {
+    let src = "[durable]\nenabled = true\n";
+    let first = migrate_durable_key_rotation(src).expect("first migrate");
+    assert_eq!(first.changed_count, 1);
+    let second = migrate_durable_key_rotation(&first.output).expect("second migrate");
     assert_eq!(second.changed_count, 0, "second run must be a no-op");
     assert_eq!(
         second.output, first.output,

--- a/crates/zeph-core/src/durable.rs
+++ b/crates/zeph-core/src/durable.rs
@@ -158,11 +158,32 @@ impl XChaCha20Poly1305Cipher {
     /// assert!(XChaCha20Poly1305Cipher::from_vault_b64("not base64!").is_err());
     /// ```
     pub fn from_vault_b64(b64_key: &str) -> Result<Self, CipherKeyError> {
-        use base64::Engine as _;
-        let bytes = base64::engine::general_purpose::STANDARD
-            .decode(b64_key.trim())
-            .map_err(|_| CipherKeyError::MalformedEncoding)?;
-        Self::from_vault_bytes(DURABLE_KEY_ID, &bytes)
+        Self::from_vault_b64_with_id(DURABLE_KEY_ID, b64_key)
+    }
+
+    /// Construct the current cipher from a base64-encoded vault value with an explicit `key_id`.
+    ///
+    /// Like [`from_vault_b64`](Self::from_vault_b64) but for an operator-controlled `key_id`
+    /// (`[durable].key_id`, `zeph durable rotate-key`, #6447) rather than the hardcoded
+    /// [`DURABLE_KEY_ID`] default — the current cipher's decode path used by
+    /// `load_durable_cipher` once a rotation has bumped the config's `key_id`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CipherKeyError::MalformedEncoding`] when `b64_key` is not valid base64, or
+    /// [`CipherKeyError::InvalidKeyLength`] when the decoded key is not exactly 32 bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zeph_core::durable::{XChaCha20Poly1305Cipher, generate_durable_key_b64};
+    ///
+    /// let key = generate_durable_key_b64();
+    /// assert!(XChaCha20Poly1305Cipher::from_vault_b64_with_id(1, &key).is_ok());
+    /// ```
+    pub fn from_vault_b64_with_id(key_id: u8, b64_key: &str) -> Result<Self, CipherKeyError> {
+        let bytes = decode_vault_key_bytes(b64_key)?;
+        Ok(Self::new(key_id, bytes))
     }
 
     /// Register a previous key for the rotation window.
@@ -247,6 +268,41 @@ pub fn generate_durable_key_b64() -> String {
     use base64::Engine as _;
     let key = Key::generate();
     base64::engine::general_purpose::STANDARD.encode(key.as_slice())
+}
+
+/// Decode a base64-encoded 32-byte vault key value into raw key bytes.
+///
+/// Shared by [`XChaCha20Poly1305Cipher::from_vault_b64_with_id`] and callers that need to
+/// register a previous key for [`XChaCha20Poly1305Cipher::with_previous`] directly — e.g. `zeph
+/// durable rotate-key`'s `load_durable_cipher` chokepoint decoding `ZEPH_DURABLE_KEY_PREVIOUS`
+/// (#6447) — so the base64 decode path is not duplicated outside this module.
+///
+/// # Errors
+///
+/// Returns [`CipherKeyError::MalformedEncoding`] when `b64_key` is not valid base64, or
+/// [`CipherKeyError::InvalidKeyLength`] when the decoded key is not exactly 32 bytes.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_core::durable::{decode_vault_key_bytes, generate_durable_key_b64};
+///
+/// let key = generate_durable_key_b64();
+/// assert_eq!(decode_vault_key_bytes(&key).unwrap().len(), 32);
+/// assert!(decode_vault_key_bytes("not base64!").is_err());
+/// ```
+pub fn decode_vault_key_bytes(b64_key: &str) -> Result<[u8; KEY_LEN], CipherKeyError> {
+    use base64::Engine as _;
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(b64_key.trim())
+        .map_err(|_| CipherKeyError::MalformedEncoding)?;
+    bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| CipherKeyError::InvalidKeyLength {
+            expected: KEY_LEN,
+            actual: bytes.len(),
+        })
 }
 
 impl PayloadCipher for XChaCha20Poly1305Cipher {

--- a/crates/zeph-durable/src/backend/local.rs
+++ b/crates/zeph-durable/src/backend/local.rs
@@ -456,6 +456,75 @@ impl LocalBackend {
         Ok(count)
     }
 
+    /// Count sealed-payload rows across `durable_journal` and `durable_promises` whose leading
+    /// on-disk byte — the AEAD key-id selector (`zeph_core::durable::XChaCha20Poly1305Cipher`'s
+    /// `key_id(1) || nonce(24) || ciphertext || tag(16)` layout) — equals `key_id`.
+    ///
+    /// Read-only; backs `zeph durable rotate-key --drop-previous`'s default-on safety scan
+    /// (#6447): a nonzero count means payloads still sealed under the previous key would become
+    /// permanently unreadable (`UnknownKeyId`) if that key were dropped now. Filters `payload IS
+    /// NOT NULL` on both tables — control entries (`EffectIntent`) carry no payload and are
+    /// irrelevant to this scan.
+    ///
+    /// The predicate is dialect-specific because `SQLite`'s `substr` on a `BLOB` returns a 1-byte
+    /// `BLOB` (compared here against a bound single-byte blob) while `PostgreSQL`'s `bytea`
+    /// cannot be compared against an integer at all (`get_byte(payload, 0)` extracts it as an
+    /// `INTEGER` instead).
+    ///
+    /// May over-count in a mixed-mode deployment where some rows were written while
+    /// `encrypt_payload = false` (plaintext, no key-id prefix): a plaintext row's leading byte is
+    /// arbitrary content that can coincidentally equal `key_id`. This is intentionally fail-safe
+    /// — it can only cause an unnecessary refusal (resolved with `--force`), never a missed match
+    /// that would let a genuinely-sealed row be dropped silently.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DurableError::Storage`] if either query fails.
+    pub async fn count_sealed_under_key_id(&self, key_id: u8) -> Result<u64, DurableError> {
+        #[cfg(feature = "postgres")]
+        {
+            let key_id_param = i32::from(key_id);
+            let (journal_count,): (i64,) = zeph_db::query_as(sql!(
+                "SELECT COUNT(*) FROM durable_journal
+                 WHERE payload IS NOT NULL AND get_byte(payload, 0) = ?"
+            ))
+            .bind(key_id_param)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| DurableError::storage("count_sealed_under_key_id", e))?;
+            let (promises_count,): (i64,) = zeph_db::query_as(sql!(
+                "SELECT COUNT(*) FROM durable_promises
+                 WHERE payload IS NOT NULL AND get_byte(payload, 0) = ?"
+            ))
+            .bind(key_id_param)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| DurableError::storage("count_sealed_under_key_id", e))?;
+            Ok((journal_count.max(0) + promises_count.max(0)).cast_unsigned())
+        }
+        #[cfg(not(feature = "postgres"))]
+        {
+            let key_byte = vec![key_id];
+            let (journal_count,): (i64,) = zeph_db::query_as(sql!(
+                "SELECT COUNT(*) FROM durable_journal
+                 WHERE payload IS NOT NULL AND substr(payload, 1, 1) = ?"
+            ))
+            .bind(key_byte.clone())
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| DurableError::storage("count_sealed_under_key_id", e))?;
+            let (promises_count,): (i64,) = zeph_db::query_as(sql!(
+                "SELECT COUNT(*) FROM durable_promises
+                 WHERE payload IS NOT NULL AND substr(payload, 1, 1) = ?"
+            ))
+            .bind(key_byte)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| DurableError::storage("count_sealed_under_key_id", e))?;
+            Ok((journal_count.max(0) + promises_count.max(0)).cast_unsigned())
+        }
+    }
+
     /// Ensure a `durable_executions` row exists for `id`, returning whether this is a resume.
     ///
     /// Inserts a fresh `running` row for a new execution (returning `false`) or detects an existing
@@ -2255,6 +2324,65 @@ mod tests {
             },
             created_at_ms: 100,
         }
+    }
+
+    /// Regression for #6447: `count_sealed_under_key_id` scans `durable_journal.payload` by its
+    /// leading byte, ignores control entries (`payload IS NULL`), and never matches an unrelated
+    /// key-id. No cipher is attached, so `seal_payload` stores the plaintext verbatim (local.rs
+    /// `seal_payload`'s `None => Ok(plaintext.to_vec())` branch) — the first byte of the crafted
+    /// payload lands on disk unchanged, letting the test control it directly without depending on
+    /// the real AEAD cipher (out of scope for `zeph-durable`, INV-1).
+    #[tokio::test]
+    async fn count_sealed_under_key_id_counts_matching_journal_rows_and_excludes_control_entries() {
+        let backend = mem_backend(1_048_576).await;
+        let exec = ExecutionId::new();
+        backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+
+        backend
+            .append(step_result(exec, 0, &[5, 0, 0]))
+            .await
+            .unwrap();
+        backend
+            .append(step_result(exec, 1, &[6, 0, 0]))
+            .await
+            .unwrap();
+        // A control entry carries no payload and must never be counted, regardless of key_id.
+        backend.append(effect_intent(exec, 2)).await.unwrap();
+
+        assert_eq!(backend.count_sealed_under_key_id(5).await.unwrap(), 1);
+        assert_eq!(backend.count_sealed_under_key_id(6).await.unwrap(), 1);
+        assert_eq!(backend.count_sealed_under_key_id(7).await.unwrap(), 0);
+    }
+
+    /// Regression for #6447: the scan also covers `durable_promises.payload`, not just the
+    /// journal — a promise resolved under the previous key must count too, or `--drop-previous`
+    /// could silently orphan it.
+    #[tokio::test]
+    async fn count_sealed_under_key_id_counts_matching_promise_rows() {
+        let backend = mem_backend(1_048_576).await;
+        let exec = ExecutionId::new();
+        backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        let promise_id = PromiseId::new();
+        backend
+            .insert_promise(promise_id, exec, [0u8; 32], 100)
+            .await
+            .unwrap();
+        // Unresolved promise row: payload is still NULL, must not be counted.
+        assert_eq!(backend.count_sealed_under_key_id(9).await.unwrap(), 0);
+
+        backend
+            .resolve_promise(promise_id, exec, &[9, 1, 2, 3], 200)
+            .await
+            .unwrap();
+
+        assert_eq!(backend.count_sealed_under_key_id(9).await.unwrap(), 1);
+        assert_eq!(backend.count_sealed_under_key_id(10).await.unwrap(), 0);
     }
 
     #[tokio::test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -817,6 +817,27 @@ pub(crate) enum DurableCommand {
         /// Execution id (UUID)
         id: String,
     },
+    /// Rotate the AEAD payload key (`ZEPH_DURABLE_KEY`), opening a windowed rotation that keeps
+    /// the previous key readable until sealed payloads are pruned, or close an open window
+    RotateKey {
+        /// Print what would change without writing to the config file or vault
+        #[arg(long)]
+        dry_run: bool,
+        /// Close an open rotation window: drop `ZEPH_DURABLE_KEY_PREVIOUS` from the vault and
+        /// clear `previous_key_id`, after verifying no sealed payload still uses the old key
+        #[arg(long)]
+        drop_previous: bool,
+        /// Skip the `--drop-previous` safety scan for sealed payloads still using the old key.
+        /// Applies only to `--drop-previous`; never bypasses the open-window or shared-database
+        /// refusals
+        #[arg(long)]
+        force: bool,
+        /// Acknowledge that this durable journal is a shared database: rotating will re-derive
+        /// the control-entry HMAC key, which has no rotation window, breaking verification for
+        /// every in-flight execution until it drains
+        #[arg(long)]
+        ack_shared_db_drain: bool,
+    },
 }
 
 /// Typed session status filter for the `agents fleet` sub-command.

--- a/src/commands/durable.rs
+++ b/src/commands/durable.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use anyhow::Context as _;
 
 use crate::bootstrap::load_config_or_default;
-use zeph_core::config::Config;
+use zeph_core::config::{Config, DurableConfig};
 use zeph_core::durable::XChaCha20Poly1305Cipher;
 use zeph_core::vault::AgeVaultProvider;
 use zeph_durable::{CancelOutcome, ExecutionId, Journal, LocalBackend};
@@ -23,6 +23,12 @@ use crate::cli::DurableCommand;
 /// Printed before any decrypted payload is shown, so the operator knows plaintext is on screen.
 const REVEAL_WARNING: &str =
     "WARNING: --reveal decrypts and prints payload bytes in cleartext. Do not share this output.";
+
+/// Vault secret name for the current AEAD payload key.
+const CURRENT_KEY_VAULT_NAME: &str = "ZEPH_DURABLE_KEY";
+/// Vault secret name for the previous AEAD payload key, present only while a `zeph durable
+/// rotate-key` rotation window is open (`config.durable.previous_key_id.is_some()`).
+const PREVIOUS_KEY_VAULT_NAME: &str = "ZEPH_DURABLE_KEY_PREVIOUS";
 
 /// Resolve the dedicated durable journal path: a sibling of the main database file.
 ///
@@ -116,16 +122,52 @@ pub(crate) fn enforce_encryption_gate(
     }
 }
 
-/// Load the AEAD cipher from the vault-stored `ZEPH_DURABLE_KEY` for `--reveal`.
-fn load_durable_cipher() -> anyhow::Result<XChaCha20Poly1305Cipher> {
+/// Build the AEAD cipher from the vault-stored `ZEPH_DURABLE_KEY`, honoring an open
+/// `zeph durable rotate-key` rotation window (`config.previous_key_id`) when one is declared.
+///
+/// The single chokepoint every consumer routes through: the CLI write path
+/// ([`load_write_cipher`]), the CLI read path ([`open_backend`]/`--reveal`), and the TUI durable
+/// poll task all resolve their cipher here, so a rotation window opened via `zeph durable
+/// rotate-key` is picked up uniformly (#6447).
+///
+/// The `previous_key_id` lookup is a **hard error**, never a best-effort skip, when
+/// `ZEPH_DURABLE_KEY_PREVIOUS` is declared but missing from the vault: this is the fail-closed
+/// branch a config-first rotation write depends on for crash safety — a crash between the config
+/// write and the vault write leaves exactly this state, and failing loud here (rather than
+/// silently building a cipher with no previous slot) is what prevents every pre-rotation payload
+/// from silently becoming undecryptable.
+///
+/// # Errors
+///
+/// Returns an error if the vault cannot be loaded, `ZEPH_DURABLE_KEY` is absent or malformed, or
+/// `previous_key_id` is set but `ZEPH_DURABLE_KEY_PREVIOUS` is missing or malformed.
+fn load_durable_cipher(config: &DurableConfig) -> anyhow::Result<XChaCha20Poly1305Cipher> {
     let dir = zeph_core::vault::default_vault_dir();
     let provider = AgeVaultProvider::load(&dir.join("vault-key.txt"), &dir.join("secrets.age"))
         .map_err(|e| anyhow::anyhow!("failed to load vault: {e}"))?;
-    let key = provider.get("ZEPH_DURABLE_KEY").ok_or_else(|| {
-        anyhow::anyhow!("ZEPH_DURABLE_KEY not found in vault; cannot --reveal payloads")
+    let key = provider.get(CURRENT_KEY_VAULT_NAME).ok_or_else(|| {
+        anyhow::anyhow!("{CURRENT_KEY_VAULT_NAME} not found in vault; cannot --reveal payloads")
     })?;
-    XChaCha20Poly1305Cipher::from_vault_b64(key)
-        .map_err(|e| anyhow::anyhow!("invalid ZEPH_DURABLE_KEY: {e}"))
+    let mut cipher = XChaCha20Poly1305Cipher::from_vault_b64_with_id(config.key_id, key)
+        .map_err(|e| anyhow::anyhow!("invalid {CURRENT_KEY_VAULT_NAME}: {e}"))?;
+
+    if let Some(prev_id) = config.previous_key_id {
+        let prev_key = provider.get(PREVIOUS_KEY_VAULT_NAME).ok_or_else(|| {
+            anyhow::anyhow!(
+                "durable config declares previous_key_id = {prev_id} but \
+                 {PREVIOUS_KEY_VAULT_NAME} is missing from the vault; refusing to build a \
+                 cipher with an inconsistent rotation state (this can happen if a previous \
+                 `zeph durable rotate-key` run crashed mid-write) — reconcile config and vault \
+                 to a consistent pair, or re-run `zeph durable rotate-key` to see recovery \
+                 guidance, before retrying"
+            )
+        })?;
+        let prev_bytes = zeph_core::durable::decode_vault_key_bytes(prev_key)
+            .map_err(|e| anyhow::anyhow!("invalid {PREVIOUS_KEY_VAULT_NAME}: {e}"))?;
+        cipher = cipher.with_previous(prev_id, prev_bytes);
+    }
+
+    Ok(cipher)
 }
 
 /// Resolve the control-entry row HMAC key (INV-8) for the durable journal at `url`, deriving it
@@ -191,7 +233,7 @@ pub(crate) fn load_write_cipher(
     if !config.durable.encrypt_payload {
         return Ok(None);
     }
-    let cipher = load_durable_cipher()?;
+    let cipher = load_durable_cipher(&config.durable)?;
     Ok(Some(Arc::new(cipher)))
 }
 
@@ -237,7 +279,7 @@ async fn open_backend(config: &Config, reveal: bool) -> anyhow::Result<Option<Lo
         backend
     };
     if reveal && config.durable.encrypt_payload {
-        let cipher = load_durable_cipher()?;
+        let cipher = load_durable_cipher(&config.durable)?;
         Ok(Some(backend.with_cipher(Arc::new(cipher))))
     } else {
         Ok(Some(backend))
@@ -429,9 +471,369 @@ pub(crate) async fn handle_durable_command(
                 }
             }
         }
+
+        DurableCommand::RotateKey {
+            dry_run,
+            drop_previous,
+            force,
+            ack_shared_db_drain,
+        } => {
+            handle_rotate_key(
+                &config_file,
+                &config,
+                RotateKeyOptions {
+                    dry_run,
+                    drop_previous,
+                    force,
+                    ack_shared_db_drain,
+                },
+            )
+            .await?;
+        }
     }
 
     Ok(())
+}
+
+/// Flags controlling `zeph durable rotate-key`'s behavior, bundled into one struct rather than
+/// four positional `bool` parameters (past clippy's `fn_params_excessive_bools` threshold, and
+/// call sites read as named fields instead of an ambiguous run of `bool`s).
+///
+/// The four flags are independent CLI switches (mirroring `DurableConfig`'s own
+/// `#[allow(clippy::struct_excessive_bools)]` precedent) — not state-machine variants, since any
+/// combination is meaningful (e.g. `--dry-run --drop-previous --force`).
+#[allow(clippy::struct_excessive_bools)]
+struct RotateKeyOptions {
+    /// Print intended changes without writing to the config file or vault.
+    dry_run: bool,
+    /// Close an open rotation window instead of opening a new one.
+    drop_previous: bool,
+    /// Skip the `--drop-previous` blob-scan (drop-previous only; never gates the open-window or
+    /// shared-database refusals — see [`handle_open_window`]).
+    force: bool,
+    /// Acknowledge rotating on a declared/detected shared database despite the control-entry
+    /// HMAC having no rotation window of its own.
+    ack_shared_db_drain: bool,
+}
+
+/// Open or close a `ZEPH_DURABLE_KEY` AEAD rotation window (`zeph durable rotate-key`, #6447).
+///
+/// Dispatches to [`handle_open_window`] or [`handle_drop_previous`] after a partial-state (XOR)
+/// detector that runs **before any write**, on both paths: if `config.durable.previous_key_id`
+/// disagrees with whether `ZEPH_DURABLE_KEY_PREVIOUS` exists in the vault, this refuses rather
+/// than guessing which side is stale — the state is only reachable by a crash mid-write or manual
+/// editing, and deriving "the old key" from whatever `ZEPH_DURABLE_KEY` currently holds would
+/// compound the inconsistency instead of resolving it.
+///
+/// # Errors
+///
+/// Returns an error if the vault cannot be loaded, the rotation state is inconsistent, or the
+/// dispatched handler fails (see [`handle_open_window`] / [`handle_drop_previous`]).
+async fn handle_rotate_key(
+    config_file: &Path,
+    config: &Config,
+    opts: RotateKeyOptions,
+) -> anyhow::Result<()> {
+    let dir = zeph_core::vault::default_vault_dir();
+    let key_path = dir.join("vault-key.txt");
+    let vault_path = dir.join("secrets.age");
+    if !key_path.exists() || !vault_path.exists() {
+        anyhow::bail!(
+            "no age vault found at {}; run `zeph --init` first to generate \
+             {CURRENT_KEY_VAULT_NAME}",
+            dir.display()
+        );
+    }
+    let mut provider = AgeVaultProvider::load(&key_path, &vault_path)
+        .map_err(|e| anyhow::anyhow!("failed to load vault: {e}"))?;
+
+    // Partial-state (XOR) detector — MANDATORY, before any write. See the doc comment above.
+    let window_declared = config.durable.previous_key_id.is_some();
+    let prev_secret_present = provider.get(PREVIOUS_KEY_VAULT_NAME).is_some();
+    if window_declared != prev_secret_present {
+        anyhow::bail!(
+            "inconsistent rotation state detected -- refusing to proceed.\n\
+             config:  [durable] previous_key_id = {:?}\n\
+             vault:   {PREVIOUS_KEY_VAULT_NAME} is {}\n\
+             \n\
+             This usually means a crash interrupted a previous `zeph durable rotate-key` run \
+             between its config write and its vault write, or one side was hand-edited. Manual \
+             recovery is required before retrying -- never derive the old key from whatever \
+             {CURRENT_KEY_VAULT_NAME} currently holds:\n\
+             - If {PREVIOUS_KEY_VAULT_NAME} is absent, {CURRENT_KEY_VAULT_NAME} in the vault \
+               still holds the pre-rotation key: edit [durable] in {} and remove \
+               `previous_key_id` (restoring `key_id` to its prior value), then retry.\n\
+             - If {PREVIOUS_KEY_VAULT_NAME} is present but config has no `previous_key_id`, \
+               either restore `previous_key_id` in the config to match, or remove the orphaned \
+               vault secret (`zeph vault rm {PREVIOUS_KEY_VAULT_NAME}`) once you have confirmed \
+               it is not needed.",
+            config.durable.previous_key_id,
+            if prev_secret_present {
+                "present"
+            } else {
+                "absent"
+            },
+            config_file.display(),
+        );
+    }
+
+    if opts.drop_previous {
+        handle_drop_previous(config_file, config, &mut provider, opts.dry_run, opts.force).await
+    } else {
+        handle_open_window(
+            config_file,
+            config,
+            &mut provider,
+            opts.dry_run,
+            opts.ack_shared_db_drain,
+        )
+    }
+}
+
+/// Open a new rotation window: generate a fresh `ZEPH_DURABLE_KEY`, stash the old key under
+/// `ZEPH_DURABLE_KEY_PREVIOUS`, and bump `[durable] key_id`/`previous_key_id`.
+///
+/// Write order is **config first, then vault** (R1): a crash between the two leaves config
+/// declaring a window that the vault does not yet back, which [`load_durable_cipher`]'s
+/// fail-closed branch turns into a loud startup error instead of a silent mis-decrypt. Refuses a
+/// second window while one is already open (R2 — the cipher holds only one previous key slot, so
+/// a second rotation would silently orphan the first previous key) and refuses on a
+/// declared/detected shared database without `--ack-shared-db-drain` (R3 — the control-entry HMAC
+/// key has no rotation window). Neither refusal is bypassable by any flag.
+fn handle_open_window(
+    config_file: &Path,
+    config: &Config,
+    provider: &mut AgeVaultProvider,
+    dry_run: bool,
+    ack_shared_db_drain: bool,
+) -> anyhow::Result<()> {
+    // R2 — refuse to open a second window; the cipher's single previous-key slot cannot hold two.
+    if let Some(prev_id) = config.durable.previous_key_id {
+        anyhow::bail!(
+            "a rotation window is already open (previous_key_id = {prev_id}); close it with \
+             `zeph durable rotate-key --drop-previous` after the retention window has elapsed, \
+             then rotate again"
+        );
+    }
+
+    // R3 — shared-DB guard, enforced (not merely documented). Never bypassable by --force.
+    let url = resolve_durable_db_url(config);
+    if is_shared_db(&config.durable, &url) && !ack_shared_db_drain {
+        let msg = "this durable journal is a shared database. Rotating ZEPH_DURABLE_KEY \
+             re-derives the control-entry HMAC key, which has no rotation window of its own -- \
+             every in-flight execution's control entries will fail ControlIntegrity until they \
+             drain. Drain (finalize/prune) all in-flight executions first, then re-run with \
+             --ack-shared-db-drain. (HMAC-key rotation window: follow-up to #6447.)";
+        if dry_run {
+            println!("DRY RUN: {msg}");
+            return Ok(());
+        }
+        anyhow::bail!("{msg}");
+    }
+
+    let Some(old_key_b64) = provider.get(CURRENT_KEY_VAULT_NAME).map(str::to_owned) else {
+        anyhow::bail!("{CURRENT_KEY_VAULT_NAME} not found in vault; nothing to rotate");
+    };
+
+    let old_key_id = config.durable.key_id;
+    let new_key_id = old_key_id.wrapping_add(1);
+
+    let vault_path = zeph_core::vault::default_vault_dir().join("secrets.age");
+    if dry_run {
+        println!(
+            "DRY RUN -- no changes written.\n\
+             Would rotate ZEPH_DURABLE_KEY: key_id {old_key_id} -> {new_key_id}\n\
+             Would set [durable] key_id = {new_key_id}, previous_key_id = {old_key_id} in {}\n\
+             Would generate a new {CURRENT_KEY_VAULT_NAME} and stash the old key under \
+             {PREVIOUS_KEY_VAULT_NAME} in {}\n\
+             A process restart is required to pick up the rotated key (no hot-reload).",
+            config_file.display(),
+            vault_path.display(),
+        );
+        return Ok(());
+    }
+
+    let new_key_b64 = zeph_core::durable::generate_durable_key_b64();
+
+    // R1 — config FIRST, then vault. A crash between the two fires load_durable_cipher's
+    // fail-closed branch (loud, no silent mis-decrypt) rather than mis-decrypting silently.
+    write_durable_config_fields(config_file, new_key_id, Some(old_key_id))?;
+
+    provider
+        .set_secret_mut(PREVIOUS_KEY_VAULT_NAME.to_owned(), old_key_b64, true)
+        .map_err(|e| anyhow::anyhow!("failed to stash previous key in vault: {e}"))?;
+    provider
+        .set_secret_mut(CURRENT_KEY_VAULT_NAME.to_owned(), new_key_b64, true)
+        .map_err(|e| anyhow::anyhow!("failed to set new {CURRENT_KEY_VAULT_NAME}: {e}"))?;
+    provider
+        .save()
+        .map_err(|e| anyhow::anyhow!("failed to save vault: {e}"))?;
+
+    println!(
+        "Rotated ZEPH_DURABLE_KEY: key_id {old_key_id} -> {new_key_id}.\n\
+         The previous key (id {old_key_id}) remains readable via the rotation window until you \
+         run `zeph durable rotate-key --drop-previous`.\n\
+         Config updated: {}\n\
+         Vault updated: {}\n\
+         A process restart is required to pick up the rotated key -- the cipher is built once \
+         at startup and does not hot-reload.",
+        config_file.display(),
+        vault_path.display(),
+    );
+    Ok(())
+}
+
+/// Close an open rotation window: verify no sealed payload still uses the previous key, then
+/// remove `ZEPH_DURABLE_KEY_PREVIOUS` from the vault and clear `previous_key_id`.
+///
+/// The blob-scan verification is default-on (R4): refuses the drop when
+/// [`LocalBackend::count_sealed_under_key_id`] finds any surviving row, since dropping the
+/// previous key then makes those blobs permanently unreadable. `--force` skips the scan for an
+/// operator who has independently confirmed pruning is complete; it applies **only** to this
+/// scan, never to the caller's partial-state detector or [`handle_open_window`]'s refusals. A
+/// call with no window open (`previous_key_id = None`, `ZEPH_DURABLE_KEY_PREVIOUS` absent — the
+/// caller's partial-state detector already guarantees these agree) is a clean informational
+/// no-op, not an error.
+async fn handle_drop_previous(
+    config_file: &Path,
+    config: &Config,
+    provider: &mut AgeVaultProvider,
+    dry_run: bool,
+    force: bool,
+) -> anyhow::Result<()> {
+    let Some(previous_key_id) = config.durable.previous_key_id else {
+        println!("No rotation window is open; nothing to drop.");
+        return Ok(());
+    };
+
+    if !force {
+        let url = resolve_durable_db_url(config);
+        if url != ":memory:" && Path::new(&url).exists() {
+            let backend = LocalBackend::open(&url, config.durable.max_payload_bytes)
+                .await
+                .map_err(|e| anyhow::anyhow!("failed to open durable journal: {e}"))?;
+            let matches = backend
+                .count_sealed_under_key_id(previous_key_id)
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!("failed to scan journal for key-id {previous_key_id}: {e}")
+                })?;
+            if matches > 0 {
+                anyhow::bail!(
+                    "refusing to drop: {matches} sealed payload(s) in {url} still tagged \
+                     key_id = {previous_key_id}. Dropping the previous key now would make them \
+                     permanently unreadable (UnknownKeyId). Wait for retention to prune them, or \
+                     pass --force to skip this scan if you have independently confirmed pruning \
+                     is complete (note: a deployment with plaintext-mode rows -- \
+                     encrypt_payload = false -- can occasionally over-count a coincidental \
+                     leading byte match; that is fail-safe, never a missed match)."
+                );
+            }
+        }
+    }
+
+    let vault_path = zeph_core::vault::default_vault_dir().join("secrets.age");
+    if dry_run {
+        println!(
+            "DRY RUN -- no changes written.\n\
+             Would remove {PREVIOUS_KEY_VAULT_NAME} from {} and clear previous_key_id \
+             (currently {previous_key_id}) from {}.",
+            vault_path.display(),
+            config_file.display(),
+        );
+        return Ok(());
+    }
+
+    write_durable_config_fields(config_file, config.durable.key_id, None)?;
+
+    provider.remove_secret_mut(PREVIOUS_KEY_VAULT_NAME);
+    provider
+        .save()
+        .map_err(|e| anyhow::anyhow!("failed to save vault: {e}"))?;
+
+    println!(
+        "Rotation window closed: removed {PREVIOUS_KEY_VAULT_NAME} and cleared previous_key_id \
+         (was {previous_key_id}). Payloads still sealed under key_id {previous_key_id} are now \
+         permanently unreadable.\n\
+         Config updated: {}\n\
+         Vault updated: {}",
+        config_file.display(),
+        vault_path.display(),
+    );
+    Ok(())
+}
+
+/// Surgically set `[durable] key_id` and `[durable] previous_key_id` in the on-disk config file
+/// at `config_file`, preserving all other content and formatting.
+///
+/// Uses `toml_edit::DocumentMut` rather than a full `Config` re-serialize (which would discard
+/// user comments/formatting) — the same rationale as the raw-text migration passes in
+/// `zeph-config`, just scoped to a single table here. Written atomically via
+/// [`crate::commands::migrate::atomic_write`].
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be read/parsed as TOML, `[durable]` exists but is not a
+/// table, or the atomic write fails.
+fn write_durable_config_fields(
+    config_file: &Path,
+    key_id: u8,
+    previous_key_id: Option<u8>,
+) -> anyhow::Result<()> {
+    let raw = if config_file.exists() {
+        std::fs::read_to_string(config_file)
+            .with_context(|| format!("failed to read {}", config_file.display()))?
+    } else {
+        String::new()
+    };
+    let mut doc = raw
+        .parse::<toml_edit::DocumentMut>()
+        .with_context(|| format!("failed to parse {}", config_file.display()))?;
+
+    let durable_item = doc
+        .entry("durable")
+        .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()));
+    let durable_table = durable_item
+        .as_table_mut()
+        .ok_or_else(|| anyhow::anyhow!("[durable] is not a table in {}", config_file.display()))?;
+
+    durable_table["key_id"] = toml_edit::value(i64::from(key_id));
+    match previous_key_id {
+        Some(id) => {
+            durable_table["previous_key_id"] = toml_edit::value(i64::from(id));
+        }
+        None => {
+            durable_table.remove("previous_key_id");
+        }
+    }
+
+    crate::commands::migrate::atomic_write(config_file, &doc.to_string())
+}
+
+/// Map an opaque "unknown cipher key-id" [`zeph_durable::DurableError`] from a `--reveal` read to
+/// an actionable message, instead of surfacing the raw decode-failure string.
+///
+/// A blob whose leading key-id byte the current in-memory cipher does not recognize almost
+/// always means the process was never restarted after a `zeph durable rotate-key` rotation (the
+/// cipher is built once at startup, R5 / #6447) — restarting picks up the rotated
+/// `ZEPH_DURABLE_KEY`/`ZEPH_DURABLE_KEY_PREVIOUS` pair. Every other error passes through
+/// unchanged.
+fn describe_reveal_error(e: &zeph_durable::DurableError) -> String {
+    if matches!(
+        e,
+        zeph_durable::DurableError::Decode {
+            context: "unknown cipher key-id"
+        }
+    ) {
+        format!(
+            "{e} -- this blob's key-id predates a key rotation the current cipher does not \
+             recognize. Restart the process to pick up the rotated ZEPH_DURABLE_KEY / \
+             ZEPH_DURABLE_KEY_PREVIOUS pair, or check `zeph durable rotate-key`'s rotation \
+             window is still open (`--drop-previous` closes it permanently)."
+        )
+    } else {
+        e.to_string()
+    }
 }
 
 /// Show one execution's entries, optionally filtered to a single `step`, redacted unless `reveal`.
@@ -452,10 +854,9 @@ async fn show_entries(
 ) -> anyhow::Result<()> {
     if reveal {
         println!("{REVEAL_WARNING}\n");
-        let mut entries = backend
-            .read_execution(exec)
-            .await
-            .map_err(|e| anyhow::anyhow!("failed to read execution: {e}"))?;
+        let mut entries = backend.read_execution(exec).await.map_err(|e| {
+            anyhow::anyhow!("failed to read execution: {}", describe_reveal_error(&e))
+        })?;
         if let Some(s) = step {
             entries.retain(|e| e.step_id.value() == s);
         }
@@ -1136,5 +1537,788 @@ mod tests {
             result.unwrap().is_some(),
             "a declared shared database with a real vault key must resolve an HMAC key"
         );
+    }
+
+    // ── `zeph durable rotate-key` (#6447) ──────────────────────────────────────────────────
+
+    /// RAII guard mirroring `VaultDirGuard` in `src/init/durable.rs` tests: points
+    /// `zeph_core::vault::default_vault_dir()` at a fresh temp dir for the test's duration via
+    /// `XDG_CONFIG_HOME`, restoring the prior value on drop. Callers must be `#[serial]` since
+    /// `XDG_CONFIG_HOME` is process-global.
+    #[allow(unsafe_code)]
+    struct VaultDirGuard {
+        _dir: tempfile::TempDir,
+        prev_xdg: Option<String>,
+    }
+
+    #[allow(unsafe_code)]
+    impl VaultDirGuard {
+        fn new() -> Self {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let prev_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+            unsafe {
+                std::env::set_var("XDG_CONFIG_HOME", dir.path());
+            }
+            Self {
+                _dir: dir,
+                prev_xdg,
+            }
+        }
+    }
+
+    #[allow(unsafe_code)]
+    impl Drop for VaultDirGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.prev_xdg {
+                    Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                    None => std::env::remove_var("XDG_CONFIG_HOME"),
+                }
+            }
+        }
+    }
+
+    /// Initialize the age vault (assumes [`VaultDirGuard`] is already in scope) and seed
+    /// `ZEPH_DURABLE_KEY`, returning the generated key.
+    fn seed_vault_with_durable_key() -> String {
+        let vault_root = zeph_core::vault::default_vault_dir();
+        zeph_core::vault::AgeVaultProvider::init_vault(&vault_root).unwrap();
+        let mut provider = zeph_core::vault::AgeVaultProvider::load(
+            &vault_root.join("vault-key.txt"),
+            &vault_root.join("secrets.age"),
+        )
+        .unwrap();
+        let key = zeph_core::durable::generate_durable_key_b64();
+        provider
+            .set_secret_mut(CURRENT_KEY_VAULT_NAME.to_owned(), key.clone(), false)
+            .unwrap();
+        provider.save().unwrap();
+        key
+    }
+
+    /// Happy path: `rotate-key` bumps `[durable] key_id`/`previous_key_id` in the config file and
+    /// stashes the old key under `ZEPH_DURABLE_KEY_PREVIOUS` in the vault, without ever printing
+    /// raw key bytes (not directly assertable here, but the handler only ever interpolates
+    /// key-ids and paths into its output strings — see `handle_open_window`).
+    #[tokio::test]
+    #[serial]
+    async fn rotate_key_opens_a_window_and_updates_config_and_vault() {
+        let _guard = VaultDirGuard::new();
+        seed_vault_with_durable_key();
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = write_config_toml(dir.path());
+
+        let result = handle_durable_command(
+            DurableCommand::RotateKey {
+                dry_run: false,
+                drop_previous: false,
+                force: false,
+                ack_shared_db_drain: false,
+            },
+            Some(&config_path),
+        )
+        .await;
+        assert!(result.is_ok(), "rotate-key must succeed: {result:?}");
+
+        let config = load_config_or_default(&config_path);
+        assert_eq!(config.durable.key_id, 1);
+        assert_eq!(config.durable.previous_key_id, Some(0));
+
+        let vault_root = zeph_core::vault::default_vault_dir();
+        let provider = zeph_core::vault::AgeVaultProvider::load(
+            &vault_root.join("vault-key.txt"),
+            &vault_root.join("secrets.age"),
+        )
+        .unwrap();
+        assert!(
+            provider.get(PREVIOUS_KEY_VAULT_NAME).is_some(),
+            "the old key must be stashed under ZEPH_DURABLE_KEY_PREVIOUS"
+        );
+    }
+
+    /// R2: a second rotation while a window is already open must be refused, and must not touch
+    /// config or vault (the first previous key stays intact).
+    #[tokio::test]
+    #[serial]
+    async fn rotate_key_refuses_a_second_window() {
+        let _guard = VaultDirGuard::new();
+        seed_vault_with_durable_key();
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = write_config_toml(dir.path());
+
+        handle_durable_command(
+            DurableCommand::RotateKey {
+                dry_run: false,
+                drop_previous: false,
+                force: false,
+                ack_shared_db_drain: false,
+            },
+            Some(&config_path),
+        )
+        .await
+        .unwrap();
+        let after_first = load_config_or_default(&config_path);
+        assert_eq!(after_first.durable.previous_key_id, Some(0));
+
+        let result = handle_durable_command(
+            DurableCommand::RotateKey {
+                dry_run: false,
+                drop_previous: false,
+                force: false,
+                ack_shared_db_drain: false,
+            },
+            Some(&config_path),
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "a second rotation while a window is open must be refused"
+        );
+
+        let after_second = load_config_or_default(&config_path);
+        assert_eq!(
+            after_second.durable, after_first.durable,
+            "the refused second rotation must not mutate config"
+        );
+    }
+
+    /// `--dry-run` must never write to the config file or the vault.
+    #[tokio::test]
+    #[serial]
+    async fn rotate_key_dry_run_writes_nothing() {
+        let _guard = VaultDirGuard::new();
+        seed_vault_with_durable_key();
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = write_config_toml(dir.path());
+        let before = std::fs::read_to_string(&config_path).unwrap();
+
+        let result = handle_durable_command(
+            DurableCommand::RotateKey {
+                dry_run: true,
+                drop_previous: false,
+                force: false,
+                ack_shared_db_drain: false,
+            },
+            Some(&config_path),
+        )
+        .await;
+        assert!(result.is_ok());
+
+        let after = std::fs::read_to_string(&config_path).unwrap();
+        assert_eq!(before, after, "--dry-run must not modify the config file");
+
+        let vault_root = zeph_core::vault::default_vault_dir();
+        let provider = zeph_core::vault::AgeVaultProvider::load(
+            &vault_root.join("vault-key.txt"),
+            &vault_root.join("secrets.age"),
+        )
+        .unwrap();
+        assert!(provider.get(PREVIOUS_KEY_VAULT_NAME).is_none());
+    }
+
+    /// A `--drop-previous` call with no rotation window open is a clean informational no-op.
+    #[tokio::test]
+    #[serial]
+    async fn rotate_key_drop_previous_is_noop_when_no_window_open() {
+        let _guard = VaultDirGuard::new();
+        seed_vault_with_durable_key();
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = write_config_toml(dir.path());
+        let before = std::fs::read_to_string(&config_path).unwrap();
+
+        let result = handle_durable_command(
+            DurableCommand::RotateKey {
+                dry_run: false,
+                drop_previous: true,
+                force: false,
+                ack_shared_db_drain: false,
+            },
+            Some(&config_path),
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "no-window drop-previous must succeed: {result:?}"
+        );
+
+        let after = std::fs::read_to_string(&config_path).unwrap();
+        assert_eq!(
+            before, after,
+            "a no-op drop-previous must not modify the config file"
+        );
+    }
+
+    /// R4: `--drop-previous` refuses when a sealed payload still carries the previous key-id, and
+    /// `--force` skips the scan and lets the drop proceed.
+    #[tokio::test]
+    #[serial]
+    async fn rotate_key_drop_previous_refuses_with_surviving_blob_unless_forced() {
+        use zeph_durable::{
+            EffectClass, EntryKind, ExecutionKind, IdempotencyKey, JournalEntry, LocalBackend,
+            StepId,
+        };
+
+        let _guard = VaultDirGuard::new();
+        seed_vault_with_durable_key();
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = write_config_toml(dir.path());
+
+        handle_durable_command(
+            DurableCommand::RotateKey {
+                dry_run: false,
+                drop_previous: false,
+                force: false,
+                ack_shared_db_drain: false,
+            },
+            Some(&config_path),
+        )
+        .await
+        .unwrap();
+
+        // Seal a payload directly under key-id 0 (the now-previous key) by writing through a
+        // no-cipher backend with a byte-0-prefixed plaintext payload — this exercises the scan
+        // predicate itself without depending on the real AEAD cipher's on-disk framing.
+        let config = load_config_or_default(&config_path);
+        let url = resolve_durable_db_url(&config);
+        let backend = LocalBackend::open(&url, config.durable.max_payload_bytes)
+            .await
+            .unwrap();
+        backend.init().await.unwrap();
+        let exec = ExecutionId::new();
+        backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        let step_id = StepId::new(0);
+        backend
+            .append(JournalEntry {
+                seq: None,
+                execution_id: exec,
+                kind: ExecutionKind::AgentTurn,
+                step_id,
+                entry: EntryKind::StepResult {
+                    idempotency_key: IdempotencyKey::derive(exec, step_id, b"tool:test"),
+                    payload: bytes::Bytes::copy_from_slice(&[0u8, 1, 2, 3]),
+                    effect: EffectClass::Idempotent,
+                    payload_version: 1,
+                },
+                created_at_ms: 0,
+            })
+            .await
+            .unwrap();
+
+        let refused = handle_durable_command(
+            DurableCommand::RotateKey {
+                dry_run: false,
+                drop_previous: true,
+                force: false,
+                ack_shared_db_drain: false,
+            },
+            Some(&config_path),
+        )
+        .await;
+        assert!(
+            refused.is_err(),
+            "drop-previous must refuse while a matching sealed payload remains"
+        );
+        assert_eq!(
+            load_config_or_default(&config_path).durable.previous_key_id,
+            Some(0),
+            "the refused drop must not clear previous_key_id"
+        );
+
+        let forced = handle_durable_command(
+            DurableCommand::RotateKey {
+                dry_run: false,
+                drop_previous: true,
+                force: true,
+                ack_shared_db_drain: false,
+            },
+            Some(&config_path),
+        )
+        .await;
+        assert!(forced.is_ok(), "--force must skip the scan: {forced:?}");
+        assert_eq!(
+            load_config_or_default(&config_path).durable.previous_key_id,
+            None,
+            "--force must still clear previous_key_id once it proceeds"
+        );
+    }
+
+    /// R1: a config that declares `previous_key_id` while the vault has no
+    /// `ZEPH_DURABLE_KEY_PREVIOUS` (the config-first crash window) must refuse rather than derive
+    /// the old key from whatever `ZEPH_DURABLE_KEY` currently holds.
+    #[tokio::test]
+    #[serial]
+    async fn rotate_key_refuses_on_partial_state() {
+        let _guard = VaultDirGuard::new();
+        seed_vault_with_durable_key();
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = write_config_toml(dir.path());
+
+        // Simulate a crash between the config write and the vault write: bump key_id/
+        // previous_key_id directly without touching the vault.
+        write_durable_config_fields(&config_path, 1, Some(0)).unwrap();
+
+        let result = handle_durable_command(
+            DurableCommand::RotateKey {
+                dry_run: false,
+                drop_previous: false,
+                force: false,
+                ack_shared_db_drain: false,
+            },
+            Some(&config_path),
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "an inconsistent (config declares window, vault has no previous secret) state must \
+             refuse rather than guess"
+        );
+    }
+
+    /// R3: rotating a declared shared database is refused without `--ack-shared-db-drain`, and
+    /// proceeds once it is passed.
+    #[tokio::test]
+    #[serial]
+    async fn rotate_key_refuses_on_shared_db_without_ack() {
+        let _guard = VaultDirGuard::new();
+        seed_vault_with_durable_key();
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.memory.sqlite_path = dir.path().join("zeph.db").to_string_lossy().into_owned();
+        config.durable.shared_db = true;
+        let toml = toml::to_string_pretty(&config).unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, toml).unwrap();
+        std::fs::write(resolve_durable_db_url(&config), []).unwrap();
+
+        let refused = handle_durable_command(
+            DurableCommand::RotateKey {
+                dry_run: false,
+                drop_previous: false,
+                force: false,
+                ack_shared_db_drain: false,
+            },
+            Some(&config_path),
+        )
+        .await;
+        assert!(
+            refused.is_err(),
+            "a shared database must refuse rotation without --ack-shared-db-drain"
+        );
+        assert_eq!(load_config_or_default(&config_path).durable.key_id, 0);
+
+        let acked = handle_durable_command(
+            DurableCommand::RotateKey {
+                dry_run: false,
+                drop_previous: false,
+                force: false,
+                ack_shared_db_drain: true,
+            },
+            Some(&config_path),
+        )
+        .await;
+        assert!(
+            acked.is_ok(),
+            "--ack-shared-db-drain must allow rotation to proceed: {acked:?}"
+        );
+        assert_eq!(load_config_or_default(&config_path).durable.key_id, 1);
+    }
+
+    // ── Gap-closing tests (team-lead review round, #6447) ──────────────────────────────────
+
+    /// Mandatory gap (impl-critic + tester, independently confirmed): `load_durable_cipher`'s
+    /// fail-closed branch is reachable on every ordinary `zeph run`/`resume` via `load_write_cipher`
+    /// (called from `runner.rs`/`scheduler_daemon.rs` on every turn), completely independent of
+    /// whether `rotate-key`'s own CLI-level partial-state guard ever ran — e.g. a hand-edited config,
+    /// or the exact post-config-first-crash state reached outside the CLI. Must hard-error, never
+    /// silently skip the previous-key slot.
+    #[tokio::test]
+    #[serial]
+    async fn load_write_cipher_fails_closed_when_previous_key_id_set_but_vault_secret_missing() {
+        let _guard = VaultDirGuard::new();
+        seed_vault_with_durable_key();
+
+        let mut config = Config::default();
+        config.durable.previous_key_id = Some(0);
+        // key_id stays default 0; ZEPH_DURABLE_KEY_PREVIOUS was never written to the vault.
+
+        let result = load_write_cipher(&config);
+        assert!(
+            result.is_err(),
+            "previous_key_id set but ZEPH_DURABLE_KEY_PREVIOUS missing must hard-error, not \
+             silently build a cipher with no previous slot"
+        );
+    }
+
+    /// Companion to the above: a genuinely consistent (config ∧ vault) previous-key pair must
+    /// build successfully, so the fail-closed branch above is proven to trigger on the
+    /// inconsistency specifically, not on `previous_key_id` being set at all.
+    #[tokio::test]
+    #[serial]
+    async fn load_write_cipher_succeeds_when_previous_key_id_and_vault_secret_are_consistent() {
+        let _guard = VaultDirGuard::new();
+        seed_vault_with_durable_key();
+
+        let vault_root = zeph_core::vault::default_vault_dir();
+        let mut provider = zeph_core::vault::AgeVaultProvider::load(
+            &vault_root.join("vault-key.txt"),
+            &vault_root.join("secrets.age"),
+        )
+        .unwrap();
+        provider
+            .set_secret_mut(
+                PREVIOUS_KEY_VAULT_NAME.to_owned(),
+                zeph_core::durable::generate_durable_key_b64(),
+                false,
+            )
+            .unwrap();
+        provider.save().unwrap();
+
+        let mut config = Config::default();
+        config.durable.key_id = 1;
+        config.durable.previous_key_id = Some(0);
+
+        let result = load_write_cipher(&config);
+        assert!(
+            result.is_ok(),
+            "a consistent (config ∧ vault) previous-key pair must build a cipher: {}",
+            result.err().map(|e| e.to_string()).unwrap_or_default()
+        );
+    }
+
+    /// Companion: `previous_key_id = None` (the default, no rotation window declared) must skip
+    /// the previous-slot lookup cleanly and never touch `ZEPH_DURABLE_KEY_PREVIOUS`.
+    #[tokio::test]
+    #[serial]
+    async fn load_write_cipher_skips_previous_slot_cleanly_when_previous_key_id_is_none() {
+        let _guard = VaultDirGuard::new();
+        seed_vault_with_durable_key();
+
+        let config = Config::default();
+        assert_eq!(config.durable.previous_key_id, None);
+
+        let result = load_write_cipher(&config);
+        assert!(
+            result.is_ok(),
+            "no declared rotation window must build a cipher with no previous slot: {}",
+            result.err().map(|e| e.to_string()).unwrap_or_default()
+        );
+    }
+
+    /// Mandatory gap: end-to-end path for R5's `describe_reveal_error` mapping — seal a payload
+    /// under key-id 0 with the real write-path cipher, open then force-drop a rotation window (so
+    /// the previous slot is genuinely gone, mirroring an operator who force-dropped after
+    /// confirming pruning by other means), and confirm the `--reveal` read path surfaces the
+    /// actionable "predates a key rotation" message instead of the raw `UnknownKeyId`/decode error.
+    #[tokio::test]
+    #[serial]
+    async fn reveal_after_drop_previous_surfaces_actionable_rotation_message() {
+        use zeph_durable::{
+            EffectClass, EntryKind, ExecutionKind, IdempotencyKey, JournalEntry, StepId,
+        };
+
+        let _guard = VaultDirGuard::new();
+        seed_vault_with_durable_key();
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.memory.sqlite_path = dir.path().join("zeph.db").to_string_lossy().into_owned();
+        let toml = toml::to_string_pretty(&config).unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, toml).unwrap();
+
+        // Seal a real payload under key-id 0 with the actual write-path cipher.
+        let cipher = load_write_cipher(&config).unwrap().unwrap();
+        let url = resolve_durable_db_url(&config);
+        let exec = ExecutionId::new();
+        {
+            let backend = LocalBackend::open(&url, config.durable.max_payload_bytes)
+                .await
+                .unwrap()
+                .with_cipher(cipher);
+            backend.init().await.unwrap();
+            backend
+                .open_execution(exec, ExecutionKind::AgentTurn)
+                .await
+                .unwrap();
+            let step_id = StepId::new(0);
+            backend
+                .append(JournalEntry {
+                    seq: None,
+                    execution_id: exec,
+                    kind: ExecutionKind::AgentTurn,
+                    step_id,
+                    entry: EntryKind::StepResult {
+                        idempotency_key: IdempotencyKey::derive(exec, step_id, b"tool:test"),
+                        payload: bytes::Bytes::copy_from_slice(b"secret result"),
+                        effect: EffectClass::Idempotent,
+                        payload_version: 1,
+                    },
+                    created_at_ms: 0,
+                })
+                .await
+                .unwrap();
+        }
+
+        // Open, then force-drop the rotation window; the sealed blob is never pruned in this test.
+        handle_durable_command(
+            DurableCommand::RotateKey {
+                dry_run: false,
+                drop_previous: false,
+                force: false,
+                ack_shared_db_drain: false,
+            },
+            Some(&config_path),
+        )
+        .await
+        .unwrap();
+        handle_durable_command(
+            DurableCommand::RotateKey {
+                dry_run: false,
+                drop_previous: true,
+                force: true,
+                ack_shared_db_drain: false,
+            },
+            Some(&config_path),
+        )
+        .await
+        .unwrap();
+
+        let final_config = load_config_or_default(&config_path);
+        assert_eq!(final_config.durable.previous_key_id, None);
+        let backend = open_backend(&final_config, true).await.unwrap().unwrap();
+        let result = show_entries(&backend, exec, true, None, false).await;
+
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("predates a key rotation"),
+            "expected the actionable rotation-restart message, got: {err}"
+        );
+    }
+
+    /// Nice-to-have gap: `--drop-previous --dry-run` with a window open and a surviving sealed
+    /// payload must still refuse (the blob-scan runs even under `--dry-run`, per the documented
+    /// design decision that a dry-run should accurately report whether the drop would be
+    /// refused) and must not mutate config or vault.
+    #[tokio::test]
+    #[serial]
+    async fn rotate_key_drop_previous_dry_run_still_refuses_with_surviving_blob() {
+        use zeph_durable::{
+            EffectClass, EntryKind, ExecutionKind, IdempotencyKey, JournalEntry, StepId,
+        };
+
+        let _guard = VaultDirGuard::new();
+        seed_vault_with_durable_key();
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = write_config_toml(dir.path());
+
+        handle_durable_command(
+            DurableCommand::RotateKey {
+                dry_run: false,
+                drop_previous: false,
+                force: false,
+                ack_shared_db_drain: false,
+            },
+            Some(&config_path),
+        )
+        .await
+        .unwrap();
+
+        let config = load_config_or_default(&config_path);
+        let url = resolve_durable_db_url(&config);
+        let backend = LocalBackend::open(&url, config.durable.max_payload_bytes)
+            .await
+            .unwrap();
+        backend.init().await.unwrap();
+        let exec = ExecutionId::new();
+        backend
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        let step_id = StepId::new(0);
+        backend
+            .append(JournalEntry {
+                seq: None,
+                execution_id: exec,
+                kind: ExecutionKind::AgentTurn,
+                step_id,
+                entry: EntryKind::StepResult {
+                    idempotency_key: IdempotencyKey::derive(exec, step_id, b"tool:test"),
+                    payload: bytes::Bytes::copy_from_slice(&[0u8, 9, 9, 9]),
+                    effect: EffectClass::Idempotent,
+                    payload_version: 1,
+                },
+                created_at_ms: 0,
+            })
+            .await
+            .unwrap();
+
+        let before_vault = {
+            let vault_root = zeph_core::vault::default_vault_dir();
+            let provider = zeph_core::vault::AgeVaultProvider::load(
+                &vault_root.join("vault-key.txt"),
+                &vault_root.join("secrets.age"),
+            )
+            .unwrap();
+            provider.get(PREVIOUS_KEY_VAULT_NAME).map(str::to_owned)
+        };
+
+        let result = handle_durable_command(
+            DurableCommand::RotateKey {
+                dry_run: true,
+                drop_previous: true,
+                force: false,
+                ack_shared_db_drain: false,
+            },
+            Some(&config_path),
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "--drop-previous --dry-run must still refuse when a matching sealed payload remains"
+        );
+        assert_eq!(
+            load_config_or_default(&config_path).durable.previous_key_id,
+            Some(0),
+            "the refused dry-run drop must not clear previous_key_id"
+        );
+
+        let after_vault = {
+            let vault_root = zeph_core::vault::default_vault_dir();
+            let provider = zeph_core::vault::AgeVaultProvider::load(
+                &vault_root.join("vault-key.txt"),
+                &vault_root.join("secrets.age"),
+            )
+            .unwrap();
+            provider.get(PREVIOUS_KEY_VAULT_NAME).map(str::to_owned)
+        };
+        assert_eq!(
+            before_vault, after_vault,
+            "the refused dry-run drop must not mutate the vault"
+        );
+    }
+
+    /// Recommended gap: end-to-end round trip through the real CLI + backend — seal a payload
+    /// under key-id 0 with the real cipher, rotate via the CLI, confirm the pre-rotation entry
+    /// still decrypts through the registered previous slot, and confirm a fresh write after
+    /// rotation carries the new key-id on disk. This is the architect's original primary
+    /// acceptance scenario for the feature.
+    #[tokio::test]
+    #[serial]
+    async fn rotate_key_round_trip_old_blob_still_decrypts_and_new_writes_use_new_key_id() {
+        use zeph_durable::{
+            EffectClass, EntryKind, ExecutionKind, IdempotencyKey, JournalEntry, StepId,
+        };
+
+        let _guard = VaultDirGuard::new();
+        seed_vault_with_durable_key();
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.memory.sqlite_path = dir.path().join("zeph.db").to_string_lossy().into_owned();
+        let toml = toml::to_string_pretty(&config).unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, toml).unwrap();
+
+        let old_cipher = load_write_cipher(&config).unwrap().unwrap();
+        let url = resolve_durable_db_url(&config);
+        let exec = ExecutionId::new();
+        {
+            let backend = LocalBackend::open(&url, config.durable.max_payload_bytes)
+                .await
+                .unwrap()
+                .with_cipher(old_cipher);
+            backend.init().await.unwrap();
+            backend
+                .open_execution(exec, ExecutionKind::AgentTurn)
+                .await
+                .unwrap();
+            let step_id = StepId::new(0);
+            backend
+                .append(JournalEntry {
+                    seq: None,
+                    execution_id: exec,
+                    kind: ExecutionKind::AgentTurn,
+                    step_id,
+                    entry: EntryKind::StepResult {
+                        idempotency_key: IdempotencyKey::derive(exec, step_id, b"tool:old"),
+                        payload: bytes::Bytes::copy_from_slice(b"pre-rotation result"),
+                        effect: EffectClass::Idempotent,
+                        payload_version: 1,
+                    },
+                    created_at_ms: 0,
+                })
+                .await
+                .unwrap();
+        }
+
+        handle_durable_command(
+            DurableCommand::RotateKey {
+                dry_run: false,
+                drop_previous: false,
+                force: false,
+                ack_shared_db_drain: false,
+            },
+            Some(&config_path),
+        )
+        .await
+        .unwrap();
+
+        let rotated_config = load_config_or_default(&config_path);
+        assert_eq!(rotated_config.durable.key_id, 1);
+        assert_eq!(rotated_config.durable.previous_key_id, Some(0));
+
+        let new_cipher = load_write_cipher(&rotated_config).unwrap().unwrap();
+        let backend = LocalBackend::open(&url, rotated_config.durable.max_payload_bytes)
+            .await
+            .unwrap()
+            .with_cipher(new_cipher);
+
+        // A fresh write after rotation must carry the new key-id on disk.
+        let new_step_id = StepId::new(1);
+        backend
+            .append(JournalEntry {
+                seq: None,
+                execution_id: exec,
+                kind: ExecutionKind::AgentTurn,
+                step_id: new_step_id,
+                entry: EntryKind::StepResult {
+                    idempotency_key: IdempotencyKey::derive(exec, new_step_id, b"tool:new"),
+                    payload: bytes::Bytes::copy_from_slice(b"post-rotation result"),
+                    effect: EffectClass::Idempotent,
+                    payload_version: 1,
+                },
+                created_at_ms: 1,
+            })
+            .await
+            .unwrap();
+        let (new_payload,): (Option<Vec<u8>>,) = zeph_db::query_as(zeph_db::sql!(
+            "SELECT payload FROM durable_journal WHERE execution_id = ? AND step_id = ?"
+        ))
+        .bind(exec.as_uuid().to_string())
+        .bind(1i64)
+        .fetch_one(backend.pool())
+        .await
+        .unwrap();
+        assert_eq!(
+            new_payload.unwrap()[0],
+            1,
+            "seals written after rotation must carry the rotated key-id"
+        );
+
+        // The pre-rotation entry must still decrypt via the registered previous slot.
+        let entries = backend.read_execution(exec).await.unwrap();
+        let old_entry = entries
+            .iter()
+            .find(|e| e.step_id.value() == 0)
+            .expect("pre-rotation entry must still be present");
+        match &old_entry.entry {
+            EntryKind::StepResult { payload, .. } => {
+                assert_eq!(payload.as_ref(), b"pre-rotation result");
+            }
+            other => panic!("unexpected entry kind: {other:?}"),
+        }
     }
 }

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -159,7 +159,10 @@ fn print_diff(old: &str, new: &str) {
 
 /// Write `content` to `path` atomically using a temporary file in the same directory,
 /// preserving the original file's permissions before renaming into place.
-fn atomic_write(path: &Path, content: &str) -> anyhow::Result<()> {
+///
+/// Shared with `zeph durable rotate-key`, which performs a surgical `toml_edit` field mutation
+/// rather than a full-document rewrite but needs the same atomic-write safety.
+pub(crate) fn atomic_write(path: &Path, content: &str) -> anyhow::Result<()> {
     use std::io::Write;
 
     let original_perms = if path.exists() {

--- a/src/init/durable.rs
+++ b/src/init/durable.rs
@@ -7,9 +7,12 @@
 //! generates a fresh AEAD `ZEPH_DURABLE_KEY`. The key is stored in the age vault during the review
 //! step ([`store_durable_key`]), never written inline in the config TOML (vault contract spec-038).
 //!
-//! A pre-existing `ZEPH_DURABLE_KEY` is reused by default: rotating it renders every payload
-//! already sealed in `durable_journal` unrecoverable, since the AEAD key is required to
-//! authenticate them on replay. Rotation requires typing an explicit confirmation phrase (#5874).
+//! A pre-existing `ZEPH_DURABLE_KEY` is reused by default: replacing it here is a **destructive
+//! reset** — it renders every payload already sealed in `durable_journal` unrecoverable, since
+//! the AEAD key is required to authenticate them on replay, and opens no rotation window.
+//! Confirming requires typing an explicit phrase (#5874). For a safe rotation that keeps
+//! previously-sealed payloads readable during a drain window, use `zeph durable rotate-key`
+//! (#6447) instead of this wizard step.
 
 use dialoguer::{Confirm, Input, Select};
 use zeph_core::config::DurableBackend;
@@ -95,13 +98,16 @@ pub(super) fn step_durable(state: &mut WizardState) -> anyhow::Result<()> {
     {
         println!(
             "A ZEPH_DURABLE_KEY already exists in the age vault. Reusing it by default — \
-             rotating it will PERMANENTLY and IRRECOVERABLY orphan every durable payload already \
-             sealed under the old key."
+             replacing it here is a DESTRUCTIVE RESET (discards existing sealed payloads, no \
+             rotation window): it PERMANENTLY and IRRECOVERABLY orphans every durable payload \
+             already sealed under the old key. For a safe rotation that keeps old payloads \
+             readable during a drain window, run `zeph durable rotate-key` instead of this \
+             wizard step."
         );
         let confirmation: String = Input::new()
             .with_prompt(format!(
-                "Type \"{ROTATE_CONFIRMATION_PHRASE}\" to rotate the key and discard all \
-                 existing sealed payloads, or leave blank to keep the existing key"
+                "Type \"{ROTATE_CONFIRMATION_PHRASE}\" to perform the destructive reset and \
+                 discard all existing sealed payloads, or leave blank to keep the existing key"
             ))
             .allow_empty(true)
             .interact_text()?;
@@ -109,7 +115,10 @@ pub(super) fn step_durable(state: &mut WizardState) -> anyhow::Result<()> {
             println!("Keeping the existing ZEPH_DURABLE_KEY.\n");
             return Ok(());
         }
-        println!("Rotating ZEPH_DURABLE_KEY — previously sealed durable payloads will be lost.");
+        println!(
+            "Performing destructive reset of ZEPH_DURABLE_KEY — previously sealed durable \
+             payloads will be lost."
+        );
     }
 
     state.durable_key_b64 = Some(zeph_core::durable::generate_durable_key_b64());

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::channel::create_channel;
-use crate::cli::{Cli, Command, VaultCommand};
+use crate::cli::{Cli, Command, DurableCommand, VaultCommand};
 use clap::Parser;
 use std::path::{Path, PathBuf};
 use zeph_channels::{AnyChannel, CliChannel};
@@ -752,5 +752,90 @@ fn cli_parse_vault_rm() {
             command: VaultCommand::Rm { key },
         }) => assert_eq!(key, "MY_KEY"),
         _ => panic!("expected VaultCommand::Rm"),
+    }
+}
+
+// DurableCommand::RotateKey CLI parsing (#6447)
+#[test]
+fn cli_parse_durable_rotate_key_defaults() {
+    let cli = Cli::try_parse_from(["zeph", "durable", "rotate-key"]).unwrap();
+    match cli.command {
+        Some(Command::Durable {
+            command:
+                DurableCommand::RotateKey {
+                    dry_run,
+                    drop_previous,
+                    force,
+                    ack_shared_db_drain,
+                },
+        }) => {
+            assert!(!dry_run, "dry_run must default to false");
+            assert!(!drop_previous, "drop_previous must default to false");
+            assert!(!force, "force must default to false");
+            assert!(
+                !ack_shared_db_drain,
+                "ack_shared_db_drain must default to false"
+            );
+        }
+        _ => panic!("expected DurableCommand::RotateKey"),
+    }
+}
+
+#[test]
+fn cli_parse_durable_rotate_key_dry_run() {
+    let cli = Cli::try_parse_from(["zeph", "durable", "rotate-key", "--dry-run"]).unwrap();
+    match cli.command {
+        Some(Command::Durable {
+            command: DurableCommand::RotateKey { dry_run, .. },
+        }) => assert!(dry_run, "--dry-run must set dry_run = true"),
+        _ => panic!("expected DurableCommand::RotateKey"),
+    }
+}
+
+#[test]
+fn cli_parse_durable_rotate_key_drop_previous_with_force() {
+    let cli = Cli::try_parse_from([
+        "zeph",
+        "durable",
+        "rotate-key",
+        "--drop-previous",
+        "--force",
+    ])
+    .unwrap();
+    match cli.command {
+        Some(Command::Durable {
+            command:
+                DurableCommand::RotateKey {
+                    drop_previous,
+                    force,
+                    ..
+                },
+        }) => {
+            assert!(
+                drop_previous,
+                "--drop-previous must set drop_previous = true"
+            );
+            assert!(force, "--force must set force = true");
+        }
+        _ => panic!("expected DurableCommand::RotateKey"),
+    }
+}
+
+#[test]
+fn cli_parse_durable_rotate_key_ack_shared_db_drain() {
+    let cli =
+        Cli::try_parse_from(["zeph", "durable", "rotate-key", "--ack-shared-db-drain"]).unwrap();
+    match cli.command {
+        Some(Command::Durable {
+            command:
+                DurableCommand::RotateKey {
+                    ack_shared_db_drain,
+                    ..
+                },
+        }) => assert!(
+            ack_shared_db_drain,
+            "--ack-shared-db-drain must set ack_shared_db_drain = true"
+        ),
+        _ => panic!("expected DurableCommand::RotateKey"),
     }
 }


### PR DESCRIPTION
## Summary

- Issue #6447 originally described operational tooling for a high-water-mark key-rotation primitive credited to #6360. That primitive does not exist in the codebase (`with_hwm_key`/`with_previous_hwm_key`/`HWM_KEY_EPOCH`/`DurableError::HighWaterMarkIntegrity` — zero matches) and #6360 is an unimplemented, open `research(security)` issue with no closing PRs. This PR rescopes #6447 to the real analogous gap it also described: `XChaCha20Poly1305Cipher::with_previous` existed but was never operationally wired.
- Adds `zeph durable rotate-key` to open/close a rotation window for the durable execution layer's AEAD payload key (`ZEPH_DURABLE_KEY`). `[durable]` gains config-driven `key_id`/`previous_key_id` (no more recompile to rotate). `load_durable_cipher` — the single chokepoint shared by the agent write path, scheduler-daemon write path, and CLI/`--reveal` read path — now builds the cipher from both fields and hard-errors if `previous_key_id` is set but the vault secret is missing.
- Design went through 2 adversarial critique rounds before implementation: caught that vault-first write ordering (originally proposed) silently mis-decrypts every pre-rotation payload on a crash, and that a second rotation while a window is open would silently orphan the first previous key's blobs. Shipped design: config-first-then-vault write order + partial-state detector, refuse-a-second-window guard, shared-DB acknowledgment gate (`--ack-shared-db-drain`), and a default-on blob-scan before `--drop-previous` discards the previous key (`--force` to skip, scoped only to that path).
- A post-implementation critique and independent tester pass both independently found the same coverage gap (the fail-closed branch was untested at the layer every normal `zeph run`/`resume` actually calls through, not just the CLI's own guard) — closed with a follow-up round of tests before review.
- `zeph --init`'s existing key-replacement wizard step is unchanged in behavior but now labels itself a destructive reset with no rotation window, pointing operators to `rotate-key` for the safe alternative.
- HMAC rotation windows on shared databases and a TUI passive rotation indicator are explicitly out of scope, filed as follow-ups: #6450, #6451.

Closes #6447

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (14418 passed, 35 skipped)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `gitleaks protect --staged --no-banner --redact`
- [x] 15 new tests in `src/commands/durable.rs` (guard sequence, fail-closed branch at the bootstrap layer, round-trip through the real CLI+backend, R5 error-mapping end-to-end) + unit/doc-test coverage across `zeph-config`, `zeph-core`, `zeph-durable`
- [x] Independent security audit (0 critical/high/medium) and performance review (clean, non-hot-path) — see PR discussion for handoff references
- [x] `.local/testing/playbooks/durable-key-rotation.md` and `.local/testing/coverage-status.md` updated
- [ ] Live CLI smoke test against a real vault+config (recommended as the next CI cycle's live-session scenario — see playbook Scenario 4)