### PR TITLE
feat(durable): add HMAC and HWM rotation windows for zeph durable rotate-key

### DIFF
--- a/.github/integrity_audited.txt
+++ b/.github/integrity_audited.txt
@@ -64,6 +64,7 @@ crates/zeph-subagent/src/manager/spawn.rs VERIFIED # resume-on-spawn transcript 
 crates/zeph-subagent/src/transcript.rs VERIFIED # the TranscriptReader/TranscriptWriter chain-verification implementation itself
 src/acp.rs VERIFIED # ACP session-lock/open path, chain-verified
 src/commands/durable.rs VERIFIED # zeph durable CLI, HWM-verified reads
+src/commands/scheduler_daemon.rs VERIFIED # open_execution calls are test-only (#[cfg(test)] mod tests), exercising the already-HWM-verified LocalBackend read path (see local.rs); no production trust-reading in this file
 src/commands/sessions.rs VERIFIED # zeph sessions resume/show CLI, chain-verified reads
 src/runner.rs VERIFIED # main CLI dispatch; configures history-integrity key rings before any reader opens
 src/serve/agent_factory.rs VERIFIED # serve-mode session bootstrap, chain-verified opens

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 ### Added
 
+- `zeph-tui`: the durable panel header now shows the active AEAD/HMAC `key_id` and, when a
+  rotation window is open (`[durable] previous_key_id` set), a passive
+  `rotation window open (previous_key_id = N)` indicator, plus a matching low-priority status-bar
+  chip (#6450). Read-only visibility — the panel offers no rotation action; rotation stays a
+  restart-required CLI-only operation (`zeph durable rotate-key`). Reuses the existing 5-second
+  `durable_poll_task`, so no new background task is spawned. **Known gap**: unlike the CLI's
+  `describe_reveal_error` (`src/commands/durable.rs`), the TUI's own reveal/inspect path does not
+  yet map `UnknownKeyId` to an actionable "previous key dropped" message — a dropped-key blob
+  surfaces as a raw decode error in the TUI. Scoped out of #6450 and this addendum; tracked as a
+  follow-up in #6459.
+
 - `zeph-config`/`zeph-core`/`zeph`: added `zeph durable rotate-key`, a windowed rotation
   command for the durable execution layer's AEAD payload key (`ZEPH_DURABLE_KEY`) — the
   `XChaCha20Poly1305Cipher::with_previous` rotation window existed but was never operationally
@@ -27,18 +38,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `durable_journal`/`durable_promises` for any payload still sealed under the previous key
   (dialect-specific predicate: SQLite blob-compare, Postgres `get_byte`) and refuses if any
   remain (`--force` skips the scan; scoped to this path only — it never bypasses the
-  open-window or shared-database refusals); a call with no window open is a clean no-op. On a
-  declared/detected shared database, `rotate-key` refuses unless `--ack-shared-db-drain` is
-  passed, since rotating also re-derives the control-entry HMAC key, which has no rotation
-  window of its own. `--dry-run` prints intended changes (including the shared-DB warning)
-  without writing anything. The cipher is built once at process startup (no hot-reload), so a
-  restart is required after rotating. A stale in-memory cipher hitting a rotated blob's
+  open-window refusal); a call with no window open is a clean no-op. `--dry-run` prints intended
+  changes without writing anything. The cipher is built once at process startup (no hot-reload),
+  so a restart is required after rotating. A stale in-memory cipher hitting a rotated blob's
   key-id now surfaces an actionable "restart to pick up the rotated key" message instead of
   the raw `UnknownKeyId`/decode error. `zeph --init`'s existing key-replacement wizard step is
   unchanged in behavior but now explicitly labels itself a destructive reset (no rotation
   window, discards sealed payloads immediately) and points to `zeph durable rotate-key` for
   the safe alternative. Added `MigrateDurableKeyRotation` (`--migrate-config` step 97) to
-  insert `key_id = 0` into an existing `[durable]` table lacking it.
+  insert `key_id = 0` into an existing `[durable]` table lacking it. On a declared/detected
+  shared database, `rotate-key` originally refused unless `--ack-shared-db-drain` was passed,
+  since rotating also re-derives the control-entry HMAC key, which had no rotation window of
+  its own at the time this landed — #6451, later in this same `[Unreleased]` section, closes
+  that gap and removes the flag and its refusal outright (see Removed below); shared-DB
+  rotation needs no acknowledgement as of this release.
 
 - `zeph-durable`: added an authenticated per-execution high-water-mark (HWM) — a signed
   `{execution_id, max_committed_step_id, committed_result_count, key_epoch}` tuple, verified once
@@ -114,6 +127,55 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   already applied to the analogous sub-agent debug-dump/outbound-LLM egress paths. Known
   limitation: combining `--bare` with `--json` interleaves two different JSON schemas on
   stdout — unsupported for now; use `--bare` without `--json` for scripted-pipeline forwarding.
+
+- `zeph-durable`: the control-entry row HMAC (INV-8) now has its own rotation window, closing
+  the gap #6447's AEAD key rotation left open (#6451). `LocalBackend` gains
+  `with_previous_hmac_key`, mirroring the AEAD cipher's `with_previous` — `verify_control_hmac`
+  now tries the current key first, falling back to the previous key when set, so a pre-rotation
+  `EffectIntent` control entry stays readable through the window on every read path (agent
+  replay, scheduler daemon, and the CLI). Unlike the AEAD cipher, the stored `hmac` column
+  carries no key-id selector (control rows have no payload envelope for one), so verification
+  is try-both rather than key-id-dispatched; this is security-equivalent for a single-slot
+  window. New `count_control_entries_under_previous_hmac` backs `--drop-previous`'s second
+  safety scan, alongside the existing AEAD blob-scan — it is not redundant with the blob-scan,
+  since a crash-orphaned `EffectIntent` (intent journaled, result never committed) has a
+  previous-key HMAC but no payload at all for the blob-scan to see. `--drop-previous` now
+  refuses while either scan is nonzero (`--force` still skips both). Writes always stamp with
+  the current key only.
+
+- `zeph-durable`/`zeph`: the durable high-water-mark (HWM, issue #6360) key gains a working
+  rotation window — wiring spec-081 FR-008's already-specified current+previous HWM window,
+  which #6453 shipped with a frozen `key_epoch` (`const HWM_KEY_EPOCH = 0`, never bumped
+  anywhere in-tree) that left the already-implemented `with_previous_hwm_key` slot unreachable.
+  Without this, any `zeph durable rotate-key` force-aborted every execution with a committed
+  `StepResult` on its next resume (`HighWaterMarkIntegrity`), and — because both the pre- and
+  post-rotation rows shared the same frozen epoch — misreported the failure as `hmac_mismatch`
+  (TAMPER) rather than the correct `key_epoch_unresolvable` (possibly re-keyed). The HWM epoch
+  now reuses the AEAD cipher's own `key_id`/`previous_key_id` rotation lifecycle instead of a
+  separate counter: `load_write_hwm_key` (`src/commands/durable.rs`) resolves a current +
+  previous `HwmSlot` pair from `config.durable.key_id`/`previous_key_id`, mirroring
+  `ControlHmacKeys`, and fails closed if `previous_key_id` is declared but
+  `ZEPH_DURABLE_KEY_PREVIOUS` is missing. `key_id` already defaults to `0`, matching the
+  existing `key_epoch = 0` rows, so there is no migration for an un-rotated deployment.
+  `open_durable_backend` and every write/read channel that attaches HWM keys (P1 agent-turn, P2
+  orchestration, the scheduler daemon — which previously never attached an HWM key at all — and
+  the CLI read path) now also attach the previous slot while a window is open. `--drop-previous`
+  gains a third safety scan, `count_integrity_rows_under_epoch` — a plain indexed `COUNT` on the
+  `durable_execution_integrity.key_epoch` column needing no key material — refusing the drop
+  while any surviving execution's HWM row still carries the previous epoch. This scan is not
+  redundant with the other two: `checkpoint_fold` reseals a folded checkpoint under the current
+  key and deletes the old-key-id `StepResult` rows it folds, but never re-signs the HWM, so a
+  checkpoint-folded pre-rotation execution can have zero surviving payload and zero control
+  entries while its integrity row still points at the previous epoch — invisible to both the
+  AEAD blob-scan and the control-HMAC scan.
+
+### Removed
+
+- `zeph durable rotate-key`: removed the `--ack-shared-db-drain` flag and its R3 refusal
+  outright (no deprecation shim, pre-v1.0.0) — the refusal existed solely because the
+  control-entry HMAC key had no rotation window of its own; #6451 closes that gap, so rotating
+  on a declared/detected shared database is now exactly as safe as local rotation and needs no
+  acknowledgement. `--ack-shared-db-drain` is now an unrecognized CLI flag.
 
 ### Fixed
 

--- a/book/src/reference/security/durable-encryption.md
+++ b/book/src/reference/security/durable-encryption.md
@@ -101,6 +101,36 @@ reader that disagrees (e.g. runs unkeyed against a keyed writer's file) now
 fails closed as soon as it encounters any row carrying a stamped HMAC, rather
 than silently trusting it as an ordinary unverified field.
 
+Like the AEAD payload cipher, the control-entry HMAC key has its own rotation
+window: verification tries the current key first, falling back to a registered
+previous key while a `zeph durable rotate-key` window is open, so a
+pre-rotation `EffectIntent` control entry stays readable on every read path
+(agent replay, scheduler daemon, and the CLI) through the window. Unlike the
+AEAD cipher, the stored `hmac` column carries no key-id selector — control
+entries have no payload envelope to carry one — so verification tries both
+keys rather than dispatching by an on-disk selector; this is
+security-equivalent for the single-slot window `rotate-key` supports.
+
+## High-water-mark (deletion detection)
+
+The AEAD seal and the control-entry HMAC both protect a row's own content and
+identity, but neither detects a committed `StepResult` row being deleted
+outright. A per-execution high-water-mark closes that gap: a signed
+`{key_epoch, max_committed_step_id, committed_result_count}` tuple is updated
+in the same transaction as every committed `StepResult`, and verified once on
+every resume. Unlike the control-entry HMAC, the high-water-mark is attached
+**unconditionally** — including single-user local deployments, which get
+deletion detection they would not otherwise have.
+
+The high-water-mark key shares `ZEPH_DURABLE_KEY`'s rotation lifecycle: its
+epoch is `[durable] key_id` (current) / `previous_key_id` (previous), the same
+fields `rotate-key` drives for the AEAD cipher, so no separate rotation
+procedure or flag is needed. A resumed execution whose signed epoch matches
+neither the current nor a registered previous key fails closed as
+"possibly re-keyed" rather than a generic tamper report, distinguishing a
+legitimate rotation the process cannot resolve from actual tampering; either
+way the resume is refused with no interactive override.
+
 ## Key rotation
 
 The `key_id` byte makes rotation possible without rewriting the journal.
@@ -134,18 +164,28 @@ zeph durable rotate-key --drop-previous
 ```
 
 This removes `ZEPH_DURABLE_KEY_PREVIOUS` from the vault and clears
-`previous_key_id`. By default it first scans the journal for any payload still
-sealed under the old key and refuses the drop if any remain; pass `--force` to
-skip that scan once you have independently confirmed pruning is complete.
-Payloads still sealed under the dropped key become permanently unreadable
-afterward. A call with no window open is a clean no-op.
+`previous_key_id`. By default it runs three independent safety scans and
+refuses the drop if any finds a surviving dependency on the previous key:
+
+- an AEAD blob-scan, refusing if any payload is still sealed under the old key,
+- a control-entry HMAC scan, refusing if any `EffectIntent` still verifies only
+  under the previous key (catching a payload-less crash-orphaned intent the
+  blob-scan cannot see), and
+- a high-water-mark scan, refusing if any execution's signed high-water-mark
+  still carries the previous key epoch (catching a checkpoint-folded
+  pre-rotation execution, whose payload and control entries may both already
+  be gone even though its high-water-mark has not migrated).
+
+Pass `--force` to skip all three scans once you have independently confirmed
+pruning is complete. Payloads and control/high-water-mark state still bound to
+the dropped key become permanently unreadable afterward. A call with no window
+open is a clean no-op.
 
 On a **shared database** (`[durable].shared_db = true`, or a `postgres://`
-journal URL), rotating also changes the derived control-entry HMAC key, which
-has no rotation window of its own — every in-flight execution's control entries
-fail closed with `ControlIntegrity` until they drain. `rotate-key` refuses on a
-shared database unless you pass `--ack-shared-db-drain`, after draining
-(finalizing/pruning) all in-flight executions first.
+journal URL), rotating also changes the derived control-entry HMAC key — this
+now has its own rotation window (see above), so shared-database rotation needs
+no special acknowledgement and works exactly like a single-user local
+rotation.
 
 `zeph --init`'s wizard step can also replace `ZEPH_DURABLE_KEY`, but that path
 is a **destructive reset**: it discards the old key immediately with no

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -2423,8 +2423,18 @@ impl<C: Channel> Agent<C> {
     /// `hmac_key` is `None` for a single-user local, non-shared database (INV-8) — see
     /// `crate::durable::derive_control_hmac_key_b64`. The `hwm_key` (issue #6360) is meant to be
     /// attached unconditionally (FR-009) — `None` only when `ZEPH_DURABLE_KEY` itself is
-    /// unavailable — see `crate::durable::derive_hwm_key_b64`.
+    /// unavailable — see `crate::durable::derive_hwm_key_b64`. `previous_hmac_key` is `Some`
+    /// only while a `zeph durable rotate-key` rotation window is open (#6451). `previous_hwm_key`
+    /// is the HWM-side counterpart, `Some` under the same condition (addendum to #6451).
+    ///
+    /// `#[allow(clippy::too_many_arguments)]`: bundling the five key-material params into one
+    /// `DurableKeyMaterial` struct is deliberately deferred (addendum to #6451, M2) — it would
+    /// re-touch every already-threaded call site (runner → builder → state → bootstrap → plan →
+    /// `scheduler_daemon`) a second time for no safety gain, since a mis-wired key `Option` here
+    /// fails closed (`ControlIntegrity`/`HighWaterMarkIntegrity`), never a silent accept. Tracked
+    /// as a follow-up.
     #[must_use]
+    #[allow(clippy::too_many_arguments)]
     pub fn with_durable_orchestration(
         mut self,
         config: zeph_config::DurableConfig,
@@ -2432,12 +2442,16 @@ impl<C: Channel> Agent<C> {
         cipher: Option<std::sync::Arc<dyn zeph_durable::PayloadCipher>>,
         hmac_key: Option<[u8; 32]>,
         hwm_key: Option<(u32, [u8; 32])>,
+        previous_hmac_key: Option<[u8; 32]>,
+        previous_hwm_key: Option<(u32, [u8; 32])>,
     ) -> Self {
         self.services.orchestration.durable_config = Some(config);
         self.services.orchestration.durable_db_url = Some(db_url);
         self.services.orchestration.durable_cipher = cipher;
         self.services.orchestration.durable_hmac_key = hmac_key;
         self.services.orchestration.durable_hwm_key = hwm_key;
+        self.services.orchestration.durable_previous_hmac_key = previous_hmac_key;
+        self.services.orchestration.durable_previous_hwm_key = previous_hwm_key;
         self
     }
 
@@ -2456,7 +2470,11 @@ impl<C: Channel> Agent<C> {
     /// derivation alongside `ConversationId` (see `durable_bootstrap.rs`) so that even if a
     /// future config override ever pointed two different memory databases at the same journal
     /// `db_url`, their executions still would not collide (#5553).
+    ///
+    /// `#[allow(clippy::too_many_arguments)]`: see [`Self::with_durable_orchestration`]'s doc —
+    /// the `DurableKeyMaterial` bundling is deferred, not skipped.
     #[must_use]
+    #[allow(clippy::too_many_arguments)]
     pub fn with_durable_agent_turns(
         mut self,
         config: zeph_config::DurableConfig,
@@ -2465,6 +2483,8 @@ impl<C: Channel> Agent<C> {
         cipher: Option<std::sync::Arc<dyn zeph_durable::PayloadCipher>>,
         hmac_key: Option<[u8; 32]>,
         hwm_key: Option<(u32, [u8; 32])>,
+        previous_hmac_key: Option<[u8; 32]>,
+        previous_hwm_key: Option<(u32, [u8; 32])>,
     ) -> Self {
         self.services.session.durable_agent_turns_config = Some(config);
         self.services.session.durable_agent_turns_db_url = Some(db_url);
@@ -2472,6 +2492,8 @@ impl<C: Channel> Agent<C> {
         self.services.session.durable_agent_turns_cipher = cipher;
         self.services.session.durable_agent_turns_hmac_key = hmac_key;
         self.services.session.durable_agent_turns_hwm_key = hwm_key;
+        self.services.session.durable_agent_turns_previous_hmac_key = previous_hmac_key;
+        self.services.session.durable_agent_turns_previous_hwm_key = previous_hwm_key;
         self
     }
 

--- a/crates/zeph-core/src/agent/durable_bootstrap.rs
+++ b/crates/zeph-core/src/agent/durable_bootstrap.rs
@@ -38,9 +38,19 @@ const RETENTION_TASK_NAME: &str = "durable.retention_sweep";
 /// stance where control entries carry no HMAC. `hwm_key` (issue #6360) is meant to be attached
 /// unconditionally (FR-009): `None` only when `ZEPH_DURABLE_KEY` itself is unavailable — unlike
 /// `hmac_key`, single-user local deployments still get high-water-mark deletion detection.
+/// `previous_hmac_key` is `Some` only while a `zeph durable rotate-key` rotation window is open
+/// (#6451). `previous_hwm_key` is the HWM-side counterpart, `Some` under the same condition
+/// (addendum to #6451): unlike `previous_hmac_key`, its epoch reuses the AEAD cipher's `key_id`
+/// lifecycle rather than being epoch-less try-both (see `HwmKeySlot`/`with_previous_hwm_key` in
+/// `zeph-durable`).
 ///
 /// Returns `None` (after logging a `tracing::warn!`) on any I/O failure so callers degrade to
 /// non-durable mode rather than fail session bootstrap (#5452 FR-004).
+///
+/// `#[allow(clippy::too_many_arguments)]`: bundling the five key-material params into one
+/// `DurableKeyMaterial` struct is deliberately deferred (addendum to #6451, M2) — see
+/// `AgentBuilder::with_durable_orchestration`'s doc for the full rationale.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn open_durable_backend(
     task_supervisor: &zeph_common::TaskSupervisor,
     writer_task_name: &'static str,
@@ -49,6 +59,8 @@ pub(crate) async fn open_durable_backend(
     cipher: Option<Arc<dyn PayloadCipher>>,
     hmac_key: Option<[u8; 32]>,
     hwm_key: Option<(u32, [u8; 32])>,
+    previous_hmac_key: Option<[u8; 32]>,
+    previous_hwm_key: Option<(u32, [u8; 32])>,
 ) -> Option<(
     Arc<DurableBackendEnum>,
     JournalWriterHandle,
@@ -77,6 +89,16 @@ pub(crate) async fn open_durable_backend(
     };
     let local = if let Some((epoch, k)) = hwm_key {
         local.with_hwm_key(epoch, k)
+    } else {
+        local
+    };
+    let local = if let Some(k) = previous_hmac_key {
+        local.with_previous_hmac_key(k)
+    } else {
+        local
+    };
+    let local = if let Some((epoch, k)) = previous_hwm_key {
+        local.with_previous_hwm_key(epoch, k)
     } else {
         local
     };
@@ -118,6 +140,12 @@ impl<C: Channel> Agent<C> {
     /// The execution is keyed on the session's `ConversationId` (not per-turn), so every turn in
     /// the session journals as a step within the *same* execution and a crash mid-session can
     /// resume from any prior turn's journal state.
+    ///
+    /// `#[allow(clippy::too_many_lines)]`: threading `previous_hwm_key` alongside the existing
+    /// key-material stash (addendum to #6451) pushed this past the line budget by two lines;
+    /// splitting this single linear bootstrap sequence into sub-functions for that would add
+    /// indirection with no readability gain.
+    #[allow(clippy::too_many_lines)]
     pub(crate) async fn ensure_session_durable_ctx(&mut self) {
         if self.services.session.durable_ctx.is_some()
             || self.services.session.durable_ctx_init_attempted
@@ -147,6 +175,8 @@ impl<C: Channel> Agent<C> {
         let cipher = self.services.session.durable_agent_turns_cipher.clone();
         let hmac_key = self.services.session.durable_agent_turns_hmac_key;
         let hwm_key = self.services.session.durable_agent_turns_hwm_key;
+        let previous_hmac_key = self.services.session.durable_agent_turns_previous_hmac_key;
+        let previous_hwm_key = self.services.session.durable_agent_turns_previous_hwm_key;
 
         tracing::debug!("durable agent_turns: opening backend start");
         let backend_result = open_durable_backend(
@@ -157,6 +187,8 @@ impl<C: Channel> Agent<C> {
             cipher,
             hmac_key,
             hwm_key,
+            previous_hmac_key,
+            previous_hwm_key,
         )
         .await;
         tracing::debug!("durable agent_turns: opening backend done");
@@ -300,7 +332,7 @@ impl<C: Channel> Agent<C> {
 
 #[cfg(test)]
 mod tests {
-    use super::RETENTION_TASK_NAME;
+    use super::{RETENTION_TASK_NAME, open_durable_backend};
     use crate::agent::agent_tests::*;
 
     fn agent_with_conversation() -> crate::agent::Agent<MockChannel> {
@@ -356,6 +388,82 @@ mod tests {
         assert!(
             names.contains(&RETENTION_TASK_NAME.to_owned()),
             "expected {RETENTION_TASK_NAME:?} among supervised tasks, got {names:?}"
+        );
+    }
+
+    /// #6451 regression (critic finding 2): agent replay is one of the three runtime read
+    /// channels that must keep verifying a pre-rotation `EffectIntent` control entry through an
+    /// open rotation window. `open_durable_backend` is the shared glue both the P1 (agent-turn)
+    /// and P2 (orchestration) adapters route through (see the module doc), so exercising it
+    /// directly covers both. `EffectIntent` never carries a payload, so this also models the
+    /// payload-less crash-orphan shape the HMAC drop-scan exists for — the AEAD blob-scan alone
+    /// could never have caught a missed `previous_hmac_key` wiring here.
+    #[tokio::test]
+    async fn open_durable_backend_reads_previous_key_control_entry_through_rotation_window() {
+        use zeph_durable::Journal as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_url = dir.path().join("durable.db").to_string_lossy().into_owned();
+        let current_key = [2u8; 32];
+        let previous_key = [1u8; 32];
+
+        let exec = zeph_durable::ExecutionId::new();
+        {
+            let pre_rotation_writer = zeph_durable::LocalBackend::open(&db_url, 1_048_576)
+                .await
+                .unwrap()
+                .with_hmac_key(previous_key);
+            pre_rotation_writer.init().await.unwrap();
+            pre_rotation_writer
+                .open_execution(exec, zeph_durable::ExecutionKind::AgentTurn)
+                .await
+                .unwrap();
+            let step_id = zeph_durable::StepId::new(0);
+            pre_rotation_writer
+                .append(zeph_durable::JournalEntry {
+                    seq: None,
+                    execution_id: exec,
+                    kind: zeph_durable::ExecutionKind::AgentTurn,
+                    step_id,
+                    entry: zeph_durable::EntryKind::EffectIntent {
+                        idempotency_key: zeph_durable::IdempotencyKey::derive(
+                            exec,
+                            step_id,
+                            b"transfer",
+                        ),
+                        effect: zeph_durable::EffectClass::ExactlyOnceGuarded,
+                        hmac: None,
+                    },
+                    created_at_ms: 0,
+                })
+                .await
+                .unwrap();
+        }
+
+        let task_supervisor =
+            zeph_common::TaskSupervisor::new(tokio_util::sync::CancellationToken::new());
+        let cfg = zeph_config::DurableConfig::default();
+        let backend_result = open_durable_backend(
+            &task_supervisor,
+            "test.durable.journal_writer",
+            &cfg,
+            &db_url,
+            None,
+            Some(current_key),
+            None,
+            Some(previous_key),
+            None,
+        )
+        .await;
+        let (backend, _writer, _task_handle) =
+            backend_result.expect("backend must open with both HMAC keys attached");
+        let zeph_durable::DurableBackendEnum::Local(local) = &*backend else {
+            panic!("expected LocalBackend");
+        };
+        assert!(
+            local.read_execution(exec).await.is_ok(),
+            "the agent-replay (P1/P2) shared backend glue must verify a pre-rotation \
+             EffectIntent control entry through the rotation window"
         );
     }
 

--- a/crates/zeph-core/src/agent/plan.rs
+++ b/crates/zeph-core/src/agent/plan.rs
@@ -332,6 +332,8 @@ impl<C: crate::channel::Channel> Agent<C> {
             let cipher = self.services.orchestration.durable_cipher.clone();
             let hmac_key = self.services.orchestration.durable_hmac_key;
             let hwm_key = self.services.orchestration.durable_hwm_key;
+            let previous_hmac_key = self.services.orchestration.durable_previous_hmac_key;
+            let previous_hwm_key = self.services.orchestration.durable_previous_hwm_key;
             let (backend, handle, task_handle) =
                 crate::agent::durable_bootstrap::open_durable_backend(
                     &self.runtime.lifecycle.task_supervisor,
@@ -341,6 +343,8 @@ impl<C: crate::channel::Channel> Agent<C> {
                     cipher,
                     hmac_key,
                     hwm_key,
+                    previous_hmac_key,
+                    previous_hwm_key,
                 )
                 .await?;
             self.services.orchestration.durable_backend = Some(backend);

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -789,6 +789,14 @@ pub(crate) struct OrchestrationState {
     /// `durable_hmac_key`, meant to be attached unconditionally (FR-009) whenever
     /// `ZEPH_DURABLE_KEY` resolves — `None` only when the vault key itself is unavailable.
     pub(crate) durable_hwm_key: Option<(u32, [u8; 32])>,
+    /// Previous control-entry row HMAC key for the P2 durable backend's rotation window (#6451).
+    /// `Some` only while a `zeph durable rotate-key` window is open
+    /// (`config.previous_key_id.is_some()`).
+    pub(crate) durable_previous_hmac_key: Option<[u8; 32]>,
+    /// Previous high-water-mark key for the P2 durable backend's rotation window (addendum to
+    /// #6451). `Some` only while a `zeph durable rotate-key` window is open, mirroring
+    /// `durable_previous_hmac_key` but epoch-addressed (see `durable_hwm_key`).
+    pub(crate) durable_previous_hwm_key: Option<(u32, [u8; 32])>,
 }
 
 /// Groups instruction hot-reload state.
@@ -1001,6 +1009,14 @@ pub(crate) struct SessionState {
     /// `durable_agent_turns_hmac_key`, meant to be attached unconditionally (FR-009) whenever
     /// `ZEPH_DURABLE_KEY` resolves — `None` only when the vault key itself is unavailable.
     pub(crate) durable_agent_turns_hwm_key: Option<(u32, [u8; 32])>,
+    /// Sibling companion to [`Self::durable_agent_turns_hmac_key`]: the previous control-entry row
+    /// HMAC key for the rotation window (#6451). `Some` only while a `zeph durable rotate-key`
+    /// window is open (`config.previous_key_id.is_some()`).
+    pub(crate) durable_agent_turns_previous_hmac_key: Option<[u8; 32]>,
+    /// Sibling companion to [`Self::durable_agent_turns_hwm_key`]: the previous high-water-mark
+    /// key for the rotation window (addendum to #6451). `Some` only while a `zeph durable
+    /// rotate-key` window is open (`config.previous_key_id.is_some()`).
+    pub(crate) durable_agent_turns_previous_hwm_key: Option<(u32, [u8; 32])>,
     /// Set to `true` the first time `ensure_session_durable_ctx` runs (success or failure) so a
     /// failed backend construction (missing vault key, disk error) is not retried on every turn.
     /// Reset to `false` by `reset_durable_ctx_for_conversation_switch` (`/new`, `/conv resume`,
@@ -1468,6 +1484,8 @@ impl SessionState {
             durable_agent_turns_cipher: None,
             durable_agent_turns_hmac_key: None,
             durable_agent_turns_hwm_key: None,
+            durable_agent_turns_previous_hmac_key: None,
+            durable_agent_turns_previous_hwm_key: None,
             durable_ctx_init_attempted: false,
             durable_writer: None,
             durable_writer_task: None,

--- a/crates/zeph-core/src/agent/state/tests.rs
+++ b/crates/zeph-core/src/agent/state/tests.rs
@@ -84,6 +84,8 @@ fn make_session_state() -> SessionState {
         durable_agent_turns_cipher: None,
         durable_agent_turns_hmac_key: None,
         durable_agent_turns_hwm_key: None,
+        durable_agent_turns_previous_hmac_key: None,
+        durable_agent_turns_previous_hwm_key: None,
         durable_ctx_init_attempted: false,
         durable_writer: None,
         durable_writer_task: None,

--- a/crates/zeph-core/src/durable.rs
+++ b/crates/zeph-core/src/durable.rs
@@ -254,15 +254,6 @@ pub fn derive_control_hmac_key_b64(b64_key: &str) -> Result<[u8; KEY_LEN], Ciphe
 /// `ZEPH_DURABLE_KEY` via BLAKE3 `derive_key`.
 const HWM_CONTEXT: &str = "zeph-durable v1 execution high-water-mark HMAC key 2026";
 
-/// The current high-water-mark key-rotation epoch (FR-008).
-///
-/// Mirrors [`DURABLE_KEY_ID`]'s role for the AEAD cipher: a non-secret marker stamped alongside
-/// every signed high-water-mark so a verifier can tell "signed under a key I don't currently hold"
-/// (re-keyed) from "signed under my current key but the hash doesn't match" (tampered). Bump this
-/// constant when `ZEPH_DURABLE_KEY` is rotated, and register the prior key as the backend's
-/// `with_previous_hwm_key` slot for the rotation window.
-pub const HWM_KEY_EPOCH: u32 = 0;
-
 /// Derive the high-water-mark key (issue #6360) from the base64-encoded `ZEPH_DURABLE_KEY` vault
 /// value.
 ///
@@ -276,6 +267,11 @@ pub const HWM_KEY_EPOCH: u32 = 0;
 /// the high-water-mark key is meant to be attached unconditionally (FR-009): it is the only
 /// mechanism that detects deletion of a committed `StepResult` row, a threat the AEAD payload seal
 /// and the row HMAC do not cover on any deployment, single-user local included.
+///
+/// This function derives only the key bytes; the non-secret rotation epoch stamped alongside them
+/// (FR-008) is `config.durable.key_id` (current) / `previous_key_id` (previous) — the same
+/// `rotate-key`-driven lifecycle the AEAD cipher's `key_id` uses — resolved by the caller
+/// (`load_write_hwm_key` in `src/commands/durable.rs`), not by this module.
 ///
 /// # Errors
 ///

--- a/crates/zeph-durable/src/backend/local.rs
+++ b/crates/zeph-durable/src/backend/local.rs
@@ -141,6 +141,11 @@ pub struct LocalBackend {
     pool: DbPool,
     cipher: Option<Arc<dyn PayloadCipher>>,
     hmac_key: Option<[u8; 32]>,
+    /// Previous control-entry HMAC key for the rotation window (#6451), mirroring the AEAD
+    /// cipher's `previous` slot. `Some` only while a `zeph durable rotate-key` window is open
+    /// (`config.previous_key_id.is_some()`); `verify_control_hmac` tries this key when a row
+    /// fails to verify under `hmac_key`. Writes always stamp with `hmac_key` only.
+    previous_hmac_key: Option<[u8; 32]>,
     /// The current high-water-mark key (issue #6360), keyed by its non-secret rotation epoch.
     /// `None` disables the HWM: no bump on commit/fold, and [`open_execution`](Self::open_execution)
     /// skips its internal high-water-mark verification entirely on resume. Unlike
@@ -186,6 +191,10 @@ impl fmt::Debug for LocalBackend {
         f.debug_struct("LocalBackend")
             .field("cipher", &self.cipher.as_ref().map(|_| "<cipher>"))
             .field("hmac_key", &self.hmac_key.as_ref().map(|_| "<redacted>"))
+            .field(
+                "previous_hmac_key",
+                &self.previous_hmac_key.as_ref().map(|_| "<redacted>"),
+            )
             .field("hwm_key_epoch", &self.hwm_key.as_ref().map(|s| s.epoch))
             .field("max_payload_bytes", &self.max_payload_bytes)
             .finish_non_exhaustive()
@@ -204,6 +213,7 @@ impl LocalBackend {
             pool,
             cipher: None,
             hmac_key: None,
+            previous_hmac_key: None,
             hwm_key: None,
             hwm_key_previous: None,
             max_payload_bytes,
@@ -252,6 +262,22 @@ impl LocalBackend {
     #[must_use]
     pub fn with_hmac_key(mut self, key: [u8; 32]) -> Self {
         self.hmac_key = Some(key);
+        self
+    }
+
+    /// Register a previous control-entry HMAC key for the rotation window (#6451), mirroring the
+    /// AEAD cipher's `with_previous` window mechanism (`zeph_core::durable::XChaCha20Poly1305Cipher`).
+    ///
+    /// The row-HMAC verification path tries this key when a row fails to
+    /// verify under the current [`with_hmac_key`](Self::with_hmac_key) key, so pre-rotation
+    /// `EffectIntent` control entries stay readable until the window is closed with `zeph durable
+    /// rotate-key --drop-previous`. Unlike the AEAD cipher's `key_id`-tagged blob layout, the
+    /// stored `hmac` column carries no key selector — a deliberate divergence, since control rows
+    /// have no payload envelope to carry one; try-both is security-equivalent for a single-slot
+    /// window. Writes always stamp with the current key only, never this one.
+    #[must_use]
+    pub fn with_previous_hmac_key(mut self, key: [u8; 32]) -> Self {
+        self.previous_hmac_key = Some(key);
         self
     }
 
@@ -572,6 +598,137 @@ impl LocalBackend {
             .map_err(|e| DurableError::storage("count_sealed_under_key_id", e))?;
             Ok((journal_count.max(0) + promises_count.max(0)).cast_unsigned())
         }
+    }
+
+    /// Count `EffectIntent` control entries whose row HMAC (INV-8) verifies **only** under the
+    /// registered [`previous_hmac_key`](Self::with_previous_hmac_key), not the current
+    /// [`hmac_key`](Self::with_hmac_key) (#6451).
+    ///
+    /// The read-side counterpart to [`count_sealed_under_key_id`](Self::count_sealed_under_key_id)
+    /// for the control-entry HMAC's own rotation window, and **not redundant** with it: the AEAD
+    /// blob-scan only sees payload-bearing rows, but a pre-rotation `EffectIntent` whose
+    /// `StepResult` was never committed (a crash between intent and result, in a still-retained
+    /// non-terminal execution) has a previous-key HMAC and no payload at all — the blob-scan
+    /// cannot see it, so dropping the previous key without this scan would silently orphan its
+    /// HMAC verification. Only `EffectIntent` rows carry a persisted+verified HMAC:
+    /// `PromiseCreated`/`TimerArmed`/`TimerFired`/`Checkpoint` all return
+    /// [`DurableError::UnsupportedEntryKind`] in `prepare_row`, and
+    /// `durable_promises` has no `hmac` column.
+    ///
+    /// Backs `zeph durable rotate-key --drop-previous`'s safety scan alongside the AEAD blob-scan
+    /// — refuse the drop while **either** is nonzero. This is a fourth, dedicated key-attach site
+    /// distinct from the three runtime read paths (agent replay, scheduler daemon, CLI read):
+    /// the caller must attach **both** [`with_hmac_key`](Self::with_hmac_key) (current) and
+    /// [`with_previous_hmac_key`](Self::with_previous_hmac_key) (previous) to this backend before
+    /// calling, or every row's HMAC is unrecomputable and this returns
+    /// [`DurableError::ControlIntegrity`] rather than a (silently wrong) count.
+    ///
+    /// Uses the precise variant — recompute-and-compare against both keys — rather than a pure
+    /// "fails under current" fail-safe: a genuinely corrupt/forged row (matches neither key) is
+    /// not counted here, since it is not something dropping the previous key would newly break;
+    /// [`read_execution`](Journal::read_execution) already rejects it on every read regardless of
+    /// which key is dropped.
+    ///
+    /// Cold path (runs only at `--drop-previous`); control rows are sparse.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DurableError::Storage`] if the query fails, or [`DurableError::ControlIntegrity`]
+    /// if matching control rows exist but this backend is missing the current or previous HMAC
+    /// key needed to recompute them.
+    pub async fn count_control_entries_under_previous_hmac(&self) -> Result<u64, DurableError> {
+        let rows: Vec<ControlHmacScanRow> = zeph_db::query_as(sql!(
+            "SELECT execution_id, step_id, idem_key, hmac
+             FROM durable_journal
+             WHERE entry_kind = 'effect_intent' AND hmac IS NOT NULL"
+        ))
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| DurableError::storage("count_control_entries_under_previous_hmac", e))?;
+
+        if rows.is_empty() {
+            return Ok(0);
+        }
+
+        let (Some(current_key), Some(previous_key)) =
+            (self.hmac_key.as_ref(), self.previous_hmac_key.as_ref())
+        else {
+            return Err(DurableError::ControlIntegrity);
+        };
+
+        let mut count = 0u64;
+        for (execution_id_raw, step_id_raw, idem_key_raw, hmac_raw) in rows {
+            let Ok(execution_id) = parse_execution_id(&execution_id_raw) else {
+                continue;
+            };
+            let Ok(step_id_value) = u32::try_from(step_id_raw) else {
+                continue;
+            };
+            let step_id = StepId::new(step_id_value);
+            let idem_key = idem_key_raw
+                .as_deref()
+                .and_then(|b| slice_to_array32(b, "effect_intent idem_key").ok())
+                .map(IdempotencyKey::from_bytes);
+            let Ok(stored) = slice_to_array32(&hmac_raw, "effect_intent hmac") else {
+                continue;
+            };
+
+            let tag = EntryKindTag::EffectIntent.as_str();
+            let expected_current = Self::keyed_control_hmac(
+                current_key,
+                execution_id,
+                step_id,
+                tag,
+                idem_key.as_ref(),
+            );
+            if blake3::Hash::from(expected_current) == blake3::Hash::from(stored) {
+                continue;
+            }
+            let expected_previous = Self::keyed_control_hmac(
+                previous_key,
+                execution_id,
+                step_id,
+                tag,
+                idem_key.as_ref(),
+            );
+            if blake3::Hash::from(expected_previous) == blake3::Hash::from(stored) {
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
+
+    /// Count `durable_execution_integrity` rows whose high-water-mark was signed under `epoch`.
+    ///
+    /// The `--drop-previous` HWM scan (addendum to #6451, spec-081 FR-008): before permanently
+    /// removing the previous rotation key, refuse if any surviving execution's HWM row is still
+    /// addressed to the previous epoch. Unlike
+    /// [`count_control_entries_under_previous_hmac`](Self::count_control_entries_under_previous_hmac),
+    /// the HWM row carries `key_epoch` in the clear, so this is a plain indexed `COUNT` — no key
+    /// material, no per-row recompute. This is also the only one of the three `--drop-previous`
+    /// scans that catches a checkpoint-folded pre-rotation execution: `checkpoint_fold` never
+    /// re-signs the HWM, so a folded execution's integrity row keeps
+    /// `key_epoch = previous_key_id` even though its old-key-id payloads are gone — invisible to
+    /// both the AEAD blob-scan
+    /// ([`count_sealed_under_key_id`](Self::count_sealed_under_key_id)) and the control-HMAC scan
+    /// (`EffectIntent`-only). Terminal-but-unpruned executions are counted too (the row is deleted
+    /// only by the retention prune sweep, never on `finalize`) — fail-safe over-refusal, resolvable
+    /// with `--force`, mirroring the other two scans' coarseness.
+    ///
+    /// Cold path (runs only at `--drop-previous`); integrity rows are sparse (one per execution).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DurableError::Storage`] if the query fails.
+    pub async fn count_integrity_rows_under_epoch(&self, epoch: u32) -> Result<u64, DurableError> {
+        let count: i64 = zeph_db::query_scalar(sql!(
+            "SELECT COUNT(*) FROM durable_execution_integrity WHERE key_epoch = ?"
+        ))
+        .bind(i64::from(epoch))
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| DurableError::storage("count_integrity_rows_under_epoch", e))?;
+        Ok(count.max(0).cast_unsigned())
     }
 
     /// Ensure a `durable_executions` row exists for `id`, returning whether this is a resume.
@@ -1711,6 +1868,24 @@ impl LocalBackend {
         idem_key: Option<&IdempotencyKey>,
     ) -> Option<[u8; 32]> {
         let key = self.hmac_key.as_ref()?;
+        Some(Self::keyed_control_hmac(
+            key,
+            execution_id,
+            step_id,
+            tag,
+            idem_key,
+        ))
+    }
+
+    /// Keyed-BLAKE3 computation over a control entry's identity, parameterized on the key so both
+    /// the current and previous rotation-window keys (#6451) can be tried against the same input.
+    fn keyed_control_hmac(
+        key: &[u8; 32],
+        execution_id: ExecutionId,
+        step_id: StepId,
+        tag: &'static str,
+        idem_key: Option<&IdempotencyKey>,
+    ) -> [u8; 32] {
         let mut input = Vec::with_capacity(16 + 4 + 16 + 32);
         input.extend_from_slice(execution_id.as_bytes());
         input.extend_from_slice(&step_id.value().to_le_bytes());
@@ -1718,11 +1893,12 @@ impl LocalBackend {
         if let Some(k) = idem_key {
             input.extend_from_slice(k.as_bytes());
         }
-        Some(*blake3::keyed_hash(key, &input).as_bytes())
+        *blake3::keyed_hash(key, &input).as_bytes()
     }
 
     /// Recompute and constant-time-verify a control entry's row HMAC read back from storage
-    /// (INV-8).
+    /// (INV-8), trying the previous rotation-window key (#6451) when the current key does not
+    /// match.
     ///
     /// A no-op only when no HMAC key is configured **and** the row carries no stored HMAC — the
     /// documented single-user local stance where control entries carry no HMAC and none is
@@ -1732,12 +1908,14 @@ impl LocalBackend {
     /// fail-closed rather than silently trusted, since an `EffectIntent`'s fields are plaintext
     /// and an unkeyed reader has no way to tell a genuine stamped row from a forged one. When a
     /// key *is* configured, every control row this backend reads must carry a matching HMAC: a
-    /// missing HMAC or a mismatch both indicate the row was forged, relocated, or written without
-    /// the configured key, and both fail closed with [`DurableError::ControlIntegrity`].
+    /// missing HMAC, or a mismatch under both the current and any registered
+    /// [`previous_hmac_key`](Self::with_previous_hmac_key), fails closed with
+    /// [`DurableError::ControlIntegrity`].
     ///
-    /// The comparison uses [`blake3::Hash`] equality, which compares in constant time (the same
+    /// Each comparison uses [`blake3::Hash`] equality, which compares in constant time (the same
     /// idiom used for the promise resolver-token check in `promise.rs`), so a forged HMAC reveals
-    /// no timing signal.
+    /// no timing signal beyond which of the (at most two) legitimate keys, if any, it was written
+    /// under — already observable via `created_at` relative to the rotation.
     fn verify_control_hmac(
         &self,
         execution_id: ExecutionId,
@@ -1746,17 +1924,29 @@ impl LocalBackend {
         idem_key: Option<&IdempotencyKey>,
         stored: Option<[u8; 32]>,
     ) -> Result<(), DurableError> {
-        let Some(expected) = self.compute_control_hmac(execution_id, step_id, tag, idem_key) else {
+        let Some(current_key) = self.hmac_key.as_ref() else {
             return if stored.is_some() {
                 Err(DurableError::ControlIntegrity)
             } else {
                 Ok(())
             };
         };
-        match stored {
-            Some(stored) if blake3::Hash::from(expected) == blake3::Hash::from(stored) => Ok(()),
-            _ => Err(DurableError::ControlIntegrity),
+        let Some(stored) = stored else {
+            return Err(DurableError::ControlIntegrity);
+        };
+        let expected_current =
+            Self::keyed_control_hmac(current_key, execution_id, step_id, tag, idem_key);
+        if blake3::Hash::from(expected_current) == blake3::Hash::from(stored) {
+            return Ok(());
         }
+        if let Some(previous_key) = self.previous_hmac_key.as_ref() {
+            let expected_previous =
+                Self::keyed_control_hmac(previous_key, execution_id, step_id, tag, idem_key);
+            if blake3::Hash::from(expected_previous) == blake3::Hash::from(stored) {
+                return Ok(());
+            }
+        }
+        Err(DurableError::ControlIntegrity)
     }
 
     /// Compute the high-water-mark HMAC (issue #6360) over the signed
@@ -1934,8 +2124,10 @@ impl LocalBackend {
                 "key_epoch_unresolvable",
                 "possibly re-keyed: this execution's signed key_epoch is neither the current key \
                  nor a registered previous rotation key — if ZEPH_DURABLE_KEY was recently \
-                 rotated, register the prior key via with_previous_hwm_key; the durable resume \
-                 path cannot proceed without it (no interactive override)",
+                 rotated, ensure the rotation window is still open (ZEPH_DURABLE_KEY_PREVIOUS \
+                 present and [durable] previous_key_id set); the window is closed permanently by \
+                 `zeph durable rotate-key --drop-previous`. The durable resume path cannot \
+                 proceed without it (no interactive override)",
             ));
         };
         let stored_hmac =
@@ -2447,6 +2639,10 @@ type JournalRowRead = (
     i64,
 );
 
+/// A `durable_journal` row read for [`LocalBackend::count_control_entries_under_previous_hmac`],
+/// in `SELECT` column order: `(execution_id, step_id, idem_key, hmac)`.
+type ControlHmacScanRow = (String, i64, Option<Vec<u8>>, Vec<u8>);
+
 /// A `durable_promises` row read back from storage, in `SELECT` column order:
 /// `(execution_id, resolver_token_hash, resolved, payload)`.
 type PromiseRowRead = (String, Vec<u8>, i64, Option<Vec<u8>>);
@@ -2615,6 +2811,45 @@ mod tests {
                 return Err(CipherError::Authentication);
             }
             Ok(sealed[8..].iter().map(|b| b ^ XOR_MASK).collect())
+        }
+    }
+
+    /// A test cipher double that embeds a `key_id` leading byte (mirroring the production
+    /// `key_id(1) || nonce || ciphertext || tag` contract documented on [`PayloadCipher`]) and,
+    /// like the real `XChaCha20Poly1305Cipher::with_previous`, can still decrypt a payload sealed
+    /// under a registered `previous_id` while always sealing new writes under `current_id` — the
+    /// minimal shape needed to exercise `checkpoint_fold`'s reseal-under-current behavior across a
+    /// simulated rotation window, without depending on the real AEAD cipher (out of scope for
+    /// `zeph-durable`, INV-1).
+    struct RotatingKeyedCipher {
+        current_id: u8,
+        previous_id: Option<u8>,
+    }
+
+    impl PayloadCipher for RotatingKeyedCipher {
+        fn seal(&self, plaintext: &[u8], aad: &PayloadAad) -> Result<Vec<u8>, CipherError> {
+            let tag = blake3::hash(&aad.canonical_bytes());
+            let mut out = vec![self.current_id];
+            out.extend_from_slice(&tag.as_bytes()[..8]);
+            out.extend(plaintext.iter().map(|b| b ^ XOR_MASK));
+            Ok(out)
+        }
+
+        fn open(&self, sealed: &[u8], aad: &PayloadAad) -> Result<Vec<u8>, CipherError> {
+            if sealed.len() < 9 {
+                return Err(CipherError::Malformed {
+                    context: "sealed blob shorter than the key-id + aad tag prefix",
+                });
+            }
+            let id = sealed[0];
+            if id != self.current_id && Some(id) != self.previous_id {
+                return Err(CipherError::UnknownKeyId { key_id: id });
+            }
+            let expected = blake3::hash(&aad.canonical_bytes());
+            if sealed[1..9] != expected.as_bytes()[..8] {
+                return Err(CipherError::Authentication);
+            }
+            Ok(sealed[9..].iter().map(|b| b ^ XOR_MASK).collect())
         }
     }
 
@@ -3044,6 +3279,158 @@ mod tests {
         let unkeyed_reader = LocalBackend::new(writer.pool().clone(), 1_048_576);
         assert_matches!(
             unkeyed_reader.read_execution(exec).await,
+            Err(DurableError::ControlIntegrity)
+        );
+    }
+
+    /// #6451: a control entry written under the pre-rotation key must still verify once a reader
+    /// registers that key as `previous_hmac_key`, even though its own `hmac_key` has moved on to
+    /// the new (post-rotation) key — the try-both rotation window, symmetric to the AEAD cipher's
+    /// `with_previous`. This is also the payload-less "crash-orphan" shape the drop-scan exists
+    /// for: `effect_intent` entries never carry a payload, so this row has a previous-key HMAC
+    /// with nothing for the AEAD blob-scan to see.
+    #[tokio::test]
+    async fn verify_control_hmac_accepts_row_under_previous_key_during_window() {
+        let writer = mem_backend(1_048_576).await.with_hmac_key([1u8; 32]);
+        let exec = ExecutionId::new();
+        writer
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        writer.append(effect_intent(exec, 0)).await.unwrap();
+
+        // Post-rotation reader: current key is the new key [2u8; 32], previous is the pre-rotation
+        // key [1u8; 32] that actually stamped the row.
+        let post_rotation_reader = LocalBackend::new(writer.pool().clone(), 1_048_576)
+            .with_hmac_key([2u8; 32])
+            .with_previous_hmac_key([1u8; 32]);
+        assert!(
+            post_rotation_reader.read_execution(exec).await.is_ok(),
+            "a row stamped under the previous key must verify during the rotation window"
+        );
+
+        // A fresh row written by the post-rotation writer stamps under the current key only, and
+        // must verify without needing the previous slot.
+        let post_rotation_writer = LocalBackend::new(writer.pool().clone(), 1_048_576)
+            .with_hmac_key([2u8; 32])
+            .with_previous_hmac_key([1u8; 32]);
+        post_rotation_writer
+            .append(effect_intent(exec, 1))
+            .await
+            .unwrap();
+        assert!(post_rotation_writer.read_execution(exec).await.is_ok());
+    }
+
+    /// #6451: a row that matches neither the current nor the registered previous key must still
+    /// fail closed — the rotation window widens acceptance to exactly two legitimate keys, never
+    /// to "any key".
+    #[tokio::test]
+    async fn verify_control_hmac_rejects_row_under_neither_current_nor_previous_key() {
+        let writer = mem_backend(1_048_576).await.with_hmac_key([9u8; 32]);
+        let exec = ExecutionId::new();
+        writer
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        writer.append(effect_intent(exec, 0)).await.unwrap();
+
+        let unrelated_reader = LocalBackend::new(writer.pool().clone(), 1_048_576)
+            .with_hmac_key([2u8; 32])
+            .with_previous_hmac_key([3u8; 32]);
+        assert_matches!(
+            unrelated_reader.read_execution(exec).await,
+            Err(DurableError::ControlIntegrity)
+        );
+    }
+
+    /// #6451: `count_control_entries_under_previous_hmac` is the drop-scan gate for
+    /// `--drop-previous` — it must count a row that verifies only under the previous key, and
+    /// must not count a row that still verifies under the current key (no false refusal once the
+    /// row has actually been re-keyed).
+    #[tokio::test]
+    async fn count_control_entries_under_previous_hmac_counts_previous_only_rows() {
+        let writer = mem_backend(1_048_576).await.with_hmac_key([1u8; 32]);
+        let exec = ExecutionId::new();
+        writer
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        // Pre-rotation row: stamped under [1u8; 32], the soon-to-be-previous key.
+        writer.append(effect_intent(exec, 0)).await.unwrap();
+
+        let scanner_mid_window = LocalBackend::new(writer.pool().clone(), 1_048_576)
+            .with_hmac_key([2u8; 32])
+            .with_previous_hmac_key([1u8; 32]);
+        assert_eq!(
+            scanner_mid_window
+                .count_control_entries_under_previous_hmac()
+                .await
+                .unwrap(),
+            1,
+            "a row stamped under the previous key only must be counted"
+        );
+
+        // A post-rotation row, stamped under the new current key, must not be counted.
+        let post_rotation_writer = LocalBackend::new(writer.pool().clone(), 1_048_576)
+            .with_hmac_key([2u8; 32])
+            .with_previous_hmac_key([1u8; 32]);
+        post_rotation_writer
+            .append(effect_intent(exec, 1))
+            .await
+            .unwrap();
+        assert_eq!(
+            post_rotation_writer
+                .count_control_entries_under_previous_hmac()
+                .await
+                .unwrap(),
+            1,
+            "the post-rotation row (verifies under current) must not add to the count"
+        );
+    }
+
+    /// #6451: once every previous-key row has been superseded (or there were none), the scan
+    /// reports zero without requiring any rows to exist at all — the clean `--drop-previous`
+    /// no-op/success path.
+    #[tokio::test]
+    async fn count_control_entries_under_previous_hmac_is_zero_on_empty_journal() {
+        let backend = mem_backend(1_048_576).await;
+        assert_eq!(
+            backend
+                .count_control_entries_under_previous_hmac()
+                .await
+                .unwrap(),
+            0
+        );
+    }
+
+    /// #6451 critic finding 1: the scan cannot be trusted without both keys attached — a caller
+    /// that opens the backend unkeyed (as the pre-fix `--drop-previous` scan site did) must get a
+    /// hard error, not a silently-wrong count that could let `--drop-previous` refuse forever (or
+    /// worse, proceed unsafely).
+    #[tokio::test]
+    async fn count_control_entries_under_previous_hmac_errors_when_keys_missing() {
+        let writer = mem_backend(1_048_576).await.with_hmac_key([1u8; 32]);
+        let exec = ExecutionId::new();
+        writer
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        writer.append(effect_intent(exec, 0)).await.unwrap();
+
+        let unkeyed_scanner = LocalBackend::new(writer.pool().clone(), 1_048_576);
+        assert_matches!(
+            unkeyed_scanner
+                .count_control_entries_under_previous_hmac()
+                .await,
+            Err(DurableError::ControlIntegrity)
+        );
+
+        let current_only_scanner =
+            LocalBackend::new(writer.pool().clone(), 1_048_576).with_hmac_key([1u8; 32]);
+        assert_matches!(
+            current_only_scanner
+                .count_control_entries_under_previous_hmac()
+                .await,
             Err(DurableError::ControlIntegrity)
         );
     }
@@ -4812,6 +5199,91 @@ mod tests {
                 .unwrap(),
             "a legitimate fold must not trip the HWM check: committed_result_count is invariant \
              across it (folded_count restores what the DELETE removed)"
+        );
+    }
+
+    /// S1 regression (addendum to #6451, spec-081 FR-008): a pre-rotation execution whose
+    /// `StepResult`s are checkpoint-folded post-rotation reseals its checkpoint snapshot under
+    /// the NEW `key_id` and DELETEs every old-key-id `StepResult` row it folds, but
+    /// `checkpoint_fold` never re-signs the HWM (`committed_result_count` is deliberately
+    /// invariant across a fold — see the doc on `checkpoint_fold`). So the integrity row keeps
+    /// `key_epoch = previous_key_id` even once no old-key-id payload survives at all. This
+    /// execution has `StepResult`s only (no `EffectIntent`), so both the AEAD blob-scan and the
+    /// control-HMAC scan see nothing — `count_integrity_rows_under_epoch` is the only one of the
+    /// three `--drop-previous` scans that catches it.
+    #[tokio::test]
+    async fn count_integrity_rows_under_epoch_catches_a_checkpoint_folded_pre_rotation_execution() {
+        let pre_rotation = mem_backend(1_048_576)
+            .await
+            .with_cipher(Arc::new(RotatingKeyedCipher {
+                current_id: 0,
+                previous_id: None,
+            }))
+            .with_hwm_key(0, [20u8; 32]);
+        let exec = ExecutionId::new();
+        pre_rotation
+            .open_execution(exec, ExecutionKind::AgentTurn)
+            .await
+            .unwrap();
+        for step in 0..3 {
+            pre_rotation
+                .append(step_result(exec, step, format!("v{step}").as_bytes()))
+                .await
+                .unwrap();
+        }
+
+        // Rotate: a fresh handle over the same journal now speaks the NEW current epoch/key-id
+        // (1), with the old one (0) registered as previous for both the cipher (so fold can still
+        // decrypt the not-yet-folded rows) and the HWM (the rotation window) — exactly mirroring
+        // a real `zeph durable rotate-key` followed by a background fold.
+        let post_rotation = LocalBackend::new(pre_rotation.pool().clone(), 1_048_576)
+            .with_cipher(Arc::new(RotatingKeyedCipher {
+                current_id: 1,
+                previous_id: Some(0),
+            }))
+            .with_hwm_key(1, [21u8; 32])
+            .with_previous_hwm_key(0, [20u8; 32]);
+
+        let folded = post_rotation.checkpoint_fold(exec, 3).await.unwrap();
+        assert_eq!(
+            folded, 3,
+            "fold must compact every committed StepResult, leaving none live"
+        );
+
+        assert_eq!(
+            post_rotation.count_sealed_under_key_id(0).await.unwrap(),
+            0,
+            "every pre-rotation payload was folded away and resealed under the new key_id; the \
+             AEAD scan sees nothing left sealed under the previous key_id"
+        );
+        assert_eq!(
+            post_rotation
+                .count_integrity_rows_under_epoch(0)
+                .await
+                .unwrap(),
+            1,
+            "the folded execution's HWM row still carries the previous epoch -- checkpoint_fold \
+             never re-signs it (S1)"
+        );
+        assert_eq!(
+            post_rotation
+                .count_integrity_rows_under_epoch(1)
+                .await
+                .unwrap(),
+            0,
+            "the row has not migrated to the current epoch -- only a fresh StepResult commit \
+             after resume would bump it"
+        );
+
+        // The folded execution is not corrupted — it must still resume cleanly through the open
+        // rotation window (this addendum's epoch=key_id design), it is just still dependent on
+        // the previous HWM key until `--drop-previous` (which S1's fix now correctly refuses).
+        assert!(
+            post_rotation
+                .open_execution(exec, ExecutionKind::AgentTurn)
+                .await
+                .unwrap(),
+            "a folded pre-rotation execution must still resume through the open rotation window"
         );
     }
 

--- a/crates/zeph-tui/src/widgets/durable.rs
+++ b/crates/zeph-tui/src/widgets/durable.rs
@@ -10,6 +10,11 @@
 //! missing) the panel shows the [`STATUS_UNAVAILABLE`] message; when `encryption_gate` (INV-8)
 //! rejects the deployment's configuration it shows [`STATUS_GATE_REJECTED`] instead, so the two
 //! distinct causes aren't conflated (see [`DurableStatus`]).
+//!
+//! The header also shows the current AEAD/HMAC `key_id` and, when a rotation window is open
+//! (`[durable] previous_key_id` set, #6451), a passive `rotation window open` indicator. This is
+//! visibility only — the panel never exposes a rotation action; rotation stays a
+//! restart-required CLI-only operation (`zeph durable rotate-key`).
 
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
@@ -61,6 +66,12 @@ pub struct DurableSnapshot {
     pub status: DurableStatus,
     /// Executions, newest first.
     pub executions: Vec<DurableRow>,
+    /// The current AEAD/HMAC key id (`[durable] key_id`, #6451).
+    pub key_id: u8,
+    /// Set when a key-rotation window is open (`[durable] previous_key_id`, #6451), carrying the
+    /// previous key id. Read-only visibility for the operator — the panel never offers a rotation
+    /// action; rotation stays a restart-required CLI-only operation (`zeph durable rotate-key`).
+    pub previous_key_id: Option<u8>,
 }
 
 fn status_color(status: &str) -> Color {
@@ -95,11 +106,21 @@ pub fn render(
     frame.render_widget(Clear, area);
 
     let exec_count = snapshot.executions.len();
-    let header_text = format!("durable · {exec_count}  [D]");
-    let header = Line::from(Span::styled(
-        header_text,
+    let mut header_spans = vec![Span::styled(
+        format!("durable · {exec_count}  key_id={}", snapshot.key_id),
+        theme.system_message.add_modifier(Modifier::BOLD),
+    )];
+    if let Some(previous_key_id) = snapshot.previous_key_id {
+        header_spans.push(Span::styled(
+            format!("  rotation window open (previous_key_id = {previous_key_id})"),
+            Style::default().fg(Color::Yellow),
+        ));
+    }
+    header_spans.push(Span::styled(
+        "  [D]",
         theme.system_message.add_modifier(Modifier::BOLD),
     ));
+    let header = Line::from(header_spans);
     let splits = Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(area);
     frame.render_widget(Paragraph::new(header), splits[0]);
 
@@ -206,6 +227,7 @@ mod tests {
         let snapshot = DurableSnapshot {
             status: DurableStatus::Unavailable,
             executions: Vec::new(),
+            ..DurableSnapshot::default()
         };
         let buf = render_over_sentinel(&snapshot);
         for cell in &buf.content {
@@ -227,6 +249,7 @@ mod tests {
         let snapshot = DurableSnapshot {
             status: DurableStatus::GateRejected,
             executions: Vec::new(),
+            ..DurableSnapshot::default()
         };
         let buf = render_over_sentinel(&snapshot);
         for cell in &buf.content {
@@ -254,6 +277,7 @@ mod tests {
                 step_count: 3,
                 age_secs: 12,
             }],
+            ..DurableSnapshot::default()
         };
         let buf = render_over_sentinel(&snapshot);
         for cell in &buf.content {
@@ -272,6 +296,7 @@ mod tests {
         let unavailable = render_over_sentinel(&DurableSnapshot {
             status: DurableStatus::Unavailable,
             executions: Vec::new(),
+            ..DurableSnapshot::default()
         });
         let rendered_unavailable: String = unavailable
             .content
@@ -284,6 +309,7 @@ mod tests {
         let gate_rejected = render_over_sentinel(&DurableSnapshot {
             status: DurableStatus::GateRejected,
             executions: Vec::new(),
+            ..DurableSnapshot::default()
         });
         let rendered_gate_rejected: String = gate_rejected
             .content
@@ -305,6 +331,7 @@ mod tests {
                 step_count: 7,
                 age_secs: 300,
             }],
+            ..DurableSnapshot::default()
         };
         let buf = render_over_sentinel(&snapshot);
         let rendered: String = buf.content.iter().map(|c| c.symbol().to_owned()).collect();
@@ -321,11 +348,57 @@ mod tests {
         let snapshot = DurableSnapshot {
             status: DurableStatus::Available,
             executions: Vec::new(),
+            ..DurableSnapshot::default()
         };
         let buf = render_over_sentinel(&snapshot);
         let rendered: String = buf.content.iter().map(|c| c.symbol().to_owned()).collect();
         assert!(rendered.contains("No durable executions recorded."));
         assert!(!rendered.contains(STATUS_UNAVAILABLE));
         assert!(!rendered.contains(STATUS_GATE_REJECTED));
+    }
+
+    /// Regression for #6450: the panel header must always show the active `key_id`, regardless
+    /// of whether a rotation window is open.
+    #[test]
+    fn header_always_shows_current_key_id() {
+        let snapshot = DurableSnapshot {
+            status: DurableStatus::Available,
+            executions: Vec::new(),
+            key_id: 3,
+            previous_key_id: None,
+        };
+        let buf = render_over_sentinel(&snapshot);
+        let rendered: String = buf.content.iter().map(|c| c.symbol().to_owned()).collect();
+        assert!(
+            rendered.contains("key_id=3"),
+            "expected current key_id in header, got: {rendered:?}"
+        );
+        assert!(
+            !rendered.contains("rotation window open"),
+            "no rotation window is open, indicator must not render, got: {rendered:?}"
+        );
+    }
+
+    /// Regression for #6450: when `previous_key_id` is set (a rotation window is open, #6451),
+    /// the panel shows a passive read-only indicator — no action button, restart-required
+    /// CLI-only rotation stays CLI-only.
+    #[test]
+    fn rotation_window_open_renders_passive_indicator_with_previous_key_id() {
+        let snapshot = DurableSnapshot {
+            status: DurableStatus::Available,
+            executions: Vec::new(),
+            key_id: 2,
+            previous_key_id: Some(1),
+        };
+        let buf = render_over_sentinel(&snapshot);
+        let rendered: String = buf.content.iter().map(|c| c.symbol().to_owned()).collect();
+        assert!(
+            rendered.contains("key_id=2"),
+            "expected current key_id in header, got: {rendered:?}"
+        );
+        assert!(
+            rendered.contains("rotation window open (previous_key_id = 1)"),
+            "expected passive rotation window indicator, got: {rendered:?}"
+        );
     }
 }

--- a/crates/zeph-tui/src/widgets/status.rs
+++ b/crates/zeph-tui/src/widgets/status.rs
@@ -521,6 +521,17 @@ fn push_extra_low_segments(
             )],
         );
     }
+    // Passive read-only durable HMAC/AEAD key-rotation window indicator (#6451, #6450). No action
+    // button here — rotation stays a restart-required CLI-only operation (`zeph durable rotate-key`).
+    if let Some(previous_key_id) = app.durable_snapshot.previous_key_id {
+        list.push(
+            Priority::Low,
+            vec![Span::styled(
+                format!(" · durable rotation window open (previous_key_id = {previous_key_id})"),
+                theme.status_bar,
+            )],
+        );
+    }
 }
 
 fn build_cocoon_spans(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -834,16 +834,11 @@ pub(crate) enum DurableCommand {
         /// clear `previous_key_id`, after verifying no sealed payload still uses the old key
         #[arg(long)]
         drop_previous: bool,
-        /// Skip the `--drop-previous` safety scan for sealed payloads still using the old key.
-        /// Applies only to `--drop-previous`; never bypasses the open-window or shared-database
-        /// refusals
+        /// Skip the `--drop-previous` safety scans for sealed payloads and control-entry HMACs
+        /// still depending on the old key. Applies only to `--drop-previous`; never bypasses the
+        /// open-window refusal
         #[arg(long)]
         force: bool,
-        /// Acknowledge that this durable journal is a shared database: rotating will re-derive
-        /// the control-entry HMAC key, which has no rotation window, breaking verification for
-        /// every in-flight execution until it drains
-        #[arg(long)]
-        ack_shared_db_drain: bool,
     },
 }
 

--- a/src/commands/durable.rs
+++ b/src/commands/durable.rs
@@ -170,71 +170,177 @@ fn load_durable_cipher(config: &DurableConfig) -> anyhow::Result<XChaCha20Poly13
     Ok(cipher)
 }
 
-/// Resolve the control-entry row HMAC key (INV-8) for the durable journal at `url`, deriving it
-/// from the vault-stored `ZEPH_DURABLE_KEY` when this deployment is a declared/detected shared
-/// database ([`is_shared_db`]).
+/// Both control-entry HMAC keys (INV-8) resolved for a durable-journal deployment: the current
+/// key, present whenever this deployment is a declared/detected shared database, and the
+/// previous key, present only while a `zeph durable rotate-key` rotation window is open
+/// (`config.previous_key_id.is_some()`, #6451) — the HMAC-side counterpart to the AEAD cipher's
+/// current/previous key pair.
+#[derive(Default)]
+pub(crate) struct ControlHmacKeys {
+    pub(crate) current: Option<[u8; 32]>,
+    pub(crate) previous: Option<[u8; 32]>,
+}
+
+/// Resolve the control-entry row HMAC keys (INV-8) for the durable journal at `url`, deriving
+/// them from the vault-stored `ZEPH_DURABLE_KEY`/`ZEPH_DURABLE_KEY_PREVIOUS` when this deployment
+/// is a declared/detected shared database ([`is_shared_db`]).
 ///
-/// Returns `Ok(None)` for a single-user local, non-shared database — the documented stance where
-/// control entries carry no HMAC and none is enforced (INV-8). Fails closed (`Err`) when the
-/// deployment is shared but `ZEPH_DURABLE_KEY` cannot be resolved or decoded: a shared database
-/// must never silently run without the row-HMAC forgery defense.
+/// Returns both fields `None` for a single-user local, non-shared database — the documented
+/// stance where control entries carry no HMAC and none is enforced (INV-8). Fails closed (`Err`)
+/// when the deployment is shared but `ZEPH_DURABLE_KEY` cannot be resolved or decoded, or when a
+/// rotation window is declared (`config.previous_key_id.is_some()`) but
+/// `ZEPH_DURABLE_KEY_PREVIOUS` cannot be resolved or decoded — mirroring
+/// [`load_durable_cipher`]'s fail-closed stance on its own previous-key slot: a shared database
+/// must never silently run without the row-HMAC forgery defense, and a declared window must never
+/// silently degrade to no previous slot (#6451).
 fn load_control_hmac_key(
     config: &zeph_core::config::DurableConfig,
     url: &str,
-) -> anyhow::Result<Option<[u8; 32]>> {
+) -> anyhow::Result<ControlHmacKeys> {
     if !is_shared_db(config, url) {
-        return Ok(None);
+        return Ok(ControlHmacKeys::default());
     }
     let dir = zeph_core::vault::default_vault_dir();
     let provider = AgeVaultProvider::load(&dir.join("vault-key.txt"), &dir.join("secrets.age"))
         .map_err(|e| anyhow::anyhow!("failed to load vault: {e}"))?;
-    let key = provider.get("ZEPH_DURABLE_KEY").ok_or_else(|| {
+    let key = provider.get(CURRENT_KEY_VAULT_NAME).ok_or_else(|| {
         anyhow::anyhow!(
-            "ZEPH_DURABLE_KEY not found in vault; required to compute the control-entry row HMAC \
-             on a shared database (INV-8)"
+            "{CURRENT_KEY_VAULT_NAME} not found in vault; required to compute the control-entry \
+             row HMAC on a shared database (INV-8)"
         )
     })?;
-    let hmac_key = zeph_core::durable::derive_control_hmac_key_b64(key).map_err(|e| {
-        anyhow::anyhow!("invalid ZEPH_DURABLE_KEY for control-entry HMAC derivation: {e}")
+    let current = zeph_core::durable::derive_control_hmac_key_b64(key).map_err(|e| {
+        anyhow::anyhow!("invalid {CURRENT_KEY_VAULT_NAME} for control-entry HMAC derivation: {e}")
     })?;
-    Ok(Some(hmac_key))
+
+    let previous = if let Some(prev_id) = config.previous_key_id {
+        let prev_key = provider.get(PREVIOUS_KEY_VAULT_NAME).ok_or_else(|| {
+            anyhow::anyhow!(
+                "durable config declares previous_key_id = {prev_id} but \
+                 {PREVIOUS_KEY_VAULT_NAME} is missing from the vault; refusing to build \
+                 control-entry HMAC keys with an inconsistent rotation state (this can happen if \
+                 a previous `zeph durable rotate-key` run crashed mid-write) — reconcile config \
+                 and vault to a consistent pair, or re-run `zeph durable rotate-key` to see \
+                 recovery guidance, before retrying"
+            )
+        })?;
+        Some(
+            zeph_core::durable::derive_control_hmac_key_b64(prev_key).map_err(|e| {
+                anyhow::anyhow!(
+                    "invalid {PREVIOUS_KEY_VAULT_NAME} for control-entry HMAC derivation: {e}"
+                )
+            })?,
+        )
+    } else {
+        None
+    };
+
+    Ok(ControlHmacKeys {
+        current: Some(current),
+        previous,
+    })
 }
 
-/// Resolve the control-entry HMAC key to attach on a durable *write* path (INV-8), mirroring
+/// Resolve the control-entry HMAC keys to attach on a durable *write* path (INV-8), mirroring
 /// [`load_write_cipher`]'s `config` → `url` resolution.
 ///
 /// # Errors
 ///
 /// Returns an error when this deployment is a shared database and `ZEPH_DURABLE_KEY` cannot be
-/// resolved from the vault.
-pub(crate) fn load_write_hmac_key(config: &Config) -> anyhow::Result<Option<[u8; 32]>> {
+/// resolved from the vault, or a rotation window is declared but `ZEPH_DURABLE_KEY_PREVIOUS`
+/// cannot be resolved.
+pub(crate) fn load_write_hmac_key(config: &Config) -> anyhow::Result<ControlHmacKeys> {
     let url = resolve_durable_db_url(config);
     load_control_hmac_key(&config.durable, &url)
 }
 
-/// Resolve the high-water-mark key (issue #6360) to attach on a durable *write* path.
+/// One high-water-mark key, addressed by its non-secret rotation epoch (FR-008) — the loader-side
+/// mirror of [`zeph_durable::LocalBackend`]'s internal `HwmKeySlot`, named per the addendum's M3
+/// so the three key loaders (`load_durable_cipher`, `load_control_hmac_key`, this one) all return
+/// a named `{epoch, key}` / `{current, previous}` shape rather than a bare tuple.
+pub(crate) struct HwmSlot {
+    pub(crate) epoch: u32,
+    pub(crate) key: [u8; 32],
+}
+
+/// Both high-water-mark keys (FR-008/FR-009) resolved for a durable-journal deployment: the
+/// current slot, present whenever `ZEPH_DURABLE_KEY` resolves from the vault, and the previous
+/// slot, present only while a `zeph durable rotate-key` rotation window is open
+/// (`config.durable.previous_key_id.is_some()`) — the HWM-side counterpart to
+/// [`ControlHmacKeys`], addendum to #6451.
+#[derive(Default)]
+pub(crate) struct HwmKeys {
+    pub(crate) current: Option<HwmSlot>,
+    pub(crate) previous: Option<HwmSlot>,
+}
+
+/// Resolve the high-water-mark keys (issue #6360) to attach on a durable *write* path.
 ///
 /// Unlike [`load_control_hmac_key`] (attached only on a declared/detected shared database), the
 /// high-water-mark key is meant to be attached unconditionally (FR-009): it is the only mechanism
 /// that detects deletion of a committed `StepResult` row, a threat class the AEAD payload seal and
 /// the shared-DB row HMAC do not cover on any deployment, single-user local included.
 ///
-/// Returns `Ok(None)` when `ZEPH_DURABLE_KEY` is not (yet) resolvable from the vault — the same
-/// graceful-degrade posture as the rest of durable bootstrap (a missing key means the mechanism is
-/// inactive for this run, not that a verification failed) — rather than hard-failing bootstrap.
-pub(crate) fn load_write_hwm_key(_config: &Config) -> anyhow::Result<Option<(u32, [u8; 32])>> {
+/// The rotation epoch stamped alongside each key (FR-008) is `config.durable.key_id` /
+/// `previous_key_id` — the HWM key reuses the AEAD cipher's own `key_id`-driven rotation
+/// lifecycle rather than a separate epoch counter, addendum to #6451: this makes the
+/// previously-dead `with_previous_hwm_key` slot (#6453) reachable for the first time, since
+/// `key_id` defaults to `0` and un-rotated deployments already stamp `key_epoch = 0` rows, no
+/// migration is needed.
+///
+/// Returns `current: None` when `ZEPH_DURABLE_KEY` is not (yet) resolvable from the vault — the
+/// same graceful-degrade posture as the rest of durable bootstrap (a missing key means the
+/// mechanism is inactive for this run, not that a verification failed) — rather than hard-failing
+/// bootstrap. Fails closed (`Err`), mirroring [`load_control_hmac_key`]'s own previous-key stance,
+/// when a rotation window is declared (`previous_key_id.is_some()`) but
+/// `ZEPH_DURABLE_KEY_PREVIOUS` cannot be resolved or decoded: a declared window must never
+/// silently degrade to no previous slot.
+///
+/// # Errors
+///
+/// Returns an error when `ZEPH_DURABLE_KEY` resolves but fails to decode, or a rotation window is
+/// declared but `ZEPH_DURABLE_KEY_PREVIOUS` cannot be resolved or decoded.
+pub(crate) fn load_write_hwm_key(config: &Config) -> anyhow::Result<HwmKeys> {
     let dir = zeph_core::vault::default_vault_dir();
     let Ok(provider) = AgeVaultProvider::load(&dir.join("vault-key.txt"), &dir.join("secrets.age"))
     else {
-        return Ok(None);
+        return Ok(HwmKeys::default());
     };
-    let Some(key) = provider.get("ZEPH_DURABLE_KEY") else {
-        return Ok(None);
+    let Some(key) = provider.get(CURRENT_KEY_VAULT_NAME) else {
+        return Ok(HwmKeys::default());
     };
     let hwm_key = zeph_core::durable::derive_hwm_key_b64(key).map_err(|e| {
-        anyhow::anyhow!("invalid ZEPH_DURABLE_KEY for high-water-mark derivation: {e}")
+        anyhow::anyhow!("invalid {CURRENT_KEY_VAULT_NAME} for high-water-mark derivation: {e}")
     })?;
-    Ok(Some((zeph_core::durable::HWM_KEY_EPOCH, hwm_key)))
+    let current = Some(HwmSlot {
+        epoch: u32::from(config.durable.key_id),
+        key: hwm_key,
+    });
+
+    let previous = if let Some(prev_id) = config.durable.previous_key_id {
+        let prev_key = provider.get(PREVIOUS_KEY_VAULT_NAME).ok_or_else(|| {
+            anyhow::anyhow!(
+                "durable config declares previous_key_id = {prev_id} but \
+                 {PREVIOUS_KEY_VAULT_NAME} is missing from the vault; refusing to build \
+                 high-water-mark keys with an inconsistent rotation state (this can happen if \
+                 a previous `zeph durable rotate-key` run crashed mid-write) — reconcile config \
+                 and vault to a consistent pair, or re-run `zeph durable rotate-key` to see \
+                 recovery guidance, before retrying"
+            )
+        })?;
+        Some(HwmSlot {
+            epoch: u32::from(prev_id),
+            key: zeph_core::durable::derive_hwm_key_b64(prev_key).map_err(|e| {
+                anyhow::anyhow!(
+                    "invalid {PREVIOUS_KEY_VAULT_NAME} for high-water-mark derivation: {e}"
+                )
+            })?,
+        })
+    } else {
+        None
+    };
+
+    Ok(HwmKeys { current, previous })
 }
 
 /// Resolve the AEAD payload cipher to attach on a durable *write* path when
@@ -273,17 +379,26 @@ pub(crate) fn load_write_cipher(
 /// gate exists to reject, regardless of whether the read is via a write path or `--reveal`
 /// (#5996). The permitted single-user local override still emits a startup `WARN` and proceeds.
 ///
-/// Also attaches the control-entry HMAC key ([`load_control_hmac_key`]) whenever this deployment
+/// Also attaches the control-entry HMAC keys ([`load_control_hmac_key`]) whenever this deployment
 /// is a declared/detected shared database, unconditionally of `reveal` — HMAC verification guards
 /// every read of a control entry (`list`/`show`/`inspect`/`prune`/`resume`/`--reveal` alike), not
-/// just the decrypted view (#6043/#6044).
+/// just the decrypted view (#6043/#6044). Attaches the previous key too when a `zeph durable
+/// rotate-key` window is open (#6451), so a pre-rotation `EffectIntent` control entry stays
+/// readable on this CLI read path through the window, mirroring the two other runtime read paths
+/// (agent replay, scheduler daemon).
+///
+/// Also attaches the high-water-mark keys ([`load_write_hwm_key`], addendum to #6451) — current
+/// unconditionally (FR-009) and previous whenever a rotation window is open — mirroring the
+/// control-entry HMAC attach above, so this CLI read path stays symmetric with the other two
+/// runtime read channels for both key families.
 ///
 /// Returns `Ok(None)` when no journal file exists yet (a friendly signal that durable execution has
 /// not run on this deployment), so the caller can print guidance instead of creating an empty file.
 async fn open_backend(config: &Config, reveal: bool) -> anyhow::Result<Option<LocalBackend>> {
     let url = resolve_durable_db_url(config);
     enforce_encryption_gate(&config.durable, &url)?;
-    let hmac_key = load_control_hmac_key(&config.durable, &url)?;
+    let hmac_keys = load_control_hmac_key(&config.durable, &url)?;
+    let hwm_keys = load_write_hwm_key(config)?;
     if url != ":memory:" && !Path::new(&url).exists() {
         println!(
             "No durable journal at {url}.\n\
@@ -298,8 +413,23 @@ async fn open_backend(config: &Config, reveal: bool) -> anyhow::Result<Option<Lo
         .init()
         .await
         .map_err(|e| anyhow::anyhow!("failed to initialize durable schema: {e}"))?;
-    let backend = if let Some(key) = hmac_key {
+    let backend = if let Some(key) = hmac_keys.current {
         backend.with_hmac_key(key)
+    } else {
+        backend
+    };
+    let backend = if let Some(key) = hmac_keys.previous {
+        backend.with_previous_hmac_key(key)
+    } else {
+        backend
+    };
+    let backend = if let Some(slot) = hwm_keys.current {
+        backend.with_hwm_key(slot.epoch, slot.key)
+    } else {
+        backend
+    };
+    let backend = if let Some(slot) = hwm_keys.previous {
+        backend.with_previous_hwm_key(slot.epoch, slot.key)
     } else {
         backend
     };
@@ -316,8 +446,19 @@ async fn open_backend(config: &Config, reveal: bool) -> anyhow::Result<Option<Lo
 /// # Errors
 ///
 /// Returns an error if the config cannot be loaded, the journal cannot be opened, or a query fails.
-#[allow(clippy::too_many_lines)]
 pub(crate) async fn handle_durable_command(
+    cmd: DurableCommand,
+    config_path: Option<&Path>,
+) -> anyhow::Result<()> {
+    // Boxed so every caller's own future only holds a thin `Pin<Box<dyn Future>>` rather than
+    // this function's full match-arm state machine inline — with `ControlHmacKeys` threaded
+    // through several branches (#6451), the inlined future crossed clippy's `large_futures`
+    // budget at essentially every call site.
+    Box::pin(handle_durable_command_inner(cmd, config_path)).await
+}
+
+#[allow(clippy::too_many_lines)]
+async fn handle_durable_command_inner(
     cmd: DurableCommand,
     config_path: Option<&Path>,
 ) -> anyhow::Result<()> {
@@ -501,7 +642,6 @@ pub(crate) async fn handle_durable_command(
             dry_run,
             drop_previous,
             force,
-            ack_shared_db_drain,
         } => {
             handle_rotate_key(
                 &config_file,
@@ -510,7 +650,6 @@ pub(crate) async fn handle_durable_command(
                     dry_run,
                     drop_previous,
                     force,
-                    ack_shared_db_drain,
                 },
             )
             .await?;
@@ -521,10 +660,10 @@ pub(crate) async fn handle_durable_command(
 }
 
 /// Flags controlling `zeph durable rotate-key`'s behavior, bundled into one struct rather than
-/// four positional `bool` parameters (past clippy's `fn_params_excessive_bools` threshold, and
-/// call sites read as named fields instead of an ambiguous run of `bool`s).
+/// three positional `bool` parameters (call sites read as named fields instead of an ambiguous
+/// run of `bool`s).
 ///
-/// The four flags are independent CLI switches (mirroring `DurableConfig`'s own
+/// The three flags are independent CLI switches (mirroring `DurableConfig`'s own
 /// `#[allow(clippy::struct_excessive_bools)]` precedent) — not state-machine variants, since any
 /// combination is meaningful (e.g. `--dry-run --drop-previous --force`).
 #[allow(clippy::struct_excessive_bools)]
@@ -533,12 +672,9 @@ struct RotateKeyOptions {
     dry_run: bool,
     /// Close an open rotation window instead of opening a new one.
     drop_previous: bool,
-    /// Skip the `--drop-previous` blob-scan (drop-previous only; never gates the open-window or
-    /// shared-database refusals — see [`handle_open_window`]).
+    /// Skip the `--drop-previous` safety scans (drop-previous only; never gates the open-window
+    /// refusal — see [`handle_open_window`]).
     force: bool,
-    /// Acknowledge rotating on a declared/detected shared database despite the control-entry
-    /// HMAC having no rotation window of its own.
-    ack_shared_db_drain: bool,
 }
 
 /// Open or close a `ZEPH_DURABLE_KEY` AEAD rotation window (`zeph durable rotate-key`, #6447).
@@ -605,13 +741,7 @@ async fn handle_rotate_key(
     if opts.drop_previous {
         handle_drop_previous(config_file, config, &mut provider, opts.dry_run, opts.force).await
     } else {
-        handle_open_window(
-            config_file,
-            config,
-            &mut provider,
-            opts.dry_run,
-            opts.ack_shared_db_drain,
-        )
+        handle_open_window(config_file, config, &mut provider, opts.dry_run)
     }
 }
 
@@ -622,15 +752,16 @@ async fn handle_rotate_key(
 /// declaring a window that the vault does not yet back, which [`load_durable_cipher`]'s
 /// fail-closed branch turns into a loud startup error instead of a silent mis-decrypt. Refuses a
 /// second window while one is already open (R2 — the cipher holds only one previous key slot, so
-/// a second rotation would silently orphan the first previous key) and refuses on a
-/// declared/detected shared database without `--ack-shared-db-drain` (R3 — the control-entry HMAC
-/// key has no rotation window). Neither refusal is bypassable by any flag.
+/// a second rotation would silently orphan the first previous key); not bypassable by any flag.
+/// On a declared/detected shared database, `ZEPH_DURABLE_KEY_PREVIOUS` now backs a rotation
+/// window for the control-entry HMAC key too ([`LocalBackend::with_previous_hmac_key`], #6451),
+/// so shared-DB rotation needs no separate acknowledgement — it is exactly as safe as local
+/// rotation.
 fn handle_open_window(
     config_file: &Path,
     config: &Config,
     provider: &mut AgeVaultProvider,
     dry_run: bool,
-    ack_shared_db_drain: bool,
 ) -> anyhow::Result<()> {
     // R2 — refuse to open a second window; the cipher's single previous-key slot cannot hold two.
     if let Some(prev_id) = config.durable.previous_key_id {
@@ -639,21 +770,6 @@ fn handle_open_window(
              `zeph durable rotate-key --drop-previous` after the retention window has elapsed, \
              then rotate again"
         );
-    }
-
-    // R3 — shared-DB guard, enforced (not merely documented). Never bypassable by --force.
-    let url = resolve_durable_db_url(config);
-    if is_shared_db(&config.durable, &url) && !ack_shared_db_drain {
-        let msg = "this durable journal is a shared database. Rotating ZEPH_DURABLE_KEY \
-             re-derives the control-entry HMAC key, which has no rotation window of its own -- \
-             every in-flight execution's control entries will fail ControlIntegrity until they \
-             drain. Drain (finalize/prune) all in-flight executions first, then re-run with \
-             --ack-shared-db-drain. (HMAC-key rotation window: follow-up to #6447.)";
-        if dry_run {
-            println!("DRY RUN: {msg}");
-            return Ok(());
-        }
-        anyhow::bail!("{msg}");
     }
 
     let Some(old_key_b64) = provider.get(CURRENT_KEY_VAULT_NAME).map(str::to_owned) else {
@@ -708,17 +824,73 @@ fn handle_open_window(
     Ok(())
 }
 
-/// Close an open rotation window: verify no sealed payload still uses the previous key, then
-/// remove `ZEPH_DURABLE_KEY_PREVIOUS` from the vault and clear `previous_key_id`.
+/// Resolve both control-entry HMAC keys from `provider` for the `--drop-previous` HMAC scan
+/// (#6451 critic finding 1): the current key (must be present) and the previous key (must be
+/// present given `previous_key_id` is `Some`, per the caller's partial-state detector).
 ///
-/// The blob-scan verification is default-on (R4): refuses the drop when
-/// [`LocalBackend::count_sealed_under_key_id`] finds any surviving row, since dropping the
-/// previous key then makes those blobs permanently unreadable. `--force` skips the scan for an
-/// operator who has independently confirmed pruning is complete; it applies **only** to this
-/// scan, never to the caller's partial-state detector or [`handle_open_window`]'s refusals. A
-/// call with no window open (`previous_key_id = None`, `ZEPH_DURABLE_KEY_PREVIOUS` absent — the
-/// caller's partial-state detector already guarantees these agree) is a clean informational
-/// no-op, not an error.
+/// A plain (non-async) helper so this derivation's intermediate `&str` vault borrows and key
+/// bytes never live inside [`handle_drop_previous`]'s generated `async fn` state machine.
+///
+/// # Errors
+///
+/// Returns an error if either vault secret is missing or fails to decode.
+fn resolve_hmac_keys_for_drop_scan(
+    provider: &AgeVaultProvider,
+    previous_key_id: u8,
+) -> anyhow::Result<([u8; 32], [u8; 32])> {
+    let current_key_b64 = provider.get(CURRENT_KEY_VAULT_NAME).ok_or_else(|| {
+        anyhow::anyhow!(
+            "{CURRENT_KEY_VAULT_NAME} not found in vault; cannot verify control-entry HMACs \
+             before dropping the previous key"
+        )
+    })?;
+    let current_hmac_key = zeph_core::durable::derive_control_hmac_key_b64(current_key_b64)
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "invalid {CURRENT_KEY_VAULT_NAME} for control-entry HMAC derivation: {e}"
+            )
+        })?;
+    let previous_key_b64 = provider.get(PREVIOUS_KEY_VAULT_NAME).ok_or_else(|| {
+        anyhow::anyhow!(
+            "durable config declares previous_key_id = {previous_key_id} but \
+             {PREVIOUS_KEY_VAULT_NAME} is missing from the vault; refusing to verify \
+             control-entry HMACs with an inconsistent rotation state"
+        )
+    })?;
+    let previous_hmac_key = zeph_core::durable::derive_control_hmac_key_b64(previous_key_b64)
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "invalid {PREVIOUS_KEY_VAULT_NAME} for control-entry HMAC derivation: {e}"
+            )
+        })?;
+    Ok((current_hmac_key, previous_hmac_key))
+}
+
+/// Close an open rotation window: verify no sealed payload and no control-entry HMAC still
+/// depends on the previous key, then remove `ZEPH_DURABLE_KEY_PREVIOUS` from the vault and clear
+/// `previous_key_id`.
+///
+/// Three independent safety scans are default-on: the AEAD blob-scan (R4) refuses the drop when
+/// [`LocalBackend::count_sealed_under_key_id`] finds any surviving payload; the HMAC scan (#6451)
+/// refuses when [`LocalBackend::count_control_entries_under_previous_hmac`] finds any control
+/// entry that verifies only under the previous key — the blob-scan alone would miss a
+/// payload-less crash-orphan `EffectIntent`; and the HWM scan (addendum to #6451) refuses when
+/// [`LocalBackend::count_integrity_rows_under_epoch`] finds any surviving execution whose
+/// high-water-mark is still addressed to the previous epoch — the only one of the three that
+/// catches a checkpoint-folded pre-rotation execution (`checkpoint_fold` never re-signs the HWM,
+/// so a folded execution's payloads and control entries can both be gone while its integrity row
+/// still carries the previous epoch; see [`LocalBackend::count_integrity_rows_under_epoch`]'s own
+/// doc). The HMAC scan needs a backend keyed with **both** the current and previous HMAC keys to
+/// recompute rows for comparison, so this is a dedicated (fourth) key-attach site, distinct from
+/// the three runtime read paths that only ever attach keys derived by [`load_control_hmac_key`];
+/// the HWM scan needs no key material at all — it is a plain indexed `COUNT` on the public
+/// `key_epoch` column, so it runs first (cheapest-first ordering) on the still-owned `backend`
+/// handle, before that handle is consumed by the HMAC scan's key attach. `--force` skips all
+/// three scans for an operator who has independently confirmed pruning is complete; it applies
+/// **only** to these scans, never to the caller's partial-state detector or
+/// [`handle_open_window`]'s refusal. A call with no window open (`previous_key_id = None`,
+/// `ZEPH_DURABLE_KEY_PREVIOUS` absent — the caller's partial-state detector already guarantees
+/// these agree) is a clean informational no-op, not an error.
 async fn handle_drop_previous(
     config_file: &Path,
     config: &Config,
@@ -752,6 +924,59 @@ async fn handle_drop_previous(
                      is complete (note: a deployment with plaintext-mode rows -- \
                      encrypt_payload = false -- can occasionally over-count a coincidental \
                      leading byte match; that is fail-safe, never a missed match)."
+                );
+            }
+
+            // HWM drop-scan (addendum to #6451): a plain indexed COUNT, no key material needed,
+            // so it runs on the still-owned `backend` handle before the HMAC scan below consumes
+            // it into `hmac_backend`. Cheapest-first ordering (indexed COUNT before the O(rows)
+            // trial-verify HMAC scan). This is the only scan that catches a checkpoint-folded
+            // pre-rotation execution — see `count_integrity_rows_under_epoch`'s doc.
+            let hwm_matches = backend
+                .count_integrity_rows_under_epoch(u32::from(previous_key_id))
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "failed to scan high-water-mark rows for epoch {previous_key_id}: {e}"
+                    )
+                })?;
+            if hwm_matches > 0 {
+                anyhow::bail!(
+                    "refusing to drop: {hwm_matches} execution(s) in {url} still carry a \
+                     high-water-mark signed under the previous key epoch ({previous_key_id}). \
+                     Dropping the previous key now would make them unresumable \
+                     (HighWaterMarkIntegrity: key_epoch_unresolvable) — this includes \
+                     checkpoint-folded executions that the payload and control-entry scans \
+                     cannot see. Wait for retention to prune the owning executions, or pass \
+                     --force to skip this scan if you have independently confirmed pruning is \
+                     complete."
+                );
+            }
+
+            // HMAC drop-scan (#6451 critic finding 1): needs both keys attached to recompute
+            // and compare each control entry's row HMAC. Resolved in a plain (non-async) helper
+            // so the derived key material and intermediate `&str` borrows do not inflate this
+            // async fn's generated state machine (clippy::large_futures).
+            let (current_hmac_key, previous_hmac_key) =
+                resolve_hmac_keys_for_drop_scan(provider, previous_key_id)?;
+            let hmac_backend = backend
+                .with_hmac_key(current_hmac_key)
+                .with_previous_hmac_key(previous_hmac_key);
+            let hmac_matches = hmac_backend
+                .count_control_entries_under_previous_hmac()
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "failed to scan control entries for previous-key-only HMACs: {e}"
+                    )
+                })?;
+            if hmac_matches > 0 {
+                anyhow::bail!(
+                    "refusing to drop: {hmac_matches} control entry(ies) in {url} still verify \
+                     only under the previous control-entry HMAC key. Dropping the previous key \
+                     now would make them permanently unreadable (ControlIntegrity). Wait for \
+                     retention to prune the owning executions, or pass --force to skip this scan \
+                     if you have independently confirmed pruning is complete."
                 );
             }
         }
@@ -1374,9 +1599,10 @@ mod tests {
     async fn load_write_hmac_key_returns_none_for_single_user_local() {
         let config = Config::default();
         assert!(!config.durable.shared_db);
+        let keys = load_write_hmac_key(&config).unwrap();
         assert!(
-            load_write_hmac_key(&config).unwrap().is_none(),
-            "single-user local, non-shared database must not resolve an HMAC key"
+            keys.current.is_none() && keys.previous.is_none(),
+            "single-user local, non-shared database must not resolve either HMAC key"
         );
     }
 
@@ -1559,7 +1785,7 @@ mod tests {
         }
 
         assert!(
-            result.unwrap().is_some(),
+            result.unwrap().current.is_some(),
             "a declared shared database with a real vault key must resolve an HMAC key"
         );
     }
@@ -1638,7 +1864,6 @@ mod tests {
                 dry_run: false,
                 drop_previous: false,
                 force: false,
-                ack_shared_db_drain: false,
             },
             Some(&config_path),
         )
@@ -1676,7 +1901,6 @@ mod tests {
                 dry_run: false,
                 drop_previous: false,
                 force: false,
-                ack_shared_db_drain: false,
             },
             Some(&config_path),
         )
@@ -1690,7 +1914,6 @@ mod tests {
                 dry_run: false,
                 drop_previous: false,
                 force: false,
-                ack_shared_db_drain: false,
             },
             Some(&config_path),
         )
@@ -1722,7 +1945,6 @@ mod tests {
                 dry_run: true,
                 drop_previous: false,
                 force: false,
-                ack_shared_db_drain: false,
             },
             Some(&config_path),
         )
@@ -1756,7 +1978,6 @@ mod tests {
                 dry_run: false,
                 drop_previous: true,
                 force: false,
-                ack_shared_db_drain: false,
             },
             Some(&config_path),
         )
@@ -1793,7 +2014,6 @@ mod tests {
                 dry_run: false,
                 drop_previous: false,
                 force: false,
-                ack_shared_db_drain: false,
             },
             Some(&config_path),
         )
@@ -1837,7 +2057,6 @@ mod tests {
                 dry_run: false,
                 drop_previous: true,
                 force: false,
-                ack_shared_db_drain: false,
             },
             Some(&config_path),
         )
@@ -1857,7 +2076,6 @@ mod tests {
                 dry_run: false,
                 drop_previous: true,
                 force: true,
-                ack_shared_db_drain: false,
             },
             Some(&config_path),
         )
@@ -1890,7 +2108,6 @@ mod tests {
                 dry_run: false,
                 drop_previous: false,
                 force: false,
-                ack_shared_db_drain: false,
             },
             Some(&config_path),
         )
@@ -1902,11 +2119,13 @@ mod tests {
         );
     }
 
-    /// R3: rotating a declared shared database is refused without `--ack-shared-db-drain`, and
-    /// proceeds once it is passed.
+    /// #6451: rotating a declared shared database now succeeds without any acknowledgement flag —
+    /// the R3 refusal (`--ack-shared-db-drain`) existed solely because the control-entry HMAC key
+    /// had no rotation window of its own; that premise is closed by `with_previous_hmac_key`, so
+    /// shared-DB rotation is exactly as safe as local rotation.
     #[tokio::test]
     #[serial]
-    async fn rotate_key_refuses_on_shared_db_without_ack() {
+    async fn rotate_key_succeeds_on_shared_db_without_any_acknowledgement() {
         let _guard = VaultDirGuard::new();
         seed_vault_with_durable_key();
         let dir = tempfile::tempdir().unwrap();
@@ -1918,37 +2137,25 @@ mod tests {
         std::fs::write(&config_path, toml).unwrap();
         std::fs::write(resolve_durable_db_url(&config), []).unwrap();
 
-        let refused = handle_durable_command(
+        let result = handle_durable_command(
             DurableCommand::RotateKey {
                 dry_run: false,
                 drop_previous: false,
                 force: false,
-                ack_shared_db_drain: false,
             },
             Some(&config_path),
         )
         .await;
         assert!(
-            refused.is_err(),
-            "a shared database must refuse rotation without --ack-shared-db-drain"
-        );
-        assert_eq!(load_config_or_default(&config_path).durable.key_id, 0);
-
-        let acked = handle_durable_command(
-            DurableCommand::RotateKey {
-                dry_run: false,
-                drop_previous: false,
-                force: false,
-                ack_shared_db_drain: true,
-            },
-            Some(&config_path),
-        )
-        .await;
-        assert!(
-            acked.is_ok(),
-            "--ack-shared-db-drain must allow rotation to proceed: {acked:?}"
+            result.is_ok(),
+            "a shared database must rotate without any acknowledgement flag now that the \
+             control-entry HMAC key has its own rotation window: {result:?}"
         );
         assert_eq!(load_config_or_default(&config_path).durable.key_id, 1);
+        assert_eq!(
+            load_config_or_default(&config_path).durable.previous_key_id,
+            Some(0)
+        );
     }
 
     // ── Gap-closing tests (team-lead review round, #6447) ──────────────────────────────────
@@ -2093,7 +2300,6 @@ mod tests {
                 dry_run: false,
                 drop_previous: false,
                 force: false,
-                ack_shared_db_drain: false,
             },
             Some(&config_path),
         )
@@ -2104,7 +2310,6 @@ mod tests {
                 dry_run: false,
                 drop_previous: true,
                 force: true,
-                ack_shared_db_drain: false,
             },
             Some(&config_path),
         )
@@ -2144,7 +2349,6 @@ mod tests {
                 dry_run: false,
                 drop_previous: false,
                 force: false,
-                ack_shared_db_drain: false,
             },
             Some(&config_path),
         )
@@ -2195,7 +2399,6 @@ mod tests {
                 dry_run: true,
                 drop_previous: true,
                 force: false,
-                ack_shared_db_drain: false,
             },
             Some(&config_path),
         )
@@ -2284,7 +2487,6 @@ mod tests {
                 dry_run: false,
                 drop_previous: false,
                 force: false,
-                ack_shared_db_drain: false,
             },
             Some(&config_path),
         )
@@ -2345,5 +2547,406 @@ mod tests {
             }
             other => panic!("unexpected entry kind: {other:?}"),
         }
+    }
+
+    /// #6451 regression (tester finding: missing CLI-read-channel coverage): the CLI read
+    /// channel (`open_backend`, backing `list`/`show`/`inspect`/`prune`/`resume`) is one of the
+    /// three runtime read channels that must verify a pre-rotation `EffectIntent` control entry
+    /// through an open rotation window (try-both: current-key-fail, previous-key-succeed) —
+    /// agent replay and the scheduler daemon already have dedicated coverage
+    /// (`open_durable_backend_reads_previous_key_control_entry_through_rotation_window` in
+    /// `zeph-core`, `scheduler_daemon_reads_previous_key_control_entry_through_rotation_window`
+    /// in `scheduler_daemon.rs`); this CLI channel did not.
+    #[tokio::test]
+    #[serial]
+    async fn cli_read_channel_verifies_previous_key_control_entry_through_rotation_window() {
+        use zeph_durable::{EffectClass, EntryKind, ExecutionKind, IdempotencyKey, JournalEntry};
+
+        let _guard = VaultDirGuard::new();
+        seed_vault_with_durable_key();
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.memory.sqlite_path = dir.path().join("zeph.db").to_string_lossy().into_owned();
+        config.durable.shared_db = true;
+        let toml = toml::to_string_pretty(&config).unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, toml).unwrap();
+
+        handle_durable_command(
+            DurableCommand::RotateKey {
+                dry_run: false,
+                drop_previous: false,
+                force: false,
+            },
+            Some(&config_path),
+        )
+        .await
+        .unwrap();
+
+        let rotated = load_config_or_default(&config_path);
+        let url = resolve_durable_db_url(&rotated);
+        let previous_hmac = load_control_hmac_key(&rotated.durable, &url)
+            .unwrap()
+            .previous
+            .expect("rotation window must be open after rotate-key");
+
+        let exec = ExecutionId::new();
+        {
+            let backend = LocalBackend::open(&url, rotated.durable.max_payload_bytes)
+                .await
+                .unwrap()
+                .with_hmac_key(previous_hmac);
+            backend.init().await.unwrap();
+            backend
+                .open_execution(exec, ExecutionKind::AgentTurn)
+                .await
+                .unwrap();
+            let step_id = zeph_durable::StepId::new(0);
+            backend
+                .append(JournalEntry {
+                    seq: None,
+                    execution_id: exec,
+                    kind: ExecutionKind::AgentTurn,
+                    step_id,
+                    entry: EntryKind::EffectIntent {
+                        idempotency_key: IdempotencyKey::derive(exec, step_id, b"transfer"),
+                        effect: EffectClass::ExactlyOnceGuarded,
+                        hmac: None,
+                    },
+                    created_at_ms: 0,
+                })
+                .await
+                .unwrap();
+        }
+
+        let result = handle_durable_command(
+            DurableCommand::Show {
+                id: exec.as_uuid().to_string(),
+                reveal: true,
+                json: false,
+            },
+            Some(&config_path),
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "the CLI read channel must verify a pre-rotation EffectIntent control entry through \
+             the open rotation window (try-both current-then-previous): {result:?}"
+        );
+    }
+
+    /// #6451 critic finding 1 (tester finding: missing end-to-end coverage): the
+    /// `--drop-previous` HMAC scan (`resolve_hmac_keys_for_drop_scan` /
+    /// `count_control_entries_under_previous_hmac`) was previously only unit-tested in isolation
+    /// at the backend level. This drives it end-to-end through `handle_durable_command` with a
+    /// payload-less `EffectIntent` (the crash-orphan shape: intent recorded, its `StepResult`
+    /// never committed) signed only under the previous control-entry HMAC key — the AEAD
+    /// blob-scan alone could never catch a missed wiring here, since there is no payload at all.
+    #[tokio::test]
+    #[serial]
+    async fn rotate_key_drop_previous_refuses_a_payload_less_previous_key_only_effect_intent() {
+        use zeph_durable::{EffectClass, EntryKind, ExecutionKind, IdempotencyKey, JournalEntry};
+
+        let _guard = VaultDirGuard::new();
+        seed_vault_with_durable_key();
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config::default();
+        config.memory.sqlite_path = dir.path().join("zeph.db").to_string_lossy().into_owned();
+        config.durable.shared_db = true;
+        let toml = toml::to_string_pretty(&config).unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, toml).unwrap();
+
+        handle_durable_command(
+            DurableCommand::RotateKey {
+                dry_run: false,
+                drop_previous: false,
+                force: false,
+            },
+            Some(&config_path),
+        )
+        .await
+        .unwrap();
+
+        let rotated = load_config_or_default(&config_path);
+        let url = resolve_durable_db_url(&rotated);
+        let previous_hmac = load_control_hmac_key(&rotated.durable, &url)
+            .unwrap()
+            .previous
+            .expect("rotation window must be open after rotate-key");
+
+        let exec = ExecutionId::new();
+        {
+            let backend = LocalBackend::open(&url, rotated.durable.max_payload_bytes)
+                .await
+                .unwrap()
+                .with_hmac_key(previous_hmac);
+            backend.init().await.unwrap();
+            backend
+                .open_execution(exec, ExecutionKind::AgentTurn)
+                .await
+                .unwrap();
+            let step_id = zeph_durable::StepId::new(0);
+            backend
+                .append(JournalEntry {
+                    seq: None,
+                    execution_id: exec,
+                    kind: ExecutionKind::AgentTurn,
+                    step_id,
+                    entry: EntryKind::EffectIntent {
+                        idempotency_key: IdempotencyKey::derive(exec, step_id, b"crash-orphan"),
+                        effect: EffectClass::ExactlyOnceGuarded,
+                        hmac: None,
+                    },
+                    created_at_ms: 0,
+                })
+                .await
+                .unwrap();
+            // Deliberately no StepResult committed: the crash-orphan shape this scan exists for.
+        }
+
+        let refused = handle_durable_command(
+            DurableCommand::RotateKey {
+                dry_run: false,
+                drop_previous: true,
+                force: false,
+            },
+            Some(&config_path),
+        )
+        .await;
+        assert!(
+            refused.is_err(),
+            "drop-previous must refuse while a payload-less EffectIntent verifies only under \
+             the previous control-entry HMAC key"
+        );
+        assert_eq!(
+            load_config_or_default(&config_path).durable.previous_key_id,
+            Some(0),
+            "the refused drop must not clear previous_key_id"
+        );
+
+        let forced = handle_durable_command(
+            DurableCommand::RotateKey {
+                dry_run: false,
+                drop_previous: true,
+                force: true,
+            },
+            Some(&config_path),
+        )
+        .await;
+        assert!(
+            forced.is_ok(),
+            "--force must skip the HMAC scan: {forced:?}"
+        );
+    }
+
+    /// S1 CLI-level coverage (addendum to #6451, spec-081 FR-008): `--drop-previous` must refuse
+    /// when a `durable_execution_integrity` row still carries the previous key epoch, even when
+    /// neither the AEAD blob-scan nor the control-HMAC scan finds anything to refuse on — the
+    /// exact shape a checkpoint-folded pre-rotation execution leaves behind (see the backend-level
+    /// fold regression,
+    /// `count_integrity_rows_under_epoch_catches_a_checkpoint_folded_pre_rotation_execution`, in
+    /// `zeph-durable`'s own test module for the full fold mechanics — `checkpoint_fold` itself is
+    /// `pub(crate)` inside `zeph-durable` and not reachable from this CLI crate, so this test
+    /// drives the scan's target state directly: an execution with no journal rows at all, but an
+    /// integrity row still addressed to the previous epoch).
+    #[tokio::test]
+    #[serial]
+    async fn rotate_key_drop_previous_refuses_when_only_the_hwm_scan_catches_a_stale_epoch_row() {
+        let _guard = VaultDirGuard::new();
+        seed_vault_with_durable_key();
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = write_config_toml(dir.path());
+
+        handle_durable_command(
+            DurableCommand::RotateKey {
+                dry_run: false,
+                drop_previous: false,
+                force: false,
+            },
+            Some(&config_path),
+        )
+        .await
+        .unwrap();
+        let rotated = load_config_or_default(&config_path);
+        assert_eq!(rotated.durable.previous_key_id, Some(0));
+
+        let url = resolve_durable_db_url(&rotated);
+        let exec = ExecutionId::new();
+        {
+            let backend = LocalBackend::open(&url, rotated.durable.max_payload_bytes)
+                .await
+                .unwrap();
+            backend.init().await.unwrap();
+            zeph_db::query(zeph_db::sql!(
+                "INSERT INTO durable_executions
+                    (execution_id, kind, status, created_at, updated_at, finalized_at)
+                 VALUES (?, 'agent_turn', 'running', 0, 0, NULL)"
+            ))
+            .bind(exec.as_uuid().to_string())
+            .execute(backend.pool())
+            .await
+            .unwrap();
+            zeph_db::query(zeph_db::sql!(
+                "INSERT INTO durable_execution_integrity
+                    (execution_id, key_epoch, max_committed_step_id, committed_result_count, hwm_hmac, updated_at)
+                 VALUES (?, 0, 0, 1, ?, 0)"
+            ))
+            .bind(exec.as_uuid().to_string())
+            .bind(vec![0u8; 32])
+            .execute(backend.pool())
+            .await
+            .unwrap();
+        }
+
+        let refused = handle_durable_command(
+            DurableCommand::RotateKey {
+                dry_run: false,
+                drop_previous: true,
+                force: false,
+            },
+            Some(&config_path),
+        )
+        .await;
+        assert!(
+            refused.is_err(),
+            "drop-previous must refuse while an integrity row still carries the previous epoch, \
+             even with no payload or control-entry evidence"
+        );
+        assert_eq!(
+            load_config_or_default(&config_path).durable.previous_key_id,
+            Some(0),
+            "the refused drop must not clear previous_key_id"
+        );
+
+        let forced = handle_durable_command(
+            DurableCommand::RotateKey {
+                dry_run: false,
+                drop_previous: true,
+                force: true,
+            },
+            Some(&config_path),
+        )
+        .await;
+        assert!(forced.is_ok(), "--force must skip the HWM scan: {forced:?}");
+    }
+
+    /// M4 (addendum to #6451): with the HWM epoch now wired to `config.durable.key_id`, a benign
+    /// rotation must classify as `key_epoch_unresolvable` ("possibly re-keyed") when resumed
+    /// without the previous slot attached, and resolve cleanly via the previous slot when the
+    /// rotation window is open — never as `hmac_mismatch` (TAMPER). Before this addendum,
+    /// `HWM_KEY_EPOCH` was a frozen `const = 0`, so a benign rotation misclassified as TAMPER
+    /// (both epochs read 0, but signed under different keys); this is the production-wiring
+    /// counterpart to `zeph-durable`'s own backend-level classification tests
+    /// (`hwm_unresolvable_key_epoch_fails_closed_not_legacy`,
+    /// `hwm_previous_epoch_key_resolves_as_rekeyed_not_tampered`).
+    #[tokio::test]
+    #[serial]
+    async fn load_write_hwm_key_epoch_matches_key_id_so_rotation_classifies_as_rekeyed_not_tamper()
+    {
+        let _guard = VaultDirGuard::new();
+        seed_vault_with_durable_key();
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = write_config_toml(dir.path());
+
+        let exec = ExecutionId::new();
+        {
+            let config = load_config_or_default(&config_path);
+            let hwm_keys = load_write_hwm_key(&config).unwrap();
+            let slot = hwm_keys.current.expect("ZEPH_DURABLE_KEY is seeded");
+            assert_eq!(
+                slot.epoch, 0,
+                "un-rotated deployment (key_id=0) must stamp epoch 0 -- no migration"
+            );
+            let url = resolve_durable_db_url(&config);
+            let backend = LocalBackend::open(&url, config.durable.max_payload_bytes)
+                .await
+                .unwrap()
+                .with_hwm_key(slot.epoch, slot.key);
+            backend.init().await.unwrap();
+            backend
+                .open_execution(exec, zeph_durable::ExecutionKind::AgentTurn)
+                .await
+                .unwrap();
+            backend
+                .append(zeph_durable::JournalEntry {
+                    seq: None,
+                    execution_id: exec,
+                    kind: zeph_durable::ExecutionKind::AgentTurn,
+                    step_id: zeph_durable::StepId::new(0),
+                    entry: zeph_durable::EntryKind::StepResult {
+                        idempotency_key: zeph_durable::IdempotencyKey::derive(
+                            exec,
+                            zeph_durable::StepId::new(0),
+                            b"tool:test",
+                        ),
+                        payload: bytes::Bytes::copy_from_slice(b"pre-rotation result"),
+                        effect: zeph_durable::EffectClass::Idempotent,
+                        payload_version: 1,
+                    },
+                    created_at_ms: 0,
+                })
+                .await
+                .unwrap();
+        }
+
+        handle_durable_command(
+            DurableCommand::RotateKey {
+                dry_run: false,
+                drop_previous: false,
+                force: false,
+            },
+            Some(&config_path),
+        )
+        .await
+        .unwrap();
+
+        let rotated = load_config_or_default(&config_path);
+        assert_eq!(rotated.durable.key_id, 1);
+        assert_eq!(rotated.durable.previous_key_id, Some(0));
+        let hwm_keys = load_write_hwm_key(&rotated).unwrap();
+        let current = hwm_keys.current.expect("current HWM slot must resolve");
+        assert_eq!(current.epoch, 1, "epoch must follow key_id after rotation");
+        let previous = hwm_keys
+            .previous
+            .expect("previous HWM slot must resolve while the window is open");
+        assert_eq!(previous.epoch, 0);
+
+        let url = resolve_durable_db_url(&rotated);
+
+        // Resume WITHOUT the previous slot attached: the row's epoch (0) is neither the current
+        // epoch (1) nor a registered previous one, so this must classify as re-keyed, not tamper.
+        let no_previous = LocalBackend::open(&url, rotated.durable.max_payload_bytes)
+            .await
+            .unwrap()
+            .with_hwm_key(current.epoch, current.key);
+        let err = no_previous
+            .open_execution(exec, zeph_durable::ExecutionKind::AgentTurn)
+            .await
+            .unwrap_err();
+        match err {
+            zeph_durable::DurableError::HighWaterMarkIntegrity { reason, .. } => {
+                assert_eq!(
+                    reason, "key_epoch_unresolvable",
+                    "a benign rotation must classify as re-keyed, never as hmac_mismatch (TAMPER)"
+                );
+            }
+            other => panic!("expected HighWaterMarkIntegrity, got {other:?}"),
+        }
+
+        // Resume WITH both slots attached (the real production wiring during the window): the
+        // previous slot resolves the row cleanly.
+        let with_previous = LocalBackend::open(&url, rotated.durable.max_payload_bytes)
+            .await
+            .unwrap()
+            .with_hwm_key(current.epoch, current.key)
+            .with_previous_hwm_key(previous.epoch, previous.key);
+        assert!(
+            with_previous
+                .open_execution(exec, zeph_durable::ExecutionKind::AgentTurn)
+                .await
+                .unwrap(),
+            "a pre-rotation execution must resume cleanly through the open rotation window"
+        );
     }
 }

--- a/src/commands/scheduler_daemon.rs
+++ b/src/commands/scheduler_daemon.rs
@@ -173,9 +173,10 @@ async fn run_foreground(
 }
 
 /// Open the scheduler's durable backend, attach the write-path AEAD cipher when
-/// `[durable] encrypt_payload = true` and the control-entry HMAC key when this deployment is a
-/// declared/detected shared database (INV-8), then spawn its journal-writer task under
-/// `sched_supervisor`.
+/// `[durable] encrypt_payload = true`, the control-entry HMAC key when this deployment is a
+/// declared/detected shared database (INV-8), and the high-water-mark key unconditionally
+/// (FR-009, addendum to #6451 — previously never attached on this channel at all), then spawn its
+/// journal-writer task under `sched_supervisor`.
 ///
 /// Returns `Ok(None)` when durable execution is disabled for the scheduler
 /// (`[durable] enabled = false` or `[durable] scheduler = false`), so the caller runs without
@@ -194,11 +195,13 @@ async fn build_durable_adapter(
     if !(config.durable.enabled && config.durable.scheduler) {
         return Ok(None);
     }
-    // Resolve the write-path cipher (which evaluates the INV-8 encryption_gate, #5996) and the
-    // control-entry HMAC key (#6043/#6044) before opening the backend, so a forbidden config
-    // fails closed without creating a stray empty journal file on disk first.
+    // Resolve the write-path cipher (which evaluates the INV-8 encryption_gate, #5996), the
+    // control-entry HMAC key (#6043/#6044), and the high-water-mark key (addendum to #6451)
+    // before opening the backend, so a forbidden config fails closed without creating a stray
+    // empty journal file on disk first.
     let cipher = crate::commands::durable::load_write_cipher(config)?;
-    let hmac_key = crate::commands::durable::load_write_hmac_key(config)?;
+    let hmac_keys = crate::commands::durable::load_write_hmac_key(config)?;
+    let hwm_keys = crate::commands::durable::load_write_hwm_key(config)?;
     let durable_url = crate::commands::durable::resolve_durable_db_url(config);
     let local = zeph_durable::LocalBackend::open(&durable_url, config.durable.max_payload_bytes)
         .await
@@ -212,8 +215,23 @@ async fn build_durable_adapter(
     } else {
         local
     };
-    let local = if let Some(key) = hmac_key {
+    let local = if let Some(key) = hmac_keys.current {
         local.with_hmac_key(key)
+    } else {
+        local
+    };
+    let local = if let Some(key) = hmac_keys.previous {
+        local.with_previous_hmac_key(key)
+    } else {
+        local
+    };
+    let local = if let Some(slot) = hwm_keys.current {
+        local.with_hwm_key(slot.epoch, slot.key)
+    } else {
+        local
+    };
+    let local = if let Some(slot) = hwm_keys.previous {
+        local.with_previous_hwm_key(slot.epoch, slot.key)
     } else {
         local
     };
@@ -297,6 +315,7 @@ fn print_status_human(status: &zeph_scheduler::DaemonStatus) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use zeph_durable::Journal as _;
 
     /// #6264: `build_durable_adapter` must spawn the retention sweep (not just the journal
     /// writer) onto `sched_supervisor`, mirroring the P1/P2 coverage in
@@ -357,5 +376,253 @@ mod tests {
             .expect("build_durable_adapter must succeed (returns None, not an error)");
         assert!(adapter.is_none());
         assert!(sched_supervisor.snapshot().is_empty());
+    }
+
+    /// #6451 regression (critic finding 2): the scheduler-daemon read channel is one of the three
+    /// runtime paths that must stay able to verify a pre-rotation `EffectIntent` control entry
+    /// through an open rotation window. `build_durable_adapter` resolves both HMAC keys via
+    /// `load_write_hmac_key` and attaches them (lines above, `hmac_keys.current` /
+    /// `hmac_keys.previous`) exactly like this test's own re-derivation, so asserting both that
+    /// adapter construction succeeds and that a backend opened with the same resolved keys can
+    /// read a payload-less control entry stamped under the previous key is a faithful regression
+    /// for this channel's wiring — including the crash-orphan shape (`EffectIntent` never carries
+    /// a payload, so the AEAD blob-scan alone could never have caught a missed wiring here).
+    #[allow(unsafe_code)]
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn scheduler_daemon_reads_previous_key_control_entry_through_rotation_window() {
+        let vault_dir = tempfile::tempdir().unwrap();
+        let prev_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", vault_dir.path());
+        }
+
+        let vault_root = zeph_core::vault::default_vault_dir();
+        zeph_core::vault::AgeVaultProvider::init_vault(&vault_root).unwrap();
+        let mut provider = zeph_core::vault::AgeVaultProvider::load(
+            &vault_root.join("vault-key.txt"),
+            &vault_root.join("secrets.age"),
+        )
+        .unwrap();
+        let old_key_b64 = zeph_core::durable::generate_durable_key_b64();
+        let new_key_b64 = zeph_core::durable::generate_durable_key_b64();
+        provider
+            .set_secret_mut(
+                "ZEPH_DURABLE_KEY_PREVIOUS".to_owned(),
+                old_key_b64.clone(),
+                false,
+            )
+            .unwrap();
+        provider
+            .set_secret_mut("ZEPH_DURABLE_KEY".to_owned(), new_key_b64, false)
+            .unwrap();
+        provider.save().unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = zeph_core::config::Config::default();
+        config.memory.sqlite_path = dir.path().join("zeph.db").to_string_lossy().into_owned();
+        config.durable.enabled = true;
+        config.durable.scheduler = true;
+        config.durable.shared_db = true;
+        config.durable.key_id = 1;
+        config.durable.previous_key_id = Some(0);
+
+        // Simulate a pre-rotation control entry: write it directly under the old (now-previous)
+        // HMAC key, before the daemon ever opens the backend.
+        let old_hmac_key = zeph_core::durable::derive_control_hmac_key_b64(&old_key_b64).unwrap();
+        let durable_url = crate::commands::durable::resolve_durable_db_url(&config);
+        let exec = zeph_durable::ExecutionId::new();
+        {
+            let pre_rotation_writer =
+                zeph_durable::LocalBackend::open(&durable_url, config.durable.max_payload_bytes)
+                    .await
+                    .unwrap()
+                    .with_hmac_key(old_hmac_key);
+            pre_rotation_writer.init().await.unwrap();
+            pre_rotation_writer
+                .open_execution(exec, zeph_durable::ExecutionKind::AgentTurn)
+                .await
+                .unwrap();
+            let step_id = zeph_durable::StepId::new(0);
+            pre_rotation_writer
+                .append(zeph_durable::JournalEntry {
+                    seq: None,
+                    execution_id: exec,
+                    kind: zeph_durable::ExecutionKind::AgentTurn,
+                    step_id,
+                    entry: zeph_durable::EntryKind::EffectIntent {
+                        idempotency_key: zeph_durable::IdempotencyKey::derive(
+                            exec,
+                            step_id,
+                            b"transfer",
+                        ),
+                        effect: zeph_durable::EffectClass::ExactlyOnceGuarded,
+                        hmac: None,
+                    },
+                    created_at_ms: 0,
+                })
+                .await
+                .unwrap();
+        }
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let sched_supervisor = zeph_common::TaskSupervisor::new(cancel);
+        let adapter = build_durable_adapter(&config, &sched_supervisor).await;
+        assert!(
+            adapter.is_ok() && adapter.unwrap().is_some(),
+            "build_durable_adapter must succeed with a consistent rotation window declared"
+        );
+
+        // Re-derive the same keys `build_durable_adapter` resolved, and confirm the pre-rotation
+        // entry is still readable through the window (the actual regression assertion) — still
+        // under the guard's vault dir, before it is restored below.
+        let hmac_keys = crate::commands::durable::load_write_hmac_key(&config).unwrap();
+        let reader =
+            zeph_durable::LocalBackend::open(&durable_url, config.durable.max_payload_bytes)
+                .await
+                .unwrap()
+                .with_hmac_key(hmac_keys.current.unwrap())
+                .with_previous_hmac_key(hmac_keys.previous.unwrap());
+        let read_result = reader.read_execution(exec).await;
+
+        unsafe {
+            match &prev_xdg {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+
+        assert!(
+            read_result.is_ok(),
+            "the scheduler-daemon read channel must verify a pre-rotation EffectIntent control \
+             entry through the rotation window"
+        );
+    }
+
+    /// Addendum to #6451 (tester-2 finding): mirrors
+    /// `scheduler_daemon_reads_previous_key_control_entry_through_rotation_window` above, but for
+    /// the high-water-mark path instead of the control-HMAC path. `build_durable_adapter`
+    /// previously never attached an HWM key at all on this channel (confirmed absent before this
+    /// addendum — unlike the control-HMAC key, the HWM key is meant to be attached
+    /// unconditionally per FR-009, so this test does not need `shared_db = true`), so this proves
+    /// both that it now attaches the current epoch unconditionally and the previous epoch while
+    /// the window is open, by resuming a pre-rotation execution with a committed `StepResult`
+    /// through the daemon's own resolved keys.
+    #[allow(unsafe_code)]
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn scheduler_daemon_resumes_previous_epoch_high_water_mark_through_rotation_window() {
+        let vault_dir = tempfile::tempdir().unwrap();
+        let prev_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", vault_dir.path());
+        }
+
+        let vault_root = zeph_core::vault::default_vault_dir();
+        zeph_core::vault::AgeVaultProvider::init_vault(&vault_root).unwrap();
+        let mut provider = zeph_core::vault::AgeVaultProvider::load(
+            &vault_root.join("vault-key.txt"),
+            &vault_root.join("secrets.age"),
+        )
+        .unwrap();
+        let old_key_b64 = zeph_core::durable::generate_durable_key_b64();
+        let new_key_b64 = zeph_core::durable::generate_durable_key_b64();
+        provider
+            .set_secret_mut(
+                "ZEPH_DURABLE_KEY_PREVIOUS".to_owned(),
+                old_key_b64.clone(),
+                false,
+            )
+            .unwrap();
+        provider
+            .set_secret_mut("ZEPH_DURABLE_KEY".to_owned(), new_key_b64, false)
+            .unwrap();
+        provider.save().unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = zeph_core::config::Config::default();
+        config.memory.sqlite_path = dir.path().join("zeph.db").to_string_lossy().into_owned();
+        config.durable.enabled = true;
+        config.durable.scheduler = true;
+        config.durable.key_id = 1;
+        config.durable.previous_key_id = Some(0);
+
+        // Commit a StepResult under the OLD (now-previous) HWM key, before the daemon ever opens
+        // the backend -- simulating an execution that committed a result pre-rotation.
+        let old_hwm_key = zeph_core::durable::derive_hwm_key_b64(&old_key_b64).unwrap();
+        let durable_url = crate::commands::durable::resolve_durable_db_url(&config);
+        let exec = zeph_durable::ExecutionId::new();
+        {
+            let pre_rotation_writer =
+                zeph_durable::LocalBackend::open(&durable_url, config.durable.max_payload_bytes)
+                    .await
+                    .unwrap()
+                    .with_hwm_key(0, old_hwm_key);
+            pre_rotation_writer.init().await.unwrap();
+            pre_rotation_writer
+                .open_execution(exec, zeph_durable::ExecutionKind::AgentTurn)
+                .await
+                .unwrap();
+            let step_id = zeph_durable::StepId::new(0);
+            pre_rotation_writer
+                .append(zeph_durable::JournalEntry {
+                    seq: None,
+                    execution_id: exec,
+                    kind: zeph_durable::ExecutionKind::AgentTurn,
+                    step_id,
+                    entry: zeph_durable::EntryKind::StepResult {
+                        idempotency_key: zeph_durable::IdempotencyKey::derive(
+                            exec,
+                            step_id,
+                            b"tool:test",
+                        ),
+                        payload: bytes::Bytes::copy_from_slice(b"pre-rotation result"),
+                        effect: zeph_durable::EffectClass::Idempotent,
+                        payload_version: 1,
+                    },
+                    created_at_ms: 0,
+                })
+                .await
+                .unwrap();
+        }
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let sched_supervisor = zeph_common::TaskSupervisor::new(cancel);
+        let adapter = build_durable_adapter(&config, &sched_supervisor).await;
+        assert!(
+            adapter.is_ok() && adapter.unwrap().is_some(),
+            "build_durable_adapter must succeed with a consistent rotation window declared"
+        );
+
+        // Re-derive the same HWM keys `build_durable_adapter` resolved, and confirm the
+        // pre-rotation execution still resumes cleanly through the window (the actual regression
+        // assertion) -- still under the guard's vault dir, before it is restored below.
+        let hwm_keys = crate::commands::durable::load_write_hwm_key(&config).unwrap();
+        let current = hwm_keys.current.expect("current HWM slot must resolve");
+        let previous = hwm_keys
+            .previous
+            .expect("previous HWM slot must resolve while the window is open");
+        let reader =
+            zeph_durable::LocalBackend::open(&durable_url, config.durable.max_payload_bytes)
+                .await
+                .unwrap()
+                .with_hwm_key(current.epoch, current.key)
+                .with_previous_hwm_key(previous.epoch, previous.key);
+        let resume_result = reader
+            .open_execution(exec, zeph_durable::ExecutionKind::AgentTurn)
+            .await;
+
+        unsafe {
+            match &prev_xdg {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+
+        assert!(
+            resume_result.is_ok(),
+            "the scheduler-daemon read channel must resume a pre-rotation execution's \
+             high-water-mark through the rotation window: {resume_result:?}"
+        );
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -3314,14 +3314,16 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         let agent = if config.durable.enabled && config.durable.orchestration {
             let durable_url = crate::commands::durable::resolve_durable_db_url(config);
             let cipher = crate::commands::durable::load_write_cipher(config)?;
-            let hmac_key = crate::commands::durable::load_write_hmac_key(config)?;
-            let hwm_key = crate::commands::durable::load_write_hwm_key(config)?;
+            let hmac_keys = crate::commands::durable::load_write_hmac_key(config)?;
+            let hwm_keys = crate::commands::durable::load_write_hwm_key(config)?;
             agent.with_durable_orchestration(
                 config.durable.clone(),
                 durable_url,
                 cipher,
-                hmac_key,
-                hwm_key,
+                hmac_keys.current,
+                hwm_keys.current.map(|s| (s.epoch, s.key)),
+                hmac_keys.previous,
+                hwm_keys.previous.map(|s| (s.epoch, s.key)),
             )
         } else {
             agent
@@ -3331,15 +3333,17 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         let agent = if config.durable.enabled && config.durable.agent_turns {
             let durable_url = crate::commands::durable::resolve_durable_db_url(config);
             let cipher = crate::commands::durable::load_write_cipher(config)?;
-            let hmac_key = crate::commands::durable::load_write_hmac_key(config)?;
-            let hwm_key = crate::commands::durable::load_write_hwm_key(config)?;
+            let hmac_keys = crate::commands::durable::load_write_hmac_key(config)?;
+            let hwm_keys = crate::commands::durable::load_write_hwm_key(config)?;
             agent.with_durable_agent_turns(
                 config.durable.clone(),
                 durable_url,
                 config.memory.sqlite_path.clone(),
                 cipher,
-                hmac_key,
-                hwm_key,
+                hmac_keys.current,
+                hwm_keys.current.map(|s| (s.epoch, s.key)),
+                hmac_keys.previous,
+                hwm_keys.previous.map(|s| (s.epoch, s.key)),
             )
         } else {
             agent

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -766,16 +766,11 @@ fn cli_parse_durable_rotate_key_defaults() {
                     dry_run,
                     drop_previous,
                     force,
-                    ack_shared_db_drain,
                 },
         }) => {
             assert!(!dry_run, "dry_run must default to false");
             assert!(!drop_previous, "drop_previous must default to false");
             assert!(!force, "force must default to false");
-            assert!(
-                !ack_shared_db_drain,
-                "ack_shared_db_drain must default to false"
-            );
         }
         _ => panic!("expected DurableCommand::RotateKey"),
     }
@@ -821,21 +816,14 @@ fn cli_parse_durable_rotate_key_drop_previous_with_force() {
     }
 }
 
+/// #6451: `--ack-shared-db-drain` was removed outright (no deprecation shim, pre-v1.0.0) once the
+/// control-entry HMAC key gained its own rotation window, closing the premise the flag existed
+/// for. Parsing it must now fail rather than silently accept an unknown flag.
 #[test]
-fn cli_parse_durable_rotate_key_ack_shared_db_drain() {
-    let cli =
-        Cli::try_parse_from(["zeph", "durable", "rotate-key", "--ack-shared-db-drain"]).unwrap();
-    match cli.command {
-        Some(Command::Durable {
-            command:
-                DurableCommand::RotateKey {
-                    ack_shared_db_drain,
-                    ..
-                },
-        }) => assert!(
-            ack_shared_db_drain,
-            "--ack-shared-db-drain must set ack_shared_db_drain = true"
-        ),
-        _ => panic!("expected DurableCommand::RotateKey"),
-    }
+fn cli_parse_durable_rotate_key_rejects_removed_ack_shared_db_drain_flag() {
+    let result = Cli::try_parse_from(["zeph", "durable", "rotate-key", "--ack-shared-db-drain"]);
+    assert!(
+        result.is_err(),
+        "--ack-shared-db-drain must no longer be a recognized flag"
+    );
 }

--- a/src/tui_bridge.rs
+++ b/src/tui_bridge.rs
@@ -736,6 +736,8 @@ mod tests {
         let (tx, mut rx) = tokio::sync::mpsc::channel::<zeph_tui::AgentEvent>(4);
         let cfg = zeph_config::DurableConfig {
             encrypt_payload: false,
+            key_id: 7,
+            previous_key_id: Some(6),
             ..zeph_config::DurableConfig::default()
         };
 
@@ -753,6 +755,10 @@ mod tests {
                     "gate rejection must be distinguishable from a plain Unavailable snapshot"
                 );
                 assert!(snapshot.executions.is_empty());
+                // Regression for #6450: key_id/previous_key_id must reach the panel even on the
+                // early-return gate-rejected branch, not just the happy-path Available branch.
+                assert_eq!(snapshot.key_id, 7);
+                assert_eq!(snapshot.previous_key_id, Some(6));
             }
             other => panic!("expected DurableSnapshot event, got {other:?}"),
         }
@@ -760,6 +766,46 @@ mod tests {
             rx.recv().await.is_none(),
             "durable_poll_task must return immediately after a gate rejection, not loop"
         );
+    }
+
+    /// Regression for #6450: the `Unavailable` early-return branch (journal file/backend could
+    /// not be opened) must also carry `key_id`/`previous_key_id` through — a third, easy-to-miss
+    /// construction site alongside `GateRejected` and the happy-path `Available` snapshot.
+    #[tokio::test]
+    async fn durable_poll_task_sends_key_ids_on_unavailable_backend_open_failure() {
+        use zeph_tui::widgets::durable::DurableStatus;
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<zeph_tui::AgentEvent>(4);
+        let cfg = zeph_config::DurableConfig {
+            key_id: 9,
+            previous_key_id: Some(8),
+            ..zeph_config::DurableConfig::default()
+        };
+
+        // A bare absolute path (no `sqlite://` scheme — `LocalBackend::open`/`connect_sqlite`
+        // takes a raw filesystem path, not a URL, and prepends its own `sqlite:` prefix) under a
+        // root-owned directory that a non-root test process cannot create. This fails
+        // `LocalBackend::open` via a clean permission-denied on `create_dir_all`, without needing
+        // a real Postgres/shared-DB setup and without leaving stray files behind. (A prior version
+        // of this test used a `sqlite://`-prefixed string here, which `connect_sqlite` treated as
+        // a literal relative path — `PathBuf::from("sqlite:///nonexistent/...")` — and created a
+        // real `sqlite:/nonexistent/` directory in the process cwd before the resulting
+        // double-prefixed URL failed to parse.)
+        durable_poll_task("/nonexistent/durable-poll-test.db".to_owned(), cfg, tx).await;
+
+        let event = rx
+            .recv()
+            .await
+            .expect("expected a DurableSnapshot event on backend open failure");
+        match event {
+            zeph_tui::AgentEvent::DurableSnapshot(snapshot) => {
+                assert_eq!(snapshot.status, DurableStatus::Unavailable);
+                assert!(snapshot.executions.is_empty());
+                assert_eq!(snapshot.key_id, 9);
+                assert_eq!(snapshot.previous_key_id, Some(8));
+            }
+            other => panic!("expected DurableSnapshot event, got {other:?}"),
+        }
     }
 }
 
@@ -896,6 +942,8 @@ pub(crate) async fn durable_poll_task(
             .send(zeph_tui::AgentEvent::DurableSnapshot(DurableSnapshot {
                 status: DurableStatus::GateRejected,
                 executions: Vec::new(),
+                key_id: cfg.key_id,
+                previous_key_id: cfg.previous_key_id,
             }))
             .await;
         return;
@@ -909,6 +957,8 @@ pub(crate) async fn durable_poll_task(
                 .send(zeph_tui::AgentEvent::DurableSnapshot(DurableSnapshot {
                     status: DurableStatus::Unavailable,
                     executions: Vec::new(),
+                    key_id: cfg.key_id,
+                    previous_key_id: cfg.previous_key_id,
                 }))
                 .await;
             return;
@@ -966,6 +1016,8 @@ pub(crate) async fn durable_poll_task(
         let snapshot = DurableSnapshot {
             status: DurableStatus::Available,
             executions,
+            key_id: cfg.key_id,
+            previous_key_id: cfg.previous_key_id,
         };
         if tx
             .send(zeph_tui::AgentEvent::DurableSnapshot(snapshot))


### PR DESCRIPTION
## Summary

- Adds `LocalBackend::with_previous_hmac_key`, mirroring the AEAD cipher's existing `with_previous` rotation window, so control-entry HMAC verification on a shared DB tries the current key then falls back to the previous key during a rotation window instead of force-aborting every in-flight execution.
- Adds a drop-scan (`count_control_entries_under_previous_hmac`) covering the payload-less crash-orphan `EffectIntent` case the pre-existing AEAD blob-scan alone would miss; `--drop-previous` refuses if either scan is nonzero.
- Removes `--ack-shared-db-drain` (flag, refusal gate, CLI surface) — it existed only because the HMAC key had no rotation window; that premise is now closed.
- Adds a passive `key_id` / "rotation window open" indicator to the TUI durable panel, reusing the existing 5s poll task. No action button — rotation stays a restart-required CLI-only operation.
- Fixes a related defect surfaced while rebasing onto the concurrently-merged transcript/durable tamper-evidence work (#6453): its high-water-mark (HWM) integrity key added a `with_previous_hwm_key` primitive but froze the rotation epoch at a constant, leaving the window unreachable, and never attached HWM keys on the scheduler-daemon read path at all. Any `rotate-key` followed by a restart force-aborted every pre-rotation execution's HWM check on **all** deployments (not just shared DBs — this is unconditional, unlike the control-HMAC gap). HWM rotation now rides the same `key_id`/`previous_key_id` lifecycle as the AEAD and control-HMAC windows, with a third drop-scan for executions whose checkpoint was folded after rotation (`checkpoint_fold` reseals under the new key without re-signing the HWM row, so neither existing scan would catch them).

Closes #6451
Closes #6450
Closes #6454

## Known scope gap

#6450 also asked to map `CipherError::UnknownKeyId` "in the TUI reveal path" — no such path exists today (the TUI durable panel only has a passive metadata toggle, never touching the cipher). Not built speculatively; tracked in #6459 for if/when a TUI reveal path is added. The CLI's existing `describe_reveal_error` is already reusable for that future work.

## Severity note on the HWM fix

Confirmed by a focused security audit: the HWM rotation gap this PR closes was a **fail-closed availability defect** (executions force-abort, never a silent integrity or confidentiality bypass — no deleted/tampered row ever went undetected because of it). No security advisory or out-of-band hotfix is warranted; shipping the fix here is sufficient. Tracked separately as #6454 for traceability since it's a distinct defect from #6451/#6450's original scope, discovered mid-implementation.

## Deferred follow-up

`open_durable_backend` and both `AgentBuilder::with_durable_*` methods now take 5+ positional key-material `Option` parameters (AEAD current/previous, control-HMAC current/previous, HWM current/previous). Bundling these into a single `DurableKeyMaterial` struct was deliberately deferred — re-bundling mid-implementation would have re-touched every already-threaded call site for no correctness benefit (mis-wiring the current positional params fails closed). Tracked as #6458.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (14571 passed, 0 failed, 35 skipped)
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace ...`)
- [x] `gitleaks protect --staged`
- [x] Regression test for the checkpoint_fold drop-scan gap (folds a pre-rotation execution post-rotation, proves the AEAD and control-HMAC scans both return 0 while the new HWM scan correctly refuses `--drop-previous`)
- [x] Regression test for scheduler-daemon HWM rotation-window resume, mirroring the existing control-HMAC scheduler-daemon test
- [x] CLI-read-channel try-both HMAC verification regression test
- [x] End-to-end `--drop-previous` HMAC-scan test with a payload-less previous-key-only `EffectIntent`
- [x] Error-classification test (benign rotation routes to `key_epoch_unresolvable`, never mis-reported as tamper)
- [x] `.local/testing/playbooks/durable-key-rotation.md` and `.local/testing/coverage-status.md` updated
- [ ] Live agent session test — not run this session; recommend before merge per the LLM serialization gate's spirit given the crypto-sensitive surface, though this PR does not touch LLM request/response serialization directly