### PR TITLE
fix(vault): respect vault-path/vault-key overrides in init, add overwrite guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+### Fixed
+
+- `zeph-vault`/`zeph`: `zeph vault init` ignored `--vault-path`/`--vault-key` overrides and
+  unconditionally overwrote an existing vault with a fresh, empty keypair — no confirmation,
+  no `--force` requirement, no partial-recovery path (#6475). Caused a real data-loss incident
+  during live testing (19 secrets destroyed with no backup). Fixed by:
+  - `src/commands/vault.rs::handle_vault_command`'s `Init` arm now dispatches through the same
+    override-resolved `key_path_owned`/`vault_path_owned` values already used by
+    `Set`/`Get`/`List`/`Rm`, instead of a freshly recomputed `default_vault_dir()`.
+  - New `AgeVaultProvider::init_vault_at(key_path, vault_path, force)` in `zeph-vault`, mirroring
+    `load`'s explicit-path signature. Refuses to overwrite when `vault-key.txt` or `secrets.age`
+    already exists at the target unless `force: true`, returning a new
+    `AgeVaultError::VaultAlreadyExists(PathBuf)` variant. `init_vault(dir)` (the directory-based
+    convenience used by ~20 existing internal call sites) is now a thin wrapper over
+    `init_vault_at` with `force: false`, so every caller gets the guard by default with no
+    signature changes required at those call sites.
+  - New `VaultCommand::Init { force: bool }` CLI flag (`vault init --force`), mirroring the
+    existing `vault set --force` UX. A `--force` overwrite prints an explicit "Overwriting
+    existing vault at ..." notice, distinct from the normal first-time "Vault initialized:"
+    success message.
+
+- `zeph`: `zeph doctor`'s `integrity.anchor` and `durable.integrity_seal` checks
+  (`check_integrity_anchor`/`check_durable_integrity_seal` in `src/commands/doctor.rs`, added by
+  #6449) ignored `--vault-path`/`--vault-key` overrides and always inspected
+  `default_vault_dir()` directly, unlike the sibling `check_vault_file_exists`/
+  `check_vault_file_mode`/`check_vault_key_mode` checks in the same `run_doctor` invocation,
+  which already resolve overrides via `crate::bootstrap::parse_vault_args` (#6479). Could report
+  a misleading `OK`/`WARN` when `--vault-path`/`--vault-key` pointed at a vault different from
+  the default. Fixed by threading the same resolved `vault_args` key/vault path into both checks,
+  falling back to `default_vault_dir()` only when no override is supplied — behavior is
+  unchanged for the common no-override case.
 
 ## [0.22.2] - 2026-07-18
 ### Added

--- a/crates/zeph-vault/src/age.rs
+++ b/crates/zeph-vault/src/age.rs
@@ -70,6 +70,11 @@ pub enum AgeVaultError {
     /// already exists in the vault.
     #[error("secret key already exists: {0} (pass overwrite=true to replace it)")]
     AlreadyExists(String),
+    /// [`AgeVaultProvider::init_vault`] (or [`AgeVaultProvider::init_vault_at`]) found an
+    /// existing `vault-key.txt` or `secrets.age` at the target location and `force` was not
+    /// set.
+    #[error("vault already exists at {0} (pass force=true / --force to overwrite it)")]
+    VaultAlreadyExists(PathBuf),
 }
 
 // ---------------------------------------------------------------------------
@@ -444,9 +449,13 @@ impl AgeVaultProvider {
     /// | `<dir>/vault-key.txt` | age identity (private + public key comment) | `0600` |
     /// | `<dir>/secrets.age`   | age-encrypted empty JSON object `{}` | default |
     ///
+    /// Refuses to overwrite a pre-existing vault at `dir` — see [`AgeVaultProvider::init_vault_at`]
+    /// for the underlying guard and a `force` escape hatch.
+    ///
     /// # Errors
     ///
-    /// Returns [`AgeVaultError`] on key/vault write failure or encryption failure.
+    /// Returns [`AgeVaultError::VaultAlreadyExists`] if `vault-key.txt` or `secrets.age` already
+    /// exists under `dir`, or [`AgeVaultError`] on key/vault write failure or encryption failure.
     ///
     /// # Examples
     ///
@@ -459,9 +468,77 @@ impl AgeVaultProvider {
     /// # Ok::<_, zeph_vault::AgeVaultError>(())
     /// ```
     pub fn init_vault(dir: &Path) -> Result<(), AgeVaultError> {
+        Self::init_vault_at(&dir.join("vault-key.txt"), &dir.join("secrets.age"), false)
+    }
+
+    /// Generates a fresh age keypair and an empty encrypted vault at explicit `key_path` and
+    /// `vault_path` locations, mirroring [`AgeVaultProvider::load`]'s explicit-path signature.
+    ///
+    /// Unlike [`AgeVaultProvider::init_vault`] (which always derives the standard
+    /// `vault-key.txt`/`secrets.age` filenames from a directory), this accepts arbitrary target
+    /// paths — the correct entry point when the caller has resolved `--vault-key`/`--vault-path`
+    /// CLI overrides that may not follow the default directory/filename convention.
+    ///
+    /// # Overwrite guard
+    ///
+    /// If either `key_path` or `vault_path` already exists and `force` is `false`, the vault is
+    /// left untouched and [`AgeVaultError::VaultAlreadyExists`] is returned — a partial prior
+    /// state (only one of the two files present) is treated the same as a full prior vault,
+    /// since it is itself evidence of an earlier init attempt worth protecting. Pass `force:
+    /// true` to regenerate the keypair and overwrite both files unconditionally.
+    ///
+    /// The existence check and the subsequent write are not wrapped in a single filesystem lock,
+    /// so a racing concurrent call between the check and the write could still both pass the
+    /// guard; this is a best-effort, not a hard mutual-exclusion guarantee.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AgeVaultError::VaultAlreadyExists`] when a vault already exists and `force` is
+    /// `false`, or [`AgeVaultError`] on key/vault write failure or encryption failure.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::path::Path;
+    /// use zeph_vault::AgeVaultProvider;
+    ///
+    /// AgeVaultProvider::init_vault_at(
+    ///     Path::new("/etc/zeph/vault-key.txt"),
+    ///     Path::new("/etc/zeph/secrets.age"),
+    ///     false,
+    /// )?;
+    /// # Ok::<_, zeph_vault::AgeVaultError>(())
+    /// ```
+    pub fn init_vault_at(
+        key_path: &Path,
+        vault_path: &Path,
+        force: bool,
+    ) -> Result<(), AgeVaultError> {
         use age::secrecy::ExposeSecret as _;
 
-        std::fs::create_dir_all(dir).map_err(AgeVaultError::KeyWrite)?;
+        let existing = if key_path.exists() {
+            Some(key_path)
+        } else if vault_path.exists() {
+            Some(vault_path)
+        } else {
+            None
+        };
+
+        if let Some(existing_path) = existing {
+            if !force {
+                return Err(AgeVaultError::VaultAlreadyExists(
+                    existing_path.to_path_buf(),
+                ));
+            }
+            println!("Overwriting existing vault at {}.", existing_path.display());
+        }
+
+        if let Some(parent) = key_path.parent() {
+            std::fs::create_dir_all(parent).map_err(AgeVaultError::KeyWrite)?;
+        }
+        if let Some(parent) = vault_path.parent() {
+            std::fs::create_dir_all(parent).map_err(AgeVaultError::VaultWrite)?;
+        }
 
         let identity = age::x25519::Identity::generate();
         let public_key = identity.to_public();
@@ -472,13 +549,11 @@ impl AgeVaultProvider {
             identity.to_string().expose_secret()
         ));
 
-        let key_path = dir.join("vault-key.txt");
-        write_private_file(&key_path, key_content.as_bytes())?;
+        write_private_file(key_path, key_content.as_bytes())?;
 
-        let vault_path = dir.join("secrets.age");
         let empty: BTreeMap<String, Zeroizing<String>> = BTreeMap::new();
         let ciphertext = encrypt_secrets(&identity, &empty)?;
-        atomic_write(&vault_path, &ciphertext)?;
+        atomic_write(vault_path, &ciphertext)?;
 
         println!("Vault initialized:");
         println!("  Key:   {}", key_path.display());
@@ -618,6 +693,93 @@ mod tests {
 
         assert!(dir.path().join("vault-key.txt").exists());
         assert!(dir.path().join("secrets.age").exists());
+    }
+
+    #[test]
+    fn init_vault_refuses_to_overwrite_existing_vault() {
+        let dir = tempdir().unwrap();
+        AgeVaultProvider::init_vault(dir.path()).unwrap();
+        let key_path = dir.path().join("vault-key.txt");
+        let vault_path = dir.path().join("secrets.age");
+        let original_key = std::fs::read(&key_path).unwrap();
+
+        let err = AgeVaultProvider::init_vault(dir.path()).unwrap_err();
+        assert!(matches!(err, AgeVaultError::VaultAlreadyExists(_)));
+
+        // Neither file was touched by the rejected re-init.
+        assert_eq!(std::fs::read(&key_path).unwrap(), original_key);
+        let _ = vault_path; // existence already implied by init_vault_creates_files
+    }
+
+    #[test]
+    fn init_vault_at_force_overwrites_existing_vault() {
+        let dir = tempdir().unwrap();
+        let key_path = dir.path().join("vault-key.txt");
+        let vault_path = dir.path().join("secrets.age");
+        AgeVaultProvider::init_vault_at(&key_path, &vault_path, false).unwrap();
+        let original_key = std::fs::read(&key_path).unwrap();
+
+        AgeVaultProvider::init_vault_at(&key_path, &vault_path, true).unwrap();
+        let new_key = std::fs::read(&key_path).unwrap();
+
+        assert_ne!(original_key, new_key, "force must regenerate the keypair");
+    }
+
+    #[test]
+    fn init_vault_at_respects_explicit_non_default_paths() {
+        let dir = tempdir().unwrap();
+        let key_path = dir.path().join("custom-key.txt");
+        let vault_path = dir.path().join("custom-vault.age");
+
+        AgeVaultProvider::init_vault_at(&key_path, &vault_path, false).unwrap();
+
+        assert!(key_path.exists());
+        assert!(vault_path.exists());
+        // The standard default-named files must not have been created as a side effect.
+        assert!(!dir.path().join("vault-key.txt").exists());
+        assert!(!dir.path().join("secrets.age").exists());
+    }
+
+    #[test]
+    fn init_vault_at_guards_when_only_vault_file_present() {
+        let dir = tempdir().unwrap();
+        let key_path = dir.path().join("vault-key.txt");
+        let vault_path = dir.path().join("secrets.age");
+        // Simulate a partial prior state: only `secrets.age` exists, `vault-key.txt` does not
+        // (e.g. an interrupted write, or a corrupted/incomplete prior init).
+        std::fs::write(&vault_path, b"not a real age file").unwrap();
+
+        let err = AgeVaultProvider::init_vault_at(&key_path, &vault_path, false).unwrap_err();
+        match err {
+            AgeVaultError::VaultAlreadyExists(path) => assert_eq!(path, vault_path),
+            other => panic!("expected VaultAlreadyExists, got {other:?}"),
+        }
+        // Neither the guard nor the refused init may have created/touched the key file.
+        assert!(!key_path.exists());
+        assert_eq!(std::fs::read(&vault_path).unwrap(), b"not a real age file");
+    }
+
+    #[test]
+    fn init_vault_at_creates_independent_parent_dirs_for_key_and_vault() {
+        let dir = tempdir().unwrap();
+        // key_path and vault_path live under two entirely separate, not-yet-existing nested
+        // parent directories — proves each parent is created independently rather than the two
+        // calls collapsing into a no-op because they happen to share an already-existing parent.
+        let key_path = dir.path().join("keys/sub/vault-key.txt");
+        let vault_path = dir.path().join("secrets/sub/secrets.age");
+
+        AgeVaultProvider::init_vault_at(&key_path, &vault_path, false).unwrap();
+
+        assert!(
+            key_path.exists(),
+            "key file must exist under its own parent chain"
+        );
+        assert!(
+            vault_path.exists(),
+            "vault file must exist under its own, separate parent chain"
+        );
+        assert!(dir.path().join("keys/sub").is_dir());
+        assert!(dir.path().join("secrets/sub").is_dir());
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1310,8 +1310,14 @@ pub(crate) enum UrlSchemeCommand {
 
 #[derive(Subcommand)]
 pub(crate) enum VaultCommand {
-    /// Generate age keypair and empty encrypted vault
-    Init,
+    /// Generate age keypair and empty encrypted vault.
+    /// Note: refuses to overwrite an already-initialized vault at the target location.
+    Init {
+        /// Overwrite an existing vault. Without this flag, `vault init` refuses to replace a
+        /// vault-key.txt/secrets.age pair that already exists at the target location.
+        #[arg(long)]
+        force: bool,
+    },
 
     /// Encrypt and store a secret.
     /// Note: VALUE is visible in process listing (ps/history). For sensitive values

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -248,7 +248,16 @@ fn check_config_parse(config_path: &Path) -> (CheckResult, Option<zeph_core::con
 /// Reports whether vault-anchor downgrade-resistance (issue #6449) is active for this
 /// deployment. `[integrity] anchor = "none"` is a documented, valid opt-out (reported `OK`, not
 /// `WARN`) — see `zeph_config::AnchorMode`.
-fn check_integrity_anchor(config: &zeph_core::config::Config) -> CheckResult {
+///
+/// `key_path`/`vault_path` are the CLI-resolved vault location (`--vault-key`/`--vault-path`
+/// overrides, falling back to `default_vault_dir()`) — the same resolution already used by
+/// [`check_vault_file_exists`]/[`check_vault_file_mode`]/[`check_vault_key_mode`], so this check
+/// never inspects an unrelated default vault when an override is in effect.
+fn check_integrity_anchor(
+    config: &zeph_core::config::Config,
+    key_path: &Path,
+    vault_path: &Path,
+) -> CheckResult {
     let start = Instant::now();
     match config.integrity.anchor {
         zeph_config::AnchorMode::None => CheckResult::ok(
@@ -257,8 +266,7 @@ fn check_integrity_anchor(config: &zeph_core::config::Config) -> CheckResult {
             elapsed_ms(start),
         ),
         zeph_config::AnchorMode::Vault => {
-            let dir = zeph_core::vault::default_vault_dir();
-            if dir.join("vault-key.txt").exists() && dir.join("secrets.age").exists() {
+            if key_path.exists() && vault_path.exists() {
                 CheckResult::ok(
                     "integrity.anchor",
                     format!(
@@ -282,7 +290,14 @@ fn check_integrity_anchor(config: &zeph_core::config::Config) -> CheckResult {
 
 /// Reports the durable integrity seal status (issue #6449): sealed/unsealed, and how many
 /// resumable pre-feature executions remain (blocking `zeph durable seal-integrity`).
-fn check_durable_integrity_seal(config: &zeph_core::config::Config) -> CheckResult {
+///
+/// `key_path`/`vault_path` are the CLI-resolved vault location — see
+/// [`check_integrity_anchor`]'s doc comment for the resolution rationale.
+fn check_durable_integrity_seal(
+    config: &zeph_core::config::Config,
+    key_path: &Path,
+    vault_path: &Path,
+) -> CheckResult {
     let start = Instant::now();
     if !config.durable.enabled {
         return CheckResult::ok(
@@ -291,9 +306,7 @@ fn check_durable_integrity_seal(config: &zeph_core::config::Config) -> CheckResu
             elapsed_ms(start),
         );
     }
-    let dir = zeph_core::vault::default_vault_dir();
-    let Ok(provider) = AgeVaultProvider::load(&dir.join("vault-key.txt"), &dir.join("secrets.age"))
-    else {
+    let Ok(provider) = AgeVaultProvider::load(key_path, vault_path) else {
         return CheckResult::warn(
             "durable.integrity_seal",
             "durable enabled but no age vault found — cannot resolve seal status",
@@ -841,21 +854,21 @@ fn check_url_scheme() -> CheckResult {
 // Main entry point
 // ---------------------------------------------------------------------------
 
-/// Run all doctor checks and return exit code (0 = ok, 1 = failures).
+/// Runs every doctor check and assembles the aggregate report, without rendering it.
 ///
-/// # Errors
-///
-/// Returns an error if config resolution or I/O fails at the top level.
+/// Split out from [`run_doctor`] so the full check pipeline — including the `--vault-path`/
+/// `--vault-key` override resolution shared by checks 2-4 and 17 (#6479) — can be exercised
+/// end-to-end in tests against an in-memory [`DoctorReport`], without needing to capture the
+/// process's real stdout (`run_doctor`'s [`finish`] writes there directly).
 #[allow(clippy::too_many_lines, clippy::too_many_arguments)]
-pub(crate) async fn run_doctor(
+async fn build_doctor_report(
     config_path: &Path,
-    json: bool,
     llm_timeout_secs: u64,
     mcp_timeout_secs: u64,
     vault_override: Option<&str>,
     vault_key_override: Option<&Path>,
     vault_path_override: Option<&Path>,
-) -> anyhow::Result<i32> {
+) -> DoctorReport {
     let total_start = Instant::now();
     let mut results: Vec<CheckResult> = Vec::new();
 
@@ -865,22 +878,22 @@ pub(crate) async fn run_doctor(
     results.push(config_result);
 
     let Some(config) = config_opt else {
-        let report = DoctorReport {
+        return DoctorReport {
             elapsed_ms: elapsed_ms(total_start),
             results,
         };
-        return finish(&report, json);
     };
 
     // 2 + 3 + 4. Vault checks
+    let vault_args_result = crate::bootstrap::parse_vault_args(
+        &config,
+        vault_override,
+        vault_key_override,
+        vault_path_override,
+    );
     {
         let start = Instant::now();
-        match crate::bootstrap::parse_vault_args(
-            &config,
-            vault_override,
-            vault_key_override,
-            vault_path_override,
-        ) {
+        match &vault_args_result {
             Ok(vault_args) => {
                 if vault_args.backend == zeph_config::VaultBackend::Age {
                     if let Some(ref vault_path) = vault_args.vault_path {
@@ -893,7 +906,11 @@ pub(crate) async fn run_doctor(
                 }
             }
             Err(e) => {
-                results.push(CheckResult::fail("vault.backend", e, elapsed_ms(start)));
+                results.push(CheckResult::fail(
+                    "vault.backend",
+                    e.clone(),
+                    elapsed_ms(start),
+                ));
             }
         }
     }
@@ -1026,14 +1043,62 @@ pub(crate) async fn run_doctor(
     results.push(check_url_scheme());
 
     // 17. integrity.anchor / durable.seal (issue #6449)
-    results.push(check_integrity_anchor(&config));
-    results.push(check_durable_integrity_seal(&config));
+    //
+    // Resolve the same vault_args computed for checks 2-4 above (--vault-key/--vault-path
+    // overrides, falling back to default_vault_dir()) so these two checks never diverge from
+    // the vault the rest of this invocation is configured against (#6479).
+    let (anchor_key_path, anchor_vault_path) = {
+        let default_dir = zeph_core::vault::default_vault_dir();
+        let (resolved_key, resolved_vault) = vault_args_result
+            .as_ref()
+            .map(|va| (va.key_path.clone(), va.vault_path.clone()))
+            .unwrap_or_default();
+        (
+            resolved_key.map_or_else(|| default_dir.join("vault-key.txt"), PathBuf::from),
+            resolved_vault.map_or_else(|| default_dir.join("secrets.age"), PathBuf::from),
+        )
+    };
+    results.push(check_integrity_anchor(
+        &config,
+        &anchor_key_path,
+        &anchor_vault_path,
+    ));
+    results.push(check_durable_integrity_seal(
+        &config,
+        &anchor_key_path,
+        &anchor_vault_path,
+    ));
 
-    let report = DoctorReport {
+    DoctorReport {
         elapsed_ms: elapsed_ms(total_start),
         results,
-    };
+    }
+}
 
+/// Runs every doctor check and renders the report to stdout (plain text or JSON).
+///
+/// # Errors
+///
+/// Returns an error if config resolution or I/O fails at the top level.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run_doctor(
+    config_path: &Path,
+    json: bool,
+    llm_timeout_secs: u64,
+    mcp_timeout_secs: u64,
+    vault_override: Option<&str>,
+    vault_key_override: Option<&Path>,
+    vault_path_override: Option<&Path>,
+) -> anyhow::Result<i32> {
+    let report = Box::pin(build_doctor_report(
+        config_path,
+        llm_timeout_secs,
+        mcp_timeout_secs,
+        vault_override,
+        vault_key_override,
+        vault_path_override,
+    ))
+    .await;
     finish(&report, json)
 }
 
@@ -1256,6 +1321,131 @@ mod tests {
             "FAIL message must include remediation command, got: {}",
             result.detail
         );
+    }
+
+    // #6479: check_integrity_anchor/check_durable_integrity_seal must inspect the vault path
+    // they're given, not an unconditionally hardcoded default_vault_dir().
+    #[test]
+    fn check_integrity_anchor_ok_when_vault_present_at_given_path() {
+        let dir = tempfile::tempdir().unwrap();
+        zeph_core::vault::AgeVaultProvider::init_vault(dir.path()).unwrap();
+        let mut config = zeph_core::config::Config::default();
+        config.integrity.anchor = zeph_config::AnchorMode::Vault;
+
+        let result = check_integrity_anchor(
+            &config,
+            &dir.path().join("vault-key.txt"),
+            &dir.path().join("secrets.age"),
+        );
+        assert_eq!(result.status, CheckStatus::Ok);
+    }
+
+    #[test]
+    fn check_integrity_anchor_warns_when_given_path_has_no_vault() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = zeph_core::config::Config::default();
+        config.integrity.anchor = zeph_config::AnchorMode::Vault;
+
+        // No vault written at `dir` — an override pointing here must WARN, independent of
+        // whether a real vault happens to exist at the machine's default_vault_dir().
+        let result = check_integrity_anchor(
+            &config,
+            &dir.path().join("vault-key.txt"),
+            &dir.path().join("secrets.age"),
+        );
+        assert_eq!(result.status, CheckStatus::Warn);
+    }
+
+    #[test]
+    fn check_durable_integrity_seal_resolves_given_vault_path() {
+        let dir = tempfile::tempdir().unwrap();
+        zeph_core::vault::AgeVaultProvider::init_vault(dir.path()).unwrap();
+        let mut config = zeph_core::config::Config::default();
+        config.durable.enabled = true;
+
+        let result = check_durable_integrity_seal(
+            &config,
+            &dir.path().join("vault-key.txt"),
+            &dir.path().join("secrets.age"),
+        );
+        // A freshly-initialized vault has no seal secret yet — WARN (not sealed), never a
+        // hard load failure, proving the given path was actually loaded.
+        assert_eq!(result.status, CheckStatus::Warn);
+        assert!(result.detail.contains("not sealed"));
+    }
+
+    #[test]
+    fn check_durable_integrity_seal_warns_when_given_path_has_no_vault() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = zeph_core::config::Config::default();
+        config.durable.enabled = true;
+
+        let result = check_durable_integrity_seal(
+            &config,
+            &dir.path().join("vault-key.txt"),
+            &dir.path().join("secrets.age"),
+        );
+        assert_eq!(result.status, CheckStatus::Warn);
+        assert!(result.detail.contains("no age vault found"));
+    }
+
+    // #6479: end-to-end regression — `build_doctor_report` (the full pipeline `run_doctor`
+    // drives) must actually thread a `--vault-path`/`--vault-key` override into checks 17/18,
+    // not just the standalone `check_integrity_anchor`/`check_durable_integrity_seal` functions
+    // tested above. This is the exact wiring gap #6479 originally had: each check function was
+    // individually correct in isolation, but the call site in `run_doctor` passed it the wrong
+    // (hardcoded default) path.
+    #[tokio::test]
+    async fn build_doctor_report_threads_vault_override_into_integrity_checks() {
+        let config_dir = tempfile::tempdir().unwrap();
+        let config_path = config_dir.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            zeph_core::config::Config::dump_defaults().expect("dump defaults"),
+        )
+        .unwrap();
+
+        // Deliberately empty — no vault-key.txt/secrets.age here. If the override were ignored
+        // (the pre-#6479 bug), this check would instead report whatever status the real machine's
+        // default_vault_dir() happens to have, which is exactly the bug this test guards against.
+        let vault_dir = tempfile::tempdir().unwrap();
+        let key_path = vault_dir.path().join("vault-key.txt");
+        let vault_path = vault_dir.path().join("secrets.age");
+
+        let report = Box::pin(build_doctor_report(
+            &config_path,
+            1, // llm_timeout_secs — bounds any localhost provider probe in dumped defaults
+            1, // mcp_timeout_secs
+            None,
+            Some(&key_path),
+            Some(&vault_path),
+        ))
+        .await;
+
+        let anchor = report
+            .results
+            .iter()
+            .find(|r| r.name == "integrity.anchor")
+            .expect("integrity.anchor check must run");
+        assert_eq!(
+            anchor.status,
+            CheckStatus::Warn,
+            "override points at an empty dir — must WARN via the override path, not silently \
+             report OK against the real default vault; got detail: {}",
+            anchor.detail
+        );
+
+        let seal = report
+            .results
+            .iter()
+            .find(|r| r.name == "durable.integrity_seal")
+            .expect("durable.integrity_seal check must run");
+        // `[durable] enabled` is false in dumped defaults, so this reports OK ("durable
+        // execution disabled") regardless of the vault override — confirms the check still runs
+        // and the override didn't cause a panic/short-circuit, without depending on `[durable]`
+        // being enabled in the default config.
+        assert_eq!(seal.status, CheckStatus::Ok);
+        assert!(seal.detail.contains("disabled"));
     }
 
     #[test]

--- a/src/commands/vault.rs
+++ b/src/commands/vault.rs
@@ -21,9 +21,16 @@ pub(crate) fn handle_vault_command(
     let vault_path_owned = vault_path.map_or_else(|| dir.join("secrets.age"), PathBuf::from);
 
     match cmd {
-        VaultCommand::Init => {
-            AgeVaultProvider::init_vault(&dir)
-                .map_err(|e| anyhow::anyhow!("vault init failed: {e}"))?;
+        VaultCommand::Init { force } => {
+            AgeVaultProvider::init_vault_at(&key_path_owned, &vault_path_owned, force).map_err(
+                |e| match e {
+                    AgeVaultError::VaultAlreadyExists(path) => anyhow::anyhow!(
+                        "vault already exists at {}. Re-run with --force to overwrite it.",
+                        path.display()
+                    ),
+                    other => anyhow::anyhow!("vault init failed: {other}"),
+                },
+            )?;
         }
         VaultCommand::Set { key, value, force } => {
             let mut provider = AgeVaultProvider::load(&key_path_owned, &vault_path_owned)
@@ -158,6 +165,86 @@ mod tests {
             Some(&vault_path),
         )
         .unwrap();
+    }
+
+    // #6475: `vault init` writes to the --vault-path/--vault-key override, not the default dir.
+    #[test]
+    fn handle_vault_command_init_respects_path_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("vault-key.txt");
+        let vault_path = dir.path().join("secrets.age");
+
+        handle_vault_command(
+            VaultCommand::Init { force: false },
+            Some(&key_path),
+            Some(&vault_path),
+        )
+        .unwrap();
+
+        assert!(
+            key_path.exists(),
+            "vault key must be written to the override path"
+        );
+        assert!(
+            vault_path.exists(),
+            "vault file must be written to the override path"
+        );
+    }
+
+    // #6475: `vault init` refuses to silently overwrite an already-initialized vault.
+    #[test]
+    fn handle_vault_command_init_existing_vault_without_force_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("vault-key.txt");
+        let vault_path = dir.path().join("secrets.age");
+
+        handle_vault_command(
+            VaultCommand::Init { force: false },
+            Some(&key_path),
+            Some(&vault_path),
+        )
+        .unwrap();
+        let original_key = std::fs::read(&key_path).unwrap();
+
+        let err = handle_vault_command(
+            VaultCommand::Init { force: false },
+            Some(&key_path),
+            Some(&vault_path),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("--force"));
+
+        // The original vault must survive the rejected re-init attempt.
+        assert_eq!(std::fs::read(&key_path).unwrap(), original_key);
+    }
+
+    // #6475: `--force` still allows a deliberate reset of an existing vault.
+    #[test]
+    fn handle_vault_command_init_existing_vault_with_force_overwrites() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("vault-key.txt");
+        let vault_path = dir.path().join("secrets.age");
+
+        handle_vault_command(
+            VaultCommand::Init { force: false },
+            Some(&key_path),
+            Some(&vault_path),
+        )
+        .unwrap();
+        let original_key = std::fs::read(&key_path).unwrap();
+
+        handle_vault_command(
+            VaultCommand::Init { force: true },
+            Some(&key_path),
+            Some(&vault_path),
+        )
+        .unwrap();
+
+        assert_ne!(
+            std::fs::read(&key_path).unwrap(),
+            original_key,
+            "--force must regenerate the keypair"
+        );
     }
 
     // R-04: Get/Rm missing-key error paths

--- a/src/init/durable.rs
+++ b/src/init/durable.rs
@@ -174,13 +174,24 @@ pub(super) fn store_durable_key(state: &WizardState) -> anyhow::Result<()> {
     let key_path = dir.join("vault-key.txt");
     let vault_path = dir.join("secrets.age");
     if !key_path.exists() || !vault_path.exists() {
+        // `init_vault` (since #6475) refuses with `AgeVaultError::VaultAlreadyExists` — and no
+        // `--force` — whenever exactly one of the two files is present (a partial prior vault
+        // state). That guard cannot be satisfied from inside this non-interactive wizard step,
+        // so a partial state now surfaces as a hard "failed to initialize age vault: vault
+        // already exists at ..." error here instead of the pre-#6475 silent regeneration (the
+        // #5874 wipe vector). This is intentional and strictly safer — it trades a confusing
+        // wizard failure for the alternative of silently destroying whichever file survived —
+        // but it does mean a partial vault state is not self-healing through this path; the
+        // operator must resolve it manually (e.g. `zeph vault init --force`) before retrying.
         zeph_core::vault::AgeVaultProvider::init_vault(&dir)
             .map_err(|e| anyhow::anyhow!("failed to initialize age vault: {e}"))?;
     }
     let mut provider = zeph_core::vault::AgeVaultProvider::load(&key_path, &vault_path)
         .map_err(|e| anyhow::anyhow!("failed to load age vault: {e}"))?;
-    // Reaching this point already implies the caller's own rotation gate approved an
-    // overwrite (no pre-existing key, or the user typed the "rotate" confirmation above).
+    // `overwrite: true` here is about the ZEPH_DURABLE_KEY *secret*, not the vault file guard
+    // above: reaching this point implies the caller's own rotation gate already approved
+    // replacing the secret (no pre-existing key, or the user typed the "rotate" confirmation
+    // above) — unrelated to, and not affected by, the vault-file-level guard on `init_vault`.
     provider
         .set_secret_mut("ZEPH_DURABLE_KEY".to_owned(), key.to_owned(), true)
         .map_err(|e| anyhow::anyhow!("failed to set ZEPH_DURABLE_KEY: {e}"))?;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -690,7 +690,18 @@ fn cli_parse_vault_init() {
     assert!(matches!(
         cli.command,
         Some(Command::Vault {
-            command: VaultCommand::Init
+            command: VaultCommand::Init { force: false }
+        })
+    ));
+}
+
+#[test]
+fn cli_parse_vault_init_force() {
+    let cli = Cli::try_parse_from(["zeph", "vault", "init", "--force"]).unwrap();
+    assert!(matches!(
+        cli.command,
+        Some(Command::Vault {
+            command: VaultCommand::Init { force: true }
         })
     ));
 }


### PR DESCRIPTION
## Summary
- `zeph vault init` now resolves `--vault-path`/`--vault-key` overrides the same way every other `vault` subcommand does (`Set`/`Get`/`List`/`Rm`), instead of silently always targeting the default vault directory.
- `AgeVaultProvider::init_vault` is now a `force: false` wrapper over a new `init_vault_at(key_path, vault_path, force)`, which refuses to overwrite an already-initialized vault unless `--force` is passed — mirroring `vault set --force`. This retrofits an overwrite guard onto all existing production call sites with no behavior change where they already pre-check file existence.
- `doctor`'s `integrity.anchor`/`durable.integrity_seal` checks now thread the CLI-resolved vault path/key override through `run_doctor` (split into a testable `build_doctor_report` + thin stdout wrapper), instead of always inspecting the default vault directory.

This closes a real production data-loss incident from live testing on 2026-07-19, where `zeph vault init` silently destroyed an already-initialized vault (19 stored secrets, no recoverable backup) because both the path-override bypass and the missing overwrite guard were present at once.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (14621/14621 passed)
- [x] `cargo test --doc` for touched crates
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace ...`)
- [x] New unit tests: overwrite guard refuses without `--force`, `--force` overwrites, partial-state guard (only one of key/vault file present), differing-parent-directory creation, `--vault-path`/`--vault-key` override redirects `vault init`, `run_doctor`-level end-to-end override test for the doctor checks
- [x] `gitleaks protect --staged` clean
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] `.local/testing/playbooks/vault.md` and `.local/testing/coverage-status.md` updated (main repo)

Closes #6475
Closes #6479