### PR TITLE
fix(subagent): close secret-leak, trust-cap, and finalize-skip gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   falling back to `default_vault_dir()` only when no override is supplied — behavior is
   unchanged for the common no-override case.
 
+### Security
+
+- `zeph-subagent`/`zeph-core`: closed three subagent trust-boundary gaps found during a security
+  audit of the sub-agent grant/spawn/transcript machinery (#6492, #6493, #6494) — in every case
+  the enforcement machinery already existed, but a wiring step was missing.
+  - **#6492 (secret leak into transcript/LLM context/debug dump)**: a delivered vault secret's
+    raw value was attached as a per-call `ExecutionContext` env override for tool execution, but
+    if the invoked tool echoed it back (e.g. `shell: echo $KEY`), the raw value landed unmasked
+    in the tool-result content pushed into `messages` — which feeds the transcript JSONL, the
+    next turn's LLM context, and the debug dump alike. Fixed with two changes: (1)
+    `SubAgentManager::deliver_secret` now registers the delivered value into the shared
+    `SecretMaskRegistry` (the same registry already used for parent-outbound masking and
+    forwarding-drain sanitization) at grant-delivery time; (2) the agent loop's
+    `handle_tool_step` now masks tool-result `content` against that registry immediately before
+    it is pushed into `messages` — a single chokepoint covering all three sinks.
+  - **#6493 (spawned sub-agent could exceed the parent's own trust level)**: `SpawnContext`'s
+    `max_trust_level`/`inherited_tool_allowlist` constraint-propagation fields (added for #3993)
+    were enforced correctly wherever set, but never populated at the one production
+    `SpawnContext` construction site (`build_spawn_context`, covering foreground, background,
+    and orchestration-driven spawns alike). `build_spawn_context` now computes the parent
+    session's own current effective trust level (the same weakest-link fold applied to the
+    parent's own tool gate) and caps every spawned sub-agent to it, so a sub-agent can never
+    receive higher privileges than its parent currently holds. `inherited_tool_allowlist` is
+    left unset pending a follow-up to add per-task orchestration-policy plumbing.
+  - **#6494 (transcript anchor finalize skipped on LLM-error exit)**: `run_agent_loop` returned
+    early via `?` on an LLM-call error/timeout, skipping the unconditional post-loop transcript
+    anchor `finalize()` — leaving the transcript chained-but-unanchored and reopening the
+    whole-strip downgrade #6449/#6461 closed. The loop now captures the error, falls through to
+    the existing finalize block unconditionally, and returns the captured error afterward; the
+    post-loop status publish is skipped on this path since the LLM-call error handler already
+    published the terminal `Failed` status.
+
 ## [0.22.2] - 2026-07-18
 ### Added
 

--- a/crates/zeph-core/src/agent/subagent_commands.rs
+++ b/crates/zeph-core/src/agent/subagent_commands.rs
@@ -828,10 +828,39 @@ impl<C: Channel> Agent<C> {
                     self.services.security.pii_filter.clone(),
                 )) as Arc<dyn zeph_llm::debug_dump::DebugDumpSink>
             }),
-            // Constraint propagation (#3993): populated by orchestration layer when spawning
-            // with explicit trust/tool restrictions. Top-level agent sessions leave these None.
+            // Constraint propagation (#3993/#6493): cap the spawned sub-agent's trust to the
+            // parent session's own current effective trust level, so a sub-agent can never
+            // receive higher privileges than the parent itself currently holds — this is the
+            // only production call site that constructs a `SpawnContext`, so every spawn path
+            // (foreground, background, and orchestration-driven via
+            // `handle_scheduler_spawn_action`) is covered. `inherited_tool_allowlist` is left
+            // `None`: the top-level agent has no explicit tool-allowlist concept of its own to
+            // narrow against (see issue tracking the follow-up per-task `TaskNode` allowlist
+            // plumbing for the orchestration layer).
+            max_trust_level: Some(self.parent_effective_trust_level()),
             ..Default::default()
         }
+    }
+    /// Compute the parent session's own current effective trust level (issue #6493).
+    ///
+    /// Mirrors the fold in [`crate::agent::context::assembly`]'s
+    /// `apply_skill_trust_and_gating` exactly, so the cap handed to a spawned sub-agent is
+    /// always consistent with what is actually enforced on the parent's own tool gate this
+    /// turn: the least-trusted level among all skills active this turn, or `Trusted` when no
+    /// skill is active.
+    fn parent_effective_trust_level(&self) -> zeph_common::SkillTrustLevel {
+        if self.services.skill.active_skill_names.is_empty() {
+            return zeph_common::SkillTrustLevel::Trusted;
+        }
+        let snapshot = self.services.skill.trust_snapshot.read();
+        self.services
+            .skill
+            .active_skill_names
+            .iter()
+            .filter_map(|name| snapshot.get(name).map(|s| s.trust_level))
+            .fold(zeph_common::SkillTrustLevel::Trusted, |acc, lvl| {
+                acc.min_trust(lvl)
+            })
     }
     /// Extract recent parent messages for history propagation (Section 5.7 in spec).
     ///
@@ -1700,6 +1729,136 @@ mod tests {
         // proves the wiring produces a working `Arc<dyn DebugDumpSink>`, not just `Some(_)`.
         let id = sink.dump_request("mock", &[], &[], serde_json::Value::Null);
         sink.dump_response(id, &zeph_llm::provider::ChatResponse::Text("ok".into()));
+    }
+
+    // ── build_spawn_context: trust-level constraint propagation (#6493) ─────
+
+    #[test]
+    fn build_spawn_context_leaves_max_trust_level_trusted_when_no_active_skills() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let agent = Agent::new(
+            provider,
+            channel,
+            registry,
+            None,
+            5,
+            MockToolExecutor::no_tools(),
+        );
+
+        let ctx = agent.build_spawn_context(&zeph_config::SubAgentConfig::default());
+        assert_eq!(
+            ctx.max_trust_level,
+            Some(zeph_common::SkillTrustLevel::Trusted),
+            "with no active skills this turn, the parent's own effective trust is Trusted, \
+             so the cap must impose no additional restriction"
+        );
+    }
+
+    #[test]
+    fn build_spawn_context_caps_trust_to_least_trusted_active_skill() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let mut agent = Agent::new(
+            provider,
+            channel,
+            registry,
+            None,
+            5,
+            MockToolExecutor::no_tools(),
+        );
+        agent.services.skill.active_skill_names = vec!["trusted-skill".into(), "evil-skill".into()];
+        agent.services.skill.trust_snapshot.write().insert(
+            "trusted-skill".into(),
+            crate::skill_invoker::SkillTrustSnapshot {
+                trust_level: zeph_common::SkillTrustLevel::Trusted,
+                requires_trust_check: false,
+                blake3_hash: String::new(),
+            },
+        );
+        agent.services.skill.trust_snapshot.write().insert(
+            "evil-skill".into(),
+            crate::skill_invoker::SkillTrustSnapshot {
+                trust_level: zeph_common::SkillTrustLevel::Quarantined,
+                requires_trust_check: false,
+                blake3_hash: String::new(),
+            },
+        );
+
+        let ctx = agent.build_spawn_context(&zeph_config::SubAgentConfig::default());
+        assert_eq!(
+            ctx.max_trust_level,
+            Some(zeph_common::SkillTrustLevel::Quarantined),
+            "the cap must be the LEAST-trusted of all active skills this turn (weakest-link), \
+             matching the fold `apply_skill_trust_and_gating` applies to the parent's own gate"
+        );
+    }
+
+    /// Records every `set_effective_trust` call — unlike `MockToolExecutor`, which falls
+    /// through to the trait's no-op default. Used by
+    /// [`spawning_a_subagent_caps_trust_to_parent_effective_level`] to observe the trust level
+    /// that actually reached the sub-agent's tool executor through the REAL production spawn
+    /// path (`handle_agent_background` → `build_spawn_context` → `SubAgentManager::spawn` →
+    /// `FilteredToolExecutor::set_effective_trust` → this executor, the same `Arc` the parent
+    /// itself uses), not a hand-built `SpawnContext` in a unit test.
+    #[derive(Default)]
+    struct TrustRecordingExecutor {
+        recorded: Arc<Mutex<Option<zeph_tools::SkillTrustLevel>>>,
+    }
+
+    impl ToolExecutor for TrustRecordingExecutor {
+        async fn execute(&self, _response: &str) -> Result<Option<ToolOutput>, ToolError> {
+            Ok(None)
+        }
+
+        fn set_skill_env(&self, _env: Option<std::collections::HashMap<String, String>>) {}
+
+        fn set_effective_trust(&self, level: zeph_tools::SkillTrustLevel) {
+            *self.recorded.lock().unwrap() = Some(level);
+        }
+
+        zeph_tools::tool_executor_no_inner_defaults!();
+    }
+
+    #[tokio::test]
+    async fn spawning_a_subagent_caps_trust_to_parent_effective_level() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = TrustRecordingExecutor::default();
+        let recorded = Arc::clone(&executor.recorded);
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        let mut mgr = zeph_subagent::SubAgentManager::new(4);
+        mgr.definitions_mut().push(subagent_def("helper"));
+        agent.services.orchestration.subagent_manager = Some(mgr);
+
+        // Parent's own current trust is restricted this turn by an active Quarantined skill.
+        agent.services.skill.active_skill_names = vec!["evil-skill".into()];
+        agent.services.skill.trust_snapshot.write().insert(
+            "evil-skill".into(),
+            crate::skill_invoker::SkillTrustSnapshot {
+                trust_level: zeph_common::SkillTrustLevel::Quarantined,
+                requires_trust_check: false,
+                blake3_hash: String::new(),
+            },
+        );
+
+        let resp = agent.handle_agent_background("helper", "do work").await;
+        assert!(
+            resp.is_some_and(|r| r.contains("started in background")),
+            "test setup: the real production spawn path must succeed"
+        );
+
+        assert_eq!(
+            *recorded.lock().unwrap(),
+            Some(zeph_tools::SkillTrustLevel::Quarantined),
+            "a sub-agent spawned while the parent's own effective trust is Quarantined must \
+             never receive a higher (Trusted) effective trust on its own tool executor — \
+             #6493's escalation gap"
+        );
     }
 
     // ── filtered_skills_for token-budget cap (#6421) ─────────────────────────

--- a/crates/zeph-subagent/src/agent_loop.rs
+++ b/crates/zeph-subagent/src/agent_loop.rs
@@ -91,6 +91,13 @@ pub(super) struct AgentLoopArgs {
     /// nothing sent. Owned exclusively by this run's own turn loop for its lifetime; never
     /// clone the inner sender into a longer-lived struct (see `forward::ForwardSender` docs).
     pub(super) forward: Option<ForwardSender>,
+    /// Shared secret-mask registry (issue #6492), the same `Arc` used for the parent's
+    /// outbound-LLM masking and the forwarding drain's `SanitizeLayers`. Applied to every
+    /// tool-result's `content` in [`handle_tool_step`] immediately before it is pushed into
+    /// `messages` — the single chokepoint feeding the transcript, the next turn's LLM
+    /// context, and the debug dump. `None` when no registry is wired (mirrors
+    /// `SubAgentManager::secret_registry`'s `None` default).
+    pub(super) secret_registry: Option<Arc<zeph_sanitizer::secret_mask::SecretMaskRegistry>>,
 }
 
 /// Record a progress heartbeat, if this loop has a live handle. No-op for `None` (untracked
@@ -508,6 +515,7 @@ async fn run_turn(
     llm_timeout: std::time::Duration,
     debug_dump_sink: Option<&dyn zeph_llm::debug_dump::DebugDumpSink>,
     forward: Option<&ForwardSender>,
+    secret_registry: Option<&zeph_sanitizer::secret_mask::SecretMaskRegistry>,
 ) -> Result<TurnOutcome, super::error::SubAgentError> {
     let response = call_provider_with_status(
         provider,
@@ -580,6 +588,7 @@ async fn run_turn(
         agent_name,
         sanitizer,
         granted_secrets,
+        secret_registry,
     )
     .await;
 
@@ -622,6 +631,7 @@ async fn handle_tool_step(
     agent_name: &str,
     sanitizer: &ContentSanitizer,
     granted_secrets: &mut HashMap<String, GrantedSecret>,
+    secret_registry: Option<&zeph_sanitizer::secret_mask::SecretMaskRegistry>,
 ) -> bool {
     match response {
         ChatResponse::Text(text) => {
@@ -788,6 +798,19 @@ async fn handle_tool_step(
                     }
                 }
 
+                // #6492: mask any known vault secret (this run's own grants and any other
+                // registered secret) out of the tool result before it reaches `messages` —
+                // the single chokepoint feeding the transcript, the next turn's LLM context,
+                // and the debug dump. `would_mask` is the allocation-free pre-check so a turn
+                // with no secret in it pays no extra cost. This mitigation is contingent on
+                // `secret_masking.enabled` (default `true` — `secret_registry` is `None` when
+                // disabled) and on the secret being at least `MIN_SECRET_LEN` (8) bytes.
+                if let Some(registry) = secret_registry
+                    && registry.would_mask(&content)
+                {
+                    content = registry.mask(&content);
+                }
+
                 result_parts.push(MessagePart::ToolResult {
                     tool_use_id: tc.id.clone(),
                     content,
@@ -854,8 +877,10 @@ pub(super) async fn run_agent_loop(
         progress_at,
         debug_dump_sink,
         forward,
+        secret_registry,
     } = args;
     let debug_dump_sink = debug_dump_sink.as_deref();
+    let secret_registry = secret_registry.as_deref();
 
     let sanitizer = ContentSanitizer::new(&content_isolation);
 
@@ -882,6 +907,11 @@ pub(super) async fn run_agent_loop(
     // Forwarded terminal state, independent of status_tx's always-Completed publish below
     // (impl-critic M1) — set to Canceled on either cancellation exit path.
     let mut forward_terminal_state = SubAgentState::Completed;
+    // #6494: captures a `run_turn` error so control still falls through to the unconditional
+    // post-loop finalize block below instead of an early `?`-return skipping it — a skipped
+    // finalize leaves the transcript chained-but-unanchored, reopening the whole-strip
+    // downgrade #6449/#6461 closed for any turn that ends on an LLM error/timeout.
+    let mut pending_error: Option<super::error::SubAgentError> = None;
 
     loop {
         record_progress(progress_at.as_ref());
@@ -896,7 +926,7 @@ pub(super) async fn run_agent_loop(
             break;
         }
 
-        match run_turn(
+        let turn_result = run_turn(
             &provider,
             &executor,
             &mut messages,
@@ -920,14 +950,27 @@ pub(super) async fn run_agent_loop(
             llm_timeout,
             debug_dump_sink,
             forward.as_ref(),
+            secret_registry,
         )
-        .await?
-        {
-            TurnOutcome::ToolCalled => any_tool_called = true,
-            TurnOutcome::NudgeSent | TurnOutcome::SecretHandled => {}
-            TurnOutcome::Done => break,
-            TurnOutcome::Cancelled => {
+        .await;
+
+        match turn_result {
+            Ok(TurnOutcome::ToolCalled) => any_tool_called = true,
+            Ok(TurnOutcome::NudgeSent | TurnOutcome::SecretHandled) => {}
+            Ok(TurnOutcome::Done) => break,
+            Ok(TurnOutcome::Cancelled) => {
                 forward_terminal_state = SubAgentState::Canceled;
+                break;
+            }
+            Err(e) => {
+                // `call_provider_with_status` already published a terminal `Failed` status
+                // (and forwarded terminal chunk) before returning this error — capture it and
+                // fall through to the unconditional post-loop finalize instead of an early
+                // return. `forward_terminal_state` is intentionally left untouched here: the
+                // post-loop `publish_completed_status` call (its only reader) is unconditionally
+                // skipped whenever `pending_error.is_some()`, which is always true on this arm,
+                // so setting it would be a dead store.
+                pending_error = Some(e);
                 break;
             }
         }
@@ -937,24 +980,36 @@ pub(super) async fn run_agent_loop(
         trim_message_history(&mut messages, max_history_messages);
     }
 
-    publish_completed_status(
-        &status_tx,
-        forward.as_ref(),
-        forward_terminal_state,
-        &last_result,
-        turns,
-        started_at,
-    );
+    // Skipped on the error path: `call_provider_with_status` already published `Failed` (and
+    // its matching forwarded terminal) before returning the error captured in `pending_error`
+    // — publishing `Completed` here as well would overwrite that status and double-forward a
+    // terminal chunk.
+    if pending_error.is_none() {
+        publish_completed_status(
+            &status_tx,
+            forward.as_ref(),
+            forward_terminal_state,
+            &last_result,
+            turns,
+            started_at,
+        );
+    }
 
     // Anchor the transcript (issue #6449): best-effort, logged rather than propagated — the
     // transcript file itself is already durably written, and a failed anchor put only means this
-    // one file falls back to #6453-level chain-only protection, never data loss.
+    // one file falls back to #6453-level chain-only protection, never data loss. Runs
+    // unconditionally on every loop exit path, including the LLM-error path above (#6494) —
+    // skipping it there left the transcript chained-but-unanchored, reopening the whole-strip
+    // downgrade #6449/#6461 closed.
     if let Some(writer) = transcript_writer
         && let Err(e) = writer.finalize().await
     {
         tracing::warn!(error = %e, task_id = %loop_task_id, "transcript anchor finalize failed");
     }
 
+    if let Some(e) = pending_error {
+        return Err(e);
+    }
     Ok(last_result)
 }
 
@@ -1227,6 +1282,103 @@ mod handle_tool_step_granted_secrets_tests {
         }
     }
 
+    /// Executor whose tool output summary echoes back exactly the string it is constructed
+    /// with — simulates a tool call that leaks a secret's raw value into its own output
+    /// (e.g. `shell: echo $SOME_VAULT_KEY`), for #6492 masking regression tests.
+    struct EchoingExecutor {
+        echo: String,
+    }
+
+    impl ErasedToolExecutor for EchoingExecutor {
+        fn execute_erased<'a>(
+            &'a self,
+            _response: &'a str,
+        ) -> Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a,
+            >,
+        > {
+            Box::pin(std::future::ready(Ok(None)))
+        }
+
+        fn execute_confirmed_erased<'a>(
+            &'a self,
+            _response: &'a str,
+        ) -> Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a,
+            >,
+        > {
+            Box::pin(std::future::ready(Ok(None)))
+        }
+
+        fn tool_definitions_erased(&self) -> Vec<ToolDef> {
+            vec![]
+        }
+
+        fn execute_tool_call_erased<'a>(
+            &'a self,
+            call: &'a ToolCall,
+        ) -> Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a,
+            >,
+        > {
+            let echo = self.echo.clone();
+            let tool_name = call.tool_id.clone();
+            Box::pin(async move {
+                Ok(Some(ToolOutput {
+                    tool_name,
+                    summary: echo,
+                    blocks_executed: 1,
+                    filter_stats: None,
+                    diff: None,
+                    streamed: false,
+                    terminal_id: None,
+                    locations: None,
+                    raw_response: None,
+                    claim_source: None,
+                    ..Default::default()
+                }))
+            })
+        }
+
+        fn is_tool_retryable_erased(&self, _tool_id: &str) -> bool {
+            false
+        }
+
+        fn requires_confirmation_erased(&self, _call: &ToolCall) -> bool {
+            false
+        }
+
+        fn execute_tool_call_confirmed_erased<'a>(
+            &'a self,
+            call: &'a ToolCall,
+        ) -> Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a,
+            >,
+        > {
+            self.execute_tool_call_erased(call)
+        }
+
+        fn checkpoint_undo_erased(&self, _n: usize) -> zeph_tools::CheckpointActionResult {
+            zeph_tools::CheckpointActionResult::unsupported()
+        }
+
+        fn checkpoint_redo_erased(&self) -> zeph_tools::CheckpointActionResult {
+            zeph_tools::CheckpointActionResult::unsupported()
+        }
+
+        fn checkpoint_list_erased(&self) -> zeph_tools::CheckpointListResult {
+            zeph_tools::CheckpointListResult::default()
+        }
+
+        fn is_tool_speculatable_erased(&self, _tool_id: &str) -> bool {
+            false
+        }
+    }
+
     fn tool_use_response() -> ChatResponse {
         ChatResponse::ToolUse {
             text: None,
@@ -1267,6 +1419,7 @@ mod handle_tool_step_granted_secrets_tests {
             "bot",
             &sanitizer,
             &mut granted_secrets,
+            None,
         )
         .await;
         assert!(!no_tool, "a tool call was made");
@@ -1309,6 +1462,7 @@ mod handle_tool_step_granted_secrets_tests {
             "bot",
             &sanitizer,
             &mut granted_secrets,
+            None,
         )
         .await;
         assert!(!no_tool);
@@ -1353,6 +1507,7 @@ mod handle_tool_step_granted_secrets_tests {
             "bot",
             &sanitizer,
             &mut granted_secrets,
+            None,
         )
         .await;
         assert!(!no_tool, "a tool call was made");
@@ -1408,6 +1563,7 @@ mod handle_tool_step_granted_secrets_tests {
             "bot",
             &sanitizer,
             &mut granted_secrets,
+            None,
         )
         .await;
         assert!(!no_tool, "a tool call was made");
@@ -1439,6 +1595,108 @@ mod handle_tool_step_granted_secrets_tests {
         assert!(
             context.env_overrides().get("EXPIRED_KEY").is_none(),
             "expired grant must not be attached to the tool call context"
+        );
+    }
+
+    // --- #6492: tool-result content masking ---
+
+    #[tokio::test]
+    async fn tool_result_containing_a_registered_secret_is_masked_before_reaching_messages() {
+        let secret_value = "sk-supersecretvalue12345678";
+        let executor = FilteredToolExecutor::new(
+            Arc::new(EchoingExecutor {
+                echo: secret_value.to_owned(),
+            }) as Arc<dyn ErasedToolExecutor>,
+            ToolPolicy::InheritAll,
+        );
+        let hooks = SubagentHooks::default();
+        let mut messages = Vec::new();
+        let mut granted_secrets = HashMap::new();
+        let sanitizer = ContentSanitizer::new(&zeph_config::ContentIsolationConfig::default());
+        let registry = zeph_sanitizer::secret_mask::SecretMaskRegistry::new();
+        registry.register(
+            "SOME_VAULT_KEY",
+            secret_value,
+            zeph_sanitizer::secret_mask::SecretCategory::ApiKey,
+        );
+
+        let no_tool = handle_tool_step(
+            &executor,
+            tool_use_response(),
+            &mut messages,
+            &hooks,
+            "task-1",
+            "bot",
+            &sanitizer,
+            &mut granted_secrets,
+            Some(&registry),
+        )
+        .await;
+        assert!(!no_tool, "a tool call was made");
+
+        let content = messages
+            .iter()
+            .find_map(|m| {
+                m.parts.iter().find_map(|p| match p {
+                    MessagePart::ToolResult { content, .. } => Some(content.clone()),
+                    _ => None,
+                })
+            })
+            .expect("a ToolResult part must be present");
+        assert!(
+            !content.contains(secret_value),
+            "raw secret must not appear in the tool-result content pushed into messages \
+             (would leak into transcript/LLM context/debug dump): {content}"
+        );
+        assert!(
+            content.contains("<SECRET:api_key:"),
+            "masked content must carry the typed placeholder: {content}"
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_result_is_left_unmasked_when_no_secret_registry_is_wired() {
+        // Regression guard: passing `None` (registry disabled / not wired) must leave
+        // tool-result content byte-for-byte identical to pre-fix behavior — masking must
+        // never be forced on when no registry is configured.
+        let secret_value = "sk-supersecretvalue12345678";
+        let executor = FilteredToolExecutor::new(
+            Arc::new(EchoingExecutor {
+                echo: secret_value.to_owned(),
+            }) as Arc<dyn ErasedToolExecutor>,
+            ToolPolicy::InheritAll,
+        );
+        let hooks = SubagentHooks::default();
+        let mut messages = Vec::new();
+        let mut granted_secrets = HashMap::new();
+        let sanitizer = ContentSanitizer::new(&zeph_config::ContentIsolationConfig::default());
+
+        let no_tool = handle_tool_step(
+            &executor,
+            tool_use_response(),
+            &mut messages,
+            &hooks,
+            "task-1",
+            "bot",
+            &sanitizer,
+            &mut granted_secrets,
+            None,
+        )
+        .await;
+        assert!(!no_tool);
+
+        let content = messages
+            .iter()
+            .find_map(|m| {
+                m.parts.iter().find_map(|p| match p {
+                    MessagePart::ToolResult { content, .. } => Some(content.clone()),
+                    _ => None,
+                })
+            })
+            .expect("a ToolResult part must be present");
+        assert!(
+            content.contains(secret_value),
+            "with no registry wired, content must be unchanged (pre-fix baseline): {content}"
         );
     }
 }

--- a/crates/zeph-subagent/src/manager/secrets.rs
+++ b/crates/zeph-subagent/src/manager/secrets.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use zeph_common::secret::Secret;
+use zeph_sanitizer::secret_mask::SecretCategory;
 
 use super::SubAgentManager;
 use crate::error::SubAgentError;
@@ -105,6 +106,15 @@ impl SubAgentManager {
             ));
         };
 
+        // Register the delivered value for masking (#6492): closes the forwarding-path leak
+        // (the drain masks against this same registry, which was never populated with the
+        // secret it was supposed to catch) and feeds the agent loop's own tool-result masking
+        // pass, which consults this registry before content reaches the transcript, LLM
+        // context, or debug dump.
+        if let Some(registry) = self.secret_registry.as_ref() {
+            registry.register(key, value.expose(), SecretCategory::from_key_name(key));
+        }
+
         handle
             .secret_tx
             .try_send(Some(GrantedSecret { value, expires_at }))
@@ -164,7 +174,58 @@ impl SubAgentManager {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
+    use tokio::sync::{mpsc, watch};
+    use tokio_util::sync::CancellationToken;
+    use zeph_common::secret::Secret;
+    use zeph_sanitizer::secret_mask::SecretMaskRegistry;
+
     use super::make_hook_env;
+    use crate::def::SubAgentDef;
+    use crate::grants::{GrantedSecret, PermissionGrants};
+    use crate::manager::{SubAgentHandle, SubAgentManager, SubAgentStatus};
+    use crate::state::SubAgentState;
+
+    /// Builds a [`SubAgentHandle`] with a LIVE `secret_tx`/`secret_rx` pair — unlike
+    /// [`SubAgentHandle::for_test`], which immediately drops the receiver (documented as
+    /// valid only for metadata inspection, never for a call that actually sends on the
+    /// channel). `deliver_secret` calls `secret_tx.try_send(..)`, so a dropped receiver
+    /// would make every delivery fail with `Channel("channel closed")` regardless of the
+    /// registration logic under test here.
+    fn handle_with_live_secret_channel(
+        id: &str,
+        def: SubAgentDef,
+    ) -> (SubAgentHandle, mpsc::Receiver<Option<GrantedSecret>>) {
+        let initial_status = SubAgentStatus {
+            state: SubAgentState::Working,
+            last_message: None,
+            turns_used: 0,
+            started_at: Instant::now(),
+        };
+        let (status_tx, status_rx) = watch::channel(initial_status);
+        drop(status_tx);
+        let (pending_secret_rx_tx, pending_secret_rx) = mpsc::channel(1);
+        drop(pending_secret_rx_tx);
+        let (secret_tx, secret_rx) = mpsc::channel(1);
+        let handle = SubAgentHandle {
+            id: id.to_owned(),
+            task_id: id.to_owned(),
+            def,
+            state: SubAgentState::Working,
+            join_handle: None,
+            cancel: CancellationToken::new(),
+            status_rx,
+            grants: PermissionGrants::default(),
+            pending_secret_rx,
+            secret_tx,
+            started_at_str: String::new(),
+            transcript_dir: None,
+            mcp_tool_names: Vec::new(),
+        };
+        (handle, secret_rx)
+    }
 
     #[test]
     fn make_hook_env_sets_agent_type_subagent() {
@@ -182,5 +243,85 @@ mod tests {
             Some("my-agent")
         );
         assert_eq!(env.get("ZEPH_TOOL_NAME").map(String::as_str), Some("Shell"));
+    }
+
+    // --- #6492: deliver_secret registers into the shared secret-mask registry ---
+
+    #[test]
+    fn deliver_secret_registers_value_into_secret_mask_registry() {
+        let mut mgr = SubAgentManager::new(4);
+        let registry = Arc::new(SecretMaskRegistry::new());
+        mgr.set_secret_registry(Arc::clone(&registry));
+
+        let (mut handle, _secret_rx) =
+            handle_with_live_secret_channel("task-1", SubAgentDef::for_test("helper"));
+        handle
+            .grants
+            .grant_secret("SOME_VAULT_KEY", Duration::from_mins(5));
+        mgr.insert_handle_for_test("task-1".to_owned(), handle);
+
+        mgr.deliver_secret(
+            "task-1",
+            "SOME_VAULT_KEY",
+            Secret::new("the-secret-value-123"),
+        )
+        .expect("delivery must succeed: an active grant exists");
+
+        assert!(
+            registry.would_mask("value is the-secret-value-123"),
+            "a delivered secret must be registered into the shared mask registry — closes \
+             the gap where the forwarding drain masked against a registry that was never \
+             populated with the secret it was supposed to catch"
+        );
+    }
+
+    #[test]
+    fn deliver_secret_without_registry_still_succeeds() {
+        // Regression guard: registering into the mask registry must stay best-effort — a
+        // session with no registry wired (the `None` default) must not lose secret delivery.
+        let mut mgr = SubAgentManager::new(4);
+
+        let (mut handle, _secret_rx) =
+            handle_with_live_secret_channel("task-1", SubAgentDef::for_test("helper"));
+        handle
+            .grants
+            .grant_secret("SOME_VAULT_KEY", Duration::from_mins(5));
+        mgr.insert_handle_for_test("task-1".to_owned(), handle);
+
+        let result = mgr.deliver_secret(
+            "task-1",
+            "SOME_VAULT_KEY",
+            Secret::new("the-secret-value-123"),
+        );
+        assert!(
+            result.is_ok(),
+            "delivery must succeed even with no registry wired"
+        );
+    }
+
+    #[test]
+    fn deliver_secret_without_active_grant_is_denied() {
+        // Baseline: delivery must still be refused when there is no active grant, unaffected
+        // by the new registration step (which only runs after the grant check succeeds).
+        let mut mgr = SubAgentManager::new(4);
+        let registry = Arc::new(SecretMaskRegistry::new());
+        mgr.set_secret_registry(Arc::clone(&registry));
+
+        let handle = SubAgentHandle::for_test("task-1", SubAgentDef::for_test("helper"));
+        mgr.insert_handle_for_test("task-1".to_owned(), handle);
+
+        let result = mgr.deliver_secret(
+            "task-1",
+            "SOME_VAULT_KEY",
+            Secret::new("the-secret-value-123"),
+        );
+        assert!(
+            result.is_err(),
+            "delivery without an active grant must be denied"
+        );
+        assert!(
+            !registry.would_mask("value is the-secret-value-123"),
+            "a denied delivery must never register the secret"
+        );
     }
 }

--- a/crates/zeph-subagent/src/manager/spawn.rs
+++ b/crates/zeph-subagent/src/manager/spawn.rs
@@ -760,6 +760,7 @@ impl SubAgentManager {
             progress_at: ctx.progress_at,
             debug_dump_sink: ctx.debug_dump_sink,
             forward: forward_sender,
+            secret_registry: self.secret_registry.clone(),
         };
 
         let join_handle = self.spawn_agent_task(Arc::from(task_id.as_str()), move || async move {
@@ -1182,6 +1183,9 @@ impl SubAgentManager {
             config.forward_transcript,
             &forward_content_isolation,
         );
+        // Cloned before the `move` closure below (same reason as `debug_dump_sink_for_loop`
+        // above): `self` cannot be captured by the `'static` task closure.
+        let secret_registry_for_loop = self.secret_registry.clone();
         let join_handle = self.spawn_agent_task(Arc::from(new_task_id.as_str()), move || {
             run_agent_loop(AgentLoopArgs {
                 provider,
@@ -1211,6 +1215,7 @@ impl SubAgentManager {
                 progress_at: None,
                 debug_dump_sink: debug_dump_sink_for_loop,
                 forward: forward_sender,
+                secret_registry: secret_registry_for_loop,
             })
         });
 

--- a/crates/zeph-subagent/src/manager/tests.rs
+++ b/crates/zeph-subagent/src/manager/tests.rs
@@ -2293,6 +2293,7 @@ fn make_agent_loop_args(
         progress_at: None,
         debug_dump_sink: None,
         forward: None,
+        secret_registry: None,
     }
 }
 
@@ -2453,6 +2454,7 @@ async fn run_agent_loop_publishes_failed_status_on_llm_call_timeout() {
         progress_at: None,
         debug_dump_sink: None,
         forward: None,
+        secret_registry: None,
     };
 
     let result = run_agent_loop(args).await;
@@ -2475,6 +2477,163 @@ async fn run_agent_loop_publishes_failed_status_on_llm_call_timeout() {
         "Failed status message should mention the timeout: {:?}",
         status.last_message
     );
+}
+
+// ── transcript anchor finalize on every loop-exit path (#6494) ───────────
+
+/// In-memory [`AnchorStore`] mock, mirroring `transcript.rs`'s own test-only mock — kept as a
+/// separate copy here (rather than exported) since it is `#[cfg(test)]`-private to that module.
+#[derive(Default)]
+struct MockAnchorStoreForLoopTest {
+    map: std::sync::Mutex<std::collections::HashMap<String, zeph_common::anchor::Anchor>>,
+}
+
+impl zeph_common::anchor::AnchorStore for MockAnchorStoreForLoopTest {
+    fn get(
+        &self,
+        subsystem: zeph_common::anchor::AnchorSubsystem,
+        file_id: &[u8],
+    ) -> Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = Result<
+                        Option<zeph_common::anchor::Anchor>,
+                        zeph_common::anchor::AnchorError,
+                    >,
+                > + Send
+                + '_,
+        >,
+    > {
+        let result = self.get_sync(subsystem, file_id);
+        Box::pin(async move { result })
+    }
+
+    fn get_sync(
+        &self,
+        subsystem: zeph_common::anchor::AnchorSubsystem,
+        file_id: &[u8],
+    ) -> Result<Option<zeph_common::anchor::Anchor>, zeph_common::anchor::AnchorError> {
+        let key = zeph_common::anchor::anchor_key(subsystem, file_id);
+        Ok(self.map.lock().unwrap().get(&key).cloned())
+    }
+
+    fn put(
+        &self,
+        subsystem: zeph_common::anchor::AnchorSubsystem,
+        file_id: &[u8],
+        anchor: zeph_common::anchor::Anchor,
+    ) -> Pin<
+        Box<
+            dyn std::future::Future<Output = Result<(), zeph_common::anchor::AnchorError>>
+                + Send
+                + '_,
+        >,
+    > {
+        let key = zeph_common::anchor::anchor_key(subsystem, file_id);
+        self.map.lock().unwrap().insert(key, anchor);
+        Box::pin(async { Ok(()) })
+    }
+
+    fn delete(
+        &self,
+        subsystem: zeph_common::anchor::AnchorSubsystem,
+        file_id: &[u8],
+    ) -> Pin<
+        Box<
+            dyn std::future::Future<Output = Result<(), zeph_common::anchor::AnchorError>>
+                + Send
+                + '_,
+        >,
+    > {
+        let key = zeph_common::anchor::anchor_key(subsystem, file_id);
+        self.map.lock().unwrap().remove(&key);
+        Box::pin(async { Ok(()) })
+    }
+}
+
+#[tokio::test]
+async fn run_agent_loop_finalizes_transcript_anchor_on_llm_error_exit_path() {
+    // Regression test for #6494: an LLM-call error/timeout must still finalize (anchor) the
+    // transcript before `run_agent_loop` returns `Err` — otherwise the transcript is left
+    // chained-but-unanchored, reopening the whole-strip downgrade #6449/#6461 closed for any
+    // turn that ends on an LLM error. `configure_history_integrity`/`configure_anchor_store`
+    // mutate process-global state; safe here because `cargo nextest` runs each test in its own
+    // process (see `transcript.rs`'s own anchor tests for the same convention).
+    crate::transcript::configure_history_integrity(Some(std::sync::Arc::new(
+        zeph_common::hash_chain::ChainKeyRing::new(
+            0,
+            zeph_common::hash_chain::ChainKey::new([9u8; 32]),
+        ),
+    )));
+    let store = std::sync::Arc::new(MockAnchorStoreForLoopTest::default());
+    crate::transcript::configure_anchor_store(Some(
+        store.clone() as std::sync::Arc<dyn zeph_common::anchor::AnchorStore>
+    ));
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("abc.jsonl");
+    let writer = crate::transcript::TranscriptWriter::new(&path).unwrap();
+
+    let provider = AnyProvider::Mock(MockProvider::default().with_delay(500));
+    let executor = FilteredToolExecutor::new(noop_executor(), ToolPolicy::InheritAll);
+
+    let (status_tx, _status_rx) = tokio::sync::watch::channel(SubAgentStatus {
+        state: SubAgentState::Working,
+        last_message: None,
+        turns_used: 0,
+        started_at: std::time::Instant::now(),
+    });
+    let (secret_request_tx, _secret_request_rx) = tokio::sync::mpsc::channel(1);
+    let (_secret_approved_tx, secret_rx) =
+        tokio::sync::mpsc::channel::<Option<crate::grants::GrantedSecret>>(1);
+
+    let args = AgentLoopArgs {
+        provider,
+        executor,
+        system_prompt: "You are a bot".into(),
+        task_prompt: "Do something".into(),
+        skills: None,
+        max_turns: 3,
+        cancel: tokio_util::sync::CancellationToken::new(),
+        status_tx,
+        started_at: std::time::Instant::now(),
+        secret_request_tx,
+        secret_rx,
+        background: false,
+        hooks: super::super::hooks::SubagentHooks::default(),
+        task_id: "test-task".into(),
+        agent_name: "test-bot".into(),
+        initial_messages: vec![],
+        transcript_writer: Some(writer),
+        spawn_depth: 0,
+        mcp_tool_names: Vec::new(),
+        content_isolation: ContentIsolationConfig::default(),
+        max_history_messages: 200,
+        // Much shorter than the mock provider's 500ms delay so the timeout branch fires
+        // deterministically instead of racing the real response.
+        llm_timeout: std::time::Duration::from_millis(30),
+        progress_at: None,
+        debug_dump_sink: None,
+        forward: None,
+        secret_registry: None,
+    };
+
+    let result = run_agent_loop(args).await;
+    assert!(
+        result.is_err(),
+        "expected the LLM-call timeout to still propagate as an error"
+    );
+
+    assert_eq!(
+        store.map.lock().unwrap().len(),
+        1,
+        "finalize() must have persisted a vault anchor even though the loop exited via the \
+         LLM-error path — a missing entry means finalize was skipped, reopening the \
+         whole-strip downgrade #6449/#6461 closed"
+    );
+
+    crate::transcript::configure_anchor_store(None);
+    crate::transcript::configure_history_integrity(None);
 }
 
 // ── idle-timeout progress heartbeat (#6245) ──────────────────────────────


### PR DESCRIPTION
## Summary
- Close three subagent trust-boundary gaps found during a security audit of the sub-agent grant/spawn/transcript machinery — in every case the enforcement machinery already existed, but a wiring step was missing.
- **#6492 (P0)**: `deliver_secret` now registers a granted vault secret into the shared `SecretMaskRegistry`, and the agent loop's `handle_tool_step` masks tool-result content against it unconditionally before the content reaches the transcript, the next turn's LLM context, or a debug dump — one chokepoint covering all three sinks.
- **#6493 (P1)**: `build_spawn_context` (the sole production `SpawnContext` constructor) now populates `max_trust_level` from the parent session's own current effective trust level, so a spawned sub-agent can never exceed its parent's privileges. `inherited_tool_allowlist` remains unset pending a follow-up for per-task orchestration-policy plumbing (no existing parent-side allowlist concept to source it from).
- **#6494 (P1)**: `run_agent_loop` no longer short-circuits via `?` on an LLM-call error — it now falls through to the existing unconditional transcript anchor `finalize()` before returning the captured error, closing the downgrade window where an unanchored chain could later be stripped and auto-trusted as legacy content.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (14616 passed / 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `gitleaks protect --staged --no-banner --redact`
- [x] New regression tests exercise the real production call paths (not hand-built bypasses) for all three fixes and are discriminating against the pre-fix code
- [x] `.local/testing/playbooks/subagent-trust-boundary.md` added; `.local/testing/coverage-status.md` updated with rows for all three fixes

## Follow-up
Per-task `TaskNode` tool-allowlist plumbing (the deferred half of #6493) is out of scope for this PR and documented in CHANGELOG.md; a tracking issue will be filed separately.