### PR TITLE
fix(acp): isolate permission.rs tests from real acp-permissions.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     (`sudo rm -rf /`), recursive-only-on-system-path (`rm -r /etc`), and home-subpath
     (`rm -rf ~/Documents`) forms that the anchored check alone cannot see.
 
+- `zeph-acp`: `permission.rs`'s test suite constructed `AcpPermissionGate::new(conn, None)`,
+  which falls back to the developer's real `acp-permissions.toml` config file instead of a
+  test fixture (#6512). Every `allow_always`/`reject_always` test persisted a real entry to
+  that file, which the live `zeph --acp` binary also reads — a test-isolation violation and a
+  security-relevant hazard (test-injected trust decisions could silently apply to the real
+  agent). Fixed by adding a `temp_perm_path()` helper and backing every gate in the test module
+  with an isolated `tempfile::tempdir()`, mirroring the pattern already used in `terminal.rs`
+  (#6511).
+
 - `zeph-llm`: `openai`/`compatible` providers could crash the turn with `tool_calls[].id must
   be unique within the request` after Focus-based context compaction (#6501). Zeph replays
   `tool_call.id` values returned by the upstream model verbatim as message history on every

--- a/crates/zeph-acp/src/permission.rs
+++ b/crates/zeph-acp/src/permission.rs
@@ -614,13 +614,29 @@ mod tests {
         acp::schema::v1::ToolCallUpdate::new(id.to_owned(), fields)
     }
 
+    /// A fresh, isolated `acp-permissions.toml` path for one test.
+    ///
+    /// `AcpPermissionGate::new(conn, None)` falls back to the real
+    /// `~/Library/Application Support/zeph/acp-permissions.toml` (or platform
+    /// equivalent) — sharing that path across test runs violates the "unique
+    /// per-test path" testing rule and pollutes the developer's real permission
+    /// file with test-injected `AllowAlways`/`RejectAlways` decisions (#6512).
+    /// Every gate constructed in this module must use its own tempdir-backed
+    /// path instead of `None`.
+    fn temp_perm_path() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("acp-permissions.toml");
+        (dir, path)
+    }
+
     #[tokio::test]
     async fn allow_once_returns_true() {
         let local = tokio::task::LocalSet::new();
         local
             .run_until(async {
                 let conn = make_conn_async("allow_once").await;
-                let (gate, handler) = AcpPermissionGate::new(conn, None);
+                let (_tmp, perm_path) = temp_perm_path();
+                let (gate, handler) = AcpPermissionGate::new(conn, Some(perm_path));
                 tokio::task::spawn_local(handler);
 
                 let sid = acp::schema::v1::SessionId::new("s1");
@@ -637,7 +653,8 @@ mod tests {
         local
             .run_until(async {
                 let conn = make_conn_async("reject_once").await;
-                let (gate, handler) = AcpPermissionGate::new(conn, None);
+                let (_tmp, perm_path) = temp_perm_path();
+                let (gate, handler) = AcpPermissionGate::new(conn, Some(perm_path));
                 tokio::task::spawn_local(handler);
 
                 let sid = acp::schema::v1::SessionId::new("s1");
@@ -654,7 +671,8 @@ mod tests {
         local
             .run_until(async {
                 let conn = make_conn_async("allow_always").await;
-                let (gate, handler) = AcpPermissionGate::new(conn, None);
+                let (_tmp, perm_path) = temp_perm_path();
+                let (gate, handler) = AcpPermissionGate::new(conn, Some(perm_path));
                 tokio::task::spawn_local(handler);
 
                 let sid = acp::schema::v1::SessionId::new("s1");
@@ -676,7 +694,8 @@ mod tests {
         local
             .run_until(async {
                 let conn = make_conn_async("reject_always").await;
-                let (gate, handler) = AcpPermissionGate::new(conn, None);
+                let (_tmp, perm_path) = temp_perm_path();
+                let (gate, handler) = AcpPermissionGate::new(conn, Some(perm_path));
                 tokio::task::spawn_local(handler);
 
                 let sid = acp::schema::v1::SessionId::new("s1");
@@ -698,7 +717,8 @@ mod tests {
         local
             .run_until(async {
                 let conn = make_conn_cancelled().await;
-                let (gate, handler) = AcpPermissionGate::new(conn, None);
+                let (_tmp, perm_path) = temp_perm_path();
+                let (gate, handler) = AcpPermissionGate::new(conn, Some(perm_path));
                 tokio::task::spawn_local(handler);
 
                 let sid = acp::schema::v1::SessionId::new("s1");
@@ -809,7 +829,8 @@ mod tests {
         local
             .run_until(async {
                 let conn = make_conn_async("allow_always").await;
-                let (gate, handler) = AcpPermissionGate::new(conn, None);
+                let (_tmp, perm_path) = temp_perm_path();
+                let (gate, handler) = AcpPermissionGate::new(conn, Some(perm_path));
                 tokio::task::spawn_local(handler);
 
                 // First call with tool_name "b" under session "a" — gets AllowAlways cached.
@@ -820,7 +841,8 @@ mod tests {
                 // A call with tool_name "a\0b" — after stripping \0 becomes "ab",
                 // which is a different cache key.
                 let conn2 = make_conn_async("reject_once").await;
-                let (gate2, handler2) = AcpPermissionGate::new(conn2, None);
+                let (_tmp2, perm_path2) = temp_perm_path();
+                let (gate2, handler2) = AcpPermissionGate::new(conn2, Some(perm_path2));
                 tokio::task::spawn_local(handler2);
 
                 let sid2 = acp::schema::v1::SessionId::new("s2");
@@ -968,7 +990,8 @@ mod tests {
         local
             .run_until(async {
                 let conn = make_conn_async("allow_always").await;
-                let (gate, handler) = AcpPermissionGate::new(conn, None);
+                let (_tmp, perm_path) = temp_perm_path();
+                let (gate, handler) = AcpPermissionGate::new(conn, Some(perm_path));
                 tokio::task::spawn_local(handler);
 
                 let sid = acp::schema::v1::SessionId::new("s1");
@@ -977,7 +1000,8 @@ mod tests {
 
                 // Different binary in a new gate backed by reject_once — must not inherit "git" cache.
                 let conn2 = make_conn_async("reject_once").await;
-                let (gate2, handler2) = AcpPermissionGate::new(conn2, None);
+                let (_tmp2, perm_path2) = temp_perm_path();
+                let (gate2, handler2) = AcpPermissionGate::new(conn2, Some(perm_path2));
                 tokio::task::spawn_local(handler2);
 
                 let sid2 = acp::schema::v1::SessionId::new("s2");


### PR DESCRIPTION
## Summary
- `permission.rs`'s test suite constructed `AcpPermissionGate::new(conn, None)` in 9 places, which falls back to the developer's real `acp-permissions.toml` config file instead of a test fixture, persisting test-injected allow/reject decisions to a file the live `zeph --acp` binary also reads.
- Adds a `temp_perm_path()` helper and backs every gate in the test module with an isolated `tempfile::tempdir()`, mirroring the pattern already used in `terminal.rs` (#6511).
- No production code changed — `default_permission_file()` is untouched.

Closes #6512

## Test plan
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" -E 'package(zeph-acp)' --lib --bins` — 168/168 passed
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 14703/14703 passed
- [x] Confirmed the real `~/Library/Application Support/zeph/acp-permissions.toml` mtime predates the test run (untouched)
- [x] Confirmed zero remaining `AcpPermissionGate::new(_, None)` call sites in `permission.rs`; workspace-wide grep confirms no other affected sites
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` clean
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` clean
- [x] `gitleaks protect --staged` clean