### PR TITLE
fix(tools): web_search follow-ups from PR #6444 review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,6 +252,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   auto-recovery or auto-unlink was introduced, since breaking a live `flock` without the
   holder's cooperation is unsafe.
 
+- `zeph-tools`: follow-ups from PR #6444's `web_search` tool review (#6445). `WebSearchExecutor`
+  now caches its SSRF-addr-pinned `reqwest::Client`, keyed by the resolved address set, and
+  reuses it across calls when DNS resolution is unchanged — the common case for the fixed Brave
+  endpoint — instead of paying a fresh TCP+TLS handshake on every search. It still rebuilds (and
+  re-pins) the client whenever the resolved addresses differ, so INVARIANT-2 (SSRF addr-pinning,
+  spec 006-1-web-search §4) continues to hold for the exact addresses each call's
+  `resolve_and_validate` just checked. Separately, Brave 429 responses now thread the real HTTP
+  status code into the egress-event telemetry (`SearchError::Blocked` gained a
+  `status: Option<u16>` field) instead of always recording `status: None`. `src/serve/deps.rs`'s
+  `web_search` wiring now uses the shared `with_search_executor()` helper instead of inlining
+  `OptionalExecutor(...)` directly, matching the other 3 production wiring sites (cosmetic, no
+  behavior change).
+
 ### Added
 
 - **Plugin install-time reputation/typosquat scanning** (spec-043, #5864): `zeph plugin add`,
@@ -952,6 +965,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   confirmed excluded, giving a real recovered-vs-failed contrast (SC-9). No production code
   changed; both mechanisms already behaved correctly, this closes the direct-assertion gap
   only.
+
+- `zeph-tools`: closed three test gaps flagged during PR #6444's `web_search` review (#6445).
+  `OptionalExecutor::execute_tool_call` — the actual dispatch path routing `web_search` through
+  the composite executor chain — now has direct tests for both the `Some` and `None` variants,
+  mirroring the sibling `execute()` coverage. `crates/zeph-core/src/config.rs`: added tests for
+  the `tools.search` vault-key opt-in gate (mirroring the `skills.registry.auth_vault_key`
+  pattern) covering both "enabled + key present resolves it" and "disabled leaves the secret
+  unset even when the vault holds it under the default key name". `migrate_search_config` now
+  has dedicated tests asserting the inserted commented-out `[tools.search]` block's content, the
+  no-op branch when a real or already-commented section is present, and idempotency — previously
+  only exercised indirectly via the migration-step-order/count assertion.
 
 ### Docs
 

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -4999,3 +4999,59 @@ fn step_89_is_idempotent() {
         "output unchanged on second run"
     );
 }
+
+// ── migrate_search_config tests (spec 006-1-web-search, #6444, #6445) ────
+
+#[test]
+fn migrate_search_config_injects_commented_block_content() {
+    let src = "[agent]\nmax_turns = 10\n";
+    let result = migrate_search_config(src).expect("migrate");
+    assert_eq!(result.changed_count, 1);
+    assert_eq!(result.sections_changed, vec!["tools.search".to_owned()]);
+    assert!(result.output.starts_with(src), "original content preserved");
+    assert!(result.output.contains("# [tools.search]"));
+    assert!(result.output.contains("# enabled = false"));
+    assert!(result.output.contains("# backend = \"brave\""));
+    assert!(
+        result
+            .output
+            .contains("# api_key_vault_key = \"ZEPH_WEB_SEARCH_API_KEY\"")
+    );
+    assert!(
+        result
+            .output
+            .contains("# endpoint = \"https://api.search.brave.com/res/v1/web/search\"")
+    );
+    assert!(result.output.contains("# max_results = 10"));
+    assert!(result.output.contains("# timeout = 15"));
+}
+
+#[test]
+fn migrate_search_config_noop_when_real_section_present() {
+    let src = "[tools.search]\nenabled = true\nbackend = \"brave\"\n";
+    let result = migrate_search_config(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+    assert!(result.sections_changed.is_empty());
+}
+
+#[test]
+fn migrate_search_config_noop_when_commented_block_already_present() {
+    let src = "[agent]\nmax_turns = 10\n\n# [tools.search]\n# enabled = false\n";
+    let result = migrate_search_config(src).expect("migrate");
+    assert_eq!(result.changed_count, 0);
+    assert_eq!(result.output, src);
+}
+
+#[test]
+fn migrate_search_config_is_idempotent() {
+    let src = "[agent]\nmax_turns = 10\n";
+    let first = migrate_search_config(src).expect("first migrate");
+    assert_eq!(first.changed_count, 1);
+    let second = migrate_search_config(&first.output).expect("second migrate");
+    assert_eq!(second.changed_count, 0, "second run must be a no-op");
+    assert_eq!(
+        second.output, first.output,
+        "output unchanged on second run"
+    );
+}

--- a/crates/zeph-core/src/config.rs
+++ b/crates/zeph-core/src/config.rs
@@ -444,4 +444,44 @@ mod tests {
 
         assert!(config.a2a.auth_token.is_none());
     }
+
+    // --- tools.search vault-key opt-in gate (spec 006-1-web-search, #6445) ---
+    // Mirrors the skills.registry.auth_vault_key opt-in-only pattern this gate copies.
+
+    #[tokio::test]
+    #[cfg(any(test, feature = "mock"))]
+    async fn resolve_secrets_web_search_enabled_resolves_key() {
+        use crate::vault::MockVaultProvider;
+
+        let vault = MockVaultProvider::new().with_secret("ZEPH_WEB_SEARCH_API_KEY", "brave-key-1");
+        let mut config = Config::load(std::path::Path::new("/nonexistent/config.toml")).unwrap();
+        config.tools.search.enabled = true;
+        config.resolve_secrets(&vault).await.unwrap();
+
+        assert_eq!(
+            config.secrets.web_search_api_key.as_ref().unwrap().expose(),
+            "brave-key-1"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(any(test, feature = "mock"))]
+    async fn resolve_secrets_web_search_disabled_key_stays_unset() {
+        use crate::vault::MockVaultProvider;
+
+        // The key is present in the vault under the default vault key name, but the tool is
+        // disabled (the default) — the gate must skip resolution entirely, so the secret
+        // stays unset even though the vault could have supplied it. `MockVaultProvider` has
+        // no call-tracking, so this asserts the observable outcome (key stays `None`) rather
+        // than literally proving `get_secret` was never invoked.
+        let vault = MockVaultProvider::new().with_secret("ZEPH_WEB_SEARCH_API_KEY", "brave-key-2");
+        let mut config = Config::load(std::path::Path::new("/nonexistent/config.toml")).unwrap();
+        assert!(
+            !config.tools.search.enabled,
+            "search must be disabled by default"
+        );
+        config.resolve_secrets(&vault).await.unwrap();
+
+        assert!(config.secrets.web_search_api_key.is_none());
+    }
 }

--- a/crates/zeph-tools/src/composite.rs
+++ b/crates/zeph-tools/src/composite.rs
@@ -784,6 +784,35 @@ mod tests {
             assert_eq!(result.unwrap().summary, "matched");
         }
 
+        #[tokio::test]
+        async fn none_execute_tool_call_returns_ok_none() {
+            let wrapped: OptionalExecutor<FileToolExecutor> = OptionalExecutor(None);
+            let call = ToolCall {
+                tool_id: ToolName::new("read"),
+                params: serde_json::Map::new(),
+                caller_id: None,
+                context: None,
+                tool_call_id: String::new(),
+                skill_name: None,
+            };
+            assert!(wrapped.execute_tool_call(&call).await.unwrap().is_none());
+        }
+
+        #[tokio::test]
+        async fn some_execute_tool_call_delegates_to_inner() {
+            let wrapped = OptionalExecutor(Some(FileToolExecutor));
+            let call = ToolCall {
+                tool_id: ToolName::new("read"),
+                params: serde_json::Map::new(),
+                caller_id: None,
+                context: None,
+                tool_call_id: String::new(),
+                skill_name: None,
+            };
+            let result = wrapped.execute_tool_call(&call).await.unwrap();
+            assert_eq!(result.unwrap().summary, "file_handler");
+        }
+
         #[test]
         fn none_tool_definitions_is_empty() {
             let wrapped: OptionalExecutor<MatchingExecutor> = OptionalExecutor(None);

--- a/crates/zeph-tools/src/search/brave.rs
+++ b/crates/zeph-tools/src/search/brave.rs
@@ -84,6 +84,7 @@ impl SearchProvider for BraveSearchProvider {
         if status.as_u16() == 429 {
             return Err(SearchError::Blocked {
                 reason: "rate limited".to_owned(),
+                status: Some(status.as_u16()),
             });
         }
         if !status.is_success() {
@@ -260,7 +261,13 @@ mod tests {
         let provider = provider_for(&server, 1_048_576);
         let client = reqwest::Client::new();
         let err = provider.search(&client, "quota test", 5).await.unwrap_err();
-        assert!(matches!(err, SearchError::Blocked { .. }));
+        assert!(matches!(
+            err,
+            SearchError::Blocked {
+                status: Some(429),
+                ..
+            }
+        ));
     }
 
     #[tokio::test]

--- a/crates/zeph-tools/src/search/mod.rs
+++ b/crates/zeph-tools/src/search/mod.rs
@@ -31,6 +31,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
+use parking_lot::RwLock;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
@@ -107,6 +108,18 @@ pub struct WebSearchExecutor {
     egress_tx: Option<tokio::sync::mpsc::Sender<EgressEvent>>,
     egress_dropped: Arc<AtomicU64>,
     ipi_filter: IpiFilter,
+    /// Last pinned `reqwest::Client`, keyed by the resolved address set (sorted and
+    /// deduplicated — see [`Self::client_for`]) it was built with. Reused across calls when
+    /// a fresh `resolve_and_validate` returns the same address set, regardless of the order
+    /// the resolver returned it in (the common case for this fixed-host endpoint), avoiding
+    /// a TCP+TLS handshake per search.
+    client_cache: RwLock<Option<(Vec<SocketAddr>, reqwest::Client)>>,
+    /// Counts calls to `build_client` inside [`Self::client_for`] (cache misses only). Test-only
+    /// instrumentation to prove a cache *hit* actually skipped the rebuild, since two
+    /// separately-built clients are otherwise indistinguishable from the outside (`reqwest::Client`
+    /// has no `PartialEq`).
+    #[cfg(test)]
+    client_rebuilds: std::sync::atomic::AtomicU32,
 }
 
 impl WebSearchExecutor {
@@ -142,6 +155,9 @@ impl WebSearchExecutor {
             egress_tx: None,
             egress_dropped: Arc::new(AtomicU64::new(0)),
             ipi_filter: IpiFilter::new(scrape_cfg.ipi_filter_threshold),
+            client_cache: RwLock::new(None),
+            #[cfg(test)]
+            client_rebuilds: std::sync::atomic::AtomicU32::new(0),
         })
     }
 
@@ -309,6 +325,46 @@ impl WebSearchExecutor {
         }
     }
 
+    /// Returns a `reqwest::Client` pinned to `addrs`, reusing the cached client when the
+    /// freshly resolved address set is unchanged since the last call — the common case for
+    /// this fixed-host endpoint — instead of paying a fresh TCP+TLS handshake on every
+    /// search. Rebuilds (and re-caches) whenever the resolved addresses differ, so
+    /// INVARIANT-2 (SSRF addr-pinning, spec 006-1-web-search §4) always holds for the exact
+    /// addresses this call's `resolve_and_validate` just checked, never a stale set from an
+    /// earlier resolution.
+    ///
+    /// The address set is sorted and deduplicated before comparison/caching: the resolver
+    /// does not guarantee stable ordering across calls (DNS round-robin), so comparing raw
+    /// slices would treat a harmless reorder of the same addresses as a change and rebuild
+    /// unnecessarily, defeating the point of caching for any host with 2+ addresses. Sorting
+    /// only changes cache-key equality, not which addresses get pinned — it does not weaken
+    /// INVARIANT-2.
+    fn client_for(&self, host: &str, addrs: &[SocketAddr]) -> reqwest::Client {
+        let mut canonical = addrs.to_vec();
+        canonical.sort_unstable();
+        canonical.dedup();
+        {
+            let cache = self.client_cache.read();
+            if let Some((cached_addrs, client)) = cache.as_ref()
+                && cached_addrs == &canonical
+            {
+                return client.clone();
+            }
+        }
+        #[cfg(test)]
+        self.client_rebuilds
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let client = build_client(host, &canonical, self.timeout);
+        *self.client_cache.write() = Some((canonical, client.clone()));
+        client
+    }
+
+    #[cfg(test)]
+    fn client_rebuild_count(&self) -> u32 {
+        self.client_rebuilds
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
     /// Runs the full search flow: SSRF-validate the endpoint, then delegate to
     /// [`issue_search`](Self::issue_search) for the pinned network request.
     ///
@@ -402,7 +458,8 @@ impl WebSearchExecutor {
         let endpoint = self.backend.endpoint();
         // INVARIANT-2: the resolved addresses are pinned into the request client via
         // `resolve_to_addrs`, closing the TOCTOU window between validation and connection.
-        let client = build_client(&host, addrs, self.timeout);
+        // `client_for` reuses the cached client when `addrs` is unchanged (see its docs).
+        let client = self.client_for(&host, addrs);
         let limit = params
             .limit
             .unwrap_or(self.max_results)
@@ -452,7 +509,7 @@ impl WebSearchExecutor {
             Err(e) => {
                 let (status, blocked, block_reason) = match &e {
                     SearchError::Http { status, .. } => (Some(*status), false, None),
-                    SearchError::Blocked { .. } => (None, true, Some("policy")),
+                    SearchError::Blocked { status, .. } => (*status, true, Some("policy")),
                     _ => (None, false, None),
                 };
                 if self.egress_config.enabled {
@@ -559,7 +616,7 @@ fn map_search_error(e: SearchError) -> ToolError {
         },
         SearchError::Http { status, message } => ToolError::Http { status, message },
         SearchError::Timeout => ToolError::Timeout { timeout_secs: 0 },
-        SearchError::Blocked { reason } => ToolError::Blocked { command: reason },
+        SearchError::Blocked { reason, .. } => ToolError::Blocked { command: reason },
         SearchError::Parse(msg) | SearchError::Provider(msg) => {
             ToolError::Execution(std::io::Error::other(msg))
         }
@@ -718,6 +775,82 @@ mod tests {
             Some(Secret::new("k")),
         );
         assert!(executor.is_some());
+    }
+
+    #[test]
+    fn client_for_reuses_cache_when_addrs_unchanged_and_rebuilds_when_addrs_differ() {
+        let executor = WebSearchExecutor::new(
+            &enabled_config(),
+            &ScrapeConfig::default(),
+            Some(Secret::new("k")),
+        )
+        .unwrap();
+        let addr_a: SocketAddr = "127.0.0.1:1".parse().unwrap();
+        let addr_b: SocketAddr = "127.0.0.1:2".parse().unwrap();
+
+        executor.client_for("search.example.com", &[addr_a]);
+        assert_eq!(executor.client_rebuild_count(), 1);
+        {
+            let cache = executor.client_cache.read();
+            let (cached_addrs, _) = cache.as_ref().expect("cache populated after first call");
+            assert_eq!(cached_addrs, &vec![addr_a]);
+        }
+
+        // Same addrs again: the cache-hit branch is taken, no rebuild, key stays the same.
+        executor.client_for("search.example.com", &[addr_a]);
+        assert_eq!(
+            executor.client_rebuild_count(),
+            1,
+            "unchanged addrs must hit the cache"
+        );
+        {
+            let cache = executor.client_cache.read();
+            let (cached_addrs, _) = cache.as_ref().unwrap();
+            assert_eq!(cached_addrs, &vec![addr_a]);
+        }
+
+        // Different addrs: the rebuild branch is taken, cache key updates.
+        executor.client_for("search.example.com", &[addr_b]);
+        assert_eq!(
+            executor.client_rebuild_count(),
+            2,
+            "changed addrs must rebuild"
+        );
+        let cache = executor.client_cache.read();
+        let (cached_addrs, _) = cache.as_ref().unwrap();
+        assert_eq!(cached_addrs, &vec![addr_b]);
+    }
+
+    #[test]
+    fn client_for_reordered_multi_addr_set_is_a_cache_hit_not_a_rebuild() {
+        // Regression test: the resolver does not guarantee stable ordering across calls for
+        // a host with 2+ addresses (DNS round-robin), so the cache key must be order-
+        // independent — otherwise a harmless reorder of the same address set forces an
+        // unnecessary rebuild on every call, defeating the point of caching.
+        let executor = WebSearchExecutor::new(
+            &enabled_config(),
+            &ScrapeConfig::default(),
+            Some(Secret::new("k")),
+        )
+        .unwrap();
+        let addr_a: SocketAddr = "127.0.0.1:1".parse().unwrap();
+        let addr_b: SocketAddr = "127.0.0.1:2".parse().unwrap();
+        let addr_c: SocketAddr = "127.0.0.1:3".parse().unwrap();
+
+        executor.client_for("search.example.com", &[addr_a, addr_b, addr_c]);
+        assert_eq!(executor.client_rebuild_count(), 1);
+
+        // Same set, fully reversed order: must be recognized as unchanged (cache hit).
+        executor.client_for("search.example.com", &[addr_c, addr_b, addr_a]);
+        assert_eq!(
+            executor.client_rebuild_count(),
+            1,
+            "reordered-but-identical resolved address set must hit the cache, not rebuild"
+        );
+
+        // Same set, shuffled order: still a hit.
+        executor.client_for("search.example.com", &[addr_b, addr_a, addr_c]);
+        assert_eq!(executor.client_rebuild_count(), 1);
     }
 
     #[test]
@@ -1030,6 +1163,11 @@ mod tests {
         let event = rx.try_recv().expect("egress event should be emitted");
         assert!(event.blocked);
         assert_eq!(event.block_reason, Some("policy"));
+        assert_eq!(
+            event.status,
+            Some(429),
+            "the real 429 status must be threaded into the egress event, not None"
+        );
     }
 
     #[tokio::test]

--- a/crates/zeph-tools/src/search/provider.rs
+++ b/crates/zeph-tools/src/search/provider.rs
@@ -46,6 +46,9 @@ pub enum SearchError {
     Blocked {
         /// Human-readable block reason.
         reason: String,
+        /// HTTP status code that triggered the block, when applicable (e.g. `429` for
+        /// backend rate-limiting). `None` for non-HTTP blocks (SSRF, denylist).
+        status: Option<u16>,
     },
     /// The backend response body could not be parsed.
     #[error("failed to parse response: {0}")]

--- a/src/serve/deps.rs
+++ b/src/serve/deps.rs
@@ -639,10 +639,7 @@ async fn build_tool_executor(
             shell_executor,
             zeph_tools::CompositeExecutor::new(
                 scrape_executor,
-                zeph_tools::CompositeExecutor::new(
-                    zeph_tools::OptionalExecutor(web_search_executor),
-                    cwd_executor,
-                ),
+                crate::agent_setup::with_search_executor(cwd_executor, web_search_executor),
             ),
         ),
     ));


### PR DESCRIPTION
## Summary

Follow-up from PR #6444 (#6358 web_search tool). The reviewer and validators scoped these items out of that PR as non-blocking polish — none affect security enforcement (SSRF/denylist/IPI remain intact).

- Cache `WebSearchExecutor`'s SSRF-addr-pinned `reqwest::Client`, keyed by the canonicalized (order-insensitive) resolved address set, instead of rebuilding it on every call. Rebuilds and re-pins whenever the resolved addresses actually change, so INVARIANT-2 (SSRF addr-pinning, spec `006-1-web-search.md` §4, FR-006) continues to hold.
- Thread the real Brave HTTP status code (e.g. 429) into egress-event telemetry instead of always recording `status: None`.
- `src/serve/deps.rs`'s `web_search` wiring now uses the shared `with_search_executor()` helper, matching the other 3 production wiring sites (cosmetic, no behavior change).
- Add direct tests for `OptionalExecutor::execute_tool_call`'s `Some`/`None` variants, the `tools.search` vault-key opt-in gate, and `migrate_search_config`'s inserted-block content and idempotency.

Item 7 from the source issue (live Brave API round-trip verification) is intentionally out of scope — no vault key is provisioned in this environment; left as a follow-up for a live-tester session once a key is available.

## Review notes

During implementation, item 1 could not be applied exactly as literally described ("cache the client the same way zeph-llm does") because a naive single long-lived client would go stale across a legitimate DNS rotation, silently weakening the SSRF addr-pinning guarantee. Adversarial review (impl-critic + tester, independently) confirmed the security design was sound but caught that the initial cache-key comparison was exact-order-sensitive against an unstable DNS resolver ordering, undermining the intended perf win. Fixed by canonicalizing (sort + dedup) the resolved address set before comparison/pinning, with a regression test proving an actual cache hit (via a `#[cfg(test)]`-only rebuild counter) across reordered address presentations.

Closes #6445

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (14536 passed, 0 failed)
- [x] New/changed tests individually re-verified
- [x] CHANGELOG.md updated under `[Unreleased]`
- [ ] Live Brave API round-trip verification (item 7) — deferred, no vault key provisioned in this environment