### PR TITLE
fix(vault): thread parse_vault_args env/config resolution into vault subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 ### Fixed
 
+- `zeph`: `zeph vault set/get/list/rm/init` ignored `ZEPH_VAULT_KEY`/`ZEPH_VAULT_PATH` env vars
+  and always fell back to the default vault directory unless overridden by `--vault-key`/
+  `--vault-path` (#6500), diverging from the resolution `zeph doctor` and agent startup already
+  perform via `parse_vault_args`. `handle_vault_command` in `src/commands/vault.rs` now threads
+  `crate::bootstrap::parse_vault_args` into its path resolution, giving `zeph vault` the same
+  CLI flag > `ZEPH_VAULT_KEY`/`ZEPH_VAULT_PATH` env var > default directory precedence.
+
 - `zeph-channels`: a negative or non-finite (`NaN`/`±inf`) `Retry-After` value from a 429
   response's header or JSON body reached `Duration::from_secs_f64` unclamped and panicked the
   process handling outbound Discord/Slack/Telegram sends (#6496). `send_with_retry` in

--- a/src/commands/vault.rs
+++ b/src/commands/vault.rs
@@ -3,6 +3,7 @@
 
 use std::path::PathBuf;
 
+use zeph_core::config::Config;
 use zeph_core::vault::{AgeVaultError, AgeVaultProvider};
 
 use crate::cli::VaultCommand;
@@ -11,14 +12,31 @@ pub(crate) fn default_vault_dir() -> PathBuf {
     zeph_core::vault::default_vault_dir()
 }
 
+/// Dispatch a `zeph vault` subcommand against the age vault.
+///
+/// Key/vault path resolution follows the same precedence as agent startup and `zeph doctor`
+/// (CLI flag > `ZEPH_VAULT_KEY`/`ZEPH_VAULT_PATH` env var > default vault directory), via
+/// [`crate::bootstrap::parse_vault_args`] — see #6500.
+///
+/// # Errors
+///
+/// Returns an error when `ZEPH_VAULT_BACKEND` is set to an unrecognized value, or when the
+/// underlying vault operation (init/load/save) fails.
 pub(crate) fn handle_vault_command(
     cmd: VaultCommand,
+    config: &Config,
     key_path: Option<&std::path::Path>,
     vault_path: Option<&std::path::Path>,
 ) -> anyhow::Result<()> {
     let dir = default_vault_dir();
-    let key_path_owned = key_path.map_or_else(|| dir.join("vault-key.txt"), PathBuf::from);
-    let vault_path_owned = vault_path.map_or_else(|| dir.join("secrets.age"), PathBuf::from);
+    let vault_args = crate::bootstrap::parse_vault_args(config, None, key_path, vault_path)
+        .map_err(|e| anyhow::anyhow!(e))?;
+    let key_path_owned = vault_args
+        .key_path
+        .map_or_else(|| dir.join("vault-key.txt"), PathBuf::from);
+    let vault_path_owned = vault_args
+        .vault_path
+        .map_or_else(|| dir.join("secrets.age"), PathBuf::from);
 
     match cmd {
         VaultCommand::Init { force } => {
@@ -145,15 +163,23 @@ mod tests {
                 value: "bar".into(),
                 force: false,
             },
+            &Config::default(),
             Some(&key_path),
             Some(&vault_path),
         )
         .unwrap();
 
-        handle_vault_command(VaultCommand::List, Some(&key_path), Some(&vault_path)).unwrap();
+        handle_vault_command(
+            VaultCommand::List,
+            &Config::default(),
+            Some(&key_path),
+            Some(&vault_path),
+        )
+        .unwrap();
 
         handle_vault_command(
             VaultCommand::Get { key: "FOO".into() },
+            &Config::default(),
             Some(&key_path),
             Some(&vault_path),
         )
@@ -161,6 +187,7 @@ mod tests {
 
         handle_vault_command(
             VaultCommand::Rm { key: "FOO".into() },
+            &Config::default(),
             Some(&key_path),
             Some(&vault_path),
         )
@@ -176,6 +203,7 @@ mod tests {
 
         handle_vault_command(
             VaultCommand::Init { force: false },
+            &Config::default(),
             Some(&key_path),
             Some(&vault_path),
         )
@@ -200,6 +228,7 @@ mod tests {
 
         handle_vault_command(
             VaultCommand::Init { force: false },
+            &Config::default(),
             Some(&key_path),
             Some(&vault_path),
         )
@@ -208,6 +237,7 @@ mod tests {
 
         let err = handle_vault_command(
             VaultCommand::Init { force: false },
+            &Config::default(),
             Some(&key_path),
             Some(&vault_path),
         )
@@ -227,6 +257,7 @@ mod tests {
 
         handle_vault_command(
             VaultCommand::Init { force: false },
+            &Config::default(),
             Some(&key_path),
             Some(&vault_path),
         )
@@ -235,6 +266,7 @@ mod tests {
 
         handle_vault_command(
             VaultCommand::Init { force: true },
+            &Config::default(),
             Some(&key_path),
             Some(&vault_path),
         )
@@ -259,6 +291,7 @@ mod tests {
             VaultCommand::Get {
                 key: "NONEXISTENT".into(),
             },
+            &Config::default(),
             Some(&key_path),
             Some(&vault_path),
         )
@@ -280,6 +313,7 @@ mod tests {
                 value: "original".into(),
                 force: false,
             },
+            &Config::default(),
             Some(&key_path),
             Some(&vault_path),
         )
@@ -291,6 +325,7 @@ mod tests {
                 value: "clobbered".into(),
                 force: false,
             },
+            &Config::default(),
             Some(&key_path),
             Some(&vault_path),
         )
@@ -315,6 +350,7 @@ mod tests {
                 value: "original".into(),
                 force: false,
             },
+            &Config::default(),
             Some(&key_path),
             Some(&vault_path),
         )
@@ -326,6 +362,7 @@ mod tests {
                 value: "updated".into(),
                 force: true,
             },
+            &Config::default(),
             Some(&key_path),
             Some(&vault_path),
         )
@@ -346,10 +383,52 @@ mod tests {
             VaultCommand::Rm {
                 key: "NONEXISTENT".into(),
             },
+            &Config::default(),
             Some(&key_path),
             Some(&vault_path),
         )
         .unwrap_err();
         assert!(err.to_string().contains("key not found"));
+    }
+
+    // #6500: `ZEPH_VAULT_KEY`/`ZEPH_VAULT_PATH` env vars are honored when no CLI override is
+    // given, matching the precedence `zeph doctor` and agent startup already get via
+    // `parse_vault_args` — previously `handle_vault_command` ignored them and always fell back
+    // to the default vault directory.
+    #[allow(unsafe_code)]
+    #[test]
+    #[serial]
+    fn handle_vault_command_respects_env_vars_without_cli_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("vault-key.txt");
+        let vault_path = dir.path().join("secrets.age");
+
+        zeph_core::vault::AgeVaultProvider::init_vault(dir.path()).unwrap();
+
+        unsafe {
+            std::env::set_var("ZEPH_VAULT_KEY", &key_path);
+            std::env::set_var("ZEPH_VAULT_PATH", &vault_path);
+        }
+
+        let result = handle_vault_command(
+            VaultCommand::Set {
+                key: "FOO".into(),
+                value: "bar".into(),
+                force: false,
+            },
+            &Config::default(),
+            None,
+            None,
+        );
+
+        unsafe {
+            std::env::remove_var("ZEPH_VAULT_KEY");
+            std::env::remove_var("ZEPH_VAULT_PATH");
+        }
+
+        result.unwrap();
+
+        let provider = zeph_core::vault::AgeVaultProvider::load(&key_path, &vault_path).unwrap();
+        assert_eq!(provider.get("FOO"), Some("bar"));
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -888,8 +888,9 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
     // Load logging config early (sync, cheap) so every code path gets file logging.
     let config_path = resolve_config_path(cli.config.as_deref());
     let base_config = load_config_or_default(&config_path);
-    let logging_config = resolve_logging_config(base_config.logging, cli.log_file.as_deref());
-    let telemetry_config = base_config.telemetry;
+    let logging_config =
+        resolve_logging_config(base_config.logging.clone(), cli.log_file.as_deref());
+    let telemetry_config = &base_config.telemetry;
     let redact_secrets = base_config.security.redact_secrets;
     let runtime_ctx = zeph_core::RuntimeContext {
         #[cfg(feature = "tui")]
@@ -918,7 +919,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
     let _tracing_guards = init_tracing(
         &logging_config,
         runtime_ctx,
-        &telemetry_config,
+        telemetry_config,
         redact_secrets,
         json_mode_early,
         #[cfg(feature = "profiling")]
@@ -966,6 +967,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         Some(Command::Vault { command: vault_cmd }) => {
             return handle_vault_command(
                 vault_cmd,
+                &base_config,
                 cli.vault_key.as_deref(),
                 cli.vault_path.as_deref(),
             );


### PR DESCRIPTION
## Summary

- `handle_vault_command` (`src/commands/vault.rs`) resolved the vault key/path only from CLI flags (`--vault-key`/`--vault-path`) or a hardcoded default directory, never consulting `ZEPH_VAULT_KEY`/`ZEPH_VAULT_PATH` env vars — unlike `crate::bootstrap::parse_vault_args`, already used by agent startup and `zeph doctor` (#6479).
- `zeph vault set/get/list/rm/init` now follow the same CLI flag > env var > default directory precedence as the rest of the agent, closing the divergence.
- Required a minimal side fix in `src/runner.rs`: `base_config.logging`/`.telemetry` were moved out before the `Vault` dispatch arm, so passing `&base_config` through needed those two fields to be borrowed/cloned instead of moved (`LoggingConfig::clone()`, `&TelemetryConfig`).

Closes #6500

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 14709 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `gitleaks protect --staged` — no leaks
- [x] New regression test `handle_vault_command_respects_env_vars_without_cli_override`, verified against old code path by hand-trace and confirmed it does not touch the real on-disk vault