### PR TITLE
fix(channels): close fail-open allowlist gap on Discord/Slack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,8 +69,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     post-loop status publish is skipped on this path since the LLM-call error handler already
     published the terminal `Failed` status.
 
-### Security
-
 - **zeph-mcp**: fixed a fail-open in `apply_allowlist` where an `Untrusted` MCP server
   (the default trust level) with no `tool_allowlist` configured exposed **all** of its tools
   with only a `warn!` log, instead of failing closed like `Sandboxed` already does (#6474).
@@ -90,6 +88,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `#[non_exhaustive]` meant any future trust variant would silently expose all tools;
   `Trusted` is now an explicit match arm and the catch-all fails closed instead.
   `Sandboxed`'s existing fail-closed behavior (with or without an allowlist) is unchanged.
+
+- `zeph-channels`: Discord and Slack channel adapters no longer fail open when their
+  user/role allowlist is left unconfigured (#6472). `DiscordChannel::new` and
+  `SlackChannel::new`/`new_with_supervisor` now refuse to start — mirroring
+  `TelegramChannel::start()`'s existing fail-closed check — when `allowed_user_ids`
+  (and, for Discord, `allowed_role_ids`) are all empty, instead of silently accepting
+  messages from any sender. This is a breaking-but-safe behavior change: existing
+  Discord/Slack configs with an empty allowlist will now fail to start until an
+  allowlist is configured; no new config field was added, since the safe default is
+  simply "require one to be set," matching Telegram's established policy.
+  - New `zeph_channels::auth` module centralizes the fail-closed startup gate
+    (`require_configured_allowlist`) and the per-message allow decision
+    (`is_identity_allowed`, `all_lists_empty`) so Telegram, Discord, and Slack share
+    one authorization primitive instead of three divergent implementations (#6498) —
+    a future channel adapter reuses the same choke point rather than reinventing it.
+  - Slack's real recv-time authorization filter (`slack/events.rs`'s webhook handler,
+    which gates which events are forwarded to the agent — the actual enforcement
+    point, since `SlackChannel::recv`/`try_recv` do not re-check the allowlist) was a
+    separate hand-rolled fail-open check; it now routes through
+    `zeph_channels::auth::is_identity_allowed` like every other allowlist check.
+  - `zeph --init`'s Discord and Slack wizard steps previously never prompted for an
+    allowlist (unlike Telegram), which combined with the fix above meant a freshly
+    initialized Discord/Slack config would refuse to start. The wizard now prompts
+    for allowed user/role IDs (Discord) and allowed user IDs (Slack), mirroring
+    Telegram's existing prompt.
 
 ## [0.22.2] - 2026-07-18
 ### Added

--- a/config/default.toml
+++ b/config/default.toml
@@ -517,17 +517,17 @@ repo_map_ttl_secs = 300
 # [discord]
 # token = ""                    # or set ZEPH_DISCORD_TOKEN
 # application_id = ""           # for slash command registration
-# allowed_user_ids = []         # Discord user IDs (empty = allow all)
-# allowed_role_ids = []         # Discord role IDs
-# allowed_channel_ids = []      # restrict to specific channels
+# allowed_user_ids = ["123456789012345678"]  # Discord user IDs; must set this or allowed_role_ids
+# allowed_role_ids = []         # Discord role IDs; must set this or allowed_user_ids
+# allowed_channel_ids = []      # restrict to specific channels (empty = all channels)
 
 # [slack]
 # bot_token = ""                # or set ZEPH_SLACK_BOT_TOKEN
 # signing_secret = ""           # or set ZEPH_SLACK_SIGNING_SECRET
 # port = 3000                   # Events API webhook port
 # webhook_host = "127.0.0.1"   # bind address for Events API webhook
-# allowed_user_ids = []         # Slack user IDs (empty = allow all)
-# allowed_channel_ids = []      # restrict to specific channels
+# allowed_user_ids = ["U01234567"]  # Slack user IDs (required, must not be empty)
+# allowed_channel_ids = []      # restrict to specific channels (empty = all channels)
 
 [mcp]
 # Allowlist of permitted commands for /mcp add (empty = allow all)

--- a/crates/zeph-channels/src/auth.rs
+++ b/crates/zeph-channels/src/auth.rs
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shared allowlist authorization primitives used by every channel adapter
+//! that gates access by sender identity (Telegram, Discord, Slack).
+//!
+//! Two responsibilities are centralized here so a future channel adapter
+//! cannot silently diverge from the fail-closed policy:
+//!
+//! * [`require_configured_allowlist`] is the **startup gate**: call it once
+//!   when the adapter is constructed, before spawning any listener or making
+//!   any network call. It refuses to start (returns `Err`) when every
+//!   allowlist relevant to the adapter is empty, rather than silently
+//!   running open to any sender.
+//! * [`is_identity_allowed`] and [`all_lists_empty`] back the **per-message
+//!   check** reused both by `Channel::recv`/`try_recv`-adjacent
+//!   `is_authorized` helpers and by
+//!   [`ConfirmLoop::confirm_accepts`](crate::confirm::ConfirmLoop::confirm_accepts).
+//!   An empty list is treated as "unrestricted" at this layer only because
+//!   the startup gate above guarantees the list is never actually empty at
+//!   call time in a correctly constructed adapter.
+
+use zeph_core::channel::ChannelError;
+
+/// Returns `true` when every list in `lists` is empty.
+///
+/// Shared by [`require_configured_allowlist`] (to refuse startup) and by
+/// adapters with more than one identity list — e.g. Discord's users + roles
+/// — that need the same "no restriction configured" short-circuit in their
+/// per-message check, so the two empty-checks cannot drift apart.
+#[must_use]
+pub fn all_lists_empty(lists: &[&[String]]) -> bool {
+    lists.iter().all(|list| list.is_empty())
+}
+
+/// Refuses to start a channel adapter whose allowlists are all empty.
+///
+/// Mirrors Telegram's original fail-closed startup check (`allowed_users`
+/// must not be empty): an unconfigured allowlist is treated as a
+/// misconfiguration to reject, never as "allow everyone". Call this before
+/// any listener is spawned or network call is made, so a misconfigured
+/// adapter has no observable side effect.
+///
+/// # Errors
+///
+/// Returns [`ChannelError::Other`] when every list in `lists` is empty.
+pub fn require_configured_allowlist(
+    channel: &str,
+    lists: &[&[String]],
+) -> Result<(), ChannelError> {
+    if all_lists_empty(lists) {
+        tracing::error!("{channel}: allowlist is empty; refusing to start an open channel");
+        return Err(ChannelError::Other(format!(
+            "{channel} allowlist must not be empty"
+        )));
+    }
+    Ok(())
+}
+
+/// Returns `true` when `identity` appears in `allowed`.
+///
+/// An empty `allowed` list is treated as "no restriction" and always returns
+/// `true` — callers MUST pair this with [`require_configured_allowlist`] at
+/// startup so that fallback never actually triggers at call time.
+#[must_use]
+pub fn is_identity_allowed(identity: Option<&str>, allowed: &[String]) -> bool {
+    allowed.is_empty() || identity.is_some_and(|id| allowed.iter().any(|a| a == id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_lists_empty_true_when_all_empty() {
+        let a: Vec<String> = vec![];
+        let b: Vec<String> = vec![];
+        assert!(all_lists_empty(&[&a, &b]));
+    }
+
+    #[test]
+    fn all_lists_empty_false_when_any_non_empty() {
+        let a: Vec<String> = vec![];
+        let b = vec!["x".to_string()];
+        assert!(!all_lists_empty(&[&a, &b]));
+    }
+
+    #[test]
+    fn require_configured_allowlist_errs_when_all_empty() {
+        let a: Vec<String> = vec![];
+        let b: Vec<String> = vec![];
+        let result = require_configured_allowlist("test", &[&a, &b]);
+        assert!(matches!(result, Err(ChannelError::Other(_))));
+    }
+
+    #[test]
+    fn require_configured_allowlist_ok_when_one_list_configured() {
+        let a: Vec<String> = vec![];
+        let b = vec!["user1".to_string()];
+        let result = require_configured_allowlist("test", &[&a, &b]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn is_identity_allowed_permits_all_when_empty() {
+        assert!(is_identity_allowed(None, &[]));
+        assert!(is_identity_allowed(Some("anyone"), &[]));
+    }
+
+    #[test]
+    fn is_identity_allowed_known_identity_is_permitted() {
+        let allowed = vec!["alice".to_string(), "bob".to_string()];
+        assert!(is_identity_allowed(Some("alice"), &allowed));
+        assert!(is_identity_allowed(Some("bob"), &allowed));
+    }
+
+    #[test]
+    fn is_identity_allowed_unknown_identity_is_rejected() {
+        let allowed = vec!["alice".to_string()];
+        assert!(!is_identity_allowed(Some("eve"), &allowed));
+        assert!(!is_identity_allowed(None, &allowed));
+    }
+}

--- a/crates/zeph-channels/src/discord/mod.rs
+++ b/crates/zeph-channels/src/discord/mod.rs
@@ -57,18 +57,30 @@ impl DiscordChannel {
     /// in the workspace-wide task registry with automatic restart on panic and lifecycle
     /// observability. Without a supervisor both tasks fall back to plain `tokio::spawn`
     /// with a warning — acceptable in tests but not recommended for production.
-    #[must_use]
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ChannelError::Other`] when `allowed_user_ids` and
+    /// `allowed_role_ids` are both empty. An unconfigured allowlist is refused
+    /// rather than treated as "allow everyone" — mirrors the Telegram channel's
+    /// fail-closed startup check (see [`crate::auth::require_configured_allowlist`]).
+    /// The check runs before any gateway connection or slash-command registration,
+    /// so a misconfigured adapter has no observable side effect.
     pub fn new(
         token: String,
         allowed_user_ids: Vec<String>,
         allowed_role_ids: Vec<String>,
         allowed_channel_ids: Vec<String>,
         supervisor: Option<&TaskSupervisor>,
-    ) -> Self {
+    ) -> Result<Self, ChannelError> {
+        crate::auth::require_configured_allowlist(
+            "discord",
+            &[&allowed_user_ids, &allowed_role_ids],
+        )?;
         let rest = rest::RestClient::new(token.clone());
         let (gateway_handle, rx) = gateway::spawn_gateway(token, supervisor);
         Self::register_slash_commands(rest.clone(), supervisor);
-        Self {
+        Ok(Self {
             rx,
             rest,
             _gateway_handle: gateway_handle,
@@ -79,7 +91,7 @@ impl DiscordChannel {
             buffer: StreamingBuffer::new(EDIT_THROTTLE),
             message_id: None,
             supervisor: supervisor.cloned(),
-        }
+        })
     }
 
     /// Register Discord slash commands in a supervised fire-and-forget task.
@@ -110,15 +122,14 @@ impl DiscordChannel {
         {
             return false;
         }
-        if self.allowed_user_ids.is_empty() && self.allowed_role_ids.is_empty() {
+        if crate::auth::all_lists_empty(&[&self.allowed_user_ids, &self.allowed_role_ids]) {
             return true;
         }
-        if self.allowed_user_ids.contains(&msg.author_id) {
-            return true;
-        }
-        msg.author_roles
-            .iter()
-            .any(|r| self.allowed_role_ids.contains(r))
+        self.allowed_user_ids.contains(&msg.author_id)
+            || msg
+                .author_roles
+                .iter()
+                .any(|r| self.allowed_role_ids.contains(r))
     }
 
     #[cfg_attr(
@@ -646,5 +657,29 @@ mod tests {
             }
         }
         assert!(confirmed);
+    }
+
+    /// Regression test for #6472: an unconfigured allowlist must refuse to
+    /// start (fail-closed), matching Telegram's `start()` semantics, instead
+    /// of silently accepting messages from any user.
+    #[test]
+    fn new_rejects_empty_allowlists() {
+        let result = DiscordChannel::new("test-token".into(), vec![], vec![], vec![], None);
+        assert!(matches!(result, Err(ChannelError::Other(_))));
+    }
+
+    /// A non-empty role allowlist alone is sufficient to pass the startup gate,
+    /// even when `allowed_user_ids` is empty — mirrors `is_authorized`'s
+    /// role-only path.
+    #[tokio::test]
+    async fn new_allows_role_only_allowlist() {
+        let result = DiscordChannel::new(
+            "test-token".into(),
+            vec![],
+            vec!["admin-role".into()],
+            vec![],
+            None,
+        );
+        assert!(result.is_ok());
     }
 }

--- a/crates/zeph-channels/src/lib.rs
+++ b/crates/zeph-channels/src/lib.rs
@@ -30,8 +30,16 @@
 //! durations that all remote channel adapters must honour for interactive
 //! dialogs.  They are intentionally centralised here so that the behaviour is
 //! consistent across Telegram, Discord, and Slack.
+//!
+//! # Shared authorization
+//!
+//! The [`auth`] module centralizes the fail-closed allowlist policy: every
+//! remote adapter refuses to start when unconfigured (see
+//! [`auth::require_configured_allowlist`]) rather than silently accepting
+//! messages from any sender.
 
 mod any;
+pub mod auth;
 pub mod cli;
 mod common;
 pub mod confirm;

--- a/crates/zeph-channels/src/slack/events.rs
+++ b/crates/zeph-channels/src/slack/events.rs
@@ -158,9 +158,7 @@ async fn handle_event(
                     {
                         return Ok(String::new());
                     }
-                    if !state.allowed_user_ids.is_empty()
-                        && !state.allowed_user_ids.iter().any(|u| u == user)
-                    {
+                    if !crate::auth::is_identity_allowed(Some(user), &state.allowed_user_ids) {
                         return Ok(String::new());
                     }
 

--- a/crates/zeph-channels/src/slack/mod.rs
+++ b/crates/zeph-channels/src/slack/mod.rs
@@ -57,7 +57,8 @@ impl SlackChannel {
     ///
     /// # Errors
     ///
-    /// Returns an error if the auth.test API call fails.
+    /// Returns an error if `allowed_user_ids` is empty or the auth.test API
+    /// call fails — see [`new_with_supervisor`] for details.
     ///
     /// [`new_with_supervisor`]: SlackChannel::new_with_supervisor
     pub async fn new(
@@ -88,7 +89,14 @@ impl SlackChannel {
     ///
     /// # Errors
     ///
-    /// Returns an error if the auth.test API call fails.
+    /// Returns [`ChannelError::Other`]
+    /// when `allowed_user_ids` is empty. An unconfigured allowlist is refused
+    /// rather than treated as "allow everyone" — mirrors the Telegram channel's
+    /// fail-closed startup check (see [`crate::auth::require_configured_allowlist`]).
+    /// The check runs before the `auth.test` API call, so a misconfigured adapter
+    /// makes no network request.
+    ///
+    /// Also returns an error if the `auth.test` API call fails.
     ///
     /// [`new`]: SlackChannel::new
     pub async fn new_with_supervisor(
@@ -100,6 +108,7 @@ impl SlackChannel {
         allowed_channel_ids: Vec<String>,
         supervisor: Option<&TaskSupervisor>,
     ) -> Result<Self, zeph_core::channel::ChannelError> {
+        crate::auth::require_configured_allowlist("slack", &[&allowed_user_ids])?;
         let api = api::SlackApi::new(bot_token);
         let bot_user_id = match api.auth_test().await {
             Ok(id) => {
@@ -138,10 +147,7 @@ impl SlackChannel {
         {
             return false;
         }
-        if self.allowed_user_ids.is_empty() {
-            return true;
-        }
-        self.allowed_user_ids.contains(&msg.user_id)
+        crate::auth::is_identity_allowed(Some(&msg.user_id), &self.allowed_user_ids)
     }
 
     #[cfg_attr(
@@ -594,5 +600,24 @@ mod tests {
         tokio::time::advance(crate::CONFIRM_TIMEOUT + Duration::from_millis(1)).await;
         let result = timeout_fut.await;
         assert!(result.is_err(), "expected timeout Err, got recv result");
+    }
+
+    /// Regression test for #6472: an unconfigured allowlist must refuse to
+    /// start (fail-closed), matching Telegram's `start()` semantics, instead
+    /// of silently accepting messages from any user. The gate runs before the
+    /// `auth.test` API call, so this never touches the network.
+    #[tokio::test(flavor = "current_thread")]
+    async fn new_with_supervisor_rejects_empty_allowlist() {
+        let result = SlackChannel::new_with_supervisor(
+            "xoxb-test".into(),
+            "signing-secret".into(),
+            "127.0.0.1".into(),
+            0,
+            vec![],
+            vec![],
+            None,
+        )
+        .await;
+        assert!(matches!(result, Err(ChannelError::Other(_))));
     }
 }

--- a/crates/zeph-channels/src/telegram.rs
+++ b/crates/zeph-channels/src/telegram.rs
@@ -306,12 +306,7 @@ impl TelegramChannel {
     /// Returns an error if the bot cannot be initialized.
     #[allow(clippy::too_many_lines)]
     pub fn start(mut self) -> Result<Self, ChannelError> {
-        if self.allowed_users.is_empty() {
-            tracing::error!("telegram.allowed_users is empty; refusing to start an open bot");
-            return Err(ChannelError::Other(
-                "telegram.allowed_users must not be empty".into(),
-            ));
-        }
+        crate::auth::require_configured_allowlist("telegram", &[&self.allowed_users])?;
 
         // Bot-to-Bot: register capability with Telegram (non-fatal, fire-and-forget).
         // bot_to_bot_active starts as false; the spawned task sets it to true only on success.
@@ -606,11 +601,12 @@ impl TelegramChannel {
 
 /// Returns `true` when `username` appears in `allowed`.
 ///
-/// An empty `allowed` list is treated as "no restriction" and always returns
-/// `true`, but `start()` rejects empty lists before the listener is spawned,
-/// so in practice `allowed` is never empty at call time.
+/// Delegates to the shared [`crate::auth::is_identity_allowed`] primitive.
+/// `start()` rejects empty lists before the listener is spawned via
+/// [`crate::auth::require_configured_allowlist`], so in practice `allowed` is
+/// never empty at call time.
 fn is_user_authorized(username: Option<&str>, allowed: &[String]) -> bool {
-    allowed.is_empty() || username.is_some_and(|u| allowed.iter().any(|a| a == u))
+    crate::auth::is_identity_allowed(username, allowed)
 }
 
 /// Returns `true` when `username` is in `allowed_bots` or the list is empty.

--- a/crates/zeph-config/src/channels.rs
+++ b/crates/zeph-config/src/channels.rs
@@ -559,7 +559,10 @@ pub struct TelegramConfig {
     /// hand-edited `config.toml` still load.
     #[serde(skip_serializing)]
     pub token: Option<String>,
-    /// Telegram usernames allowed to interact with the bot (empty = allow all).
+    /// Telegram usernames allowed to interact with the bot.
+    ///
+    /// Must not be empty: the channel refuses to start (fail-closed) rather
+    /// than run open to any sender when unconfigured.
     #[serde(default)]
     pub allowed_users: Vec<String>,
     /// Skill allowlist for this channel.
@@ -636,10 +639,20 @@ pub struct DiscordConfig {
     pub token: Option<String>,
     /// Public Discord application snowflake — not a secret, safe to serialize.
     pub application_id: Option<String>,
+    /// Discord user snowflakes allowed to interact with the bot.
+    ///
+    /// At least one of `allowed_user_ids` or `allowed_role_ids` must be
+    /// non-empty: the channel refuses to start (fail-closed) rather than run
+    /// open to any sender when both are unconfigured.
     #[serde(default)]
     pub allowed_user_ids: Vec<String>,
+    /// Discord role snowflakes allowed to interact with the bot.
+    ///
+    /// See [`allowed_user_ids`](Self::allowed_user_ids) for the fail-closed
+    /// startup requirement shared with this field.
     #[serde(default)]
     pub allowed_role_ids: Vec<String>,
+    /// Discord channel snowflakes the bot responds in (empty = all channels).
     #[serde(default)]
     pub allowed_channel_ids: Vec<String>,
     #[serde(default)]
@@ -688,8 +701,13 @@ pub struct SlackConfig {
     pub webhook_host: String,
     #[serde(default = "default_slack_port")]
     pub port: u16,
+    /// Slack user IDs allowed to interact with the bot.
+    ///
+    /// Must not be empty: the channel refuses to start (fail-closed) rather
+    /// than run open to any sender when unconfigured.
     #[serde(default)]
     pub allowed_user_ids: Vec<String>,
+    /// Slack channel IDs the bot responds in (empty = all channels).
     #[serde(default)]
     pub allowed_channel_ids: Vec<String>,
     #[serde(default)]

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -202,7 +202,8 @@ pub(crate) async fn create_channel_inner(
             dc.allowed_role_ids.clone(),
             dc.allowed_channel_ids.clone(),
             supervisor.as_ref(),
-        );
+        )
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
         tracing::info!("running in Discord mode");
         return Ok((AnyChannel::Discord(channel), None));
     }

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -59,8 +59,18 @@ pub(crate) struct WizardState {
     pub(crate) telegram_stream_interval_ms: u64,
     pub(crate) discord_token: Option<String>,
     pub(crate) discord_app_id: Option<String>,
+    /// Discord user snowflakes allowed to interact with the bot. Required (together with
+    /// `discord_allowed_role_ids`) since `DiscordChannel::new` now refuses to start when both
+    /// are empty (#6472) — the wizard must prompt so `--init` never produces an unstartable
+    /// config.
+    pub(crate) discord_allowed_user_ids: Vec<String>,
+    /// Discord role snowflakes allowed to interact with the bot. See `discord_allowed_user_ids`.
+    pub(crate) discord_allowed_role_ids: Vec<String>,
     pub(crate) slack_bot_token: Option<String>,
     pub(crate) slack_signing_secret: Option<String>,
+    /// Slack user IDs allowed to interact with the bot. Required since
+    /// `SlackChannel::new_with_supervisor` now refuses to start when empty (#6472).
+    pub(crate) slack_allowed_user_ids: Vec<String>,
     pub(crate) vault_backend: String,
     pub(crate) auto_update_check: bool,
     pub(crate) scheduler_enabled: bool,
@@ -388,8 +398,11 @@ impl Default for WizardState {
             telegram_stream_interval_ms: 3000,
             discord_token: None,
             discord_app_id: None,
+            discord_allowed_user_ids: Vec::new(),
+            discord_allowed_role_ids: Vec::new(),
             slack_bot_token: None,
             slack_signing_secret: None,
+            slack_allowed_user_ids: Vec::new(),
             vault_backend: String::new(),
             auto_update_check: false,
             scheduler_enabled: false,
@@ -734,6 +747,26 @@ fn step_channel(state: &mut WizardState) -> anyhow::Result<()> {
                     .with_prompt("Discord application ID")
                     .interact_text()?,
             );
+            let user_ids: String = Input::new()
+                .with_prompt(
+                    "Allowed Discord user IDs (comma-separated; required unless a role is set)",
+                )
+                .default(String::new())
+                .interact_text()?;
+            state.discord_allowed_user_ids = user_ids
+                .split(',')
+                .map(|s| s.trim().to_owned())
+                .filter(|s| !s.is_empty())
+                .collect();
+            let role_ids: String = Input::new()
+                .with_prompt("Allowed Discord role IDs (comma-separated, optional)")
+                .default(String::new())
+                .interact_text()?;
+            state.discord_allowed_role_ids = role_ids
+                .split(',')
+                .map(|s| s.trim().to_owned())
+                .filter(|s| !s.is_empty())
+                .collect();
         }
         3 => {
             state.channel = ChannelChoice::Slack;
@@ -746,6 +779,15 @@ fn step_channel(state: &mut WizardState) -> anyhow::Result<()> {
                         .interact()?,
                 );
             }
+            let user_ids: String = Input::new()
+                .with_prompt("Allowed Slack user IDs (comma-separated)")
+                .default(String::new())
+                .interact_text()?;
+            state.slack_allowed_user_ids = user_ids
+                .split(',')
+                .map(|s| s.trim().to_owned())
+                .filter(|s| !s.is_empty())
+                .collect();
         }
         _ => unreachable!(),
     }
@@ -1107,8 +1149,8 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
             config.discord = Some(DiscordConfig {
                 token: None,
                 application_id: state.discord_app_id.clone(),
-                allowed_user_ids: vec![],
-                allowed_role_ids: vec![],
+                allowed_user_ids: state.discord_allowed_user_ids.clone(),
+                allowed_role_ids: state.discord_allowed_role_ids.clone(),
                 allowed_channel_ids: vec![],
                 skills: ChannelSkillsConfig::default(),
                 allowed_tools: None,
@@ -1120,7 +1162,7 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
                 signing_secret: None,
                 webhook_host: "127.0.0.1".into(),
                 port: 3000,
-                allowed_user_ids: vec![],
+                allowed_user_ids: state.slack_allowed_user_ids.clone(),
                 allowed_channel_ids: vec![],
                 skills: ChannelSkillsConfig::default(),
                 allowed_tools: None,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -400,10 +400,14 @@ fn build_config_discord_channel() {
         channel: ChannelChoice::Discord,
         discord_token: Some("tok".into()),
         discord_app_id: Some("123".into()),
+        discord_allowed_user_ids: vec!["111".into()],
+        discord_allowed_role_ids: vec!["222".into()],
         ..WizardState::default()
     };
     let config = build_config(&state);
-    assert!(config.discord.is_some());
+    let discord = config.discord.expect("discord config must be set");
+    assert_eq!(discord.allowed_user_ids, vec!["111"]);
+    assert_eq!(discord.allowed_role_ids, vec!["222"]);
 }
 
 #[test]
@@ -414,10 +418,12 @@ fn build_config_slack_channel() {
         channel: ChannelChoice::Slack,
         slack_bot_token: Some("xoxb".into()),
         slack_signing_secret: Some("secret".into()),
+        slack_allowed_user_ids: vec!["U0123".into()],
         ..WizardState::default()
     };
     let config = build_config(&state);
-    assert!(config.slack.is_some());
+    let slack = config.slack.expect("slack config must be set");
+    assert_eq!(slack.allowed_user_ids, vec!["U0123"]);
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -198,7 +198,7 @@ async fn create_channel_telegram_with_empty_allowed_users_errors() {
         result
             .unwrap_err()
             .to_string()
-            .contains("allowed_users must not be empty")
+            .contains("telegram allowlist must not be empty")
     );
 }
 


### PR DESCRIPTION
## Summary

- Discord and Slack channel adapters no longer fail open when their user/role allowlist is left unconfigured — `DiscordChannel::new` and `SlackChannel::new`/`new_with_supervisor` now refuse to start, mirroring `TelegramChannel::start()`'s existing fail-closed check, instead of silently accepting messages from any sender.
- A new `zeph_channels::auth` module centralizes the fail-closed startup gate (`require_configured_allowlist`) and the per-message allow decision (`is_identity_allowed`, `all_lists_empty`) so Telegram, Discord, and Slack share one authorization primitive instead of three divergent implementations — a future channel adapter reuses the same choke point rather than reinventing it.
- Slack's real recv-time authorization filter (`slack/events.rs`'s webhook handler — the actual enforcement point, since `SlackChannel::recv`/`try_recv` do not re-check the allowlist) was a separate hand-rolled fail-open check; it now routes through the same primitive.
- `zeph --init`'s Discord and Slack wizard steps previously never prompted for an allowlist (unlike Telegram); combined with the fix above, a freshly initialized config would have been unstartable. The wizard now prompts for allowed user/role IDs (Discord) and allowed user IDs (Slack), mirroring Telegram's existing prompt.

This is an intentional breaking-but-safe behavior change: existing Discord/Slack configs with an empty allowlist will now fail to start until an allowlist is configured. No config shape changed, so no migration step was needed.

Closes #6472
Closes #6498

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" -E 'package(zeph-channels)'` — 299/299 pass
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `gitleaks protect --staged --no-banner --redact`
- [x] New regression tests: Discord (`new_rejects_empty_allowlists`, `new_allows_role_only_allowlist`), Slack (`new_with_supervisor_rejects_empty_allowlist`), init wizard round-trip (`build_config_discord_channel`, `build_config_slack_channel`)
- [x] `.local/testing/playbooks/discord.md` and `slack.md` updated with the new fail-closed scenario; `.local/testing/coverage-status.md` rows updated
- [ ] Live testing (Telegram/Discord/Slack bot round-trip) — not performed in this session per project convention (separate CI-cycle activity); implementation verified via unit/static checks only