### PR TITLE
fix(serve): wire ContentSanitizer and ML classifier pipeline into zeph serve sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `ignore_instructions` injection payload is spotlight-wrapped and flagged rather than stored
   verbatim, closing the gap where the original SEC-CC-03 sanitizer call had zero test coverage.
 
+- `zeph`: `zeph serve-sessions`'s `/sessions*` HTTP/SSE agents (spec-068 §9, the entry point most
+  exposed to untrusted external input) were missing most of the sanitizer/classifier security
+  pipeline that `runner.rs`/`daemon.rs`/`acp.rs` already apply — quarantine summarization,
+  guardrail filtering, the ML injection classifier + enforcement mode, the three-class refinement
+  classifier, PII detection (both the primary and NER union-merge layers), causal-IPI analysis,
+  NLI entailment sanitization, VIGIL pre-sanitizer gating, PAAC secret masking, and the
+  feedback/reward-signal classifier were all silently absent regardless of config (#6580, #6582;
+  meta-issue #6581, the "wire X into ACP/serve/daemon" defect class). `ServeAgentDeps`
+  (`src/serve/deps.rs`) gains `quarantine_provider`/`guardrail_provider`/`classifiers_config`
+  (feature-gated)/`pii_filter_enabled` (feature-gated)/`causal_ipi_config`/`causal_provider`/
+  `nli_config`/`nli_provider`/`secret_registry`/`vigil_config`/`feedback_classifier`, populated in
+  `assemble_serve_deps` with the same construction logic `src/acp.rs`'s `build_acp_deps` already
+  uses for `SharedAgentDeps`; `agent_factory::build_agent_factory`'s per-session `build_agent`
+  closure now wires all of them onto the built `Agent` via the same `_with_cfg` helpers and
+  ordering `spawn_acp_agent` uses (enforcement-mode after the injection classifier; secret-masking
+  last, after every `with_*_provider` call, since it retroactively wraps each already-set
+  provider). Tool-output anomaly detection (`config.tools.anomaly`) needed no change here — it is
+  already wired for `/sessions*` agents via the pre-existing `Agent::apply_session_config` call in
+  `build_agent_factory` (`crates/zeph-core/src/agent/builder.rs`'s `apply_session_config` calls
+  `with_anomaly_detector` internally when `[tools.anomaly] enabled = true`), the same path
+  `runner.rs`/`daemon.rs`/`acp.rs` go through; those three also make a second, redundant explicit
+  `with_anomaly_detector` call, which `serve` correctly does not duplicate. Added a parity
+  regression test
+  (`acp::tests::build_combined_deps_wires_equivalent_security_pipeline_from_config`) asserting
+  both `ServeAgentDeps` and `SharedAgentDeps` reflect the exact configured values for every field
+  above when built from the same config via the real `build_combined_deps`, so a future PR that
+  silently drops one of them fails a test instead of shipping unnoticed.
+
 - `zeph-core`: the vault-anchor reconcile sweep (`run_anchor_sweep`) hard-deleted a transcript/
   session anchor the instant its backing file was absent, with no grace period or persisted
   "was-anchored" record (#6462). Since file absence is attacker-controlled under this feature's

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -460,27 +460,42 @@ pub(crate) struct SharedAgentDeps {
     // Optional runtime providers (contain HTTP client pools; excluded from session_config)
     summary_provider: Option<zeph_llm::any::AnyProvider>,
     judge_provider: Option<zeph_llm::any::AnyProvider>,
-    feedback_classifier: Option<zeph_llm::classifier::llm::LlmClassifier>,
+    /// `pub(crate)` (unlike most sibling fields) solely so the `#6580`/`#6582` serve/ACP
+    /// security-pipeline parity test
+    /// (`acp::tests::build_combined_deps_wires_equivalent_security_pipeline_from_config`) can
+    /// compare it against `ServeAgentDeps::feedback_classifier` — mirrors `memory`'s doc comment
+    /// above.
+    pub(crate) feedback_classifier: Option<zeph_llm::classifier::llm::LlmClassifier>,
+    /// `pub(crate)`: see `feedback_classifier`'s doc comment.
     #[cfg(feature = "classifiers")]
-    classifiers_config: zeph_core::config::ClassifiersConfig,
+    pub(crate) classifiers_config: zeph_core::config::ClassifiersConfig,
     /// `security.pii_filter.enabled` — gates the NER union-merge PII layer (#5463),
-    /// mirroring the check in `agent_setup::apply_pii_ner_classifier`.
+    /// mirroring the check in `agent_setup::apply_pii_ner_classifier`. `pub(crate)`: see
+    /// `feedback_classifier`'s doc comment.
     #[cfg(feature = "classifiers")]
-    pii_filter_enabled: bool,
-    causal_ipi_config: zeph_sanitizer::causal_ipi::CausalIpiConfig,
+    pub(crate) pii_filter_enabled: bool,
+    /// `pub(crate)`: see `feedback_classifier`'s doc comment.
+    pub(crate) causal_ipi_config: zeph_sanitizer::causal_ipi::CausalIpiConfig,
     causal_provider: Option<zeph_llm::any::AnyProvider>,
-    nli_config: zeph_sanitizer::nli::NliConfig,
+    /// `pub(crate)`: see `feedback_classifier`'s doc comment.
+    pub(crate) nli_config: zeph_sanitizer::nli::NliConfig,
     nli_provider: Option<zeph_llm::any::AnyProvider>,
-    secret_registry: Option<std::sync::Arc<zeph_sanitizer::secret_mask::SecretMaskRegistry>>,
-    vigil_config: zeph_config::VigilConfig,
+    /// `pub(crate)`: see `feedback_classifier`'s doc comment.
+    pub(crate) secret_registry:
+        Option<std::sync::Arc<zeph_sanitizer::secret_mask::SecretMaskRegistry>>,
+    /// `pub(crate)`: see `feedback_classifier`'s doc comment.
+    pub(crate) vigil_config: zeph_config::VigilConfig,
     probe_provider: Option<zeph_llm::any::AnyProvider>,
     planner_provider: Option<zeph_llm::any::AnyProvider>,
     verify_provider: Option<zeph_llm::any::AnyProvider>,
     ensemble_members: Vec<(String, zeph_llm::any::AnyProvider)>,
     orchestrator_provider: Option<zeph_llm::any::AnyProvider>,
     predicate_provider: Option<zeph_llm::any::AnyProvider>,
-    quarantine_provider: Option<(zeph_llm::any::AnyProvider, zeph_sanitizer::QuarantineConfig)>,
-    guardrail_provider: Option<(
+    /// `pub(crate)`: see `feedback_classifier`'s doc comment.
+    pub(crate) quarantine_provider:
+        Option<(zeph_llm::any::AnyProvider, zeph_sanitizer::QuarantineConfig)>,
+    /// `pub(crate)`: see `feedback_classifier`'s doc comment.
+    pub(crate) guardrail_provider: Option<(
         zeph_llm::any::AnyProvider,
         zeph_sanitizer::guardrail::GuardrailConfig,
     )>,
@@ -4813,6 +4828,157 @@ mod tests {
             "acp_deps.rl_head and serve_deps.rl_head must share the same in-memory RoutingHead \
              instance loaded once by build_shared_core (#5974)"
         );
+    }
+
+    /// #6580/#6582/#6581 parity regression: before this PR, `ServeAgentDeps` (`/sessions*`, the
+    /// HTTP/SSE entry point most exposed to untrusted external input, spec-068 §9) had no
+    /// quarantine/guardrail/classifier/causal-IPI/NLI/VIGIL/secret-masking/feedback-classifier
+    /// fields at all, so `assemble_serve_deps` never wired any of them regardless of config —
+    /// silently leaving `/sessions*` agents without most of the security pipeline CLI/TUI/daemon/
+    /// ACP already apply. Drives the real `build_combined_deps` against a config with every one
+    /// of these settings pushed to a non-default value (same pattern as
+    /// `build_combined_deps_wires_skill_matching_config_from_config` above), then asserts BOTH
+    /// `serve_deps` and `acp_deps` reflect the exact configured values — not just that the two
+    /// happen to match each other, which would also pass if both silently stayed on shared
+    /// struct defaults. This is the parity test that closes the gap meta-issue #6581 tracks (a
+    /// 24th instance of the wire-X-into-serve defect class): a future PR that drops one of these
+    /// fields from `assemble_serve_deps` fails this test instead of shipping unnoticed.
+    #[cfg(feature = "acp-http")]
+    #[tokio::test]
+    #[allow(clippy::too_many_lines)] // exhaustive field-by-field assertions across 2 deps structs
+    async fn build_combined_deps_wires_equivalent_security_pipeline_from_config() {
+        let mut config =
+            zeph_core::config::Config::load(std::path::Path::new("/nonexistent")).unwrap();
+        config.llm.providers = vec![zeph_core::config::ProviderEntry {
+            provider_type: zeph_core::config::ProviderKind::Ollama,
+            base_url: Some("http://127.0.0.1:1".to_owned()),
+            model: Some("test-model".to_owned()),
+            ..Default::default()
+        }];
+        config.memory.sqlite_path = ":memory:".to_owned();
+        config.security.vigil.strict_mode = true;
+        config.security.vigil.sanitize_max_chars = 12345;
+        // Default quarantine model ("claude") is not in `[[llm.providers]]` above — point it at
+        // the configured ollama provider so resolution succeeds and both sides get `Some(..)`.
+        config.security.content_isolation.quarantine.enabled = true;
+        config.security.content_isolation.quarantine.model = "ollama".to_owned();
+        config.security.guardrail.enabled = true;
+        config.security.causal_ipi.enabled = true;
+        config.security.causal_ipi.threshold = 0.42;
+        config.security.content_isolation.nli.enabled = true;
+        config.security.content_isolation.nli.threshold = 0.33;
+        config.security.pii_filter.enabled = true;
+        // `detector_mode = Model` with an empty `feedback_provider` falls back to the session's
+        // primary provider (see `AppBuilder::build_feedback_classifier`), so no extra provider
+        // setup is needed for `feedback_classifier` to resolve to `Some(..)`.
+        config.skills.learning.detector_mode = zeph_core::config::DetectorMode::Model;
+        #[cfg(feature = "classifiers")]
+        {
+            config.classifiers.enabled = true;
+            config.classifiers.injection_threshold = 0.81;
+        }
+
+        let app = crate::bootstrap::AppBuilder::for_test(config);
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let supervisor = std::sync::Arc::new(zeph_common::TaskSupervisor::new(cancel));
+
+        let (serve_deps, acp_deps, _keepalive) = Box::pin(build_combined_deps(&app, &supervisor))
+            .await
+            .expect("build_combined_deps must succeed against a mock-provider AppBuilder");
+
+        for (label, vigil) in [
+            ("serve_deps", &serve_deps.vigil_config),
+            ("acp_deps", &acp_deps.vigil_config),
+        ] {
+            assert!(
+                vigil.strict_mode,
+                "config.security.vigil.strict_mode must flow into {label}"
+            );
+            assert_eq!(
+                vigil.sanitize_max_chars, 12345,
+                "config.security.vigil.sanitize_max_chars must flow into {label}"
+            );
+        }
+        for (label, causal) in [
+            ("serve_deps", &serve_deps.causal_ipi_config),
+            ("acp_deps", &acp_deps.causal_ipi_config),
+        ] {
+            assert!(
+                causal.enabled,
+                "config.security.causal_ipi.enabled must flow into {label}"
+            );
+            assert!(
+                (causal.threshold - 0.42).abs() < f32::EPSILON,
+                "config.security.causal_ipi.threshold must flow into {label}"
+            );
+        }
+        for (label, nli) in [
+            ("serve_deps", &serve_deps.nli_config),
+            ("acp_deps", &acp_deps.nli_config),
+        ] {
+            assert!(
+                nli.enabled,
+                "config.security.content_isolation.nli.enabled must flow into {label}"
+            );
+            assert!(
+                (nli.threshold - 0.33).abs() < f32::EPSILON,
+                "config.security.content_isolation.nli.threshold must flow into {label}"
+            );
+        }
+        assert!(
+            serve_deps.quarantine_provider.is_some(),
+            "config.security.content_isolation.quarantine.enabled must produce a resolved \
+             quarantine_provider on serve_deps"
+        );
+        assert!(
+            acp_deps.quarantine_provider.is_some(),
+            "config.security.content_isolation.quarantine.enabled must produce a resolved \
+             quarantine_provider on acp_deps"
+        );
+        assert!(
+            serve_deps.guardrail_provider.is_some(),
+            "config.security.guardrail.enabled must produce a resolved guardrail_provider on \
+             serve_deps"
+        );
+        assert!(
+            acp_deps.guardrail_provider.is_some(),
+            "config.security.guardrail.enabled must produce a resolved guardrail_provider on \
+             acp_deps"
+        );
+        assert!(
+            serve_deps.feedback_classifier.is_some(),
+            "config.skills.learning.detector_mode = Model must produce a resolved \
+             feedback_classifier on serve_deps"
+        );
+        assert!(
+            acp_deps.feedback_classifier.is_some(),
+            "config.skills.learning.detector_mode = Model must produce a resolved \
+             feedback_classifier on acp_deps"
+        );
+        #[cfg(feature = "classifiers")]
+        {
+            for (label, classifiers) in [
+                ("serve_deps", &serve_deps.classifiers_config),
+                ("acp_deps", &acp_deps.classifiers_config),
+            ] {
+                assert!(
+                    classifiers.enabled,
+                    "config.classifiers.enabled must flow into {label}"
+                );
+                assert!(
+                    (classifiers.injection_threshold - 0.81).abs() < f32::EPSILON,
+                    "config.classifiers.injection_threshold must flow into {label}"
+                );
+            }
+            assert!(
+                serve_deps.pii_filter_enabled,
+                "config.security.pii_filter.enabled must flow into serve_deps"
+            );
+            assert!(
+                acp_deps.pii_filter_enabled,
+                "config.security.pii_filter.enabled must flow into acp_deps"
+            );
+        }
     }
 
     /// #5959/#6022 regression: before this PR, `SharedAgentDeps` had no

--- a/src/serve/agent_factory.rs
+++ b/src/serve/agent_factory.rs
@@ -207,6 +207,10 @@ pub(crate) async fn build_agent_factory(
         // Capture before apply_session_config consumes deps.session_config (mirrors
         // spawn_acp_agent's debug_config capture in src/acp.rs).
         let debug_config = deps.session_config.debug_config.clone();
+        // #6580/#6582: captured before Agent::new_with_registry_arc below moves deps.provider —
+        // the causal-IPI/NLI sanitizers need their own clone of the session's primary provider
+        // as a probe-call fallback, mirroring spawn_acp_agent's `provider.clone()` uses.
+        let security_provider = deps.provider.clone();
 
         // #6045: wrap ScopedToolExecutor fresh per session (when
         // `[security.capability_scopes]` is configured) around the already trust/policy/
@@ -320,6 +324,57 @@ pub(crate) async fn build_agent_factory(
         // #6386: propagate `[tools] enabled` onto this session's Agent so a `false` value
         // actually suppresses tool definitions, matching src/runner.rs/src/acp.rs/src/daemon.rs.
         .with_tools_enabled(deps.tools_enabled);
+        // #6580/#6582: wire the sanitizer/classifier security pipeline — quarantine, guardrail,
+        // ML injection classification, PII detection, causal-IPI, NLI, VIGIL, and secret masking
+        // — onto this session's Agent, using the same `_with_cfg` helpers and ordering
+        // `src/acp.rs`'s `spawn_acp_agent` uses (see its equivalent block for the two hard
+        // ordering constraints: enforcement-mode must follow the injection classifier, and
+        // secret-masking must run after every `with_*_provider` call above it, since it
+        // retroactively wraps each already-set `AnyProvider` field). Previously entirely absent
+        // from `/sessions*` agents — the HTTP/SSE entry point most exposed to untrusted external
+        // input (spec-068 §9) had none of this pipeline.
+        agent = crate::agent_setup::apply_quarantine_provider(agent, deps.quarantine_provider);
+        agent = crate::agent_setup::apply_guardrail(agent, deps.guardrail_provider);
+        #[cfg(feature = "classifiers")]
+        {
+            agent = crate::agent_setup::apply_injection_classifier_with_cfg(
+                agent,
+                &deps.classifiers_config,
+            );
+            if deps.classifiers_config.enabled {
+                agent = agent.with_enforcement_mode(deps.classifiers_config.enforcement_mode);
+            }
+            agent = crate::agent_setup::apply_three_class_classifier_with_cfg(
+                agent,
+                &deps.classifiers_config,
+            );
+            agent =
+                crate::agent_setup::apply_pii_classifier_with_cfg(agent, &deps.classifiers_config);
+            agent = crate::agent_setup::apply_pii_ner_classifier_with_cfg(
+                agent,
+                &deps.classifiers_config,
+                deps.pii_filter_enabled,
+            );
+        }
+        agent = crate::agent_setup::apply_causal_analyzer_with_cfg(
+            agent,
+            security_provider.clone(),
+            deps.causal_provider,
+            &deps.causal_ipi_config,
+            deps.secret_registry.as_ref(),
+        );
+        agent = crate::agent_setup::apply_nli_sanitizer_with_cfg(
+            agent,
+            security_provider,
+            deps.nli_provider,
+            &deps.nli_config,
+            deps.secret_registry.as_ref(),
+        );
+        agent = crate::agent_setup::apply_secret_masking(agent, deps.secret_registry);
+        agent = crate::agent_setup::apply_vigil(agent, &deps.vigil_config);
+        if let Some(fc) = deps.feedback_classifier {
+            agent = agent.with_llm_classifier(fc);
+        }
         if !preloaded_messages.is_empty() {
             agent = agent.with_preloaded_messages(preloaded_messages);
         }
@@ -949,6 +1004,19 @@ mod tests {
             safe_mode: false,
             allowed_paths: vec![],
             tools_enabled: true,
+            quarantine_provider: None,
+            guardrail_provider: None,
+            #[cfg(feature = "classifiers")]
+            classifiers_config: zeph_core::config::ClassifiersConfig::default(),
+            #[cfg(feature = "classifiers")]
+            pii_filter_enabled: false,
+            causal_ipi_config: zeph_sanitizer::causal_ipi::CausalIpiConfig::default(),
+            causal_provider: None,
+            nli_config: zeph_sanitizer::nli::NliConfig::default(),
+            nli_provider: None,
+            secret_registry: None,
+            vigil_config: zeph_config::VigilConfig::default(),
+            feedback_classifier: None,
         };
 
         let (_, build_agent) =
@@ -1040,6 +1108,19 @@ mod tests {
             safe_mode: false,
             allowed_paths: vec![],
             tools_enabled: true,
+            quarantine_provider: None,
+            guardrail_provider: None,
+            #[cfg(feature = "classifiers")]
+            classifiers_config: zeph_core::config::ClassifiersConfig::default(),
+            #[cfg(feature = "classifiers")]
+            pii_filter_enabled: false,
+            causal_ipi_config: zeph_sanitizer::causal_ipi::CausalIpiConfig::default(),
+            causal_provider: None,
+            nli_config: zeph_sanitizer::nli::NliConfig::default(),
+            nli_provider: None,
+            secret_registry: None,
+            vigil_config: zeph_config::VigilConfig::default(),
+            feedback_classifier: None,
         };
 
         let (resume_banner, build_agent) =
@@ -1128,6 +1209,19 @@ mod tests {
             safe_mode: false,
             allowed_paths: vec![],
             tools_enabled: true,
+            quarantine_provider: None,
+            guardrail_provider: None,
+            #[cfg(feature = "classifiers")]
+            classifiers_config: zeph_core::config::ClassifiersConfig::default(),
+            #[cfg(feature = "classifiers")]
+            pii_filter_enabled: false,
+            causal_ipi_config: zeph_sanitizer::causal_ipi::CausalIpiConfig::default(),
+            causal_provider: None,
+            nli_config: zeph_sanitizer::nli::NliConfig::default(),
+            nli_provider: None,
+            secret_registry: None,
+            vigil_config: zeph_config::VigilConfig::default(),
+            feedback_classifier: None,
         };
 
         let (_, build_agent) =
@@ -1242,6 +1336,19 @@ mod tests {
             safe_mode: false,
             allowed_paths: vec![],
             tools_enabled: true,
+            quarantine_provider: None,
+            guardrail_provider: None,
+            #[cfg(feature = "classifiers")]
+            classifiers_config: zeph_core::config::ClassifiersConfig::default(),
+            #[cfg(feature = "classifiers")]
+            pii_filter_enabled: false,
+            causal_ipi_config: zeph_sanitizer::causal_ipi::CausalIpiConfig::default(),
+            causal_provider: None,
+            nli_config: zeph_sanitizer::nli::NliConfig::default(),
+            nli_provider: None,
+            secret_registry: None,
+            vigil_config: zeph_config::VigilConfig::default(),
+            feedback_classifier: None,
         };
 
         let (_, build_agent) =
@@ -1345,6 +1452,19 @@ mod tests {
             safe_mode: false,
             allowed_paths: vec![],
             tools_enabled: true,
+            quarantine_provider: None,
+            guardrail_provider: None,
+            #[cfg(feature = "classifiers")]
+            classifiers_config: zeph_core::config::ClassifiersConfig::default(),
+            #[cfg(feature = "classifiers")]
+            pii_filter_enabled: false,
+            causal_ipi_config: zeph_sanitizer::causal_ipi::CausalIpiConfig::default(),
+            causal_provider: None,
+            nli_config: zeph_sanitizer::nli::NliConfig::default(),
+            nli_provider: None,
+            secret_registry: None,
+            vigil_config: zeph_config::VigilConfig::default(),
+            feedback_classifier: None,
         };
 
         let (_, build_agent) =
@@ -1447,6 +1567,19 @@ mod tests {
             safe_mode: false,
             allowed_paths: vec![],
             tools_enabled: true,
+            quarantine_provider: None,
+            guardrail_provider: None,
+            #[cfg(feature = "classifiers")]
+            classifiers_config: zeph_core::config::ClassifiersConfig::default(),
+            #[cfg(feature = "classifiers")]
+            pii_filter_enabled: false,
+            causal_ipi_config: zeph_sanitizer::causal_ipi::CausalIpiConfig::default(),
+            causal_provider: None,
+            nli_config: zeph_sanitizer::nli::NliConfig::default(),
+            nli_provider: None,
+            secret_registry: None,
+            vigil_config: zeph_config::VigilConfig::default(),
+            feedback_classifier: None,
         };
 
         let (_, build_agent) =
@@ -1546,6 +1679,19 @@ mod tests {
             safe_mode: false,
             allowed_paths: vec![],
             tools_enabled: true,
+            quarantine_provider: None,
+            guardrail_provider: None,
+            #[cfg(feature = "classifiers")]
+            classifiers_config: zeph_core::config::ClassifiersConfig::default(),
+            #[cfg(feature = "classifiers")]
+            pii_filter_enabled: false,
+            causal_ipi_config: zeph_sanitizer::causal_ipi::CausalIpiConfig::default(),
+            causal_provider: None,
+            nli_config: zeph_sanitizer::nli::NliConfig::default(),
+            nli_provider: None,
+            secret_registry: None,
+            vigil_config: zeph_config::VigilConfig::default(),
+            feedback_classifier: None,
         };
 
         let (_, build_agent) =
@@ -1628,6 +1774,19 @@ mod tests {
             safe_mode: false,
             allowed_paths: vec![],
             tools_enabled: true,
+            quarantine_provider: None,
+            guardrail_provider: None,
+            #[cfg(feature = "classifiers")]
+            classifiers_config: zeph_core::config::ClassifiersConfig::default(),
+            #[cfg(feature = "classifiers")]
+            pii_filter_enabled: false,
+            causal_ipi_config: zeph_sanitizer::causal_ipi::CausalIpiConfig::default(),
+            causal_provider: None,
+            nli_config: zeph_sanitizer::nli::NliConfig::default(),
+            nli_provider: None,
+            secret_registry: None,
+            vigil_config: zeph_config::VigilConfig::default(),
+            feedback_classifier: None,
         }
     }
 

--- a/src/serve/deps.rs
+++ b/src/serve/deps.rs
@@ -129,6 +129,33 @@ pub(crate) struct ServeAgentDeps {
     /// `AdversarialPolicyGateExecutor` instances per session (via
     /// `agent_setup::apply_policy_gate_chain`) reusing these shared pieces.
     pub(crate) policy_gate_pieces: crate::agent_setup::PolicyGatePieces,
+    /// #6580/#6582: sanitizer/classifier security pipeline snapshot, wired into every session's
+    /// `Agent` in `agent_factory::build_agent_factory` via the same `_with_cfg` helpers
+    /// `src/acp.rs`'s `spawn_acp_agent` uses — mirrors `SharedAgentDeps`'s equivalent fields.
+    /// Previously `/sessions*` agents got none of quarantine/guardrail/ML injection
+    /// classification/PII detection/causal-IPI/NLI/VIGIL/secret-masking, leaving the HTTP/SSE
+    /// entry point (the one most exposed to untrusted external input, spec-068 §9) without most
+    /// of the security pipeline CLI/TUI/daemon/ACP already apply.
+    pub(crate) quarantine_provider: Option<(AnyProvider, zeph_sanitizer::QuarantineConfig)>,
+    pub(crate) guardrail_provider:
+        Option<(AnyProvider, zeph_sanitizer::guardrail::GuardrailConfig)>,
+    #[cfg(feature = "classifiers")]
+    pub(crate) classifiers_config: zeph_core::config::ClassifiersConfig,
+    /// `security.pii_filter.enabled` — gates the NER union-merge PII layer, mirroring the check
+    /// in `agent_setup::apply_pii_ner_classifier`.
+    #[cfg(feature = "classifiers")]
+    pub(crate) pii_filter_enabled: bool,
+    pub(crate) causal_ipi_config: zeph_sanitizer::causal_ipi::CausalIpiConfig,
+    pub(crate) causal_provider: Option<AnyProvider>,
+    pub(crate) nli_config: zeph_sanitizer::nli::NliConfig,
+    pub(crate) nli_provider: Option<AnyProvider>,
+    pub(crate) secret_registry: Option<Arc<zeph_sanitizer::secret_mask::SecretMaskRegistry>>,
+    pub(crate) vigil_config: zeph_config::VigilConfig,
+    /// `config.skills.learning` feedback/reward-signal classifier (`detector_mode = "model"`) —
+    /// unrelated to the sanitizer pipeline above, but also absent from `/sessions*` agents before
+    /// #6580; wired into `Agent::with_llm_classifier` per session, mirroring `src/runner.rs`/
+    /// `src/daemon.rs`/`src/acp.rs`.
+    pub(crate) feedback_classifier: Option<zeph_llm::classifier::llm::LlmClassifier>,
     pub(crate) memory: Arc<SemanticMemory>,
     pub(crate) history_limit: u32,
     pub(crate) recall_limit: usize,
@@ -461,6 +488,50 @@ pub(crate) async fn assemble_serve_deps(
         app.secret_registry().as_ref(),
     );
 
+    // #6580/#6582: resolve the causal-IPI/NLI dedicated providers once here — provider
+    // resolution is static config work, mirroring `src/acp.rs`'s `SharedAgentDeps` build. The
+    // remaining sanitizer/classifier fields below (`quarantine_provider`, `guardrail_provider`,
+    // `classifiers_config`, `secret_registry`, `vigil_config`, `feedback_classifier`) need no
+    // extra resolution and are built inline in the `Ok(ServeAgentDeps { ... })` literal.
+    let causal_ipi_config = config.security.causal_ipi.clone();
+    let causal_provider = causal_ipi_config
+        .provider
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .and_then(
+            |name| match crate::bootstrap::create_named_provider(name, config) {
+                Ok(p) => {
+                    tracing::info!(provider = %name, "causal IPI dedicated provider configured (serve)");
+                    Some(p)
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        provider = %name,
+                        error = %e,
+                        "causal IPI provider resolution failed, falling back to primary (serve)"
+                    );
+                    None
+                }
+            },
+        );
+    let nli_config = config.security.content_isolation.nli.clone();
+    let nli_provider = nli_config.provider.as_non_empty().and_then(|name| {
+        match crate::bootstrap::create_named_provider(name, config) {
+            Ok(p) => {
+                tracing::info!(provider = %name, "NLI dedicated provider configured (serve)");
+                Some(p)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    provider = %name,
+                    error = %e,
+                    "NLI provider resolution failed, falling back to primary (serve)"
+                );
+                None
+            }
+        }
+    });
+
     Ok(ServeAgentDeps {
         provider: core.provider.clone(),
         embedding_provider: core.embedding_provider.clone(),
@@ -489,6 +560,19 @@ pub(crate) async fn assemble_serve_deps(
         permission_policy,
         audit_logger,
         policy_gate_pieces,
+        quarantine_provider: app.build_quarantine_provider(),
+        guardrail_provider: app.build_guardrail_provider(),
+        #[cfg(feature = "classifiers")]
+        classifiers_config: config.classifiers.clone(),
+        #[cfg(feature = "classifiers")]
+        pii_filter_enabled: config.security.pii_filter.enabled,
+        causal_ipi_config,
+        causal_provider,
+        nli_config,
+        nli_provider,
+        secret_registry: app.secret_registry(),
+        vigil_config: config.security.vigil.clone(),
+        feedback_classifier: app.build_feedback_classifier(&core.provider),
         memory: Arc::clone(&core.memory),
         history_limit,
         recall_limit,

--- a/src/serve/handlers.rs
+++ b/src/serve/handlers.rs
@@ -608,6 +608,19 @@ mod tests {
             safe_mode: false,
             allowed_paths: vec![],
             tools_enabled: true,
+            quarantine_provider: None,
+            guardrail_provider: None,
+            #[cfg(feature = "classifiers")]
+            classifiers_config: zeph_core::config::ClassifiersConfig::default(),
+            #[cfg(feature = "classifiers")]
+            pii_filter_enabled: false,
+            causal_ipi_config: zeph_sanitizer::causal_ipi::CausalIpiConfig::default(),
+            causal_provider: None,
+            nli_config: zeph_sanitizer::nli::NliConfig::default(),
+            nli_provider: None,
+            secret_registry: None,
+            vigil_config: zeph_config::VigilConfig::default(),
+            feedback_classifier: None,
         };
         AppState {
             registry: Arc::new(LiveSessionRegistry::new()),

--- a/src/serve/test_support.rs
+++ b/src/serve/test_support.rs
@@ -73,6 +73,7 @@ impl ServeTestHarness {
         Self::build(false).await
     }
 
+    #[allow(clippy::too_many_lines)] // exhaustive ServeAgentDeps test fixture literal
     async fn build(persistence_enabled: bool) -> Self {
         let memory = Arc::new(
             SemanticMemory::new(
@@ -153,6 +154,19 @@ impl ServeTestHarness {
             safe_mode: false,
             allowed_paths: vec![],
             tools_enabled: true,
+            quarantine_provider: None,
+            guardrail_provider: None,
+            #[cfg(feature = "classifiers")]
+            classifiers_config: zeph_core::config::ClassifiersConfig::default(),
+            #[cfg(feature = "classifiers")]
+            pii_filter_enabled: false,
+            causal_ipi_config: zeph_sanitizer::causal_ipi::CausalIpiConfig::default(),
+            causal_provider: None,
+            nli_config: zeph_sanitizer::nli::NliConfig::default(),
+            nli_provider: None,
+            secret_registry: None,
+            vigil_config: zeph_config::VigilConfig::default(),
+            feedback_classifier: None,
         };
 
         let state = AppState {


### PR DESCRIPTION
## Summary

- `src/serve/agent_factory.rs` built every `/sessions*` `Agent` (the `zeph serve` HTTP/SSE path — the entry point most exposed to untrusted external input, spec-068 §9) without any of the ContentSanitizer pipeline (quarantine, guardrail, PII classifier/NER, three-class classifier, causal-IPI analyzer, NLI sanitizer, Vigil, secret masking) and without the ML injection classifier or `[classifiers].enforcement_mode`, even though `src/runner.rs`, `src/daemon.rs`, and `src/acp.rs` all applied this pipeline already. An operator who enabled hardening config (`[security.vigil]`, `[classifiers]`, secret masking, NLI, etc.) believing it covered every channel silently got none of it on Telegram/Discord/Slack sessions.
- Mirrors `src/acp.rs`'s `spawn_acp_agent`: snapshots the same sanitizer/classifier config and resolved providers into `ServeAgentDeps` during `assemble_serve_deps`, then wires them onto each session's `Agent` in `build_agent_factory` using the same `_with_cfg` helpers and ordering (enforcement-mode after the injection classifier; secret-masking last, since it retroactively wraps every already-set provider field).
- Widens 9 `SharedAgentDeps` fields in `src/acp.rs` to `pub(crate)` (visibility-only) and adds a parity regression test (`acp::tests::build_combined_deps_wires_equivalent_security_pipeline_from_config`) driving `build_combined_deps` against a non-default security config, asserting both `ServeAgentDeps` and `SharedAgentDeps` reflect the configured values.

Closes #6580
Closes #6582

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 14879 passed, 36 skipped, 0 failures
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `gitleaks protect --staged`
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] `.local/testing/playbooks/wire-x-acp-daemon-serve-6580-6582.md` added with concrete scenarios
- [x] `.local/testing/coverage-status.md` row added (status: Untested — pending a live `zeph serve-sessions` verification pass in a future CI session)
- [ ] Live-session verification against a running `zeph serve-sessions` (playbook scenarios) — tracked separately per project convention, not required to land this fix