### PR TITLE
fix(gateway): fail closed on missing auth token, disclose webhook in wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Security
 
+- `zeph-gateway`/`zeph`: `[gateway] enabled = true` with no `auth_token` let any caller that
+  could reach the HTTP listener inject arbitrary content into the agent's turn loop via an
+  unauthenticated `POST /webhook` (#6487). `GatewayServer::serve` previously only logged a
+  `tracing::warn!` and kept running with `require_auth` hardcoded to `false` in `build_router`,
+  and the `--init` wizard had no dedicated `[gateway]` step — the only path that touched
+  `config.gateway` was `step_prometheus`'s side-effect auto-enable, which never set an
+  `auth_token` or disclosed that it also opens the webhook endpoint. Fixed with three
+  defense-in-depth changes:
+  - `GatewayServer::serve` now refuses to start (`GatewayError::MissingAuthToken`) when
+    `enabled = true` and no non-empty bearer token is configured, instead of warning and
+    continuing. Deployments with a real `auth_token` (inline or vault-resolved) are unaffected.
+  - `build_router`'s `AuthConfig::require_auth` is now derived from whether a token was actually
+    passed in, instead of being hardcoded to `false`.
+  - `--init`'s Prometheus step now discloses that enabling it also opens `[gateway]`'s
+    `POST /webhook` endpoint, and prints `zeph vault set ZEPH_GATEWAY_TOKEN <token>` instructions
+    (the wizard never prompts for the raw token — it is resolved from the age vault at startup,
+    like the other vault-only secrets).
+  - New `zeph doctor` check (`gateway.auth`) flags `[gateway] enabled = true` with no resolvable
+    `auth_token` before a real launch attempt.
+
 - `zeph-subagent`/`zeph-core`: closed three subagent trust-boundary gaps found during a security
   audit of the sub-agent grant/spawn/transcript machinery (#6492, #6493, #6494) — in every case
   the enforcement machinery already existed, but a wiring step was missing.

--- a/crates/zeph-gateway/src/error.rs
+++ b/crates/zeph-gateway/src/error.rs
@@ -21,6 +21,19 @@ pub enum GatewayError {
     /// This typically indicates a listener failure or an OS-level socket error.
     #[error("server error: {0}")]
     Server(#[source] std::io::Error),
+
+    /// The gateway is enabled but no bearer token was configured (#6487).
+    ///
+    /// `POST /webhook` forwards its body directly into the agent's turn loop as if it came
+    /// from a trusted channel — starting without a token would let any local or network
+    /// caller that can reach the listener inject arbitrary content. Set `[gateway] auth_token`
+    /// (resolved from the age vault key `ZEPH_GATEWAY_TOKEN`) before starting the gateway.
+    #[error(
+        "refusing to start gateway: no auth_token configured — every request would be \
+         unauthenticated. Set [gateway] auth_token or store one at vault key ZEPH_GATEWAY_TOKEN \
+         (`zeph vault set ZEPH_GATEWAY_TOKEN <token>`)"
+    )]
+    MissingAuthToken,
 }
 
 #[cfg(test)]

--- a/crates/zeph-gateway/src/lib.rs
+++ b/crates/zeph-gateway/src/lib.rs
@@ -14,8 +14,9 @@
 //!
 //! - Bearer token comparison is performed in constant time via BLAKE3 + `subtle::ConstantTimeEq`
 //!   to prevent timing-oracle attacks (see [`GatewayServer::with_auth`]).
-//! - When no token is configured the server logs a warning. Callers are expected to enforce
-//!   access control at the network layer (firewall, upstream reverse proxy) in that case.
+//! - A bearer token is mandatory: [`GatewayServer::serve`] refuses to start
+//!   ([`GatewayError::MissingAuthToken`]) when no non-empty token is configured, since
+//!   `/webhook` forwards its body directly into the agent's turn loop (#6487).
 //! - Payload fields are sanitised with [`zeph_common::sanitize`] before forwarding.
 //!
 //! # Rate limiting

--- a/crates/zeph-gateway/src/router.rs
+++ b/crates/zeph-gateway/src/router.rs
@@ -36,7 +36,15 @@ pub(crate) fn build_router(
     max_body_size: usize,
     trusted_proxy_cidrs: &[String],
 ) -> Router {
-    let auth_cfg = AuthConfig::new(auth_token, false);
+    // require_auth mirrors whether a token is actually configured (#6487), matching the same
+    // trim-then-empty-check `AuthConfig::new` itself applies when normalizing `token_hash` — a
+    // whitespace-only token is "not configured" by both measures. When a token is set, this is a
+    // no-op (the token-present branch in `auth_middleware` already checks every request
+    // regardless of `require_auth`), but it keeps `AuthConfig` internally consistent instead of
+    // unconditionally claiming "auth not required" while a token silently guards every request.
+    // `GatewayServer::serve` refuses to start with no token at all (#6487), so in practice this
+    // only reaches `require_auth = false` via direct `build_router` calls (tests).
+    let auth_cfg = AuthConfig::new(auth_token, auth_token.is_some_and(|t| !t.trim().is_empty()));
     let rate_state = RateLimitState::new(rate_limit, trusted_proxy_cidrs);
 
     let protected = Router::new()

--- a/crates/zeph-gateway/src/server.rs
+++ b/crates/zeph-gateway/src/server.rs
@@ -34,7 +34,7 @@ pub(crate) struct AppState {
 ///
 /// | Setting | Default |
 /// |---|---|
-/// | Bearer auth | disabled (open) |
+/// | Bearer auth | none configured — [`GatewayServer::serve`] refuses to start until [`GatewayServer::with_auth`] sets one (#6487) |
 /// | Rate limit | 120 requests / 60 s per IP |
 /// | Max body size | 1 MiB (1 048 576 bytes) |
 ///
@@ -130,8 +130,9 @@ impl GatewayServer {
     /// in constant time (BLAKE3 + `subtle::ConstantTimeEq`) to prevent
     /// timing-oracle attacks.
     ///
-    /// When `token` is `None`, bearer authentication is disabled and a warning
-    /// is logged at startup.
+    /// When `token` is `None` (or empty), [`GatewayServer::serve`] refuses to start
+    /// ([`GatewayError::MissingAuthToken`]) rather than serve `/webhook` unauthenticated
+    /// (#6487).
     ///
     /// # Example
     ///
@@ -302,6 +303,11 @@ impl GatewayServer {
     ///   permission denied, etc.).
     /// - [`GatewayError::Server`] — the server encountered a fatal I/O error
     ///   after binding.
+    /// - [`GatewayError::MissingAuthToken`] — no bearer token was configured via
+    ///   [`GatewayServer::with_auth`] (#6487). The gateway refuses to start rather than serve
+    ///   `/webhook` unauthenticated; this is a hard startup failure, not a warning, because an
+    ///   unauthenticated `/webhook` lets any caller that reaches the listener inject content
+    ///   directly into the agent's turn loop.
     #[tracing::instrument(name = "gateway.serve", skip_all)]
     pub async fn serve(self) -> Result<(), GatewayError> {
         let state = AppState {
@@ -311,12 +317,18 @@ impl GatewayServer {
         };
 
         // Non-emptiness, not `is_none()` (#6268): a vault-resolved token that resolves to an
-        // empty string must trigger this warning the same as no token at all — `Some("")`
-        // used to silently suppress it while `AuthConfig` (correctly) rejects every request.
-        if self.auth_token.as_deref().is_none_or(str::is_empty) {
-            tracing::warn!(
-                "gateway running without bearer auth — ensure firewall or upstream proxy enforces access control"
-            );
+        // empty (or whitespace-only) string must be treated the same as no token at all.
+        // Trimming matches `AuthConfig::new`'s own normalization (`http_middleware.rs`) — without
+        // it, a whitespace-only token would pass this gate and `doctor`'s check, yet
+        // `AuthConfig` would still normalize it to "no token configured" internally and reject
+        // every request with `require_auth = true`, producing a confusing "started fine but
+        // 401s everything" state instead of a clear refusal to start.
+        if self
+            .auth_token
+            .as_deref()
+            .is_none_or(|t| t.trim().is_empty())
+        {
+            return Err(GatewayError::MissingAuthToken);
         }
 
         let router = build_router(
@@ -447,5 +459,75 @@ mod tests {
         let (_stx, srx) = watch::channel(false);
         let server = GatewayServer::new("not_an_ip", 9999, tx, srx);
         assert_eq!(server.addr.port(), 9999);
+    }
+
+    /// #6487: `serve()` must refuse to start when no auth token was configured at all — this
+    /// is the exact misconfiguration that previously only logged a warning while accepting every
+    /// unauthenticated `/webhook` request.
+    #[tokio::test]
+    async fn serve_refuses_to_start_without_auth_token() {
+        let (tx, _rx) = mpsc::channel(1);
+        let (_stx, srx) = watch::channel(false);
+        let server = GatewayServer::new("127.0.0.1", 0, tx, srx);
+        let err = server
+            .serve()
+            .await
+            .expect_err("must refuse to start without a token");
+        assert!(matches!(err, GatewayError::MissingAuthToken));
+    }
+
+    /// #6268/#6487: a token that resolves to an empty string (e.g. a blank vault secret) must
+    /// be treated exactly like no token at all, not silently accepted as a valid `""` secret.
+    #[tokio::test]
+    async fn serve_refuses_to_start_with_empty_auth_token() {
+        let (tx, _rx) = mpsc::channel(1);
+        let (_stx, srx) = watch::channel(false);
+        let server = GatewayServer::new("127.0.0.1", 0, tx, srx).with_auth(Some(String::new()));
+        let err = server
+            .serve()
+            .await
+            .expect_err("empty token must be treated as missing");
+        assert!(matches!(err, GatewayError::MissingAuthToken));
+    }
+
+    /// #6487 (critic M2): a whitespace-only token must be treated exactly like no token at
+    /// all. Without trimming, this would pass the startup gate and `doctor`'s check, yet
+    /// `AuthConfig::new` (`zeph-common`) independently normalizes it to "not configured" and
+    /// sets `require_auth = true` — every request would then 401, a confusing "started but
+    /// rejects everything" state instead of a clear refusal to start.
+    #[tokio::test]
+    async fn serve_refuses_to_start_with_whitespace_only_auth_token() {
+        let (tx, _rx) = mpsc::channel(1);
+        let (_stx, srx) = watch::channel(false);
+        let server = GatewayServer::new("127.0.0.1", 0, tx, srx).with_auth(Some("   ".into()));
+        let err = server
+            .serve()
+            .await
+            .expect_err("whitespace-only token must be treated as missing");
+        assert!(matches!(err, GatewayError::MissingAuthToken));
+    }
+
+    /// #6487: a legitimate deployment that configures a real `auth_token` must be unaffected by
+    /// the fail-closed startup check — `serve()` must bind and run normally until shutdown.
+    #[tokio::test]
+    async fn serve_starts_normally_with_auth_token_configured() {
+        let (tx, _rx) = mpsc::channel(1);
+        let (stx, srx) = watch::channel(false);
+        let server = GatewayServer::new("127.0.0.1", 0, tx, srx).with_auth(Some("secret".into()));
+        let handle = tokio::spawn(server.serve());
+
+        // Give the listener a moment to bind before signalling shutdown.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        stx.send(true)
+            .expect("shutdown watch channel must accept the signal");
+
+        let result = tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("serve must return promptly once shutdown is signalled")
+            .expect("serve task must not panic");
+        assert!(
+            result.is_ok(),
+            "serve must exit cleanly once a token is configured: {result:?}"
+        );
     }
 }

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 use zeph_core::redact::scrub_content;
-use zeph_core::vault::AgeVaultProvider;
+use zeph_core::vault::{AgeVaultProvider, VaultProvider};
 
 /// Individual check outcome.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -328,6 +328,69 @@ fn check_durable_integrity_seal(
              executions remain (issue #6449)",
             elapsed_ms(start),
         )
+    }
+}
+
+/// Reports whether `[gateway] enabled = true` has a resolvable, non-empty bearer token
+/// (#6487). `GatewayServer::serve` now refuses to start in this exact state (`/webhook` would
+/// otherwise forward unauthenticated external content directly into the agent's turn loop), so
+/// this check surfaces the misconfiguration at `doctor` time instead of only at a failed launch.
+///
+/// `key_path`/`vault_path` are the same CLI-resolved vault location used by the other vault-aware
+/// checks (see [`check_integrity_anchor`]'s doc comment for the resolution rationale) — this
+/// check never inspects an unrelated default vault when an override is in effect.
+///
+/// Non-emptiness is checked after trimming, matching `AuthConfig::new`'s own normalization
+/// (`zeph_common::http_middleware`) and `GatewayServer::serve`'s startup gate (critic M2): a
+/// whitespace-only token must report the same `Fail` as no token at all, not a misleading `Ok`
+/// for a value that `AuthConfig` will itself treat as "not configured" at runtime.
+async fn check_gateway_auth(
+    config: &zeph_core::config::Config,
+    key_path: &Path,
+    vault_path: &Path,
+) -> CheckResult {
+    let start = Instant::now();
+    if !config.gateway.enabled {
+        return CheckResult::ok("gateway.auth", "gateway disabled", elapsed_ms(start));
+    }
+    if config
+        .gateway
+        .auth_token
+        .as_deref()
+        .is_some_and(|t| !t.trim().is_empty())
+    {
+        return CheckResult::ok(
+            "gateway.auth",
+            "auth_token configured directly in config.toml",
+            elapsed_ms(start),
+        );
+    }
+    let Ok(provider) = AgeVaultProvider::load(key_path, vault_path) else {
+        return CheckResult::fail(
+            "gateway.auth",
+            "gateway enabled but no auth_token and no age vault found to resolve \
+             ZEPH_GATEWAY_TOKEN from — the gateway will refuse to start; run `zeph vault set \
+             ZEPH_GATEWAY_TOKEN <token>`",
+            elapsed_ms(start),
+        );
+    };
+    match provider.get_secret("ZEPH_GATEWAY_TOKEN").await {
+        Ok(Some(val)) if !val.trim().is_empty() => CheckResult::ok(
+            "gateway.auth",
+            "ZEPH_GATEWAY_TOKEN resolved from vault",
+            elapsed_ms(start),
+        ),
+        Ok(_) => CheckResult::fail(
+            "gateway.auth",
+            "gateway enabled but ZEPH_GATEWAY_TOKEN is not set in the vault — the gateway will \
+             refuse to start; run `zeph vault set ZEPH_GATEWAY_TOKEN <token>`",
+            elapsed_ms(start),
+        ),
+        Err(e) => CheckResult::warn(
+            "gateway.auth",
+            format!("could not resolve ZEPH_GATEWAY_TOKEN from vault: {e}"),
+            elapsed_ms(start),
+        ),
     }
 }
 
@@ -1070,6 +1133,9 @@ async fn build_doctor_report(
         &anchor_vault_path,
     ));
 
+    // 18. gateway.auth (issue #6487)
+    results.push(check_gateway_auth(&config, &anchor_key_path, &anchor_vault_path).await);
+
     DoctorReport {
         elapsed_ms: elapsed_ms(total_start),
         results,
@@ -1447,6 +1513,189 @@ mod tests {
         // being enabled in the default config.
         assert_eq!(seal.status, CheckStatus::Ok);
         assert!(seal.detail.contains("disabled"));
+
+        // #6487 (critic M5): confirms `check_gateway_auth` is actually wired into
+        // `build_doctor_report`'s pipeline, not just independently correct when called directly
+        // (all 5 dedicated `check_gateway_auth_*` tests below call it directly). Dumped defaults
+        // have `[gateway] enabled = false`, so this reports OK — the point is that the check ran
+        // at all through the real pipeline; a removed or misplaced wiring line would make this
+        // `find` return `None` instead.
+        let gateway_auth = report
+            .results
+            .iter()
+            .find(|r| r.name == "gateway.auth")
+            .expect("gateway.auth check must run as part of build_doctor_report");
+        assert_eq!(gateway_auth.status, CheckStatus::Ok);
+        assert!(gateway_auth.detail.contains("disabled"));
+    }
+
+    // #6487 (critic M5): dedicated end-to-end regression — `build_doctor_report` must surface a
+    // `Fail` for `gateway.auth` when the *parsed config* (not a directly-constructed one) has
+    // gateway enabled with no token anywhere, proving the check_gateway_auth(...).await call at
+    // the `results.push` site actually executes with the right config/vault-path plumbing.
+    #[tokio::test]
+    async fn build_doctor_report_wires_gateway_auth_check_and_fails_when_unsafe() {
+        let config_dir = tempfile::tempdir().unwrap();
+        let config_path = config_dir.path().join("config.toml");
+        // Mutate the struct and re-serialize, rather than appending a second `[gateway]` TOML
+        // header onto `dump_defaults()`'s output — the defaults already emit an active
+        // `[gateway]` section (`enabled = false`), so appending another would be a duplicate
+        // table and fail `check_config_parse` before `check_gateway_auth` ever ran.
+        let mut config = zeph_core::config::Config::default();
+        config.gateway.enabled = true;
+        let toml_src = toml::to_string_pretty(&config).expect("serialize config");
+        std::fs::write(&config_path, toml_src).unwrap();
+
+        // No vault at all — ZEPH_GATEWAY_TOKEN cannot resolve from anywhere.
+        let vault_dir = tempfile::tempdir().unwrap();
+        let key_path = vault_dir.path().join("vault-key.txt");
+        let vault_path = vault_dir.path().join("secrets.age");
+
+        let report = Box::pin(build_doctor_report(
+            &config_path,
+            1,
+            1,
+            None,
+            Some(&key_path),
+            Some(&vault_path),
+        ))
+        .await;
+
+        let gateway_auth = report
+            .results
+            .iter()
+            .find(|r| r.name == "gateway.auth")
+            .expect("gateway.auth check must run as part of build_doctor_report");
+        assert_eq!(
+            gateway_auth.status,
+            CheckStatus::Fail,
+            "gateway enabled with no resolvable token anywhere must Fail through the real \
+             pipeline, got detail: {}",
+            gateway_auth.detail
+        );
+        assert!(gateway_auth.detail.contains("vault set ZEPH_GATEWAY_TOKEN"));
+    }
+
+    // #6487: gateway.auth doctor check.
+
+    #[tokio::test]
+    async fn check_gateway_auth_ok_when_gateway_disabled() {
+        let config = zeph_core::config::Config::default();
+        let dir = tempfile::tempdir().unwrap();
+        let result = check_gateway_auth(
+            &config,
+            &dir.path().join("vault-key.txt"),
+            &dir.path().join("secrets.age"),
+        )
+        .await;
+        assert_eq!(result.status, CheckStatus::Ok);
+        assert!(result.detail.contains("disabled"));
+    }
+
+    #[tokio::test]
+    async fn check_gateway_auth_ok_when_token_set_directly_in_config() {
+        let mut config = zeph_core::config::Config::default();
+        config.gateway.enabled = true;
+        config.gateway.auth_token = Some("inline-secret".into());
+        let dir = tempfile::tempdir().unwrap();
+        let result = check_gateway_auth(
+            &config,
+            &dir.path().join("vault-key.txt"),
+            &dir.path().join("secrets.age"),
+        )
+        .await;
+        assert_eq!(result.status, CheckStatus::Ok);
+        assert!(result.detail.contains("config.toml"));
+    }
+
+    #[tokio::test]
+    async fn check_gateway_auth_fails_when_enabled_with_no_token_and_no_vault() {
+        let mut config = zeph_core::config::Config::default();
+        config.gateway.enabled = true;
+        let dir = tempfile::tempdir().unwrap();
+        let result = check_gateway_auth(
+            &config,
+            &dir.path().join("vault-key.txt"),
+            &dir.path().join("secrets.age"),
+        )
+        .await;
+        assert_eq!(result.status, CheckStatus::Fail);
+        assert!(result.detail.contains("vault set ZEPH_GATEWAY_TOKEN"));
+    }
+
+    #[tokio::test]
+    async fn check_gateway_auth_fails_when_enabled_with_vault_present_but_no_token_key() {
+        let mut config = zeph_core::config::Config::default();
+        config.gateway.enabled = true;
+        let dir = tempfile::tempdir().unwrap();
+        zeph_core::vault::AgeVaultProvider::init_vault(dir.path()).unwrap();
+        let result = check_gateway_auth(
+            &config,
+            &dir.path().join("vault-key.txt"),
+            &dir.path().join("secrets.age"),
+        )
+        .await;
+        assert_eq!(result.status, CheckStatus::Fail);
+        assert!(result.detail.contains("ZEPH_GATEWAY_TOKEN is not set"));
+    }
+
+    #[tokio::test]
+    async fn check_gateway_auth_ok_when_token_resolves_from_vault() {
+        let mut config = zeph_core::config::Config::default();
+        config.gateway.enabled = true;
+        let dir = tempfile::tempdir().unwrap();
+        zeph_core::vault::AgeVaultProvider::init_vault(dir.path()).unwrap();
+        let key_path = dir.path().join("vault-key.txt");
+        let vault_path = dir.path().join("secrets.age");
+        let mut provider =
+            zeph_core::vault::AgeVaultProvider::load(&key_path, &vault_path).unwrap();
+        provider
+            .set_secret_mut("ZEPH_GATEWAY_TOKEN".into(), "vault-secret".into(), false)
+            .unwrap();
+        provider.save().unwrap();
+
+        let result = check_gateway_auth(&config, &key_path, &vault_path).await;
+        assert_eq!(result.status, CheckStatus::Ok);
+        assert!(result.detail.contains("resolved from vault"));
+    }
+
+    // #6487 (critic M2): whitespace-only tokens must Fail, not silently pass as "configured" —
+    // `AuthConfig::new` (zeph-common) trims before checking emptiness, so a whitespace-only
+    // value would otherwise report OK here while the gateway 401s every real request at runtime.
+
+    #[tokio::test]
+    async fn check_gateway_auth_fails_when_inline_config_token_is_whitespace_only() {
+        let mut config = zeph_core::config::Config::default();
+        config.gateway.enabled = true;
+        config.gateway.auth_token = Some("   ".into());
+        let dir = tempfile::tempdir().unwrap();
+        let result = check_gateway_auth(
+            &config,
+            &dir.path().join("vault-key.txt"),
+            &dir.path().join("secrets.age"),
+        )
+        .await;
+        assert_eq!(result.status, CheckStatus::Fail);
+    }
+
+    #[tokio::test]
+    async fn check_gateway_auth_fails_when_vault_token_is_whitespace_only() {
+        let mut config = zeph_core::config::Config::default();
+        config.gateway.enabled = true;
+        let dir = tempfile::tempdir().unwrap();
+        zeph_core::vault::AgeVaultProvider::init_vault(dir.path()).unwrap();
+        let key_path = dir.path().join("vault-key.txt");
+        let vault_path = dir.path().join("secrets.age");
+        let mut provider =
+            zeph_core::vault::AgeVaultProvider::load(&key_path, &vault_path).unwrap();
+        provider
+            .set_secret_mut("ZEPH_GATEWAY_TOKEN".into(), "   ".into(), false)
+            .unwrap();
+        provider.save().unwrap();
+
+        let result = check_gateway_auth(&config, &key_path, &vault_path).await;
+        assert_eq!(result.status, CheckStatus::Fail);
+        assert!(result.detail.contains("ZEPH_GATEWAY_TOKEN is not set"));
     }
 
     #[test]

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -2026,12 +2026,25 @@ fn step_prometheus(state: &mut WizardState) -> anyhow::Result<()> {
     println!("== Prometheus Metrics Export ==\n");
     println!("Requires the binary to be compiled with --features prometheus.");
     println!("Exposes a /metrics endpoint on the HTTP gateway for Prometheus scraping.");
-    println!("Enabling this will also enable [gateway] if it is not already set.\n");
+    println!(
+        "Enabling this also enables the [gateway] HTTP listener if it is not already set. \
+         The same listener additionally exposes a POST /webhook endpoint that forwards \
+         external content directly into the agent's turn loop, as if from a trusted channel \
+         (#6487).\n"
+    );
 
     state.prometheus_enabled = Confirm::new()
         .with_prompt("Enable Prometheus metrics export?")
         .default(false)
         .interact()?;
+
+    if state.prometheus_enabled {
+        println!(
+            "  The gateway refuses to start without a bearer token (#6487). Store one with:\n    \
+             zeph vault set ZEPH_GATEWAY_TOKEN <token>\n  \
+             This wizard never prompts for the raw token — see CLAUDE.md Secrets & Vault."
+        );
+    }
 
     println!();
     Ok(())


### PR DESCRIPTION
## Summary
- `GatewayServer::serve()` now fails closed (refuses to start) when `auth_token` is missing or blank, instead of only logging a warning and continuing unauthenticated.
- `build_router` derives `require_auth` from whether a token is actually configured instead of hardcoding `false`.
- The `--init` wizard's Prometheus step now discloses that enabling it also opens the gateway's `POST /webhook` ingestion endpoint (which forwards content directly into the agent's turn loop), and prints `zeph vault set ZEPH_GATEWAY_TOKEN <token>` instructions instead of silently leaving the token unset.
- New `doctor` check (`gateway.auth`) flags `gateway.enabled = true` with no resolvable auth token, in config or vault.

Closes #6487

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci -p zeph-gateway -p zeph --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run -p zeph-gateway` (37/37, including new missing/empty/whitespace-only/present-token tests)
- [x] `cargo nextest run --features full` on doctor + gateway_auth tests (46/46, including a new end-to-end wiring test through `build_doctor_report`)
- [x] `cargo test --doc -p zeph-gateway`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features -p zeph-gateway`
- [x] `gitleaks protect --staged`
- [x] `.local/testing/playbooks/gateway.md` and `.local/testing/coverage-status.md` updated (main repo root)
- [x] `CHANGELOG.md` updated under `[Unreleased]`