### PR TITLE
feat(subagent): wire per-task tool-allowlist into SpawnContext inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   wall-clock (not sweep-cycle) based, so it survives process restarts and is independent of the
   hourly sweep interval. Cap-eviction (the separate LRU path) is unaffected.
 
+- `zeph-orchestration`/`zeph-core`: `SpawnContext::inherited_tool_allowlist` was always `None` in
+  production because no per-task allowlist concept existed to source it from at the
+  `build_spawn_context` call site — only `SpawnContext::max_trust_level` was wired from the
+  parent's own effective trust level (#6503), leaving the tool-allowlist half of #6493 deferred
+  (#6504). `TaskNode` (`crates/zeph-orchestration/src/graph.rs`) gains a new
+  `tool_allowlist: Option<Vec<String>>` field (`None` = no per-task narrowing; `Some(vec![])`
+  narrows the spawned sub-agent to zero tools, fail-closed — use `None`, not an empty list, to
+  impose no restriction), and `handle_scheduler_spawn_action`
+  (`crates/zeph-core/src/agent/scheduler_loop.rs`) now populates
+  `SpawnContext::inherited_tool_allowlist` from it, mirroring the existing `network_denied`
+  wiring. The existing `apply_constraint_propagation` intersection logic
+  (`crates/zeph-subagent/src/manager/spawn.rs`) already consumed this field correctly and is
+  unchanged. **Scope note**: this closes the orchestration-policy plumbing only — nothing yet
+  populates `TaskNode.tool_allowlist` from a planner, config, or the parent session's own
+  `PermissionRule` deny lists, so production sub-agent spawns are unaffected until a follow-up
+  populates the field (tracked in #6526 and #6527).
+
 - `zeph`: `zeph vault set/get/list/rm/init` ignored `ZEPH_VAULT_KEY`/`ZEPH_VAULT_PATH` env vars
   and always fell back to the default vault directory unless overridden by `--vault-key`/
   `--vault-path` (#6500), diverging from the resolution `zeph doctor` and agent startup already

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -498,6 +498,7 @@ impl<C: crate::channel::Channel> Agent<C> {
     ///
     /// Returns `(spawn_success, concurrency_fail, done_status)`.
     /// `done_status` is `Some` when spawn failure forces the scheduler to emit a `Done` action.
+    #[allow(clippy::too_many_lines)] // sub-agent dispatch setup: task lookup, constraint computation, spawn-context assembly, task-supervisor wiring are tightly coupled — extracting would obscure the control flow
     pub(super) async fn handle_scheduler_spawn_action(
         &mut self,
         scheduler: &mut zeph_orchestration::DagScheduler,

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -66,6 +66,17 @@ fn network_denied_for_task(task: Option<&zeph_orchestration::TaskNode>) -> bool 
     )
 }
 
+/// Extracts `task`'s `tool_allowlist` (if any) as the `HashSet` consumed by
+/// `SpawnContext::inherited_tool_allowlist` / `apply_constraint_propagation`. `None` (task
+/// missing or no per-task allowlist set) means no per-task narrowing is applied — the
+/// sub-agent's tool set is governed solely by its own `SubAgentDef` policy.
+fn task_tool_allowlist(
+    task: Option<&zeph_orchestration::TaskNode>,
+) -> Option<std::collections::HashSet<String>> {
+    task.and_then(|t| t.tool_allowlist.as_ref())
+        .map(|v| v.iter().cloned().collect())
+}
+
 /// Reconstruct a [`zeph_orchestration::ToolCallSummary`] trace from a loaded transcript's
 /// messages, pairing each `MessagePart::ToolUse` with its later `MessagePart::ToolResult` (by
 /// `tool_use_id`) for the `ok` field. A `ToolUse` with no matching `ToolResult` (e.g. the
@@ -499,6 +510,7 @@ impl<C: crate::channel::Channel> Agent<C> {
         let task = scheduler.graph().tasks.get(task_id.index());
         let task_title = task.map_or("unknown", |t| t.title.as_str());
         let network_denied = network_denied_for_task(task);
+        let task_allowlist = task_tool_allowlist(task);
 
         let provider = self.provider.clone();
         let tool_executor = Arc::clone(&self.tool_executor);
@@ -522,6 +534,7 @@ impl<C: crate::channel::Channel> Agent<C> {
 
         let mut spawn_ctx = self.build_spawn_context(&cfg);
         spawn_ctx.network_denied = network_denied;
+        spawn_ctx.inherited_tool_allowlist = task_allowlist;
 
         // Idle-timeout progress heartbeat (issue #6245, Alt-A): the driver owns creation of
         // the Arc. One clone flows into the sub-agent loop via `spawn_ctx.progress_at`
@@ -1647,7 +1660,8 @@ impl<C: crate::channel::Channel> Agent<C> {
 mod tests {
     use super::{
         CommandHandoffContext, append_shared_state_block, determine_task_outcome,
-        lookahead_effective_depth, network_denied_for_task, tool_trace_from_messages,
+        lookahead_effective_depth, network_denied_for_task, task_tool_allowlist,
+        tool_trace_from_messages,
     };
 
     #[test]
@@ -1712,6 +1726,34 @@ mod tests {
     fn deny_scope_returns_true() {
         let node = task_with_scope(Some(zeph_orchestration::NetworkScope::Deny));
         assert!(network_denied_for_task(Some(&node)));
+    }
+
+    // ── task_tool_allowlist (issue #6504) ───────────────────────────────────
+
+    fn task_with_allowlist(allowlist: Option<Vec<String>>) -> zeph_orchestration::TaskNode {
+        let mut node = zeph_orchestration::TaskNode::new(0, "t", "d");
+        node.tool_allowlist = allowlist;
+        node
+    }
+
+    #[test]
+    fn no_task_allowlist_returns_none() {
+        assert_eq!(task_tool_allowlist(None), None);
+    }
+
+    #[test]
+    fn missing_tool_allowlist_returns_none() {
+        let node = task_with_allowlist(None);
+        assert_eq!(task_tool_allowlist(Some(&node)), None);
+    }
+
+    #[test]
+    fn populated_tool_allowlist_converts_to_hash_set() {
+        let node = task_with_allowlist(Some(vec!["shell".to_string(), "read".to_string()]));
+        let expected: std::collections::HashSet<String> = ["shell".to_string(), "read".to_string()]
+            .into_iter()
+            .collect();
+        assert_eq!(task_tool_allowlist(Some(&node)), Some(expected));
     }
 
     // ── determine_task_outcome / append_shared_state_block (spec-080, #6363) ────────

--- a/crates/zeph-orchestration/src/graph.rs
+++ b/crates/zeph-orchestration/src/graph.rs
@@ -471,6 +471,7 @@ pub struct RecoveryAction {
 /// assert_eq!(node.execution_mode, ExecutionMode::Parallel);
 /// assert!(node.network_scope.is_none());
 /// assert!(node.asset_sensitivity.is_none());
+/// assert!(node.tool_allowlist.is_none());
 /// assert!(node.timeout.is_none());
 /// assert!(node.recovery.is_none());
 /// assert!(node.routed_from.is_none());
@@ -552,6 +553,17 @@ pub struct TaskNode {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub asset_sensitivity: Option<zeph_config::AssetSensitivity>,
 
+    /// Per-task tool allowlist inherited by the spawned sub-agent. When `Some(list)`, the
+    /// sub-agent's effective tool set is narrowed to the intersection of this list and its
+    /// own `SubAgentDef` policy (see `apply_constraint_propagation`). `None` = no per-task
+    /// narrowing. `Some([])` narrows the sub-agent to ZERO tools (fail-closed) — use `None`,
+    /// not an empty list, to impose no restriction. Tool names are matched after
+    /// `normalize_tool_id`, so raw names are fine. This is the explicit-allowlist mechanism;
+    /// any future `asset_sensitivity`-derived tool narrowing should populate this same field
+    /// rather than introduce a parallel path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_allowlist: Option<Vec<String>>,
+
     /// Per-task timeout override. `None` = use the graph-global `task_timeout_secs`
     /// default for both spawned and `RunInline` dispatch. See [`TimeoutPolicy`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -630,6 +642,7 @@ impl TaskNode {
             token_budget_cents: None,
             network_scope: None,
             asset_sensitivity: None,
+            tool_allowlist: None,
             timeout: None,
             recovery: None,
             routed_from: None,
@@ -1174,6 +1187,7 @@ mod tests {
         let node: TaskNode = serde_json::from_str(json).expect("should deserialize old JSON");
         assert!(node.network_scope.is_none());
         assert!(node.asset_sensitivity.is_none());
+        assert!(node.tool_allowlist.is_none());
         assert!(node.timeout.is_none());
         assert!(node.recovery.is_none());
     }
@@ -1248,6 +1262,7 @@ mod tests {
         let node = TaskNode::new(0, "t", "d");
         assert!(node.network_scope.is_none());
         assert!(node.asset_sensitivity.is_none());
+        assert!(node.tool_allowlist.is_none());
     }
 
     #[test]
@@ -1376,5 +1391,37 @@ mod tests {
             !json.contains("asset_sensitivity"),
             "none should be omitted"
         );
+    }
+
+    #[test]
+    fn test_task_node_skip_serializing_if_none_tool_allowlist() {
+        let node = TaskNode::new(0, "t", "d");
+        let json = serde_json::to_string(&node).unwrap();
+        assert!(!json.contains("tool_allowlist"), "none should be omitted");
+    }
+
+    #[test]
+    fn test_task_node_tool_allowlist_roundtrip() {
+        let mut node = TaskNode::new(0, "t", "d");
+        node.tool_allowlist = Some(vec!["shell".to_string(), "read".to_string()]);
+        let json = serde_json::to_string(&node).unwrap();
+        let restored: TaskNode = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            restored.tool_allowlist,
+            Some(vec!["shell".to_string(), "read".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_task_node_tool_allowlist_empty_vec_distinct_from_none() {
+        // `Some(vec![])` (fail-closed, zero tools) must round-trip distinctly from `None`
+        // (no restriction) — the two are not equivalent despite both being "empty" in a
+        // loose sense. See the `tool_allowlist` field doc for the fail-closed semantics.
+        let mut node = TaskNode::new(0, "t", "d");
+        node.tool_allowlist = Some(vec![]);
+        let json = serde_json::to_string(&node).unwrap();
+        let restored: TaskNode = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.tool_allowlist, Some(vec![]));
+        assert_ne!(restored.tool_allowlist, None);
     }
 }

--- a/crates/zeph-orchestration/src/router.rs
+++ b/crates/zeph-orchestration/src/router.rs
@@ -163,6 +163,7 @@ mod tests {
             token_budget_cents: None,
             network_scope: None,
             asset_sensitivity: None,
+            tool_allowlist: None,
             timeout: None,
             recovery: None,
             routed_from: None,

--- a/crates/zeph-subagent/src/filter.rs
+++ b/crates/zeph-subagent/src/filter.rs
@@ -841,6 +841,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn empty_allow_list_blocks_every_tool() {
+        // `AllowList(vec![])` (fail-closed, e.g. from an empty `tool_allowlist` intersection
+        // in `apply_constraint_propagation`) must block ALL tool calls, not just unlisted
+        // ones — `.any()` over an empty list is always `false`.
+        let exec =
+            FilteredToolExecutor::new(stub_box(&["shell", "web"]), ToolPolicy::AllowList(vec![]));
+        let call = ToolCall {
+            tool_id: "shell".into(),
+            params: serde_json::Map::default(),
+            caller_id: None,
+            context: None,
+
+            tool_call_id: String::new(),
+            skill_name: None,
+        };
+        let res = exec.execute_tool_call_erased(&call).await;
+        assert!(res.is_err(), "empty AllowList must block every tool call");
+    }
+
+    #[tokio::test]
     async fn deny_list_blocks_listed_tool() {
         let exec = FilteredToolExecutor::new(
             stub_box(&["shell", "web"]),

--- a/crates/zeph-subagent/src/manager/tests.rs
+++ b/crates/zeph-subagent/src/manager/tests.rs
@@ -4350,6 +4350,26 @@ fn constraint_propagation_intersection_is_case_insensitive() {
     }
 }
 
+#[test]
+fn constraint_propagation_empty_parent_allowlist_is_fail_closed_zero_tools() {
+    // `Some(HashSet::new())` (explicit empty allowlist) must yield ZERO tools regardless of
+    // the agent's own policy — this is the fail-closed distinction from `None` (no
+    // narrowing). Covers `InheritAll`, `AllowList`, and `DenyList` starting policies.
+    let ctx = ctx_with_allowlist(&[]);
+
+    let mut inherit_all = def_with_inherit_all();
+    apply_constraint_propagation(&mut inherit_all, &ctx);
+    assert_matches!(&inherit_all.tools, ToolPolicy::AllowList(v) if v.is_empty());
+
+    let mut allow_list = def_with_allow_list(&["shell", "read"]);
+    apply_constraint_propagation(&mut allow_list, &ctx);
+    assert_matches!(&allow_list.tools, ToolPolicy::AllowList(v) if v.is_empty());
+
+    let mut deny_list = def_with_deny_list(&["shell"]);
+    apply_constraint_propagation(&mut deny_list, &ctx);
+    assert_matches!(&deny_list.tools, ToolPolicy::AllowList(v) if v.is_empty());
+}
+
 #[cfg(test)]
 mod worktree_predicate_tests {
     use zeph_config::BgIsolation;


### PR DESCRIPTION
## Summary

- PR #6503 wired `SpawnContext::max_trust_level` from the parent session's own effective trust level, closing the trust-cap half of #6493, but left `SpawnContext::inherited_tool_allowlist` unset since no per-task allowlist concept existed to source it from.
- Adds `TaskNode::tool_allowlist: Option<Vec<String>>` (`crates/zeph-orchestration/src/graph.rs`) and populates `SpawnContext::inherited_tool_allowlist` from it in `handle_scheduler_spawn_action` (`crates/zeph-core/src/agent/scheduler_loop.rs`), mirroring the existing `network_denied` wiring.
- The consumer, `apply_constraint_propagation` (`crates/zeph-subagent/src/manager/spawn.rs:221-292`), already intersected this field correctly and is unchanged.
- Empty-allowlist semantics are fail-closed by design: `None` = no per-task narrowing, `Some(vec![])` narrows the sub-agent to zero tools — verified at both the intersection layer and the `filter.rs` enforcement layer.

## Scope note (important)

This PR wires the orchestration-policy plumbing only. Nothing currently populates `TaskNode::tool_allowlist` in production — no planner, config, or parent-session `PermissionRule`-derivation path exists yet. Production sub-agent spawns are therefore unaffected by this PR alone, and the original #6504 reproduction (a parent restricted by its own `PermissionRule` deny lists still spawning unnarrowed sub-agents) is not yet closed by production behavior change. Two follow-up issues track the deferred population sources:

- #6526 — planner/config population of `TaskNode.tool_allowlist`
- #6527 — deriving the parent session's own effective tool-allowlist from its `PermissionRule` deny lists (harder problem: requires enumerating the parent's complete effective tool universe)

## Test plan

- [x] `TaskNode.tool_allowlist` serde default/roundtrip/empty-vs-None-distinctness tests (`graph.rs`)
- [x] `task_tool_allowlist()` helper: `None` task, task with `None` field, populated task (`scheduler_loop.rs`)
- [x] `apply_constraint_propagation` empty-set fail-closed across `InheritAll`/`AllowList`/`DenyList` starting policies (`manager/tests.rs`)
- [x] `filter.rs` enforcement-layer test confirming an empty `AllowList` blocks every tool via the real dispatch path
- [x] `cargo +nightly fmt --check`, `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`, full-workspace `cargo nextest`, rustdoc gate — all clean
- [x] Full team-develop pass: architect → critic (design, minor) → developer → tester/perf/security/impl-critic (parallel, all PASS/approved) → reviewer (changes_requested → fixed clippy `too_many_lines` regression → approved)

Closes #6504