### PR TITLE
fix(security): wire security controls into all agent entry points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   above when built from the same config via the real `build_combined_deps`, so a future PR that
   silently drops one of them fails a test instead of shipping unnoticed.
 
+- `zeph-tools`/`zeph-core`/`zeph-context`: three security- and fidelity-relevant controls were
+  wired only from `src/runner.rs` (the CLI/TUI entry point) and silently skipped by
+  `src/daemon.rs` (A2A/gateway daemon), `src/acp.rs` (ACP/IDE embedding), and
+  `src/serve/agent_factory.rs`/`src/serve/deps.rs` (Telegram/Discord/Slack multi-channel
+  serving) — the latest instances of a recurring "wire X into ACP/serve/daemon" defect class
+  (tracked in #6581, 23+ confirmed instances). `RiskChainAccumulator`, the shell executor's
+  multi-step attack-chain detector (`SensitiveRead` -> `NetworkEgress`, e.g.
+  `exfil_read_then_send`/`cred_then_egress`), was never constructed outside the CLI path, so
+  `ShellExecutor::execute`'s risk-chain check was a silent no-op in 3 of 4 deployment modes
+  (#6578). The MAGE shadow-memory trajectory risk gate (`mage_accumulator`,
+  `config.memory.shadow_memory`) stayed on `TrajectoryRiskAccumulator::new_noop()` outside the
+  CLI path, regressing previously-closed #4417 (#6579). Typed-page CAM fidelity enforcement
+  (`TypedPagesState`, `config.memory.compression.typed_pages`) was never built outside the CLI
+  path, so invariant enforcement/audit for compaction was unconditionally disabled elsewhere
+  (#6574). All three are now extracted into shared helpers in `src/agent_setup.rs`
+  (`wire_risk_chain`, `build_typed_pages_state`, `apply_entrypoint_security_controls`) called
+  identically from all four entry points, so a future dropped call site is a one-line diff
+  against a shared, tested helper rather than a silently-incomplete duplicated wiring block.
+
 - `zeph-core`: the vault-anchor reconcile sweep (`run_anchor_sweep`) hard-deleted a transcript/
   session anchor the instant its backing file was absent, with no grace period or persisted
   "was-anchored" record (#6462). Since file absence is attacker-controlled under this feature's

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -581,6 +581,24 @@ pub(crate) struct SharedAgentDeps {
     startup_shell_overlay: zeph_core::ShellOverlaySnapshot,
     /// Live-rebuild handle for the `ShellExecutor`'s `blocked_commands` policy.
     shell_policy_handle: zeph_tools::ShellPolicyHandle,
+    /// Shared multi-step shell attack-chain detector, attached to the shared `ShellExecutor`
+    /// above via `agent_setup::wire_risk_chain`. `spawn_acp_agent` passes the same `Arc` into
+    /// every session's `Agent::with_risk_chain_accumulator` via
+    /// `agent_setup::apply_entrypoint_security_controls` (#6578) — mirrors `src/runner.rs` and
+    /// `src/daemon.rs`. See `agent_setup::wire_risk_chain`'s doc comment for the cross-session
+    /// sharing caveat under concurrent ACP sessions on this connection.
+    risk_chain_accumulator: std::sync::Arc<zeph_tools::RiskChainAccumulator>,
+    /// Typed-page CAM fidelity state (#6574), built once per connection via
+    /// `agent_setup::build_typed_pages_state` since `[memory.compression.typed_pages]` is static
+    /// config. `spawn_acp_agent` clones the `Arc` into every session via
+    /// `agent_setup::apply_entrypoint_security_controls` — mirrors `src/runner.rs` and
+    /// `src/daemon.rs`.
+    typed_pages_state: Option<std::sync::Arc<zeph_context::typed_page::TypedPagesState>>,
+    /// `config.memory.shadow_memory` (#6579), wired into `Agent::with_mage_accumulator_config`
+    /// per session via `agent_setup::apply_entrypoint_security_controls` — mirrors
+    /// `src/runner.rs` and `src/daemon.rs`. Replaces the noop `TrajectoryRiskAccumulator` set by
+    /// `SecurityState::default()`.
+    shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig,
 
     // Scheduler runtime objects (broadcast senders; not config-derived values)
     /// Scheduler executor shared across sessions. Initialized once at startup.
@@ -816,6 +834,11 @@ async fn build_acp_deps(
         }
         acp_audit_logger = Some(logger);
     }
+    // #6578: wire the multi-step shell attack-chain detector, matching src/runner.rs's
+    // `agent_setup::build_tool_setup` — previously only the CLI/TUI path constructed a
+    // `RiskChainAccumulator`, so ACP sessions' `ShellExecutor` silently skipped the
+    // `SensitiveRead` -> `NetworkEgress` chain check entirely.
+    let (shell_executor, risk_chain_accumulator) = agent_setup::wire_risk_chain(shell_executor);
     let file_executor = zeph_tools::FileExecutor::new(
         config
             .tools
@@ -1132,6 +1155,12 @@ async fn build_acp_deps(
     // `provider_pool` too (previously left empty, breaking `resolve_background_provider`).
     let provider_config_snapshot = agent_setup::build_provider_config_snapshot(config);
     let acp_auth_clients = resolve_acp_auth_clients(&config.acp, app.vault()).await?;
+    // #6574: typed-page CAM fidelity enforcement, matching src/runner.rs and src/daemon.rs —
+    // previously only the CLI/TUI path built `TypedPagesState`, so ACP sessions' compaction
+    // pipeline silently skipped invariant enforcement/audit even when
+    // `[memory.compression.typed_pages] enabled = true`.
+    let typed_pages_state =
+        agent_setup::build_typed_pages_state(config, Some(&acp_mem_supervisor)).await;
 
     let deps = SharedAgentDeps {
         provider,
@@ -1320,6 +1349,9 @@ async fn build_acp_deps(
             zeph_core::ShellOverlaySnapshot { blocked, allowed }
         },
         shell_policy_handle,
+        risk_chain_accumulator,
+        typed_pages_state,
+        shadow_memory_config: config.memory.shadow_memory.clone(),
     };
 
     let keepalive: Box<dyn std::any::Any> = Box::new((skill_watcher, config_watcher));
@@ -1631,6 +1663,7 @@ async fn spawn_acp_agent(
     let nli_provider = d.nli_provider.clone();
     let secret_registry = d.secret_registry.clone();
     let vigil_config = d.vigil_config.clone();
+    let mage_accumulator_config = d.shadow_memory_config.clone();
     let probe_provider = d.probe_provider.clone();
     let planner_provider = d.planner_provider.clone();
     let verify_provider = d.verify_provider.clone();
@@ -2247,6 +2280,16 @@ async fn spawn_acp_agent(
     );
     agent = agent_setup::apply_secret_masking(agent, secret_registry);
     agent = agent_setup::apply_vigil(agent, &vigil_config);
+    // Risk-chain accumulator (#6578), MAGE trajectory-risk gate (#6579), typed-page CAM fidelity
+    // (#6574) — shared with src/runner.rs/src/daemon.rs/src/serve/agent_factory.rs via one call
+    // site so the three controls cannot silently drop out of sync across entry points again
+    // (#6581).
+    agent = agent_setup::apply_entrypoint_security_controls(
+        agent,
+        d.risk_chain_accumulator.clone(),
+        mage_accumulator_config.clone(),
+        d.typed_pages_state.clone(),
+    );
 
     if debug_config.enabled {
         // Use session_id as a subdirectory prefix so concurrent sessions never share the same

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -642,9 +642,7 @@ pub(crate) async fn build_tool_setup(
     if let Some(ref logger) = audit_logger {
         mcp_executor = mcp_executor.with_audit(Arc::clone(logger));
     }
-    let risk_chain_accumulator = Arc::new(zeph_tools::RiskChainAccumulator::new(None));
-    shell_executor = shell_executor.with_risk_chain(Arc::clone(&risk_chain_accumulator));
-    tracing::info!("security.risk_chain: RiskChainAccumulator wired to ShellExecutor");
+    let (shell_executor, risk_chain_accumulator) = wire_risk_chain(shell_executor);
     let shell_policy_handle = shell_executor.policy_handle();
     let shell_executor = Arc::new(shell_executor);
     let shell_executor_handle = Some(Arc::clone(&shell_executor));
@@ -689,6 +687,45 @@ pub(crate) async fn build_tool_setup(
         mcp_media_enabled,
         clock,
     }
+}
+
+/// Construct a [`zeph_tools::RiskChainAccumulator`] and attach it to `shell_executor` via
+/// `.with_risk_chain(...)`.
+///
+/// Every entry point that builds its own `ShellExecutor` (`runner.rs` via [`build_tool_setup`],
+/// `daemon.rs`, `acp.rs`, `serve/deps.rs`) must call this so the multi-step shell attack-chain
+/// detector (`SensitiveRead` -> `NetworkEgress`, e.g. `exfil_read_then_send`) is actually
+/// enforced — without it, `ShellExecutor::execute`'s risk-chain check is silently skipped
+/// (#6578). Pass the returned `Arc` to `Agent::with_risk_chain_accumulator` (via
+/// [`apply_entrypoint_security_controls`]) so `begin_turn()` resets the per-turn score at each
+/// turn boundary.
+///
+/// # Known limitation: cross-session sharing in ACP/serve
+///
+/// [`zeph_tools::RiskChainAccumulator`]'s own contract is "one instance per agent turn, reset at
+/// each turn boundary." `runner.rs` and `daemon.rs` satisfy this exactly (one agent per process).
+/// `acp.rs` and `serve/deps.rs`, however, call this function once per **connection**/**server**
+/// (because the underlying `ShellExecutor` itself is already shared at that scope, predating this
+/// fix) and then hand the *same* `Arc` to every concurrent session built on top of it. Since
+/// `Agent::begin_turn()` unconditionally calls `reset()` on whatever accumulator it holds, one
+/// session's turn boundary can wipe another concurrent session's mid-chain `SensitiveRead` state
+/// (false negative — silently defeats the very detector this function exists to wire in), and
+/// interleaved calls from different sessions can cross-combine into a spurious chain fire on an
+/// unrelated session (false positive). This is not a regression introduced here — these entry
+/// points had zero risk-chain detection before this fix — but it means the detector is not fully
+/// session-isolated under concurrent ACP/serve load. A real fix needs either a per-session
+/// `ShellExecutor` or routing `record()` calls through session-scoped state at call time; both are
+/// out of scope for this wiring-consistency fix (#6578/#6581).
+pub(crate) fn wire_risk_chain(
+    shell_executor: zeph_tools::ShellExecutor,
+) -> (
+    zeph_tools::ShellExecutor,
+    Arc<zeph_tools::RiskChainAccumulator>,
+) {
+    let risk_chain_accumulator = Arc::new(zeph_tools::RiskChainAccumulator::new(None));
+    let shell_executor = shell_executor.with_risk_chain(Arc::clone(&risk_chain_accumulator));
+    tracing::info!("security.risk_chain: RiskChainAccumulator wired to ShellExecutor");
+    (shell_executor, risk_chain_accumulator)
 }
 
 /// Wrap `inner` in a [`zeph_tools::CompressedExecutor`] when `cfg.enabled = true` and a DB pool
@@ -908,6 +945,104 @@ pub(crate) fn apply_guardrail<C: Channel>(
     } else {
         agent
     }
+}
+
+/// Build [`zeph_context::typed_page::TypedPagesState`] from config, or return `None` when disabled.
+///
+/// Opens the audit sink (async) before the synchronous agent builder chain so that
+/// [`zeph_context::typed_page::CompactionAuditSink::open`] can be awaited here.
+///
+/// # Security
+///
+/// `config.memory.compression.typed_pages.audit_path` is **operator-only trusted input** — it is
+/// read from the agent's configuration file, which already requires file-system write access.
+/// No canonicalization or prefix-check is performed because the threat model does not include
+/// less-privileged config editing. Do not propagate this path from end-user input.
+#[tracing::instrument(name = "agent_setup.build_typed_pages_state", skip_all)]
+pub(crate) async fn build_typed_pages_state(
+    config: &Config,
+    supervisor: Option<&zeph_common::TaskSupervisor>,
+) -> Option<Arc<zeph_context::typed_page::TypedPagesState>> {
+    use zeph_config::TypedPagesEnforcement;
+    use zeph_context::typed_page::{CompactionAuditSink, InvariantRegistry, TypedPagesState};
+
+    let tp_cfg = &config.memory.compression.typed_pages;
+    if !tp_cfg.enabled {
+        return None;
+    }
+
+    let audit_sink = if tp_cfg.audit_path.is_empty() {
+        // Derive a default audit path from the SQLite parent directory.
+        let default_path = Path::new(&config.memory.sqlite_path)
+            .parent()
+            .map(|p| p.join("audit").join("compaction.jsonl"));
+
+        if let Some(path) = default_path {
+            match CompactionAuditSink::open(&path, tp_cfg.audit_channel_capacity, supervisor).await
+            {
+                Ok(sink) => {
+                    tracing::info!(
+                        path = %path.display(),
+                        "typed-pages audit sink opened (default path)"
+                    );
+                    Some(sink)
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "typed-pages audit sink could not be opened at default path, audit disabled: {e:#}"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        }
+    } else {
+        let path = PathBuf::from(&tp_cfg.audit_path);
+        match CompactionAuditSink::open(&path, tp_cfg.audit_channel_capacity, supervisor).await {
+            Ok(sink) => {
+                tracing::info!(path = %path.display(), "typed-pages audit sink opened");
+                Some(sink)
+            }
+            Err(e) => {
+                tracing::warn!("typed-pages audit sink could not be opened, audit disabled: {e:#}");
+                None
+            }
+        }
+    };
+
+    let is_active = tp_cfg.enforcement == TypedPagesEnforcement::Active;
+    Some(Arc::new(TypedPagesState {
+        registry: InvariantRegistry::default(),
+        audit_sink,
+        is_active,
+    }))
+}
+
+/// Apply the three security/fidelity controls that must stay identical across every entry point:
+/// the shell risk-chain accumulator (#6578), the MAGE trajectory-risk gate (#6579), and typed-page
+/// CAM fidelity enforcement (#6574). Previously each was wired only in `runner.rs`'s CLI/TUI
+/// bootstrap and silently skipped by `daemon.rs`, `acp.rs`, and `serve/agent_factory.rs` — this
+/// helper is the single call site all four entry points share so the three controls cannot drift
+/// out of sync again (tracked defect class: `#6581`).
+///
+/// `risk_chain_accumulator` is the `Arc` returned by [`wire_risk_chain`] — the same instance
+/// attached to the entry point's `ShellExecutor`. `mage_accumulator_config` is
+/// `config.memory.shadow_memory.clone()`. `typed_pages_state` is the result of
+/// [`build_typed_pages_state`]. Takes the decomposed config value rather than `&Config` because
+/// `acp.rs`'s `SharedAgentDeps` never holds a full `Config` (it decomposes config into
+/// per-session fields at connection-build time) — matching that convention keeps the call site
+/// identical across all four entry points.
+pub(crate) fn apply_entrypoint_security_controls<C: Channel>(
+    agent: Agent<C>,
+    risk_chain_accumulator: Arc<zeph_tools::RiskChainAccumulator>,
+    mage_accumulator_config: zeph_config::TrajectoryRiskAccumulatorConfig,
+    typed_pages_state: Option<Arc<zeph_context::typed_page::TypedPagesState>>,
+) -> Agent<C> {
+    agent
+        .with_risk_chain_accumulator(risk_chain_accumulator)
+        .with_mage_accumulator_config(mage_accumulator_config)
+        .with_typed_pages_state(typed_pages_state)
 }
 
 /// Wire the `CandleClassifier` injection backend into the agent's sanitizer.
@@ -4176,6 +4311,99 @@ mod tests {
             names.contains("mem-hebbian-consolidation"),
             "status_tx=Some(...) must still register the hebbian-consolidation loop, got \
              {names:?}"
+        );
+    }
+
+    // --- #6578/#6579/#6574 entry-point security wiring regressions ---
+    //
+    // `Agent::services` (where `risk_chain_accumulator`/`mage_accumulator`/`typed_pages_state`
+    // actually live) is `pub(crate)` to `zeph-core`, not visible from this binary crate, so
+    // these tests cannot assert "the Agent now contains X" directly the way zeph-core's own
+    // `agent/tests/mage_signal_mapping_tests.rs` does. Instead they prove wiring via `Arc`
+    // strong-count: `wire_risk_chain`/`apply_entrypoint_security_controls` must retain a live
+    // clone of the accumulator/typed-pages `Arc`, not merely construct-and-discard it — the
+    // exact failure mode of the original bug (`ShellExecutor.risk_chain`/`AgentBuilder`'s
+    // security services silently staying `None`/noop when a call site is missing). Full
+    // integration coverage across daemon/acp/serve is impractical here (heavy bootstrap); the
+    // architectural defense is that all 4 entry points now call the same
+    // `apply_entrypoint_security_controls`/`wire_risk_chain` functions tested below, so a future
+    // dropped call site is a one-line diff against a shared, tested helper rather than a
+    // silently-incomplete duplicated wiring block.
+
+    /// #6578: `wire_risk_chain` must hand `ShellExecutor::with_risk_chain` a live clone of the
+    /// `Arc` it returns to the caller — a strong count that never rises above 1 would mean the
+    /// executor never actually retained the accumulator, reproducing the original defect where
+    /// `ShellExecutor.risk_chain` stayed `None` and the multi-step attack-chain check
+    /// (`SensitiveRead` -> `NetworkEgress`) was silently skipped.
+    #[test]
+    fn wire_risk_chain_attaches_the_returned_accumulator_to_the_executor() {
+        let shell_executor = zeph_tools::ShellExecutor::new(&zeph_tools::ShellConfig::default());
+        let (shell_executor, accumulator) = wire_risk_chain(shell_executor);
+        assert_eq!(
+            Arc::strong_count(&accumulator),
+            2,
+            "ShellExecutor::with_risk_chain must retain a clone of the accumulator it was \
+             given, not just construct-and-discard it"
+        );
+        drop(shell_executor);
+        assert_eq!(
+            Arc::strong_count(&accumulator),
+            1,
+            "dropping the wired ShellExecutor must release its clone of the accumulator"
+        );
+    }
+
+    /// #6578/#6574: `apply_entrypoint_security_controls` — the single call site all 4 entry
+    /// points (`runner.rs`, `daemon.rs`, `acp.rs`, `serve/agent_factory.rs`) now share — must
+    /// actually forward `risk_chain_accumulator` and `typed_pages_state` onto the `Agent` via
+    /// `with_risk_chain_accumulator`/`with_typed_pages_state`, not drop them on the floor.
+    /// `with_mage_accumulator_config` (#6579) constructs a fresh, non-`Arc` accumulator from the
+    /// config value, so it has no refcount to assert on here; exercising it below is a
+    /// panic/compile smoke check that the call happens at all — the accumulator's own
+    /// enabled/disabled behavior is covered by zeph-core's `mage_signal_mapping_tests.rs`.
+    #[test]
+    fn apply_entrypoint_security_controls_attaches_risk_chain_and_typed_pages() {
+        let agent = make_agent();
+        let risk_chain_accumulator = Arc::new(zeph_tools::RiskChainAccumulator::new(None));
+        let typed_pages_state = Arc::new(zeph_context::typed_page::TypedPagesState {
+            registry: zeph_context::typed_page::InvariantRegistry::default(),
+            audit_sink: None,
+            is_active: false,
+        });
+        assert_eq!(Arc::strong_count(&risk_chain_accumulator), 1);
+        assert_eq!(Arc::strong_count(&typed_pages_state), 1);
+
+        let agent = apply_entrypoint_security_controls(
+            agent,
+            Arc::clone(&risk_chain_accumulator),
+            zeph_config::TrajectoryRiskAccumulatorConfig::default(),
+            Some(Arc::clone(&typed_pages_state)),
+        );
+
+        assert_eq!(
+            Arc::strong_count(&risk_chain_accumulator),
+            2,
+            "apply_entrypoint_security_controls must store the accumulator on the Agent via \
+             with_risk_chain_accumulator (#6578) — a count that never rises above 1 reproduces \
+             the bug where 3 of 4 entry points silently skipped this wiring"
+        );
+        assert_eq!(
+            Arc::strong_count(&typed_pages_state),
+            2,
+            "apply_entrypoint_security_controls must store the state on the Agent via \
+             with_typed_pages_state (#6574) — a count that never rises above 1 reproduces the \
+             bug where 3 of 4 entry points silently skipped typed-page CAM fidelity enforcement"
+        );
+        drop(agent);
+        assert_eq!(
+            Arc::strong_count(&risk_chain_accumulator),
+            1,
+            "dropping the Agent must release its clone of the risk-chain accumulator"
+        );
+        assert_eq!(
+            Arc::strong_count(&typed_pages_state),
+            1,
+            "dropping the Agent must release its clone of the typed-pages state"
         );
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -360,11 +360,13 @@ impl zeph_a2a::TaskProcessor for AgentTaskProcessor {
 /// Deliberately its own struct, not merged with `crate::runner::BuildAgentDeps`: the daemon
 /// path wires `with_mcp`/`with_mcp_shared_tools`/`with_provider_pool` inline (the CLI path
 /// defers those to feature-gated chaining after `build_agent` returns, inside `run()`), and
-/// never wires session-sink, compression, typed-pages, autosave, shutdown-summary,
-/// compaction-provider, tiered-retrieval, or bare-mode config at all. Forcing both paths into
-/// one struct would need `None`/default placeholders for whichever fields the other path
-/// doesn't use, reintroducing the exact default-vs-omitted wiring-regression defect class this
-/// issue exists to catch.
+/// never wires session-sink, compression, autosave, shutdown-summary, compaction-provider,
+/// tiered-retrieval, or bare-mode config at all. Typed-pages state, the risk-chain accumulator,
+/// and the MAGE trajectory-risk gate are wired post-`build_daemon_agent` via
+/// `agent_setup::apply_entrypoint_security_controls`, not through this struct (#6574/#6578/
+/// #6579). Forcing both paths into one struct would need `None`/default placeholders for
+/// whichever fields the other path doesn't use, reintroducing the exact default-vs-omitted
+/// wiring-regression defect class this issue exists to catch.
 struct BuildDaemonAgentDeps<'a, F>
 where
     F: Fn() -> Vec<PathBuf> + Send + Sync + 'static,
@@ -735,6 +737,11 @@ pub(crate) async fn run_daemon(
         }
         daemon_audit_logger = Some(logger);
     }
+    // #6578: wire the multi-step shell attack-chain detector, matching src/runner.rs's
+    // `agent_setup::build_tool_setup` — previously only the CLI/TUI path constructed a
+    // `RiskChainAccumulator`, so the daemon's `ShellExecutor` silently skipped the
+    // `SensitiveRead` -> `NetworkEgress` chain check entirely.
+    let (shell_executor, risk_chain_accumulator) = agent_setup::wire_risk_chain(shell_executor);
     let file_executor = zeph_tools::FileExecutor::new(
         config
             .tools
@@ -1088,6 +1095,12 @@ pub(crate) async fn run_daemon(
         None
     };
 
+    // #6574: typed-page CAM fidelity enforcement, matching src/runner.rs — previously only the
+    // CLI/TUI path built `TypedPagesState`, so the daemon's compaction pipeline silently skipped
+    // invariant enforcement/audit even when `[memory.compression.typed_pages] enabled = true`.
+    let typed_pages_state =
+        agent_setup::build_typed_pages_state(config, Some(&task_supervisor)).await;
+
     let deps = BuildDaemonAgentDeps {
         config,
         provider: provider.clone(),
@@ -1114,6 +1127,17 @@ pub(crate) async fn run_daemon(
         clock,
     };
     let agent = Box::pin(build_daemon_agent(deps, loopback_channel)).await;
+
+    // Risk-chain accumulator (#6578), MAGE trajectory-risk gate (#6579), typed-page CAM fidelity
+    // (#6574) — shared with src/runner.rs/src/acp.rs/src/serve/agent_factory.rs via one call
+    // site so the three controls cannot silently drop out of sync across entry points again
+    // (#6581).
+    let agent = agent_setup::apply_entrypoint_security_controls(
+        agent,
+        risk_chain_accumulator,
+        config.memory.shadow_memory.clone(),
+        typed_pages_state,
+    );
 
     // #6022: wire code-RAG retrieval (static repo-map/IndexMcpServer injection plus automatic
     // per-turn code-context retrieval) — mirrors src/runner.rs. Previously the daemon only

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -150,78 +150,6 @@ fn check_legacy_artifact_paths(config: &Config) {
     }
 }
 
-/// Build [`zeph_context::typed_page::TypedPagesState`] from config, or return `None` when disabled.
-///
-/// Opens the audit sink (async) before the synchronous agent builder chain so that
-/// [`zeph_context::typed_page::CompactionAuditSink::open`] can be awaited here.
-///
-/// # Security
-///
-/// `config.memory.compression.typed_pages.audit_path` is **operator-only trusted input** — it is
-/// read from the agent's configuration file, which already requires file-system write access.
-/// No canonicalization or prefix-check is performed because the threat model does not include
-/// less-privileged config editing. Do not propagate this path from end-user input.
-#[tracing::instrument(name = "runner.build_typed_pages_state", skip_all)]
-async fn build_typed_pages_state(
-    config: &Config,
-    supervisor: Option<&zeph_common::TaskSupervisor>,
-) -> Option<std::sync::Arc<zeph_context::typed_page::TypedPagesState>> {
-    use zeph_config::TypedPagesEnforcement;
-    use zeph_context::typed_page::{CompactionAuditSink, InvariantRegistry, TypedPagesState};
-
-    let tp_cfg = &config.memory.compression.typed_pages;
-    if !tp_cfg.enabled {
-        return None;
-    }
-
-    let audit_sink = if tp_cfg.audit_path.is_empty() {
-        // Derive a default audit path from the SQLite parent directory.
-        let default_path = std::path::Path::new(&config.memory.sqlite_path)
-            .parent()
-            .map(|p| p.join("audit").join("compaction.jsonl"));
-
-        if let Some(path) = default_path {
-            match CompactionAuditSink::open(&path, tp_cfg.audit_channel_capacity, supervisor).await
-            {
-                Ok(sink) => {
-                    tracing::info!(
-                        path = %path.display(),
-                        "typed-pages audit sink opened (default path)"
-                    );
-                    Some(sink)
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "typed-pages audit sink could not be opened at default path, audit disabled: {e:#}"
-                    );
-                    None
-                }
-            }
-        } else {
-            None
-        }
-    } else {
-        let path = std::path::PathBuf::from(&tp_cfg.audit_path);
-        match CompactionAuditSink::open(&path, tp_cfg.audit_channel_capacity, supervisor).await {
-            Ok(sink) => {
-                tracing::info!(path = %path.display(), "typed-pages audit sink opened");
-                Some(sink)
-            }
-            Err(e) => {
-                tracing::warn!("typed-pages audit sink could not be opened, audit disabled: {e:#}");
-                None
-            }
-        }
-    };
-
-    let is_active = tp_cfg.enforcement == TypedPagesEnforcement::Active;
-    Some(std::sync::Arc::new(TypedPagesState {
-        registry: InvariantRegistry::default(),
-        audit_sink,
-        is_active,
-    }))
-}
-
 /// Merge on-disk logging config with the optional CLI `--log-file` override.
 ///
 /// Priority: CLI flag > config file > built-in defaults.
@@ -264,7 +192,6 @@ where
     memory: std::sync::Arc<zeph_memory::semantic::SemanticMemory>,
     conversation_id: zeph_memory::ConversationId,
     session_sink: Option<std::sync::Arc<zeph_agent_persistence::SessionSink>>,
-    typed_pages_state: Option<std::sync::Arc<zeph_context::typed_page::TypedPagesState>>,
     shutdown_rx: tokio::sync::watch::Receiver<bool>,
     config_path: std::path::PathBuf,
     config_reload_rx: tokio::sync::mpsc::Receiver<zeph_core::config_watcher::ConfigEvent>,
@@ -323,7 +250,6 @@ where
     .with_session_sink(deps.session_sink)
     .with_session_persistence_config(Some(config.session.clone()))
     .with_compression(config.memory.compression.clone())
-    .with_typed_pages_state(deps.typed_pages_state)
     .with_routing(config.memory.store_routing.clone())
     .with_shutdown(deps.shutdown_rx)
     .with_config_reload(deps.config_path, deps.config_reload_rx)
@@ -2679,8 +2605,10 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
     let channel = crate::gateway_spawn::GatewayChannel::new(channel, gateway_input_rx);
 
     // Build TypedPagesState if enabled (#3630). Done before the builder chain because
-    // CompactionAuditSink::open is async.
-    let typed_pages_state = build_typed_pages_state(config, Some(&*supervisor)).await;
+    // CompactionAuditSink::open is async. Applied post-`build_agent` via
+    // `agent_setup::apply_entrypoint_security_controls`, alongside the risk-chain and MAGE
+    // accumulator wiring, so all 4 entry points share one call site (#6574/#6578/#6579).
+    let typed_pages_state = agent_setup::build_typed_pages_state(config, Some(&*supervisor)).await;
 
     // Precompute before moving into `BuildAgentDeps` — mirrors the inline chain's prior
     // expression-argument evaluation order exactly.
@@ -2713,7 +2641,6 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
             memory: std::sync::Arc::clone(&memory),
             conversation_id,
             session_sink: session_sink.clone(),
-            typed_pages_state,
             shutdown_rx: shutdown_rx.clone(),
             config_path,
             config_reload_rx,
@@ -2814,9 +2741,15 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
     // `memory_executor` (wired above) so sanitize_tool_output's ratcheting is visible to
     // MemoryToolExecutor's confirmation check.
     let agent = agent.with_memory_consent_trust_slot(memory_consent_trust_slot);
-    let agent = agent.with_risk_chain_accumulator(tool_setup.risk_chain_accumulator);
-    // Wire MAGE accumulator from config — replaces the noop set by SecurityState::default().
-    let agent = agent.with_mage_accumulator_config(config.memory.shadow_memory.clone());
+    // Risk-chain accumulator (#6578), MAGE trajectory-risk gate (#6579), typed-page CAM fidelity
+    // (#6574) — shared with daemon.rs/acp.rs/serve/agent_factory.rs via one call site so the
+    // three controls cannot silently drop out of sync across entry points again (#6581).
+    let agent = agent_setup::apply_entrypoint_security_controls(
+        agent,
+        tool_setup.risk_chain_accumulator,
+        config.memory.shadow_memory.clone(),
+        typed_pages_state,
+    );
     // Spec 050 Phase 2: wire ShadowSentinel into agent so begin_turn() calls advance_turn().
     let agent = if let Some(sentinel) = shadow_sentinel_arc {
         agent.with_shadow_sentinel(sentinel)
@@ -4836,7 +4769,6 @@ mod tests {
             memory: std::sync::Arc::clone(&memory),
             conversation_id,
             session_sink: None,
-            typed_pages_state: None,
             shutdown_rx,
             config_path: std::path::PathBuf::new(),
             config_reload_rx,
@@ -4929,7 +4861,6 @@ mod tests {
             memory: std::sync::Arc::clone(&memory),
             conversation_id,
             session_sink: None,
-            typed_pages_state: None,
             shutdown_rx,
             config_path: std::path::PathBuf::new(),
             config_reload_rx,

--- a/src/serve/agent_factory.rs
+++ b/src/serve/agent_factory.rs
@@ -396,6 +396,16 @@ pub(crate) async fn build_agent_factory(
         // sanitize_tool_output's ratcheting is visible to MemoryToolExecutor's confirmation
         // check.
         agent = agent.with_memory_consent_trust_slot(memory_consent_trust_slot);
+        // Risk-chain accumulator (#6578), MAGE trajectory-risk gate (#6579), typed-page CAM
+        // fidelity (#6574) — shared with src/runner.rs/src/daemon.rs/src/acp.rs via one call
+        // site so the three controls cannot silently drop out of sync across entry points again
+        // (#6581).
+        agent = crate::agent_setup::apply_entrypoint_security_controls(
+            agent,
+            deps.risk_chain_accumulator,
+            deps.shadow_memory_config,
+            deps.typed_pages_state,
+        );
         if let Some(head) = rl_head {
             agent = agent.with_rl_head(head);
         }
@@ -1017,6 +1027,9 @@ mod tests {
             secret_registry: None,
             vigil_config: zeph_config::VigilConfig::default(),
             feedback_classifier: None,
+            risk_chain_accumulator: Arc::new(zeph_tools::RiskChainAccumulator::new(None)),
+            typed_pages_state: None,
+            shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
         };
 
         let (_, build_agent) =
@@ -1121,6 +1134,9 @@ mod tests {
             secret_registry: None,
             vigil_config: zeph_config::VigilConfig::default(),
             feedback_classifier: None,
+            risk_chain_accumulator: Arc::new(zeph_tools::RiskChainAccumulator::new(None)),
+            typed_pages_state: None,
+            shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
         };
 
         let (resume_banner, build_agent) =
@@ -1222,6 +1238,9 @@ mod tests {
             secret_registry: None,
             vigil_config: zeph_config::VigilConfig::default(),
             feedback_classifier: None,
+            risk_chain_accumulator: Arc::new(zeph_tools::RiskChainAccumulator::new(None)),
+            typed_pages_state: None,
+            shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
         };
 
         let (_, build_agent) =
@@ -1349,6 +1368,9 @@ mod tests {
             secret_registry: None,
             vigil_config: zeph_config::VigilConfig::default(),
             feedback_classifier: None,
+            risk_chain_accumulator: Arc::new(zeph_tools::RiskChainAccumulator::new(None)),
+            typed_pages_state: None,
+            shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
         };
 
         let (_, build_agent) =
@@ -1465,6 +1487,9 @@ mod tests {
             secret_registry: None,
             vigil_config: zeph_config::VigilConfig::default(),
             feedback_classifier: None,
+            risk_chain_accumulator: Arc::new(zeph_tools::RiskChainAccumulator::new(None)),
+            typed_pages_state: None,
+            shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
         };
 
         let (_, build_agent) =
@@ -1580,6 +1605,9 @@ mod tests {
             secret_registry: None,
             vigil_config: zeph_config::VigilConfig::default(),
             feedback_classifier: None,
+            risk_chain_accumulator: Arc::new(zeph_tools::RiskChainAccumulator::new(None)),
+            typed_pages_state: None,
+            shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
         };
 
         let (_, build_agent) =
@@ -1692,6 +1720,9 @@ mod tests {
             secret_registry: None,
             vigil_config: zeph_config::VigilConfig::default(),
             feedback_classifier: None,
+            risk_chain_accumulator: Arc::new(zeph_tools::RiskChainAccumulator::new(None)),
+            typed_pages_state: None,
+            shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
         };
 
         let (_, build_agent) =
@@ -1787,6 +1818,9 @@ mod tests {
             secret_registry: None,
             vigil_config: zeph_config::VigilConfig::default(),
             feedback_classifier: None,
+            risk_chain_accumulator: Arc::new(zeph_tools::RiskChainAccumulator::new(None)),
+            typed_pages_state: None,
+            shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
         }
     }
 

--- a/src/serve/deps.rs
+++ b/src/serve/deps.rs
@@ -205,6 +205,24 @@ pub(crate) struct ServeAgentDeps {
     /// `Agent::with_tools_enabled` so `[tools] enabled = false` actually suppresses tool
     /// definitions for `/sessions`-built agents, matching `runner.rs`/`daemon.rs`/`acp.rs`.
     pub(crate) tools_enabled: bool,
+    /// Shared multi-step shell attack-chain detector, attached to the shared `ShellExecutor`
+    /// inside `tool_executor` via `agent_setup::wire_risk_chain`. `agent_factory` passes the
+    /// same `Arc` into every session's `Agent::with_risk_chain_accumulator` via
+    /// `agent_setup::apply_entrypoint_security_controls` (#6578) — mirrors `src/runner.rs`,
+    /// `src/daemon.rs`, and `src/acp.rs`. See `agent_setup::wire_risk_chain`'s doc comment for
+    /// the cross-session sharing caveat under concurrent `/sessions*` load.
+    pub(crate) risk_chain_accumulator: Arc<zeph_tools::RiskChainAccumulator>,
+    /// Typed-page CAM fidelity state (#6574), built once at startup via
+    /// `agent_setup::build_typed_pages_state` since `[memory.compression.typed_pages]` is static
+    /// config. `agent_factory` clones the `Arc` into every session via
+    /// `agent_setup::apply_entrypoint_security_controls` — mirrors `src/runner.rs`,
+    /// `src/daemon.rs`, and `src/acp.rs`.
+    pub(crate) typed_pages_state: Option<Arc<zeph_context::typed_page::TypedPagesState>>,
+    /// `config.memory.shadow_memory` (#6579), wired into `Agent::with_mage_accumulator_config`
+    /// per session via `agent_setup::apply_entrypoint_security_controls` — mirrors
+    /// `src/runner.rs`, `src/daemon.rs`, and `src/acp.rs`. Replaces the noop
+    /// `TrajectoryRiskAccumulator` set by `SecurityState::default()`.
+    pub(crate) shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig,
 }
 
 /// Assemble [`ServeAgentDeps`] once at `zeph serve-sessions` startup, plus the resolved bearer
@@ -272,8 +290,14 @@ pub(crate) async fn assemble_serve_deps(
              this serve-sessions process (serve wires no hooks or MCP tools yet)"
         );
     }
-    let (tool_executor, permission_policy, audit_logger) =
+    let (tool_executor, permission_policy, audit_logger, risk_chain_accumulator) =
         build_tool_executor(config, supervisor).await?;
+    // #6574: typed-page CAM fidelity enforcement, matching src/runner.rs/src/daemon.rs/
+    // src/acp.rs — previously only the CLI/TUI path built `TypedPagesState`, so `/sessions`-
+    // built agents' compaction pipeline silently skipped invariant enforcement/audit even when
+    // `[memory.compression.typed_pages] enabled = true`.
+    let typed_pages_state =
+        crate::agent_setup::build_typed_pages_state(config, Some(supervisor)).await;
     // R2 (SEC-H1): built once, eagerly, here — its outputs (`PolicyEnforcer`/`PolicyValidator`/
     // `PolicyLlmClient` Arcs) are immutable and safe to share across sessions; this also keeps
     // the fallible/logging async prep (policy-file load, provider resolution) at server
@@ -596,6 +620,9 @@ pub(crate) async fn assemble_serve_deps(
             .map(PathBuf::from)
             .collect(),
         tools_enabled: config.tools.enabled,
+        risk_chain_accumulator,
+        typed_pages_state,
+        shadow_memory_config: config.memory.shadow_memory.clone(),
     })
 }
 
@@ -643,6 +670,7 @@ async fn build_tool_executor(
     Arc<dyn ErasedToolExecutor>,
     zeph_tools::PermissionPolicy,
     Option<Arc<zeph_tools::AuditLogger>>,
+    Arc<zeph_tools::RiskChainAccumulator>,
 )> {
     let permission_policy =
         zeph_tools::build_permission_policy(&config.tools, config.security.autonomy_level);
@@ -701,6 +729,12 @@ async fn build_tool_executor(
         }
         audit_logger = Some(logger);
     }
+    // #6578: wire the multi-step shell attack-chain detector, matching src/runner.rs's
+    // `agent_setup::build_tool_setup` — previously only the CLI/TUI path constructed a
+    // `RiskChainAccumulator`, so `/sessions`-built agents' `ShellExecutor` silently skipped the
+    // `SensitiveRead` -> `NetworkEgress` chain check entirely.
+    let (shell_executor, risk_chain_accumulator) =
+        crate::agent_setup::wire_risk_chain(shell_executor);
     let file_executor = zeph_tools::FileExecutor::new(
         config
             .tools
@@ -729,7 +763,12 @@ async fn build_tool_executor(
             ),
         ),
     ));
-    Ok((base, permission_policy, audit_logger))
+    Ok((
+        base,
+        permission_policy,
+        audit_logger,
+        risk_chain_accumulator,
+    ))
 }
 
 #[cfg(test)]

--- a/src/serve/handlers.rs
+++ b/src/serve/handlers.rs
@@ -621,6 +621,9 @@ mod tests {
             secret_registry: None,
             vigil_config: zeph_config::VigilConfig::default(),
             feedback_classifier: None,
+            risk_chain_accumulator: Arc::new(zeph_tools::RiskChainAccumulator::new(None)),
+            typed_pages_state: None,
+            shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
         };
         AppState {
             registry: Arc::new(LiveSessionRegistry::new()),

--- a/src/serve/test_support.rs
+++ b/src/serve/test_support.rs
@@ -167,6 +167,9 @@ impl ServeTestHarness {
             secret_registry: None,
             vigil_config: zeph_config::VigilConfig::default(),
             feedback_classifier: None,
+            risk_chain_accumulator: Arc::new(zeph_tools::RiskChainAccumulator::new(None)),
+            typed_pages_state: None,
+            shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
         };
 
         let state = AppState {


### PR DESCRIPTION
## Summary

Three security- and fidelity-relevant controls were wired only from `src/runner.rs` (the CLI/TUI entry point) and silently skipped in `src/daemon.rs` (A2A/gateway daemon), `src/acp.rs` (ACP/IDE embedding), and `src/serve/agent_factory.rs`/`src/serve/deps.rs` (Telegram/Discord/Slack multi-channel serving) — the latest instances of a recurring "wire X into ACP/serve/daemon" defect class tracked in #6581 (23+ confirmed instances).

- **`RiskChainAccumulator`** (#6578) — the shell executor's multi-step attack-chain detector (`SensitiveRead` -> `NetworkEgress`, e.g. `exfil_read_then_send`/`cred_then_egress`). Never constructed outside the CLI path, so `ShellExecutor::execute`'s risk-chain check was a silent no-op in 3 of 4 deployment modes.
- **MAGE shadow-memory trajectory risk gate** (`mage_accumulator`, #6579) — stayed on `TrajectoryRiskAccumulator::new_noop()` outside the CLI path, regressing previously-closed #4417.
- **Typed-page CAM fidelity enforcement** (`TypedPagesState`, #6574) — never built outside the CLI path, so invariant enforcement/audit for compaction was unconditionally disabled elsewhere.

All three are now extracted into shared helpers in `src/agent_setup.rs` (`wire_risk_chain`, `build_typed_pages_state`, `apply_entrypoint_security_controls`) called identically from all four entry points, so a future dropped call site is a one-line diff against a shared, tested helper rather than a silently-incomplete duplicated wiring block.

### Known limitation (documented, not fixed here)

In ACP and serve modes, `RiskChainAccumulator` is constructed once per connection/server and shared (same `Arc`) across all concurrent sessions. Since `Agent::begin_turn()` unconditionally resets its per-turn state, concurrent sessions can interfere with each other's detection state (false negative/positive, worst for multi-tenant serve). This is strictly better than the pre-fix state (no detection at all in these modes); true per-session isolation is out of scope for this wiring-consistency fix and is documented inline on `wire_risk_chain` and the relevant field docs. Follow-up issue to be filed for per-session isolation.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (14880 passed)
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace ...`)
- [x] New unit tests in `agent_setup.rs` verifying the shared helpers are exercised by production call sites (Arc strong-count based, given `Agent::services` is `pub(crate)` to `zeph-core`)
- [x] Independently verified: all 4 entry points call the same 3 shared helpers with identical argument shapes; config threading traced back to real operator config in each mode; same `RiskChainAccumulator` Arc shared between `ShellExecutor` and `Agent` so `begin_turn()` reset semantics hold; MAGE `enabled` flag still respected in all modes; `runner.rs` refactor confirmed behavior-preserving

Closes #6578
Closes #6579
Closes #6574