### PR TITLE
fix(skills): reuse trust snapshot on transient load failure instead of failing open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 ### Fixed
 
+- `zeph-core`: a transient `skill_trust` DB read failure made every active skill fail open to
+  `SkillTrustLevel::Trusted` for the whole turn, including skills an operator had explicitly
+  `Blocked` or left `Quarantined` (#6482). `Agent::build_skill_trust_map` collapsed both "table
+  has no rows" and "the read errored" into the same empty `HashMap`, so a lock-contention or
+  disk I/O hiccup on `load_all_skill_trust()` silently unsanitized skill bodies and unblocked
+  `QUARANTINE_DENIED` tools (`bash`, `write`, `edit`, `delete_path`, `fetch`, `memory_save`,
+  `diagnostics`, ...) for that turn — the same fail-open-on-missing-governance-input defect
+  class already closed for Discord/Slack allowlists (#6502) and MCP trust levels (#6505). Fixed
+  by a new `SkillTrustMapLoad::{Fresh, LoadFailed}` return type: `apply_skill_trust_and_gating`
+  and `reload_skills` now reuse the previous turn's `trust_snapshot` on `LoadFailed` instead of
+  overwriting it with an empty map, so a transient failure degrades to stale-but-real trust
+  data rather than maximum trust.
+
 - `zeph-llm`: `openai`/`compatible` providers could crash the turn with `tool_calls[].id must
   be unique within the request` after Focus-based context compaction (#6501). Zeph replays
   `tool_call.id` values returned by the upstream model verbatim as message history on every

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -1663,13 +1663,29 @@ impl<C: Channel> Agent<C> {
         std::collections::HashMap<String, crate::skill_invoker::SkillTrustSnapshot>,
         Vec<Skill>,
     ) {
-        let trust_map = self.build_skill_trust_map().await;
-
-        self.services
-            .skill
-            .trust_snapshot
-            .write()
-            .clone_from(&trust_map);
+        let trust_map = match self.build_skill_trust_map().await {
+            crate::agent::trust_commands::SkillTrustMapLoad::Fresh(map) => {
+                self.services.skill.trust_snapshot.write().clone_from(&map);
+                map
+            }
+            crate::agent::trust_commands::SkillTrustMapLoad::LoadFailed => {
+                // Do NOT overwrite the persisted snapshot — leave it exactly as the previous
+                // turn left it, and reuse it as this turn's local trust map too, so every
+                // downstream use (catalog filter, effective_trust fold, PASTE activation)
+                // sees the stale-but-real data instead of failing open to Trusted.
+                //
+                // Residual: on the very first turn ever, `trust_snapshot` still holds its
+                // `HashMap::new()` construction-time value, so a load failure on that one
+                // narrow bootstrap window still yields an empty map (the original
+                // fail-open-to-Trusted behavior). There is no "previous" state before the
+                // first turn to fall back to — accepted per the issue's remediation scope.
+                tracing::warn!(
+                    "apply_skill_trust_and_gating: trust snapshot load failed, reusing \
+                     previous turn's snapshot (stale this turn)"
+                );
+                self.services.skill.trust_snapshot.read().clone()
+            }
+        };
 
         let remaining_skills: Vec<Skill> = all_skills
             .iter()
@@ -3864,6 +3880,84 @@ mod tests {
         assert!(
             !prompt.contains("<current_time>"),
             "time reminder must not appear when time_reminder_enabled = false"
+        );
+    }
+
+    // ── #6482: skill trust snapshot must not fail open on a transient load failure ──
+
+    #[tokio::test]
+    async fn skill_trust_snapshot_reused_when_trust_load_fails_not_reset_to_trusted() {
+        // A dropped/unreachable skill_trust table must not be treated as "no trust data" —
+        // that would make every skill resolve to SkillTrustLevel::MISSING_ENTRY_FALLBACK
+        // (Trusted) for the turn, unblocking QUARANTINE_DENIED tools for a skill an
+        // operator explicitly quarantined. The fix reuses the previous turn's snapshot.
+        let provider = AnyProvider::Mock(MockProvider::with_responses(vec![
+            "ok".to_owned(),
+            "ok2".to_owned(),
+        ]));
+        let memory = zeph_memory::semantic::SemanticMemory::new(
+            ":memory:",
+            "http://127.0.0.1:1",
+            None,
+            provider.clone(),
+            "test-model",
+        )
+        .await
+        .unwrap();
+        let cid = memory.sqlite().create_conversation().await.unwrap();
+        memory
+            .sqlite()
+            .upsert_skill_trust(
+                "evil-skill",
+                zeph_common::SkillTrustLevel::Quarantined,
+                zeph_memory::store::SourceKind::Local,
+                None,
+                None,
+                "hash1",
+            )
+            .await
+            .unwrap();
+        let memory = Arc::new(memory);
+
+        let mut agent = Agent::new(
+            provider,
+            MockChannel::new(vec![]),
+            create_test_registry(),
+            None,
+            5,
+            MockToolExecutor::no_tools(),
+        )
+        .with_memory(memory.clone(), cid, 50, 5, 50);
+
+        agent.rebuild_system_prompt("query").await;
+        assert_eq!(
+            agent
+                .services
+                .skill
+                .trust_snapshot
+                .read()
+                .get("evil-skill")
+                .map(|s| s.trust_level),
+            Some(zeph_common::SkillTrustLevel::Quarantined),
+            "first turn must load the real trust snapshot from the store"
+        );
+
+        sqlx::query("DROP TABLE skill_trust")
+            .execute(memory.sqlite().pool())
+            .await
+            .unwrap();
+
+        agent.rebuild_system_prompt("query").await;
+        assert_eq!(
+            agent
+                .services
+                .skill
+                .trust_snapshot
+                .read()
+                .get("evil-skill")
+                .map(|s| s.trust_level),
+            Some(zeph_common::SkillTrustLevel::Quarantined),
+            "a load failure must reuse the previous snapshot, not fail open to an empty map"
         );
     }
 }

--- a/crates/zeph-core/src/agent/skill_reload.rs
+++ b/crates/zeph-core/src/agent/skill_reload.rs
@@ -246,7 +246,19 @@ impl<C: Channel> Agent<C> {
         // straight from metadata (already loaded in `all_meta` above) needs no further I/O.
         // Blocked skills are excluded, mirroring `apply_skill_trust_and_gating`'s per-turn
         // catalog filter.
-        let trust_map = self.build_skill_trust_map().await;
+        let trust_map = match self.build_skill_trust_map().await {
+            crate::agent::trust_commands::SkillTrustMapLoad::Fresh(map) => map,
+            crate::agent::trust_commands::SkillTrustMapLoad::LoadFailed => {
+                // Same fail-closed policy as `apply_skill_trust_and_gating`: a transient
+                // read failure must not be treated as "no trust data" (which would drop
+                // the Blocked-skill catalog filter below) — reuse the last-known snapshot.
+                tracing::warn!(
+                    "reload_skills: trust snapshot load failed, reusing previous snapshot \
+                     for catalog filtering"
+                );
+                self.services.skill.trust_snapshot.read().clone()
+            }
+        };
         let catalog_skills: Vec<Skill> = all_meta
             .iter()
             .filter(|m| {

--- a/crates/zeph-core/src/agent/trust_commands.rs
+++ b/crates/zeph-core/src/agent/trust_commands.rs
@@ -173,36 +173,58 @@ impl<C: Channel> Agent<C> {
         }
     }
 
-    pub(super) async fn build_skill_trust_map(&mut self) -> HashMap<String, SkillTrustSnapshot> {
+    /// Loads the current skill trust map from the store.
+    ///
+    /// Invariant: a load failure (`Err` from `load_all_skill_trust`) must never be treated
+    /// as "no trust data" — that would make every skill resolve to
+    /// `SkillTrustLevel::MISSING_ENTRY_FALLBACK` (`Trusted`) for the turn, unblocking
+    /// `QUARANTINE_DENIED` tools for skills an operator explicitly demoted. Callers MUST
+    /// reuse the previous turn's snapshot on `LoadFailed` instead of overwriting it with an
+    /// empty map. Memory being unconfigured (`None`) is a permanent, expected condition with
+    /// no prior trust state to protect, so it legitimately yields an empty `Fresh` map.
+    pub(super) async fn build_skill_trust_map(&mut self) -> SkillTrustMapLoad {
         // Clone Arc before .await so no &self fields are held across suspension points.
         let memory = self.services.memory.persistence.memory.clone();
         let Some(memory) = memory else {
-            return HashMap::new();
+            return SkillTrustMapLoad::Fresh(HashMap::new());
         };
         let rows = match memory.sqlite().load_all_skill_trust().await {
             Ok(rows) => rows,
             Err(error) => {
                 tracing::warn!(
                     %error,
-                    "build_skill_trust_map: load_all_skill_trust failed, skills will render \
-                     with no trust-map entry this turn"
+                    "build_skill_trust_map: load_all_skill_trust failed, reusing last-known \
+                     trust snapshot instead of failing open to Trusted"
                 );
-                return HashMap::new();
+                return SkillTrustMapLoad::LoadFailed;
             }
         };
-        rows.into_iter()
-            .map(|r| {
-                (
-                    r.skill_name,
-                    SkillTrustSnapshot {
-                        trust_level: r.trust_level,
-                        requires_trust_check: r.requires_trust_check,
-                        blake3_hash: r.blake3_hash,
-                    },
-                )
-            })
-            .collect()
+        SkillTrustMapLoad::Fresh(
+            rows.into_iter()
+                .map(|r| {
+                    (
+                        r.skill_name,
+                        SkillTrustSnapshot {
+                            trust_level: r.trust_level,
+                            requires_trust_check: r.requires_trust_check,
+                            blake3_hash: r.blake3_hash,
+                        },
+                    )
+                })
+                .collect(),
+        )
     }
+}
+
+/// Result of [`Agent::build_skill_trust_map`], distinguishing a genuine store read failure
+/// from a legitimate (possibly empty) result so callers never conflate the two.
+pub(super) enum SkillTrustMapLoad {
+    /// Loaded successfully — may legitimately be empty (memory unconfigured, or the table
+    /// has no rows yet).
+    Fresh(HashMap<String, SkillTrustSnapshot>),
+    /// `load_all_skill_trust` returned an error. Callers must NOT treat this as "no
+    /// entries" — reuse the last-known-good snapshot instead of failing open to Trusted.
+    LoadFailed,
 }
 
 #[cfg(test)]
@@ -544,5 +566,48 @@ mod tests {
             .await
             .unwrap();
         assert!(out.contains("requires_trust_check=true"));
+    }
+
+    #[tokio::test]
+    async fn build_skill_trust_map_returns_load_failed_on_read_error_not_empty_fresh() {
+        // Regression for #6482: a genuine store read failure must be distinguishable from
+        // "no trust data" (Fresh(empty)) — collapsing both into an empty map is what let
+        // every skill fail open to SkillTrustLevel::MISSING_ENTRY_FALLBACK (Trusted).
+        let memory = test_memory().await;
+        memory
+            .sqlite()
+            .upsert_skill_trust(
+                "evil-skill",
+                SkillTrustLevel::Quarantined,
+                SourceKind::Local,
+                None,
+                None,
+                "hash1",
+            )
+            .await
+            .unwrap();
+        let mut agent = agent_with_memory(memory.clone());
+
+        match agent.build_skill_trust_map().await {
+            SkillTrustMapLoad::Fresh(map) => {
+                assert_eq!(
+                    map.get("evil-skill").map(|s| s.trust_level),
+                    Some(SkillTrustLevel::Quarantined)
+                );
+            }
+            SkillTrustMapLoad::LoadFailed => panic!("expected a successful Fresh load"),
+        }
+
+        sqlx::query("DROP TABLE skill_trust")
+            .execute(memory.sqlite().pool())
+            .await
+            .unwrap();
+
+        match agent.build_skill_trust_map().await {
+            SkillTrustMapLoad::Fresh(_) => {
+                panic!("a dropped table must surface as LoadFailed, not an empty Fresh map")
+            }
+            SkillTrustMapLoad::LoadFailed => {}
+        }
     }
 }


### PR DESCRIPTION
## Summary

- `Agent::build_skill_trust_map` collapsed a genuine `load_all_skill_trust()` store-read error into the same empty `HashMap` used for "memory not configured"/"table has no rows", so a transient DB read failure (lock contention, disk I/O hiccup) made every active skill fail open to `SkillTrustLevel::Trusted` for the whole turn — including a skill an operator had explicitly `Blocked` or left `Quarantined`. Body content was dispatched unsanitized and `QUARANTINE_DENIED` tools (`bash`, `write`, `edit`, `delete_path`, `fetch`, `memory_save`, `diagnostics`, ...) became available.
- Same fail-open-on-missing-governance-input defect class already closed for Discord/Slack allowlists (#6472) and MCP trust levels (#6474).
- Fixed by a new `SkillTrustMapLoad::{Fresh, LoadFailed}` return type: `apply_skill_trust_and_gating` and a second, independently-discovered call site (`reload_skills`'s Blocked-skill catalog filter) now reuse the previous turn's `trust_snapshot` on `LoadFailed` instead of overwriting it with an empty map, for both the persisted `Arc<RwLock<...>>` state and the local trust map used for that turn's catalog filter / `effective_trust` fold / PASTE activation.
- Accepted, documented residual: the very first turn ever (before any snapshot has been established) still fails open on a `LoadFailed`, since there is no prior state to reuse — inherent and out of scope per the issue's own remediation description.

Closes #6482

## Test plan

- [x] New unit test `build_skill_trust_map_returns_load_failed_on_read_error_not_empty_fresh` (`crates/zeph-core/src/agent/trust_commands.rs`) — forces a genuine read error via `DROP TABLE skill_trust` and asserts `LoadFailed`, not an empty `Fresh`.
- [x] New full-turn regression test `skill_trust_snapshot_reused_when_trust_load_fails_not_reset_to_trusted` (`crates/zeph-core/src/agent/context/assembly.rs`) — drives two `rebuild_system_prompt` calls with a table drop in between, asserts the persisted `trust_snapshot` still shows a seeded skill as `Quarantined` after the failure instead of resetting to empty/Trusted.
- [x] Adversarial critique (verdict: minor, no blocking issues) and code review (verdict: approved, no changes requested) both completed.
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 14663/14663 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `gitleaks protect --staged --no-banner --redact`
- [ ] Live-session verification of the transient-failure scenario (playbook `.local/testing/playbooks/trust-gate.md` section 4) — not yet run, tracked for the next CI cycle.