### PR TITLE
feat(core): enable runaway tool-call rate limiting and daily cost cap by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+### Changed
+
+- `zeph-config`/`zeph-core`: the tool rate limiter (`[security.rate_limit]`) and the daily
+  LLM cost cap (`[cost].max_daily_cents`) are now enabled by default, guarding a fresh install
+  against a runaway agent loop hammering a tool category or burning unbounded API spend
+  (#6469). `RateLimitConfig::default().enabled` flips `false` → `true` (per-category limits
+  unchanged: shell 30/min, web 20/min, memory 60/min, mcp 40/min, other 60/min, 30s cooldown),
+  and `default_max_daily_cents()` flips `0` (unlimited) → `2500` ($25.00/day; local-only
+  Ollama/Candle usage always costs `0` and never trips this cap). A named-fn serde default
+  (`default_rate_limit_enabled`) replaces `RateLimitConfig::enabled`'s bare
+  `#[serde(default)]` so a present-but-partial `[security.rate_limit]` section (only one
+  sub-limit set) resolves `enabled = true` consistently with an absent section — previously
+  these two cases silently disagreed. **Only sparse/absent `[cost]`/`[security.rate_limit]`
+  sections pick up the new defaults** — any config file that already sets `enabled` or
+  `max_daily_cents` explicitly (including the old defaults `false`/`0`) is unaffected. The
+  `--init` wizard's rate-limiter prompt now defaults to "yes", and a new prompt asks for the
+  daily cost cap in USD (pre-filled $25.00). Budget-exhausted and rate-limit-trip messages now
+  include a one-line remediation hint pointing at the relevant config key. A new
+  `zeph_cost_budget_exhausted_total` Prometheus counter mirrors the existing
+  `zeph_security_rate_limit_trips` metric.
+
 ### Fixed
 
 - `zeph-core`: the vault-anchor reconcile sweep (`run_anchor_sweep`) hard-deleted a transcript/

--- a/book/src/advanced/observability.md
+++ b/book/src/advanced/observability.md
@@ -34,7 +34,7 @@ Per-model cost tracking with daily budget enforcement.
 ```toml
 [cost]
 enabled = true
-max_daily_cents = 500   # Daily spending limit in cents (USD)
+max_daily_cents = 2500   # Daily spending limit in cents (default: 2500 = $25.00; 0 = unlimited)
 ```
 
 ### Built-in Pricing

--- a/book/src/getting-started/wizard.md
+++ b/book/src/getting-started/wizard.md
@@ -178,7 +178,8 @@ Debug dump is intended for context debugging — use it when you need to inspect
 Configure security features:
 
 - **PII filter** — scrub emails, phone numbers, SSNs, and credit card numbers from tool outputs before they reach the LLM context and debug dumps (default: enabled)
-- **Tool rate limiter** — sliding-window per-category limits (shell 30/min, web 20/min, memory 60/min) to prevent runaway tool calls (default: disabled)
+- **Tool rate limiter** — sliding-window per-category limits (shell 30/min, web 20/min, memory 60/min) to prevent runaway tool calls (default: enabled)
+- **Daily LLM cost cap** — refuses new turns once cumulative daily spend crosses the cap, guarding against unbounded API spend from a runaway loop; local-only (Ollama/Candle) usage always costs `0` and never trips it (default: $25.00/day; `0` = unlimited)
 - **Skill scan on load** — scan skill content for injection patterns when skills are loaded; logs warnings but does not block execution (default: enabled)
 - **Pre-execution verification** — block destructive commands (e.g. `rm -rf /`) and injection patterns before every tool call (default: enabled)
   - **Allowed paths** — comma-separated path prefixes where destructive commands are permitted (empty = deny all). Example: `/tmp,/home/user/scratch`

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -671,6 +671,15 @@ block_markdown_images = true  # Strip external markdown images from LLM output
 validate_tool_urls = true     # Flag tool calls using URLs from injection-flagged content
 guard_memory_writes = true    # Skip Qdrant embedding for injection-flagged content
 
+[security.rate_limit]
+enabled = true              # Per-category sliding-window tool rate limiter (default: true)
+shell_calls_per_minute = 30
+web_calls_per_minute = 20
+memory_calls_per_minute = 60
+mcp_calls_per_minute = 40
+other_calls_per_minute = 60
+circuit_breaker_cooldown_secs = 30  # Cooldown after a limit trips
+
 [timeouts]
 llm_seconds = 120           # LLM chat completion timeout
 embedding_seconds = 30      # Embedding generation timeout
@@ -684,8 +693,8 @@ exporter = "none"           # "none" or "otlp" (requires `otel` feature)
 endpoint = "http://localhost:4317"
 
 [cost]
-enabled = false
-max_daily_cents = 500       # Daily budget in cents (USD), UTC midnight reset
+enabled = true
+max_daily_cents = 2500      # Daily budget in cents, UTC midnight reset (default: 2500 = $25.00; 0 = unlimited)
 
 [cocoon]
 # show_balance = true              # Display TON balance in TUI sidebar (default: true). Set to false to show "*** TON" instead

--- a/config/default.toml
+++ b/config/default.toml
@@ -658,8 +658,9 @@ strict = false
 [cost]
 # Track LLM API costs and enforce daily budget
 enabled = true
-# Maximum daily spend in cents (0 = unlimited)
-max_daily_cents = 0
+# Maximum daily spend in cents (0 = unlimited). Default: 2500 ($25.00/day) — a runaway-loop
+# guardrail; local-only (Ollama/Candle) usage always costs 0 so never trips this cap.
+max_daily_cents = 2500
 
 
 [vault]
@@ -1026,6 +1027,23 @@ subagent_inheritance_factor = 0.5
 # Example scope: enable all tools for the default task type
 # [security.capability_scopes.general]
 # patterns = ["*"]
+
+[security.rate_limit]
+# Per-category sliding-window tool rate limiter with circuit breaker. Enabled by default —
+# guards against a runaway agent loop hammering a single tool category (issue #6469).
+enabled = true
+# Maximum shell tool calls per minute (default: 30)
+shell_calls_per_minute = 30
+# Maximum web tool calls per minute (default: 20)
+web_calls_per_minute = 20
+# Maximum memory tool calls per minute (default: 60)
+memory_calls_per_minute = 60
+# Maximum MCP tool calls per minute (default: 40)
+mcp_calls_per_minute = 40
+# Maximum other tool calls per minute (default: 60)
+other_calls_per_minute = 60
+# Seconds the circuit breaker stays tripped after a limit is exceeded (default: 30)
+circuit_breaker_cooldown_secs = 30
 
 # ShadowSentinel Phase 2: persistent safety event stream + LLM pre-execution probe (spec 050).
 # Defence-in-depth only — PolicyGateExecutor and TrajectorySentinel remain the primary gate.

--- a/crates/zeph-config/src/features.rs
+++ b/crates/zeph-config/src/features.rs
@@ -150,7 +150,7 @@ impl std::fmt::Display for VaultBackend {
 }
 
 fn default_max_daily_cents() -> u32 {
-    0
+    2500
 }
 
 fn default_otlp_endpoint() -> String {
@@ -907,14 +907,14 @@ impl Default for VaultConfig {
 /// ```toml
 /// [cost]
 /// enabled = true
-/// max_daily_cents = 500  # $5.00 per day
+/// max_daily_cents = 2500  # $25.00 per day (the default)
 /// ```
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CostConfig {
     /// Track and display token costs. Default: `true`.
     #[serde(default = "default_true")]
     pub enabled: bool,
-    /// Daily spending cap in US cents (`0` = unlimited). Default: `0`.
+    /// Daily spending cap in US cents (`0` = unlimited). Default: `2500` ($25.00/day).
     #[serde(default = "default_max_daily_cents")]
     pub max_daily_cents: u32,
 }
@@ -1490,6 +1490,37 @@ mod tests {
     #[test]
     fn registry_backend_kind_display() {
         assert_eq!(RegistryBackendKind::SkillsSh.to_string(), "skills-sh");
+    }
+
+    // --- CostConfig defaults (issue #6469) ---
+
+    #[test]
+    fn cost_config_default_has_nonzero_daily_cap() {
+        let cfg = CostConfig::default();
+        assert!(cfg.enabled);
+        assert_eq!(cfg.max_daily_cents, 2500);
+    }
+
+    #[test]
+    fn cost_config_absent_section_picks_up_new_default() {
+        let cfg: CostConfig = toml::from_str("").unwrap();
+        assert!(cfg.enabled);
+        assert_eq!(cfg.max_daily_cents, 2500);
+    }
+
+    #[test]
+    fn cost_config_explicit_zero_is_preserved() {
+        let cfg: CostConfig = toml::from_str("max_daily_cents = 0").unwrap();
+        assert_eq!(
+            cfg.max_daily_cents, 0,
+            "explicit 0 must mean unlimited, not be overridden"
+        );
+    }
+
+    #[test]
+    fn cost_config_explicit_nonzero_is_preserved() {
+        let cfg: CostConfig = toml::from_str("max_daily_cents = 500").unwrap();
+        assert_eq!(cfg.max_daily_cents, 500);
     }
 }
 

--- a/crates/zeph-config/src/migrate/features.rs
+++ b/crates/zeph-config/src/migrate/features.rs
@@ -1126,3 +1126,78 @@ pub fn migrate_skill_trust_require_check(toml_src: &str) -> Result<MigrationResu
         },
     })
 }
+
+/// Step 101 — appends a commented `[security.rate_limit]` advisory block when the section is
+/// entirely absent (issue #6469).
+///
+/// The tool rate limiter now defaults to `enabled = true` at the struct-default level
+/// (`RateLimitConfig::default()`), so an absent section already behaves as if it were present
+/// with the values below — this step is purely for discoverability, matching
+/// [`migrate_integrity_config`](super::migrate_integrity_config)'s advisory-only pattern. It
+/// never activates a live value: the runtime posture comes entirely from serde field defaults,
+/// not from this migration.
+///
+/// # Errors
+///
+/// Returns [`MigrateError`] if the source is not valid TOML.
+pub fn migrate_rate_limit_advisory(toml_src: &str) -> Result<MigrationResult, MigrateError> {
+    if section_header_present(toml_src, "security.rate_limit")
+        || toml_src.contains("# [security.rate_limit]")
+    {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "\n# [security.rate_limit] — per-category sliding-window tool rate limiter with \
+         circuit breaker. Enabled by default; values below match the built-in defaults (issue #6469).\n\
+         # [security.rate_limit]\n\
+         # enabled = true\n\
+         # shell_calls_per_minute = 30\n\
+         # web_calls_per_minute = 20\n\
+         # memory_calls_per_minute = 60\n\
+         # mcp_calls_per_minute = 40\n\
+         # other_calls_per_minute = 60\n\
+         # circuit_breaker_cooldown_secs = 30\n";
+    let output = format!("{toml_src}{comment}");
+
+    Ok(MigrationResult {
+        output,
+        changed_count: 1,
+        sections_changed: vec!["security.rate_limit".to_owned()],
+    })
+}
+
+#[cfg(test)]
+mod rate_limit_advisory_tests {
+    use super::*;
+
+    #[test]
+    fn migrate_rate_limit_advisory_appends_block() {
+        let base = "[agent]\nname = \"zeph\"\n";
+        let result = migrate_rate_limit_advisory(base).unwrap();
+        assert_eq!(result.changed_count, 1);
+        assert!(result.output.contains("# [security.rate_limit]"));
+        assert!(result.output.contains("# enabled = true"));
+        assert!(result.output.contains("# shell_calls_per_minute = 30"));
+    }
+
+    #[test]
+    fn migrate_rate_limit_advisory_idempotent_on_commented_output() {
+        let base = "[agent]\nname = \"zeph\"\n";
+        let first = migrate_rate_limit_advisory(base).unwrap();
+        let second = migrate_rate_limit_advisory(&first.output).unwrap();
+        assert_eq!(second.changed_count, 0, "second run must not double-append");
+        assert_eq!(second.output, first.output);
+    }
+
+    #[test]
+    fn migrate_rate_limit_advisory_noop_when_active_section_present() {
+        let base = "[security.rate_limit]\nenabled = false\n";
+        let result = migrate_rate_limit_advisory(base).unwrap();
+        assert_eq!(result.changed_count, 0);
+        assert_eq!(result.output, base);
+    }
+}

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -29,8 +29,8 @@ pub use features::{
     migrate_orchestration_asset_sensitivity, migrate_orchestration_command_config,
     migrate_orchestration_ensemble, migrate_orchestration_idle_timeout,
     migrate_orchestration_persistence, migrate_orchestration_whole_plan_verifier_timeout,
-    migrate_skill_trust_require_check, migrate_skills_registry, migrate_tui_delights,
-    migrate_tui_mouse, migrate_tui_theme_config, migrate_tui_theme_defaults,
+    migrate_rate_limit_advisory, migrate_skill_trust_require_check, migrate_skills_registry,
+    migrate_tui_delights, migrate_tui_mouse, migrate_tui_theme_config, migrate_tui_theme_defaults,
 };
 pub use infra::*;
 pub use integrity::migrate_integrity_config;
@@ -627,16 +627,17 @@ use steps::{
     MigrateOverflowMaxPerCallOverride, MigratePiiFilterNames, MigratePlannerModelToProvider,
     MigratePluginsReputationConfig, MigratePolicyProviderAndUtilityWindow,
     MigrateProviderMaxConcurrent, MigrateQdrantApiKey, MigrateQdrantTimeoutSecs,
-    MigrateQualityConfig, MigrateSandboxConfig, MigrateSandboxEgressFilter, MigrateSchedulerDaemon,
-    MigrateSearchConfig, MigrateSecretMaskingConfig, MigrateServeConfig,
-    MigrateSessionPersistProviderOverrides, MigrateSessionPersistenceConfig,
-    MigrateSessionProviderPersistence, MigrateSessionRecapConfig, MigrateSessionResumeConfig,
-    MigrateShadowSentinelConfig, MigrateShellCheckpointsConfig, MigrateShellTransactional,
-    MigrateSkillTrustRequireCheck, MigrateSkillsRegistry, MigrateSttToProvider,
-    MigrateSupervisorConfig, MigrateTelemetryConfig, MigrateToolsCompressionConfig,
-    MigrateTraceMetadata, MigrateTuiDelights, MigrateTuiMouse, MigrateTuiThemeConfig,
-    MigrateTuiThemeDefaults, MigrateUtilityHighGainTools, MigrateVigilConfig,
-    MigrateWorktreeConfig, MigrateWorktreeGitTimeout, MigrateWorktreeQuotaFields,
+    MigrateQualityConfig, MigrateRateLimitAdvisory, MigrateSandboxConfig,
+    MigrateSandboxEgressFilter, MigrateSchedulerDaemon, MigrateSearchConfig,
+    MigrateSecretMaskingConfig, MigrateServeConfig, MigrateSessionPersistProviderOverrides,
+    MigrateSessionPersistenceConfig, MigrateSessionProviderPersistence, MigrateSessionRecapConfig,
+    MigrateSessionResumeConfig, MigrateShadowSentinelConfig, MigrateShellCheckpointsConfig,
+    MigrateShellTransactional, MigrateSkillTrustRequireCheck, MigrateSkillsRegistry,
+    MigrateSttToProvider, MigrateSupervisorConfig, MigrateTelemetryConfig,
+    MigrateToolsCompressionConfig, MigrateTraceMetadata, MigrateTuiDelights, MigrateTuiMouse,
+    MigrateTuiThemeConfig, MigrateTuiThemeDefaults, MigrateUtilityHighGainTools,
+    MigrateVigilConfig, MigrateWorktreeConfig, MigrateWorktreeGitTimeout,
+    MigrateWorktreeQuotaFields,
 };
 
 /// Ordered registry of all sequential migration steps (steps 1–99).
@@ -844,6 +845,8 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             // Step 100 — add [integrity] advisory block for vault-anchor downgrade-resistance
             // (issue #6449)
             Box::new(MigrateIntegrityConfig),
+            // Step 101 — advisory notice for [security.rate_limit] default-on posture (#6469)
+            Box::new(MigrateRateLimitAdvisory),
         ]
     });
 

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -75,7 +75,11 @@
 //! step 98 adds a `[plugins.reputation]` advisory block for the install-time
 //! name-similarity/typosquat check (spec-043, #5864); step 99 adds a documentation-only
 //! advisory comment to an existing active `[durable]` table noting that row-HMAC +
-//! high-water-mark tamper-evidence (issue #6360) is unconditional, not a new opt-in toggle.
+//! high-water-mark tamper-evidence (issue #6360) is unconditional, not a new opt-in toggle;
+//! step 100 adds a commented `[integrity]` advisory block for vault-anchor
+//! downgrade-resistance (issue #6449); step 101 adds a commented `[security.rate_limit]`
+//! advisory block — purely documentary, the tool rate limiter already defaults to enabled
+//! at the struct-default level (issue #6469).
 //!
 //! Each struct is a zero-size type that delegates to the corresponding free function in
 //! `super`. They exist solely to satisfy the object-safe [`super::Migration`] trait so the
@@ -111,11 +115,11 @@ use super::{
     migrate_planner_model_to_provider, migrate_plugins_reputation_config,
     migrate_policy_provider_and_utility_window, migrate_provider_max_concurrent,
     migrate_qdrant_api_key, migrate_qdrant_timeout_secs, migrate_quality_config,
-    migrate_sandbox_config, migrate_sandbox_egress_filter, migrate_scheduler_daemon_config,
-    migrate_search_config, migrate_secret_masking_config, migrate_serve_config,
-    migrate_session_persist_provider_overrides, migrate_session_persistence_config,
-    migrate_session_provider_persistence, migrate_session_recap_config,
-    migrate_session_resume_config, migrate_shadow_sentinel_config,
+    migrate_rate_limit_advisory, migrate_sandbox_config, migrate_sandbox_egress_filter,
+    migrate_scheduler_daemon_config, migrate_search_config, migrate_secret_masking_config,
+    migrate_serve_config, migrate_session_persist_provider_overrides,
+    migrate_session_persistence_config, migrate_session_provider_persistence,
+    migrate_session_recap_config, migrate_session_resume_config, migrate_shadow_sentinel_config,
     migrate_shell_checkpoints_config, migrate_shell_transactional,
     migrate_skill_trust_require_check, migrate_skills_registry, migrate_stt_to_provider,
     migrate_supervisor_config, migrate_telemetry_config, migrate_tools_compression_config,
@@ -1280,5 +1284,18 @@ impl Migration for MigrateIntegrityConfig {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_integrity_config(toml_src)
+    }
+}
+
+/// Step 101 — adds a commented `[security.rate_limit]` advisory block; purely documentary,
+/// the tool rate limiter already defaults to enabled at the struct-default level (#6469).
+pub(super) struct MigrateRateLimitAdvisory;
+impl Migration for MigrateRateLimitAdvisory {
+    fn name(&self) -> &'static str {
+        "migrate_rate_limit_advisory"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_rate_limit_advisory(toml_src)
     }
 }

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -9,8 +9,8 @@ use super::*;
 fn migrations_registry_has_all_steps() {
     assert_eq!(
         MIGRATIONS.len(),
-        100,
-        "MIGRATIONS registry must contain all 100 sequential steps"
+        101,
+        "MIGRATIONS registry must contain all 101 sequential steps"
     );
     for m in MIGRATIONS.iter() {
         assert!(
@@ -2093,7 +2093,7 @@ fn migrate_focus_auto_consolidate_noop_when_only_commented_section() {
 
 #[test]
 fn registry_has_fifty_entries() {
-    assert_eq!(MIGRATIONS.len(), 100);
+    assert_eq!(MIGRATIONS.len(), 101);
 }
 
 #[test]
@@ -2235,6 +2235,7 @@ fn registry_preserves_order_matches_dispatch() {
         "migrate_plugins_reputation_config",
         "migrate_durable_hwm_advisory",
         "migrate_integrity_config",
+        "migrate_rate_limit_advisory",
     ];
     let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
     assert_eq!(actual, expected);

--- a/crates/zeph-config/src/rate_limit.rs
+++ b/crates/zeph-config/src/rate_limit.rs
@@ -27,13 +27,17 @@ fn default_cooldown_secs() -> u64 {
     30
 }
 
+fn default_rate_limit_enabled() -> bool {
+    true
+}
+
 /// Configuration for the tool rate limiter, nested under `[security.rate_limit]`.
 ///
-/// Disabled by default. All limits are calls per 60-second window.
+/// Enabled by default. All limits are calls per 60-second window.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct RateLimitConfig {
     /// Master switch. When `false`, all checks are no-ops.
-    #[serde(default)]
+    #[serde(default = "default_rate_limit_enabled")]
     pub enabled: bool,
     /// Maximum shell tool calls per minute.
     #[serde(default = "default_shell_limit")]
@@ -58,7 +62,7 @@ pub struct RateLimitConfig {
 impl Default for RateLimitConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
+            enabled: true,
             shell_calls_per_minute: default_shell_limit(),
             web_calls_per_minute: default_web_limit(),
             memory_calls_per_minute: default_memory_limit(),
@@ -66,5 +70,51 @@ impl Default for RateLimitConfig {
             other_calls_per_minute: default_other_limit(),
             circuit_breaker_cooldown_secs: default_cooldown_secs(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_enabled() {
+        assert!(RateLimitConfig::default().enabled);
+    }
+
+    #[test]
+    fn absent_section_defaults_to_enabled() {
+        let cfg: RateLimitConfig = toml::from_str("").unwrap();
+        assert!(
+            cfg.enabled,
+            "absent [security.rate_limit] must default to enabled = true"
+        );
+    }
+
+    /// Regression test for the serde field-default split-brain (issue #6469): a
+    /// present-but-partial section must resolve `enabled` via the named default
+    /// function, not `bool::default()` (`false`), so it agrees with an absent section.
+    #[test]
+    fn partial_section_still_defaults_to_enabled() {
+        let cfg: RateLimitConfig = toml::from_str("shell_calls_per_minute = 50").unwrap();
+        assert!(
+            cfg.enabled,
+            "partial [security.rate_limit] section must still default enabled = true"
+        );
+        assert_eq!(cfg.shell_calls_per_minute, 50);
+    }
+
+    #[test]
+    fn explicit_disabled_is_preserved() {
+        let cfg: RateLimitConfig = toml::from_str("enabled = false").unwrap();
+        assert!(!cfg.enabled, "explicit enabled = false must be preserved");
+    }
+
+    #[test]
+    fn explicit_disabled_with_partial_section_is_preserved() {
+        let cfg: RateLimitConfig =
+            toml::from_str("enabled = false\nshell_calls_per_minute = 50").unwrap();
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.shell_calls_per_minute, 50);
     }
 }

--- a/crates/zeph-config/src/security.rs
+++ b/crates/zeph-config/src/security.rs
@@ -534,7 +534,7 @@ pub struct SecurityConfig {
     /// PII filter for tool outputs and debug dumps (enabled by default).
     #[serde(default)]
     pub pii_filter: PiiFilterConfig,
-    /// Tool action rate limiter (opt-in, disabled by default).
+    /// Tool action rate limiter (enabled by default).
     #[serde(default)]
     pub rate_limit: RateLimitConfig,
     /// Pre-execution verifiers (enabled by default).
@@ -812,5 +812,42 @@ no_providers_backoff_secs = 10
         let cfg: TimeoutConfig = toml::from_str("").expect("deserialize empty");
         assert_eq!(cfg.context_prep_timeout_secs, 30);
         assert_eq!(cfg.no_providers_backoff_secs, 2);
+    }
+
+    // ------------------------------------------------------------------
+    // SecurityConfig.rate_limit — default-on split-brain guard (issue #6469)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn security_config_absent_rate_limit_section_is_enabled() {
+        let cfg: SecurityConfig = toml::from_str("").expect("deserialize empty");
+        assert!(cfg.rate_limit.enabled);
+    }
+
+    /// A `[security.rate_limit]` section present in the file but only setting one
+    /// sub-limit must still resolve `enabled = true` — this is the split-brain the
+    /// named-default-fn fix closes (an absent section and a partial section must agree).
+    #[test]
+    fn security_config_partial_rate_limit_section_is_enabled() {
+        let toml = r"
+[rate_limit]
+shell_calls_per_minute = 50
+";
+        let cfg: SecurityConfig = toml::from_str(toml).expect("deserialize");
+        assert!(
+            cfg.rate_limit.enabled,
+            "partial [security.rate_limit] section must default enabled = true"
+        );
+        assert_eq!(cfg.rate_limit.shell_calls_per_minute, 50);
+    }
+
+    #[test]
+    fn security_config_explicit_rate_limit_disabled_is_preserved() {
+        let toml = r"
+[rate_limit]
+enabled = false
+";
+        let cfg: SecurityConfig = toml::from_str(toml).expect("deserialize");
+        assert!(!cfg.rate_limit.enabled);
     }
 }

--- a/crates/zeph-core/src/agent/rate_limiter.rs
+++ b/crates/zeph-core/src/agent/rate_limiter.rs
@@ -8,7 +8,7 @@
 //! calls in that category are rejected until the cooldown expires.
 //!
 //! Configured under `[security.rate_limit]` in the agent config file.
-//! Disabled by default — opt-in.
+//! Enabled by default.
 
 use std::collections::{HashMap, VecDeque};
 use std::time::Instant;
@@ -82,7 +82,8 @@ impl RateLimitExceeded {
         format!(
             "[rate-limited] {} calls exceeded {}/min (current: {}). \
              Circuit breaker active, cooldown: {}s. \
-             Try again later or use a different approach.",
+             Try again later or use a different approach. \
+             (adjust via `[security.rate_limit]` in config.toml, or set enabled = false to disable)",
             self.category.as_str(),
             self.limit,
             self.count,
@@ -296,7 +297,10 @@ mod tests {
 
     #[test]
     fn disabled_always_allows() {
-        let mut limiter = ToolRateLimiter::new(RateLimitConfig::default());
+        let mut limiter = ToolRateLimiter::new(RateLimitConfig {
+            enabled: false,
+            ..Default::default()
+        });
         let results = limiter.check_batch(&["shell", "shell", "shell"]);
         assert!(results.iter().all(Option::is_none));
     }
@@ -415,7 +419,10 @@ mod tests {
 
     #[test]
     fn disabled_empty_batch_returns_empty() {
-        let mut limiter = ToolRateLimiter::new(RateLimitConfig::default());
+        let mut limiter = ToolRateLimiter::new(RateLimitConfig {
+            enabled: false,
+            ..Default::default()
+        });
         let results = limiter.check_batch(&[]);
         assert!(results.is_empty());
     }

--- a/crates/zeph-core/src/agent/tool_execution/llm_dispatch.rs
+++ b/crates/zeph-core/src/agent/tool_execution/llm_dispatch.rs
@@ -69,6 +69,7 @@ impl<C: Channel> Agent<C> {
         if let Some(ref tracker) = self.runtime.metrics.cost_tracker
             && let Err(e) = tracker.check_budget()
         {
+            self.update_metrics(|m| m.cost_budget_exhausted += 1);
             self.channel
                 .send(&format!("Budget limit reached: {e}"))
                 .await?;
@@ -363,6 +364,7 @@ impl<C: Channel> Agent<C> {
         if let Some(ref tracker) = self.runtime.metrics.cost_tracker
             && let Err(e) = tracker.check_budget()
         {
+            self.update_metrics(|m| m.cost_budget_exhausted += 1);
             self.channel
                 .send(&format!("Budget limit reached: {e}"))
                 .await?;

--- a/crates/zeph-core/src/cost.rs
+++ b/crates/zeph-core/src/cost.rs
@@ -9,7 +9,10 @@ use parking_lot::Mutex;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-#[error("daily budget exhausted: spent {spent_cents:.2} / {budget_cents:.2} cents")]
+#[error(
+    "daily budget exhausted: spent {spent_cents:.2} / {budget_cents:.2} cents \
+     (raise or disable via `[cost] max_daily_cents` in config.toml; 0 = unlimited)"
+)]
 pub struct BudgetExhausted {
     pub spent_cents: f64,
     pub budget_cents: f64,

--- a/crates/zeph-core/src/metrics.rs
+++ b/crates/zeph-core/src/metrics.rs
@@ -478,6 +478,9 @@ pub struct MetricsSnapshot {
     pub pii_ner_circuit_breaker_trips: u64,
     pub memory_validation_failures: u64,
     pub rate_limit_trips: u64,
+    /// Number of times `CostTracker::check_budget()` returned `BudgetExhausted`, blocking
+    /// the next LLM call for the rest of the day.
+    pub cost_budget_exhausted: u64,
     pub pre_execution_blocks: u64,
     pub pre_execution_warnings: u64,
     /// `true` when a guardrail filter is active for this session.

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -179,6 +179,9 @@ pub(crate) struct WizardState {
     // Security
     pub(crate) pii_filter_enabled: bool,
     pub(crate) rate_limit_enabled: bool,
+    /// Daily LLM cost cap in US cents (`0` = unlimited). Distinct from
+    /// `budget_hint_enabled`, which only injects soft system-prompt hints.
+    pub(crate) max_daily_cents: u32,
     pub(crate) skill_scan_on_load: bool,
     pub(crate) skill_require_integrity_check_on_promote: bool,
     pub(crate) skill_cross_session_rollout: bool,
@@ -480,7 +483,8 @@ impl Default for WizardState {
             experiments_schedule_enabled: false,
             experiments_schedule_cron: String::new(),
             pii_filter_enabled: true,
-            rate_limit_enabled: false,
+            rate_limit_enabled: true,
+            max_daily_cents: 2500,
             skill_scan_on_load: true,
             skill_require_integrity_check_on_promote: true,
             skill_cross_session_rollout: false,
@@ -1280,6 +1284,7 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
 
     config.security.pii_filter.enabled = state.pii_filter_enabled;
     config.security.rate_limit.enabled = state.rate_limit_enabled;
+    config.cost.max_daily_cents = state.max_daily_cents;
     config.security.pre_execution_verify.enabled = state.pre_execution_verify_enabled;
     if !state.pre_execution_verify_allowed_paths.is_empty() {
         config

--- a/src/init/security.rs
+++ b/src/init/security.rs
@@ -197,6 +197,21 @@ fn prompt_abs_paths(label: &str) -> anyhow::Result<Vec<String>> {
     }
 }
 
+/// Parse a wizard-entered USD amount into cents, clamped to `[0, u32::MAX]`.
+///
+/// Non-numeric input falls back to the wizard's suggested default (2500 cents = $25.00),
+/// matching the pre-filled prompt value rather than silently accepting a typo as `0`.
+/// Negative values clamp to `0` (unlimited), consistent with `max_daily_cents`'s meaning.
+fn parse_daily_cap_dollars(s: &str) -> u32 {
+    s.trim().parse::<f64>().map_or(2500, |dollars| {
+        let cents = (dollars.max(0.0) * 100.0).round();
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        {
+            cents.min(f64::from(u32::MAX)) as u32
+        }
+    })
+}
+
 pub(super) fn step_security(state: &mut WizardState) -> anyhow::Result<()> {
     println!("== Security ==\n");
     println!(
@@ -210,10 +225,18 @@ pub(super) fn step_security(state: &mut WizardState) -> anyhow::Result<()> {
         .interact()?;
     state.rate_limit_enabled = Confirm::new()
         .with_prompt(
-            "Enable tool rate limiter? (sliding-window per-category limits: shell 30/min, web 20/min, memory 60/min)",
+            "Enable tool rate limiter? (sliding-window per-category limits: shell 30/min, web 20/min, memory 60/min; recommended)",
         )
-        .default(false)
+        .default(true)
         .interact()?;
+
+    let daily_cap_dollars: String = Input::new()
+        .with_prompt(
+            "Daily LLM cost cap in USD (guards against a runaway loop burning API spend; 0 = unlimited)",
+        )
+        .default("25.00".to_owned())
+        .interact_text()?;
+    state.max_daily_cents = parse_daily_cap_dollars(&daily_cap_dollars);
     state.skill_scan_on_load = Confirm::new()
         .with_prompt(
             "Scan skill content for injection patterns on load? (advisory — logs warnings, does not block; recommended)",
@@ -507,5 +530,39 @@ mod tests {
     fn sandbox_platform_support_unsupported_returns_false() {
         let (can_enable, _) = sandbox_platform_support();
         assert!(!can_enable);
+    }
+
+    // --- parse_daily_cap_dollars (issue #6469) ---
+
+    #[test]
+    fn parse_daily_cap_dollars_zero_means_unlimited() {
+        assert_eq!(parse_daily_cap_dollars("0"), 0);
+    }
+
+    #[test]
+    fn parse_daily_cap_dollars_default_value() {
+        assert_eq!(parse_daily_cap_dollars("25.00"), 2500);
+    }
+
+    #[test]
+    fn parse_daily_cap_dollars_fractional_rounds_to_nearest_cent() {
+        assert_eq!(parse_daily_cap_dollars("12.344"), 1234);
+        assert_eq!(parse_daily_cap_dollars("12.346"), 1235);
+    }
+
+    #[test]
+    fn parse_daily_cap_dollars_non_numeric_falls_back_to_default() {
+        assert_eq!(parse_daily_cap_dollars("not a number"), 2500);
+        assert_eq!(parse_daily_cap_dollars(""), 2500);
+    }
+
+    #[test]
+    fn parse_daily_cap_dollars_negative_clamps_to_zero() {
+        assert_eq!(parse_daily_cap_dollars("-5"), 0);
+    }
+
+    #[test]
+    fn parse_daily_cap_dollars_trims_whitespace() {
+        assert_eq!(parse_daily_cap_dollars("  25.00  "), 2500);
     }
 }

--- a/src/metrics_export.rs
+++ b/src/metrics_export.rs
@@ -169,6 +169,7 @@ pub struct PrometheusMetrics {
     security_exfiltration_blocks_total: Counter,
     security_quarantine_total: Family<QuarantineResultLabels, Counter>,
     security_rate_limit_trips_total: Counter,
+    cost_budget_exhausted_total: Counter,
 
     // --- Orchestration metrics ---
     orchestration_plans_total: Counter,
@@ -348,6 +349,13 @@ impl PrometheusMetrics {
             security_rate_limit_trips_total.clone(),
         );
 
+        let cost_budget_exhausted_total = Counter::default();
+        registry.register(
+            "zeph_cost_budget_exhausted",
+            "Total times the daily cost budget was exhausted, blocking further LLM calls",
+            cost_budget_exhausted_total.clone(),
+        );
+
         let orchestration_plans_total = Counter::default();
         registry.register(
             "zeph_orchestration_plans",
@@ -474,6 +482,7 @@ impl PrometheusMetrics {
             security_exfiltration_blocks_total,
             security_quarantine_total,
             security_rate_limit_trips_total,
+            cost_budget_exhausted_total,
             orchestration_plans_total,
             orchestration_tasks_total,
             mcp_servers,
@@ -691,6 +700,11 @@ impl PrometheusMetrics {
         let rate_delta = counter_delta(current.rate_limit_trips, prev.rate_limit_trips);
         if rate_delta > 0 {
             self.security_rate_limit_trips_total.inc_by(rate_delta);
+        }
+
+        let budget_delta = counter_delta(current.cost_budget_exhausted, prev.cost_budget_exhausted);
+        if budget_delta > 0 {
+            self.cost_budget_exhausted_total.inc_by(budget_delta);
         }
 
         // --- Orchestration counters ---
@@ -1012,6 +1026,24 @@ mod tests {
             "missing direction label"
         );
         assert!(buf.ends_with("# EOF\n"), "OpenMetrics requires EOF marker");
+    }
+
+    #[test]
+    #[allow(clippy::field_reassign_with_default)]
+    fn test_cost_budget_exhausted_metric_sync() {
+        let pm = PrometheusMetrics::new();
+
+        let mut snap = MetricsSnapshot::default();
+        snap.cost_budget_exhausted = 2;
+
+        pm.sync(&snap, &MetricsSnapshot::default());
+
+        let mut buf = String::new();
+        prometheus_client::encoding::text::encode(&mut buf, &pm.registry).unwrap();
+        assert!(
+            buf.contains("zeph_cost_budget_exhausted_total 2"),
+            "missing or wrong cost_budget_exhausted counter, got:\n{buf}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- A fresh Zeph install shipped with the tool-call rate limiter disabled and no daily cost cap, leaving no built-in defense against a stuck tool-call loop or unbounded LLM spend. Both enforcement mechanisms (`ToolRateLimiter`, `CostTracker::check_budget()`) already existed and were fully wired into the tool-dispatch and LLM-dispatch hot paths — this is a default-value + wizard-prompt + metrics change, not new enforcement logic.
- Fixes a serde split-brain bug found during architecture review: `RateLimitConfig.enabled` used a bare `#[serde(default)]` on the field (resolving to `false`) while `impl Default` set `true`, so an absent `[security.rate_limit]` TOML section was protected but a present-but-partial section (e.g. only one sub-limit configured) silently stayed disabled. Both paths now agree via a named default fn, verified with regression tests at both the leaf `RateLimitConfig` and nested `SecurityConfig` level.
- Rate limiter now enabled by default (unchanged per-category thresholds: shell 30/min, web 20/min, memory 60/min, mcp 40/min, other 60/min, 30s cooldown).
- Daily cost cap now defaults to $25.00/day (2500 cents), not unlimited (`0`).
- Explicit user-set values (`enabled = false`, `max_daily_cents = 0`, or any other explicit non-zero value) are preserved unchanged — this only affects sparse/absent config sections.
- Adds a `zeph_cost_budget_exhausted_total` Prometheus counter mirroring the existing `zeph_security_rate_limit_trips` metric.
- Adds remediation hints to the budget-exhausted and rate-limit-exceeded user-facing messages (how to raise/disable via config.toml).
- Updates the `--init` wizard: rate-limit prompt now defaults to enabled; new prompt for the daily cost cap in dollars.
- Adds an optional advisory-only migration step (`migrate_rate_limit_advisory`) that documents the new defaults for existing configs via commented-out TOML — purely documentary, cannot activate a live value.
- Syncs `config/default.toml` and `book/src/` docs with the new defaults.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 14791/14791 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] New regression tests: absent/partial `[security.rate_limit]` section resolves `enabled = true` (the split-brain guard), explicit `enabled = false` preserved, explicit `max_daily_cents = 0`/non-zero preserved, `CostConfig` absent-section default, wizard dollars-to-cents parsing (extracted to a pure fn with unit tests)
- [x] `gitleaks protect --staged`
- [ ] Live-testing playbook (`.local/testing/playbooks/security.md`, Scenarios 1-6) — not yet run; tracked in `coverage-status.md` as `Untested`, to be exercised in a future CI/live-testing cycle

Closes #6469