### PR TITLE
fix(bootstrap,durable): resolve vault CLI overrides across all key-material call sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,40 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   identically from all four entry points, so a future dropped call site is a one-line diff
   against a shared, tested helper rather than a silently-incomplete duplicated wiring block.
 
+- CLI-level `--vault-key`/`--vault-path` overrides were silently ignored by several vault-key
+  consumers that resolved secrets straight from `zeph_core::vault::default_vault_dir()` instead
+  of the same CLI-resolved location `doctor.rs`/`vault.rs` already use post-#6499 (#6547, #6548).
+  The history-chain integrity bootstrap (`configure_history_integrity`, formerly
+  `configure_history_integrity_from_default_vault`, in `src/runner.rs`) resolved
+  `ZEPH_HISTORY_KEY` from the default vault unconditionally, so `zeph doctor`'s
+  `integrity.anchor` check could report OK against an override vault while the real runtime
+  writer never looked at it — hash-chain tamper-evidence was silently inactive whenever a
+  non-default vault location was used (#6547). The four `zeph durable` key-material loaders
+  (`load_write_hwm_key`, `load_write_hmac_key`, `load_integrity_seal`, `load_write_cipher` in
+  `src/commands/durable.rs`) had the identical hardcoded pattern with no override parameter in
+  any of their signatures (#6548); fixing them required threading the resolved paths through
+  their shared callees (`load_durable_cipher`, `load_control_hmac_key`, `open_backend`) and
+  through the `zeph durable` CLI dispatch (`handle_durable_command`, previously the only
+  subcommand handler that didn't already forward `--vault`/`--vault-key`/`--vault-path`,
+  unlike `zeph bench`). `zeph durable rotate-key` (`handle_rotate_key`/`handle_open_window`/
+  `handle_drop_previous`) had the identical hardcoded-`default_vault_dir()` pattern for its
+  own vault read+write — not just a loader call, so it needed the resolved paths threaded
+  through its own signature — closing a within-subcommand inconsistency where `zeph durable
+  seal-integrity --vault-key X` would already honor the override while `zeph durable
+  rotate-key --vault-key X` silently targeted the default vault instead. The same gap existed
+  in the scheduler daemon
+  (`src/commands/scheduler_daemon.rs`): `zeph serve --foreground` never threaded the override
+  into `build_durable_adapter`, and the non-foreground path re-exec'd its detached child with
+  only `--config`, dropping `--vault-key`/`--vault-path` entirely for the long-running daemon
+  process. The detach re-exec's argument-construction logic is now split into a standalone
+  `build_detach_args` helper so the `--vault`/`--vault-key`/`--vault-path` forwarding is
+  independently unit-testable without spawning a process. Added
+  `crate::bootstrap::resolve_vault_paths` (`src/bootstrap/config.rs`) as the shared
+  CLI-override-aware path resolver (wrapping `parse_vault_args`, falling back to
+  `default_vault_dir()` only when no override is given or resolution fails) so every consumer
+  resolves the vault location identically. Behavior is unchanged when no `--vault-key`/
+  `--vault-path` override is passed.
+
 - `zeph-core`: the vault-anchor reconcile sweep (`run_anchor_sweep`) hard-deleted a transcript/
   session anchor the instant its backing file was absent, with no grace period or persisted
   "was-anchored" record (#6462). Since file absence is attacker-controlled under this feature's

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -150,6 +150,37 @@ pub fn parse_vault_args(
     })
 }
 
+/// Resolve the CLI-overridable vault key/vault-file paths as concrete [`PathBuf`]s, falling back
+/// to `default_vault_dir()` when no `--vault-key`/`--vault-path` override is given (or
+/// `parse_vault_args` fails, e.g. an unrecognized `--vault` backend, or the resolved backend is
+/// not `age`).
+///
+/// Never fails the caller — mirrors the graceful-degrade posture every vault-key consumer in this
+/// codebase already commits to (an absent or misconfigured vault disables the dependent feature
+/// for this run rather than aborting startup).
+///
+/// Shared by every vault-key consumer that resolves paths outside of full `AppBuilder`
+/// construction — the history-chain integrity bootstrap (`runner.rs`) and the `zeph durable`
+/// key-material loaders (`commands/durable.rs`) — so `--vault-key`/`--vault-path` overrides are
+/// honored consistently everywhere a key is loaded, matching the resolution `doctor.rs`/`vault.rs`
+/// already use post-#6499 (#6547, #6548).
+pub fn resolve_vault_paths(
+    config: &Config,
+    cli_backend: Option<&str>,
+    cli_key_path: Option<&Path>,
+    cli_vault_path: Option<&Path>,
+) -> (PathBuf, PathBuf) {
+    let default_dir = zeph_core::vault::default_vault_dir();
+    let (resolved_key, resolved_vault) =
+        parse_vault_args(config, cli_backend, cli_key_path, cli_vault_path)
+            .map(|va| (va.key_path, va.vault_path))
+            .unwrap_or_default();
+    (
+        resolved_key.map_or_else(|| default_dir.join("vault-key.txt"), PathBuf::from),
+        resolved_vault.map_or_else(|| default_dir.join("secrets.age"), PathBuf::from),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -10,7 +10,9 @@ pub mod oauth;
 pub mod provider;
 pub mod skills;
 
-pub use config::{load_config_or_default, parse_vault_args, resolve_config_path};
+pub use config::{
+    load_config_or_default, parse_vault_args, resolve_config_path, resolve_vault_paths,
+};
 pub use health::{health_check, warmup_provider};
 pub use mcp::{create_mcp_manager_with_vault, create_mcp_registry, wire_trust_calibration};
 pub use oauth::VaultCredentialStore;

--- a/src/bootstrap/tests.rs
+++ b/src/bootstrap/tests.rs
@@ -148,6 +148,69 @@ fn resolve_config_path_default() {
 }
 
 #[test]
+fn resolve_vault_paths_cli_override_takes_precedence() {
+    // #6547/#6548: --vault-key/--vault-path must win over default_vault_dir(), the same
+    // resolution doctor.rs/vault.rs already use post-#6499.
+    let config = Config::load(Path::new("/nonexistent")).unwrap();
+    let (key_path, vault_path) = resolve_vault_paths(
+        &config,
+        None,
+        Some(Path::new("/cli/vault-key.txt")),
+        Some(Path::new("/cli/secrets.age")),
+    );
+    assert_eq!(key_path, PathBuf::from("/cli/vault-key.txt"));
+    assert_eq!(vault_path, PathBuf::from("/cli/secrets.age"));
+    let default_dir = zeph_core::vault::default_vault_dir();
+    assert_ne!(
+        key_path,
+        default_dir.join("vault-key.txt"),
+        "an explicit --vault-key override must not silently collapse to default_vault_dir()"
+    );
+}
+
+#[test]
+fn resolve_vault_paths_falls_back_to_default_vault_dir_when_no_override() {
+    // Behavior must be unchanged from pre-#6547/#6548 when no CLI override is given.
+    let config = Config::load(Path::new("/nonexistent")).unwrap();
+    let (key_path, vault_path) = resolve_vault_paths(&config, None, None, None);
+    let default_dir = zeph_core::vault::default_vault_dir();
+    assert_eq!(key_path, default_dir.join("vault-key.txt"));
+    assert_eq!(vault_path, default_dir.join("secrets.age"));
+}
+
+#[test]
+fn resolve_vault_paths_mixed_single_flag_overrides_are_independent() {
+    // Each of --vault-key/--vault-path is resolved independently (per parse_vault_args), so
+    // passing only one must not force the other to fall back too, and vice versa.
+    let config = Config::load(Path::new("/nonexistent")).unwrap();
+    let default_dir = zeph_core::vault::default_vault_dir();
+
+    let (key_path, vault_path) =
+        resolve_vault_paths(&config, None, Some(Path::new("/cli/vault-key.txt")), None);
+    assert_eq!(key_path, PathBuf::from("/cli/vault-key.txt"));
+    assert_eq!(vault_path, default_dir.join("secrets.age"));
+
+    let (key_path, vault_path) =
+        resolve_vault_paths(&config, None, None, Some(Path::new("/cli/secrets.age")));
+    assert_eq!(key_path, default_dir.join("vault-key.txt"));
+    assert_eq!(vault_path, PathBuf::from("/cli/secrets.age"));
+}
+
+#[test]
+#[serial_test::serial]
+fn resolve_vault_paths_unknown_backend_gracefully_falls_back_to_default_vault_dir() {
+    // parse_vault_args fails on an unrecognized --vault value; resolve_vault_paths must never
+    // propagate that failure (every caller of this helper degrades gracefully rather than
+    // aborting startup on a vault misconfiguration).
+    let config = Config::load(Path::new("/nonexistent")).unwrap();
+    let (key_path, vault_path) =
+        resolve_vault_paths(&config, Some("not-a-real-backend"), None, None);
+    let default_dir = zeph_core::vault::default_vault_dir();
+    assert_eq!(key_path, default_dir.join("vault-key.txt"));
+    assert_eq!(vault_path, default_dir.join("secrets.age"));
+}
+
+#[test]
 fn vault_args_struct_env_backend() {
     let args = VaultArgs {
         backend: zeph_config::VaultBackend::Env,

--- a/src/commands/durable.rs
+++ b/src/commands/durable.rs
@@ -141,9 +141,12 @@ pub(crate) fn enforce_encryption_gate(
 ///
 /// Returns an error if the vault cannot be loaded, `ZEPH_DURABLE_KEY` is absent or malformed, or
 /// `previous_key_id` is set but `ZEPH_DURABLE_KEY_PREVIOUS` is missing or malformed.
-fn load_durable_cipher(config: &DurableConfig) -> anyhow::Result<XChaCha20Poly1305Cipher> {
-    let dir = zeph_core::vault::default_vault_dir();
-    let provider = AgeVaultProvider::load(&dir.join("vault-key.txt"), &dir.join("secrets.age"))
+fn load_durable_cipher(
+    config: &DurableConfig,
+    key_path: &Path,
+    vault_path: &Path,
+) -> anyhow::Result<XChaCha20Poly1305Cipher> {
+    let provider = AgeVaultProvider::load(key_path, vault_path)
         .map_err(|e| anyhow::anyhow!("failed to load vault: {e}"))?;
     let key = provider.get(CURRENT_KEY_VAULT_NAME).ok_or_else(|| {
         anyhow::anyhow!("{CURRENT_KEY_VAULT_NAME} not found in vault; cannot --reveal payloads")
@@ -196,12 +199,13 @@ pub(crate) struct ControlHmacKeys {
 fn load_control_hmac_key(
     config: &zeph_core::config::DurableConfig,
     url: &str,
+    key_path: &Path,
+    vault_path: &Path,
 ) -> anyhow::Result<ControlHmacKeys> {
     if !is_shared_db(config, url) {
         return Ok(ControlHmacKeys::default());
     }
-    let dir = zeph_core::vault::default_vault_dir();
-    let provider = AgeVaultProvider::load(&dir.join("vault-key.txt"), &dir.join("secrets.age"))
+    let provider = AgeVaultProvider::load(key_path, vault_path)
         .map_err(|e| anyhow::anyhow!("failed to load vault: {e}"))?;
     let key = provider.get(CURRENT_KEY_VAULT_NAME).ok_or_else(|| {
         anyhow::anyhow!(
@@ -249,9 +253,13 @@ fn load_control_hmac_key(
 /// Returns an error when this deployment is a shared database and `ZEPH_DURABLE_KEY` cannot be
 /// resolved from the vault, or a rotation window is declared but `ZEPH_DURABLE_KEY_PREVIOUS`
 /// cannot be resolved.
-pub(crate) fn load_write_hmac_key(config: &Config) -> anyhow::Result<ControlHmacKeys> {
+pub(crate) fn load_write_hmac_key(
+    config: &Config,
+    key_path: &Path,
+    vault_path: &Path,
+) -> anyhow::Result<ControlHmacKeys> {
     let url = resolve_durable_db_url(config);
-    load_control_hmac_key(&config.durable, &url)
+    load_control_hmac_key(&config.durable, &url, key_path, vault_path)
 }
 
 /// One high-water-mark key, addressed by its non-secret rotation epoch (FR-008) — the loader-side
@@ -300,10 +308,12 @@ pub(crate) struct HwmKeys {
 ///
 /// Returns an error when `ZEPH_DURABLE_KEY` resolves but fails to decode, or a rotation window is
 /// declared but `ZEPH_DURABLE_KEY_PREVIOUS` cannot be resolved or decoded.
-pub(crate) fn load_write_hwm_key(config: &Config) -> anyhow::Result<HwmKeys> {
-    let dir = zeph_core::vault::default_vault_dir();
-    let Ok(provider) = AgeVaultProvider::load(&dir.join("vault-key.txt"), &dir.join("secrets.age"))
-    else {
+pub(crate) fn load_write_hwm_key(
+    config: &Config,
+    key_path: &Path,
+    vault_path: &Path,
+) -> anyhow::Result<HwmKeys> {
+    let Ok(provider) = AgeVaultProvider::load(key_path, vault_path) else {
         return Ok(HwmKeys::default());
     };
     let Some(key) = provider.get(CURRENT_KEY_VAULT_NAME) else {
@@ -350,10 +360,10 @@ pub(crate) fn load_write_hwm_key(config: &Config) -> anyhow::Result<HwmKeys> {
 /// (migration posture unchanged), never a hard-fail of bootstrap.
 pub(crate) fn load_integrity_seal(
     _config: &Config,
+    key_path: &Path,
+    vault_path: &Path,
 ) -> (bool, std::collections::HashSet<zeph_durable::ExecutionId>) {
-    let dir = zeph_core::vault::default_vault_dir();
-    let Ok(provider) = AgeVaultProvider::load(&dir.join("vault-key.txt"), &dir.join("secrets.age"))
-    else {
+    let Ok(provider) = AgeVaultProvider::load(key_path, vault_path) else {
         return (false, std::collections::HashSet::new());
     };
     zeph_core::anchor_store::load_durable_integrity_seal(&provider)
@@ -373,6 +383,8 @@ pub(crate) fn load_integrity_seal(
 /// path must never silently persist plaintext while the config declares payloads encrypted.
 pub(crate) fn load_write_cipher(
     config: &Config,
+    key_path: &Path,
+    vault_path: &Path,
 ) -> anyhow::Result<Option<Arc<dyn zeph_durable::PayloadCipher>>> {
     let url = resolve_durable_db_url(config);
     enforce_encryption_gate(&config.durable, &url)?;
@@ -380,7 +392,7 @@ pub(crate) fn load_write_cipher(
     if !config.durable.encrypt_payload {
         return Ok(None);
     }
-    let cipher = load_durable_cipher(&config.durable)?;
+    let cipher = load_durable_cipher(&config.durable, key_path, vault_path)?;
     Ok(Some(Arc::new(cipher)))
 }
 
@@ -410,11 +422,16 @@ pub(crate) fn load_write_cipher(
 ///
 /// Returns `Ok(None)` when no journal file exists yet (a friendly signal that durable execution has
 /// not run on this deployment), so the caller can print guidance instead of creating an empty file.
-async fn open_backend(config: &Config, reveal: bool) -> anyhow::Result<Option<LocalBackend>> {
+async fn open_backend(
+    config: &Config,
+    reveal: bool,
+    key_path: &Path,
+    vault_path: &Path,
+) -> anyhow::Result<Option<LocalBackend>> {
     let url = resolve_durable_db_url(config);
     enforce_encryption_gate(&config.durable, &url)?;
-    let hmac_keys = load_control_hmac_key(&config.durable, &url)?;
-    let hwm_keys = load_write_hwm_key(config)?;
+    let hmac_keys = load_control_hmac_key(&config.durable, &url, key_path, vault_path)?;
+    let hwm_keys = load_write_hwm_key(config, key_path, vault_path)?;
     if url != ":memory:" && !Path::new(&url).exists() {
         println!(
             "No durable journal at {url}.\n\
@@ -450,7 +467,7 @@ async fn open_backend(config: &Config, reveal: bool) -> anyhow::Result<Option<Lo
         backend
     };
     if reveal && config.durable.encrypt_payload {
-        let cipher = load_durable_cipher(&config.durable)?;
+        let cipher = load_durable_cipher(&config.durable, key_path, vault_path)?;
         Ok(Some(backend.with_cipher(Arc::new(cipher))))
     } else {
         Ok(Some(backend))
@@ -470,21 +487,43 @@ async fn open_backend(config: &Config, reveal: bool) -> anyhow::Result<Option<Lo
 pub(crate) async fn handle_durable_command(
     cmd: DurableCommand,
     config_path: Option<&Path>,
+    vault_override: Option<&str>,
+    vault_key_override: Option<&Path>,
+    vault_path_override: Option<&Path>,
 ) -> anyhow::Result<()> {
     // Boxed so every caller's own future only holds a thin `Pin<Box<dyn Future>>` rather than
     // this function's full match-arm state machine inline — with `ControlHmacKeys` threaded
     // through several branches (#6451), the inlined future crossed clippy's `large_futures`
     // budget at essentially every call site.
-    Box::pin(handle_durable_command_inner(cmd, config_path)).await
+    Box::pin(handle_durable_command_inner(
+        cmd,
+        config_path,
+        vault_override,
+        vault_key_override,
+        vault_path_override,
+    ))
+    .await
 }
 
 #[allow(clippy::too_many_lines)]
 async fn handle_durable_command_inner(
     cmd: DurableCommand,
     config_path: Option<&Path>,
+    vault_override: Option<&str>,
+    vault_key_override: Option<&Path>,
+    vault_path_override: Option<&Path>,
 ) -> anyhow::Result<()> {
     let config_file = crate::bootstrap::resolve_config_path(config_path);
     let config = load_config_or_default(&config_file);
+    // CLI-resolved vault key/secrets-file paths (--vault-key/--vault-path overrides, falling
+    // back to default_vault_dir()) — see `crate::bootstrap::resolve_vault_paths` (#6548). Shared
+    // by every key-material loader this command dispatches to below.
+    let (vault_key_path, vault_secrets_path) = crate::bootstrap::resolve_vault_paths(
+        &config,
+        vault_override,
+        vault_key_override,
+        vault_path_override,
+    );
 
     match cmd {
         DurableCommand::List {
@@ -493,7 +532,9 @@ async fn handle_durable_command_inner(
             limit,
             json,
         } => {
-            let Some(backend) = open_backend(&config, false).await? else {
+            let Some(backend) =
+                open_backend(&config, false, &vault_key_path, &vault_secrets_path).await?
+            else {
                 return Ok(());
             };
             let rows = backend
@@ -532,7 +573,9 @@ async fn handle_durable_command_inner(
         DurableCommand::Show { id, reveal, json } => {
             let exec = ExecutionId::parse_str(&id)
                 .map_err(|e| anyhow::anyhow!("invalid execution id '{id}': {e}"))?;
-            let Some(backend) = open_backend(&config, reveal).await? else {
+            let Some(backend) =
+                open_backend(&config, reveal, &vault_key_path, &vault_secrets_path).await?
+            else {
                 return Ok(());
             };
             show_entries(&backend, exec, reveal, None, json).await?;
@@ -546,14 +589,18 @@ async fn handle_durable_command_inner(
         } => {
             let exec = ExecutionId::parse_str(&id)
                 .map_err(|e| anyhow::anyhow!("invalid execution id '{id}': {e}"))?;
-            let Some(backend) = open_backend(&config, reveal).await? else {
+            let Some(backend) =
+                open_backend(&config, reveal, &vault_key_path, &vault_secrets_path).await?
+            else {
                 return Ok(());
             };
             show_entries(&backend, exec, reveal, Some(step), json).await?;
         }
 
         DurableCommand::Prune { dry_run } => {
-            let Some(backend) = open_backend(&config, false).await? else {
+            let Some(backend) =
+                open_backend(&config, false, &vault_key_path, &vault_secrets_path).await?
+            else {
                 return Ok(());
             };
             let policy = &config.durable.retention;
@@ -585,7 +632,9 @@ async fn handle_durable_command_inner(
         DurableCommand::Resume { id } => {
             let exec = ExecutionId::parse_str(&id)
                 .map_err(|e| anyhow::anyhow!("invalid execution id '{id}': {e}"))?;
-            let Some(backend) = open_backend(&config, false).await? else {
+            let Some(backend) =
+                open_backend(&config, false, &vault_key_path, &vault_secrets_path).await?
+            else {
                 return Ok(());
             };
             // FR-011: a canceled execution is refused distinctly, before the generic
@@ -621,7 +670,9 @@ async fn handle_durable_command_inner(
         DurableCommand::Cancel { id } => {
             let exec = ExecutionId::parse_str(&id)
                 .map_err(|e| anyhow::anyhow!("invalid execution id '{id}': {e}"))?;
-            let Some(backend) = open_backend(&config, false).await? else {
+            let Some(backend) =
+                open_backend(&config, false, &vault_key_path, &vault_secrets_path).await?
+            else {
                 return Ok(());
             };
             let outcome = backend
@@ -672,6 +723,8 @@ async fn handle_durable_command_inner(
                     drop_previous,
                     force,
                 },
+                &vault_key_path,
+                &vault_secrets_path,
             )
             .await?;
         }
@@ -680,7 +733,14 @@ async fn handle_durable_command_inner(
             grandfather,
             dry_run,
         } => {
-            handle_seal_integrity(&config, &grandfather, dry_run).await?;
+            handle_seal_integrity(
+                &config,
+                &grandfather,
+                dry_run,
+                &vault_key_path,
+                &vault_secrets_path,
+            )
+            .await?;
         }
     }
 
@@ -700,8 +760,10 @@ async fn handle_seal_integrity(
     config: &Config,
     grandfather: &[String],
     dry_run: bool,
+    key_path: &Path,
+    vault_path: &Path,
 ) -> anyhow::Result<()> {
-    let Some(backend) = open_backend(config, false).await? else {
+    let Some(backend) = open_backend(config, false, key_path, vault_path).await? else {
         anyhow::bail!("no durable journal found; nothing to seal");
     };
 
@@ -747,16 +809,14 @@ async fn handle_seal_integrity(
         return Ok(());
     }
 
-    let dir = zeph_core::vault::default_vault_dir();
-    let key_path = dir.join("vault-key.txt");
-    let vault_path = dir.join("secrets.age");
     if !key_path.exists() || !vault_path.exists() {
         anyhow::bail!(
-            "no age vault found at {}; run `zeph --init` first",
-            dir.display()
+            "no age vault found (key: {}, vault: {}); run `zeph --init` first",
+            key_path.display(),
+            vault_path.display()
         );
     }
-    let mut provider = AgeVaultProvider::load(&key_path, &vault_path)
+    let mut provider = AgeVaultProvider::load(key_path, vault_path)
         .map_err(|e| anyhow::anyhow!("failed to load vault: {e}"))?;
 
     if !grandfather_ids.is_empty() {
@@ -837,18 +897,18 @@ async fn handle_rotate_key(
     config_file: &Path,
     config: &Config,
     opts: RotateKeyOptions,
+    key_path: &Path,
+    vault_path: &Path,
 ) -> anyhow::Result<()> {
-    let dir = zeph_core::vault::default_vault_dir();
-    let key_path = dir.join("vault-key.txt");
-    let vault_path = dir.join("secrets.age");
     if !key_path.exists() || !vault_path.exists() {
         anyhow::bail!(
-            "no age vault found at {}; run `zeph --init` first to generate \
+            "no age vault found (key: {}, vault: {}); run `zeph --init` first to generate \
              {CURRENT_KEY_VAULT_NAME}",
-            dir.display()
+            key_path.display(),
+            vault_path.display()
         );
     }
-    let mut provider = AgeVaultProvider::load(&key_path, &vault_path)
+    let mut provider = AgeVaultProvider::load(key_path, vault_path)
         .map_err(|e| anyhow::anyhow!("failed to load vault: {e}"))?;
 
     // Partial-state (XOR) detector — MANDATORY, before any write. See the doc comment above.
@@ -882,9 +942,17 @@ async fn handle_rotate_key(
     }
 
     if opts.drop_previous {
-        handle_drop_previous(config_file, config, &mut provider, opts.dry_run, opts.force).await
+        handle_drop_previous(
+            config_file,
+            config,
+            &mut provider,
+            opts.dry_run,
+            opts.force,
+            vault_path,
+        )
+        .await
     } else {
-        handle_open_window(config_file, config, &mut provider, opts.dry_run)
+        handle_open_window(config_file, config, &mut provider, opts.dry_run, vault_path)
     }
 }
 
@@ -905,6 +973,7 @@ fn handle_open_window(
     config: &Config,
     provider: &mut AgeVaultProvider,
     dry_run: bool,
+    vault_path: &Path,
 ) -> anyhow::Result<()> {
     // R2 — refuse to open a second window; the cipher's single previous-key slot cannot hold two.
     if let Some(prev_id) = config.durable.previous_key_id {
@@ -922,7 +991,6 @@ fn handle_open_window(
     let old_key_id = config.durable.key_id;
     let new_key_id = old_key_id.wrapping_add(1);
 
-    let vault_path = zeph_core::vault::default_vault_dir().join("secrets.age");
     if dry_run {
         println!(
             "DRY RUN -- no changes written.\n\
@@ -1040,6 +1108,7 @@ async fn handle_drop_previous(
     provider: &mut AgeVaultProvider,
     dry_run: bool,
     force: bool,
+    vault_path: &Path,
 ) -> anyhow::Result<()> {
     let Some(previous_key_id) = config.durable.previous_key_id else {
         println!("No rotation window is open; nothing to drop.");
@@ -1125,7 +1194,6 @@ async fn handle_drop_previous(
         }
     }
 
-    let vault_path = zeph_core::vault::default_vault_dir().join("secrets.age");
     if dry_run {
         println!(
             "DRY RUN -- no changes written.\n\
@@ -1495,9 +1563,15 @@ mod tests {
         let url = resolve_durable_db_url(&config);
         std::fs::write(&url, []).unwrap();
 
-        let backend = open_backend(&config, true)
-            .await
-            .expect("--reveal must succeed without ZEPH_DURABLE_KEY when encrypt_payload=false");
+        let vault_dir = zeph_core::vault::default_vault_dir();
+        let backend = open_backend(
+            &config,
+            true,
+            &vault_dir.join("vault-key.txt"),
+            &vault_dir.join("secrets.age"),
+        )
+        .await
+        .expect("--reveal must succeed without ZEPH_DURABLE_KEY when encrypt_payload=false");
         assert!(backend.is_some());
     }
 
@@ -1518,14 +1592,27 @@ mod tests {
         let url = resolve_durable_db_url(&config);
         std::fs::write(&url, []).unwrap();
 
-        let result = open_backend(&config, false).await;
+        let vault_dir = zeph_core::vault::default_vault_dir();
+        let result = open_backend(
+            &config,
+            false,
+            &vault_dir.join("vault-key.txt"),
+            &vault_dir.join("secrets.age"),
+        )
+        .await;
         assert!(
             result.is_err(),
             "open_backend must fail closed for encrypt_payload=false on a declared shared_db (INV-8)"
         );
 
         // Also rejected on the --reveal path, before any decryption is even attempted.
-        let reveal_result = open_backend(&config, true).await;
+        let reveal_result = open_backend(
+            &config,
+            true,
+            &vault_dir.join("vault-key.txt"),
+            &vault_dir.join("secrets.age"),
+        )
+        .await;
         assert!(
             reveal_result.is_err(),
             "open_backend --reveal must fail closed for the same forbidden combination"
@@ -1554,7 +1641,13 @@ mod tests {
             std::env::set_var("XDG_CONFIG_HOME", vault_dir.path());
         }
 
-        let result = open_backend(&config, true).await;
+        let result = open_backend(
+            &config,
+            true,
+            &vault_dir.path().join("vault-key.txt"),
+            &vault_dir.path().join("secrets.age"),
+        )
+        .await;
 
         unsafe {
             match &prev_xdg {
@@ -1614,9 +1707,13 @@ mod tests {
         provider.save().unwrap();
 
         // Exercise the exact glue the write paths (runner.rs, scheduler_daemon.rs) call.
-        let cipher = load_write_cipher(&config)
-            .expect("cipher load must succeed with a real vault key")
-            .expect("encrypt_payload=true must produce a cipher");
+        let cipher = load_write_cipher(
+            &config,
+            &vault_root.join("vault-key.txt"),
+            &vault_root.join("secrets.age"),
+        )
+        .expect("cipher load must succeed with a real vault key")
+        .expect("encrypt_payload=true must produce a cipher");
 
         let url = resolve_durable_db_url(&config);
         let backend = LocalBackend::open(&url, config.durable.max_payload_bytes)
@@ -1691,8 +1788,14 @@ mod tests {
         let mut config = Config::default();
         config.durable.encrypt_payload = false;
         config.durable.shared_db = true;
+        let vault_dir = zeph_core::vault::default_vault_dir();
         assert!(
-            load_write_cipher(&config).is_err(),
+            load_write_cipher(
+                &config,
+                &vault_dir.join("vault-key.txt"),
+                &vault_dir.join("secrets.age"),
+            )
+            .is_err(),
             "encrypt_payload=false on a declared shared_db must fail closed (INV-8)"
         );
     }
@@ -1704,7 +1807,16 @@ mod tests {
         let mut config = Config::default();
         config.durable.encrypt_payload = false;
         // shared_db left at its default (false) - the permitted dev-only override.
-        assert!(load_write_cipher(&config).unwrap().is_none());
+        let vault_dir = zeph_core::vault::default_vault_dir();
+        assert!(
+            load_write_cipher(
+                &config,
+                &vault_dir.join("vault-key.txt"),
+                &vault_dir.join("secrets.age"),
+            )
+            .unwrap()
+            .is_none()
+        );
     }
 
     /// Regression for #5996: `is_shared_db` recognizes a `postgres://`/`postgresql://` URL scheme
@@ -1729,8 +1841,14 @@ mod tests {
         // memory.sqlite_path drives resolve_durable_db_url; a `postgres://`-looking value
         // exercises the URL-scheme branch of `is_shared_db` without needing a real Postgres build.
         config.memory.sqlite_path = "postgres://user@host/db".to_owned();
+        let vault_dir = zeph_core::vault::default_vault_dir();
         assert!(
-            load_write_cipher(&config).is_err(),
+            load_write_cipher(
+                &config,
+                &vault_dir.join("vault-key.txt"),
+                &vault_dir.join("secrets.age"),
+            )
+            .is_err(),
             "a postgres:// resolved URL must be treated as shared even without shared_db=true"
         );
     }
@@ -1742,7 +1860,13 @@ mod tests {
     async fn load_write_hmac_key_returns_none_for_single_user_local() {
         let config = Config::default();
         assert!(!config.durable.shared_db);
-        let keys = load_write_hmac_key(&config).unwrap();
+        let vault_dir = zeph_core::vault::default_vault_dir();
+        let keys = load_write_hmac_key(
+            &config,
+            &vault_dir.join("vault-key.txt"),
+            &vault_dir.join("secrets.age"),
+        )
+        .unwrap();
         assert!(
             keys.current.is_none() && keys.previous.is_none(),
             "single-user local, non-shared database must not resolve either HMAC key"
@@ -1765,7 +1889,11 @@ mod tests {
             std::env::set_var("XDG_CONFIG_HOME", vault_dir.path());
         }
 
-        let result = load_write_hmac_key(&config);
+        let result = load_write_hmac_key(
+            &config,
+            &vault_dir.path().join("vault-key.txt"),
+            &vault_dir.path().join("secrets.age"),
+        );
 
         unsafe {
             match &prev_xdg {
@@ -1809,7 +1937,16 @@ mod tests {
 
         let exec = ExecutionId::new();
         {
-            let backend = open_backend(&config, false).await.unwrap().unwrap();
+            let vault_dir = zeph_core::vault::default_vault_dir();
+            let backend = open_backend(
+                &config,
+                false,
+                &vault_dir.join("vault-key.txt"),
+                &vault_dir.join("secrets.age"),
+            )
+            .await
+            .unwrap()
+            .unwrap();
             backend
                 .open_execution(exec, zeph_durable::ExecutionKind::AgentTurn)
                 .await
@@ -1821,6 +1958,9 @@ mod tests {
                 id: exec.as_uuid().to_string(),
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         )
         .await;
         assert!(
@@ -1828,7 +1968,16 @@ mod tests {
             "canceling a running execution must succeed: {result:?}"
         );
 
-        let backend = open_backend(&config, false).await.unwrap().unwrap();
+        let vault_dir = zeph_core::vault::default_vault_dir();
+        let backend = open_backend(
+            &config,
+            false,
+            &vault_dir.join("vault-key.txt"),
+            &vault_dir.join("secrets.age"),
+        )
+        .await
+        .unwrap()
+        .unwrap();
         let status = backend.execution_status(exec).await.unwrap();
         assert_eq!(status, Some(zeph_durable::ExecutionStatus::Canceled));
     }
@@ -1844,6 +1993,9 @@ mod tests {
                 id: ExecutionId::new().as_uuid().to_string(),
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         )
         .await;
         assert!(
@@ -1863,7 +2015,16 @@ mod tests {
 
         let exec = ExecutionId::new();
         {
-            let backend = open_backend(&config, false).await.unwrap().unwrap();
+            let vault_dir = zeph_core::vault::default_vault_dir();
+            let backend = open_backend(
+                &config,
+                false,
+                &vault_dir.join("vault-key.txt"),
+                &vault_dir.join("secrets.age"),
+            )
+            .await
+            .unwrap()
+            .unwrap();
             backend
                 .open_execution(exec, zeph_durable::ExecutionKind::AgentTurn)
                 .await
@@ -1877,6 +2038,9 @@ mod tests {
                 id: exec.as_uuid().to_string(),
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         )
         .await;
         assert!(
@@ -1918,7 +2082,11 @@ mod tests {
             .unwrap();
         provider.save().unwrap();
 
-        let result = load_write_hmac_key(&config);
+        let result = load_write_hmac_key(
+            &config,
+            &vault_root.join("vault-key.txt"),
+            &vault_root.join("secrets.age"),
+        );
 
         unsafe {
             match &prev_xdg {
@@ -1930,6 +2098,285 @@ mod tests {
         assert!(
             result.unwrap().current.is_some(),
             "a declared shared database with a real vault key must resolve an HMAC key"
+        );
+    }
+
+    // ── CLI vault-override resolution (issue #6548) ────────────────────────────────────────
+    //
+    // Each of the four key-material loaders must honor an explicit `--vault-key`/`--vault-path`
+    // override rather than silently reading `default_vault_dir()`. Every test below redirects
+    // `default_vault_dir()` (via `XDG_CONFIG_HOME`) at an *empty* temp dir — so if a loader
+    // regressed back to reading `default_vault_dir()` internally instead of the paths passed
+    // in, it would find no key and the assertion would fail — while seeding the real
+    // `ZEPH_DURABLE_KEY` at a *separate* explicit override location.
+
+    #[allow(unsafe_code)]
+    #[tokio::test]
+    #[serial]
+    async fn load_write_cipher_respects_explicit_override_path_not_default_vault_dir() {
+        let empty_default_dir = tempfile::tempdir().unwrap();
+        let prev_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", empty_default_dir.path());
+        }
+
+        let override_dir = tempfile::tempdir().unwrap();
+        zeph_core::vault::AgeVaultProvider::init_vault(override_dir.path()).unwrap();
+        let mut provider = zeph_core::vault::AgeVaultProvider::load(
+            &override_dir.path().join("vault-key.txt"),
+            &override_dir.path().join("secrets.age"),
+        )
+        .unwrap();
+        provider
+            .set_secret_mut(
+                "ZEPH_DURABLE_KEY".to_owned(),
+                zeph_core::durable::generate_durable_key_b64(),
+                false,
+            )
+            .unwrap();
+        provider.save().unwrap();
+
+        let mut config = Config::default();
+        config.durable.encrypt_payload = true;
+
+        let result = load_write_cipher(
+            &config,
+            &override_dir.path().join("vault-key.txt"),
+            &override_dir.path().join("secrets.age"),
+        );
+
+        unsafe {
+            match &prev_xdg {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+
+        assert!(
+            result.is_ok() && result.unwrap().is_some(),
+            "load_write_cipher must resolve ZEPH_DURABLE_KEY from the explicit override path, \
+             not default_vault_dir() (#6548)"
+        );
+    }
+
+    #[allow(unsafe_code)]
+    #[tokio::test]
+    #[serial]
+    async fn load_write_hmac_key_respects_explicit_override_path_not_default_vault_dir() {
+        let empty_default_dir = tempfile::tempdir().unwrap();
+        let prev_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", empty_default_dir.path());
+        }
+
+        let override_dir = tempfile::tempdir().unwrap();
+        zeph_core::vault::AgeVaultProvider::init_vault(override_dir.path()).unwrap();
+        let mut provider = zeph_core::vault::AgeVaultProvider::load(
+            &override_dir.path().join("vault-key.txt"),
+            &override_dir.path().join("secrets.age"),
+        )
+        .unwrap();
+        provider
+            .set_secret_mut(
+                "ZEPH_DURABLE_KEY".to_owned(),
+                zeph_core::durable::generate_durable_key_b64(),
+                false,
+            )
+            .unwrap();
+        provider.save().unwrap();
+
+        let mut config = Config::default();
+        config.durable.shared_db = true;
+
+        let result = load_write_hmac_key(
+            &config,
+            &override_dir.path().join("vault-key.txt"),
+            &override_dir.path().join("secrets.age"),
+        );
+
+        unsafe {
+            match &prev_xdg {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+
+        assert!(
+            result.is_ok_and(|k| k.current.is_some()),
+            "load_write_hmac_key must resolve ZEPH_DURABLE_KEY from the explicit override path, \
+             not default_vault_dir() (#6548)"
+        );
+    }
+
+    #[allow(unsafe_code)]
+    #[tokio::test]
+    #[serial]
+    async fn load_write_hwm_key_respects_explicit_override_path_not_default_vault_dir() {
+        let empty_default_dir = tempfile::tempdir().unwrap();
+        let prev_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", empty_default_dir.path());
+        }
+
+        let override_dir = tempfile::tempdir().unwrap();
+        zeph_core::vault::AgeVaultProvider::init_vault(override_dir.path()).unwrap();
+        let mut provider = zeph_core::vault::AgeVaultProvider::load(
+            &override_dir.path().join("vault-key.txt"),
+            &override_dir.path().join("secrets.age"),
+        )
+        .unwrap();
+        provider
+            .set_secret_mut(
+                "ZEPH_DURABLE_KEY".to_owned(),
+                zeph_core::durable::generate_durable_key_b64(),
+                false,
+            )
+            .unwrap();
+        provider.save().unwrap();
+
+        let config = Config::default();
+
+        let result = load_write_hwm_key(
+            &config,
+            &override_dir.path().join("vault-key.txt"),
+            &override_dir.path().join("secrets.age"),
+        );
+
+        unsafe {
+            match &prev_xdg {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+
+        assert!(
+            result.is_ok_and(|k| k.current.is_some()),
+            "load_write_hwm_key must resolve ZEPH_DURABLE_KEY from the explicit override path, \
+             not default_vault_dir() (#6548)"
+        );
+    }
+
+    #[allow(unsafe_code)]
+    #[tokio::test]
+    #[serial]
+    async fn load_integrity_seal_respects_explicit_override_path_not_default_vault_dir() {
+        let empty_default_dir = tempfile::tempdir().unwrap();
+        let prev_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", empty_default_dir.path());
+        }
+
+        let override_dir = tempfile::tempdir().unwrap();
+        zeph_core::vault::AgeVaultProvider::init_vault(override_dir.path()).unwrap();
+        let mut provider = zeph_core::vault::AgeVaultProvider::load(
+            &override_dir.path().join("vault-key.txt"),
+            &override_dir.path().join("secrets.age"),
+        )
+        .unwrap();
+        provider
+            .set_secret_mut(
+                zeph_core::anchor_store::DURABLE_INTEGRITY_SEALED_KEY.to_owned(),
+                "1".to_owned(),
+                true,
+            )
+            .unwrap();
+        provider.save().unwrap();
+
+        let config = Config::default();
+
+        let (sealed, _grandfather) = load_integrity_seal(
+            &config,
+            &override_dir.path().join("vault-key.txt"),
+            &override_dir.path().join("secrets.age"),
+        );
+
+        unsafe {
+            match &prev_xdg {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+
+        assert!(
+            sealed,
+            "load_integrity_seal must resolve the seal marker from the explicit override path, \
+             not default_vault_dir() (#6548)"
+        );
+    }
+
+    /// #6547/#6548 (impl-critic follow-up): `zeph durable rotate-key` — a full vault
+    /// read-then-write, not just a loader — must also honor an explicit `--vault-key`/
+    /// `--vault-path` override rather than reading `default_vault_dir()`, mirroring
+    /// `seal-integrity`'s sibling coverage above. `default_vault_dir()` is redirected at an
+    /// *empty* temp dir (via `XDG_CONFIG_HOME`), so if `handle_rotate_key` regressed back to
+    /// reading it internally instead of the CLI-resolved override, it would fail with "no age
+    /// vault found" instead of succeeding.
+    #[allow(unsafe_code)]
+    #[tokio::test]
+    #[serial]
+    async fn rotate_key_respects_explicit_override_path_not_default_vault_dir() {
+        let empty_default_dir = tempfile::tempdir().unwrap();
+        let prev_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", empty_default_dir.path());
+        }
+
+        let override_dir = tempfile::tempdir().unwrap();
+        zeph_core::vault::AgeVaultProvider::init_vault(override_dir.path()).unwrap();
+        let mut provider = zeph_core::vault::AgeVaultProvider::load(
+            &override_dir.path().join("vault-key.txt"),
+            &override_dir.path().join("secrets.age"),
+        )
+        .unwrap();
+        provider
+            .set_secret_mut(
+                CURRENT_KEY_VAULT_NAME.to_owned(),
+                zeph_core::durable::generate_durable_key_b64(),
+                false,
+            )
+            .unwrap();
+        provider.save().unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = write_config_toml(dir.path());
+
+        let result = handle_durable_command(
+            DurableCommand::RotateKey {
+                dry_run: false,
+                drop_previous: false,
+                force: false,
+            },
+            Some(&config_path),
+            None,
+            Some(&override_dir.path().join("vault-key.txt")),
+            Some(&override_dir.path().join("secrets.age")),
+        )
+        .await;
+
+        unsafe {
+            match &prev_xdg {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+
+        assert!(
+            result.is_ok(),
+            "rotate-key must resolve the vault from the explicit --vault-key/--vault-path \
+             override, not default_vault_dir() (which is empty in this test): {result:?}"
+        );
+        assert_eq!(load_config_or_default(&config_path).durable.key_id, 1);
+
+        // The rotated ZEPH_DURABLE_KEY_PREVIOUS must land in the OVERRIDE vault, not the
+        // (empty) default_vault_dir().
+        let override_provider = zeph_core::vault::AgeVaultProvider::load(
+            &override_dir.path().join("vault-key.txt"),
+            &override_dir.path().join("secrets.age"),
+        )
+        .unwrap();
+        assert!(
+            override_provider.get(PREVIOUS_KEY_VAULT_NAME).is_some(),
+            "rotation must write ZEPH_DURABLE_KEY_PREVIOUS into the override vault"
         );
     }
 
@@ -2009,6 +2456,9 @@ mod tests {
                 force: false,
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         )
         .await;
         assert!(result.is_ok(), "rotate-key must succeed: {result:?}");
@@ -2046,6 +2496,9 @@ mod tests {
                 force: false,
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         )
         .await
         .unwrap();
@@ -2059,6 +2512,9 @@ mod tests {
                 force: false,
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         )
         .await;
         assert!(
@@ -2090,6 +2546,9 @@ mod tests {
                 force: false,
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         )
         .await;
         assert!(result.is_ok());
@@ -2123,6 +2582,9 @@ mod tests {
                 force: false,
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         )
         .await;
         assert!(
@@ -2159,6 +2621,9 @@ mod tests {
                 force: false,
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         )
         .await
         .unwrap();
@@ -2202,6 +2667,9 @@ mod tests {
                 force: false,
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         )
         .await;
         assert!(
@@ -2221,6 +2689,9 @@ mod tests {
                 force: true,
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         )
         .await;
         assert!(forced.is_ok(), "--force must skip the scan: {forced:?}");
@@ -2253,6 +2724,9 @@ mod tests {
                 force: false,
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         )
         .await;
         assert!(
@@ -2287,6 +2761,9 @@ mod tests {
                 force: false,
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         )
         .await;
         assert!(
@@ -2319,7 +2796,12 @@ mod tests {
         config.durable.previous_key_id = Some(0);
         // key_id stays default 0; ZEPH_DURABLE_KEY_PREVIOUS was never written to the vault.
 
-        let result = load_write_cipher(&config);
+        let vault_root = zeph_core::vault::default_vault_dir();
+        let result = load_write_cipher(
+            &config,
+            &vault_root.join("vault-key.txt"),
+            &vault_root.join("secrets.age"),
+        );
         assert!(
             result.is_err(),
             "previous_key_id set but ZEPH_DURABLE_KEY_PREVIOUS missing must hard-error, not \
@@ -2355,7 +2837,11 @@ mod tests {
         config.durable.key_id = 1;
         config.durable.previous_key_id = Some(0);
 
-        let result = load_write_cipher(&config);
+        let result = load_write_cipher(
+            &config,
+            &vault_root.join("vault-key.txt"),
+            &vault_root.join("secrets.age"),
+        );
         assert!(
             result.is_ok(),
             "a consistent (config ∧ vault) previous-key pair must build a cipher: {}",
@@ -2374,7 +2860,12 @@ mod tests {
         let config = Config::default();
         assert_eq!(config.durable.previous_key_id, None);
 
-        let result = load_write_cipher(&config);
+        let vault_root = zeph_core::vault::default_vault_dir();
+        let result = load_write_cipher(
+            &config,
+            &vault_root.join("vault-key.txt"),
+            &vault_root.join("secrets.age"),
+        );
         assert!(
             result.is_ok(),
             "no declared rotation window must build a cipher with no previous slot: {}",
@@ -2405,7 +2896,14 @@ mod tests {
         std::fs::write(&config_path, toml).unwrap();
 
         // Seal a real payload under key-id 0 with the actual write-path cipher.
-        let cipher = load_write_cipher(&config).unwrap().unwrap();
+        let vault_root = zeph_core::vault::default_vault_dir();
+        let cipher = load_write_cipher(
+            &config,
+            &vault_root.join("vault-key.txt"),
+            &vault_root.join("secrets.age"),
+        )
+        .unwrap()
+        .unwrap();
         let url = resolve_durable_db_url(&config);
         let exec = ExecutionId::new();
         {
@@ -2445,6 +2943,9 @@ mod tests {
                 force: false,
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         )
         .await
         .unwrap();
@@ -2455,13 +2956,24 @@ mod tests {
                 force: true,
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         )
         .await
         .unwrap();
 
         let final_config = load_config_or_default(&config_path);
         assert_eq!(final_config.durable.previous_key_id, None);
-        let backend = open_backend(&final_config, true).await.unwrap().unwrap();
+        let backend = open_backend(
+            &final_config,
+            true,
+            &vault_root.join("vault-key.txt"),
+            &vault_root.join("secrets.age"),
+        )
+        .await
+        .unwrap()
+        .unwrap();
         let result = show_entries(&backend, exec, true, None, false).await;
 
         let err = result.unwrap_err().to_string();
@@ -2494,6 +3006,9 @@ mod tests {
                 force: false,
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         )
         .await
         .unwrap();
@@ -2544,6 +3059,9 @@ mod tests {
                 force: false,
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         )
         .await;
         assert!(
@@ -2593,7 +3111,14 @@ mod tests {
         let config_path = dir.path().join("config.toml");
         std::fs::write(&config_path, toml).unwrap();
 
-        let old_cipher = load_write_cipher(&config).unwrap().unwrap();
+        let vault_root = zeph_core::vault::default_vault_dir();
+        let old_cipher = load_write_cipher(
+            &config,
+            &vault_root.join("vault-key.txt"),
+            &vault_root.join("secrets.age"),
+        )
+        .unwrap()
+        .unwrap();
         let url = resolve_durable_db_url(&config);
         let exec = ExecutionId::new();
         {
@@ -2632,6 +3157,9 @@ mod tests {
                 force: false,
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         )
         .await
         .unwrap();
@@ -2640,7 +3168,13 @@ mod tests {
         assert_eq!(rotated_config.durable.key_id, 1);
         assert_eq!(rotated_config.durable.previous_key_id, Some(0));
 
-        let new_cipher = load_write_cipher(&rotated_config).unwrap().unwrap();
+        let new_cipher = load_write_cipher(
+            &rotated_config,
+            &vault_root.join("vault-key.txt"),
+            &vault_root.join("secrets.age"),
+        )
+        .unwrap()
+        .unwrap();
         let backend = LocalBackend::open(&url, rotated_config.durable.max_payload_bytes)
             .await
             .unwrap()
@@ -2722,16 +3256,25 @@ mod tests {
                 force: false,
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         )
         .await
         .unwrap();
 
         let rotated = load_config_or_default(&config_path);
         let url = resolve_durable_db_url(&rotated);
-        let previous_hmac = load_control_hmac_key(&rotated.durable, &url)
-            .unwrap()
-            .previous
-            .expect("rotation window must be open after rotate-key");
+        let vault_root = zeph_core::vault::default_vault_dir();
+        let previous_hmac = load_control_hmac_key(
+            &rotated.durable,
+            &url,
+            &vault_root.join("vault-key.txt"),
+            &vault_root.join("secrets.age"),
+        )
+        .unwrap()
+        .previous
+        .expect("rotation window must be open after rotate-key");
 
         let exec = ExecutionId::new();
         {
@@ -2769,6 +3312,9 @@ mod tests {
                 json: false,
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         )
         .await;
         assert!(
@@ -2807,16 +3353,25 @@ mod tests {
                 force: false,
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         )
         .await
         .unwrap();
 
         let rotated = load_config_or_default(&config_path);
         let url = resolve_durable_db_url(&rotated);
-        let previous_hmac = load_control_hmac_key(&rotated.durable, &url)
-            .unwrap()
-            .previous
-            .expect("rotation window must be open after rotate-key");
+        let vault_root = zeph_core::vault::default_vault_dir();
+        let previous_hmac = load_control_hmac_key(
+            &rotated.durable,
+            &url,
+            &vault_root.join("vault-key.txt"),
+            &vault_root.join("secrets.age"),
+        )
+        .unwrap()
+        .previous
+        .expect("rotation window must be open after rotate-key");
 
         let exec = ExecutionId::new();
         {
@@ -2855,6 +3410,9 @@ mod tests {
                 force: false,
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         )
         .await;
         assert!(
@@ -2875,6 +3433,9 @@ mod tests {
                 force: true,
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         )
         .await;
         assert!(
@@ -2908,6 +3469,9 @@ mod tests {
                 force: false,
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         )
         .await
         .unwrap();
@@ -2949,6 +3513,9 @@ mod tests {
                 force: false,
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         )
         .await;
         assert!(
@@ -2969,6 +3536,9 @@ mod tests {
                 force: true,
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         )
         .await;
         assert!(forced.is_ok(), "--force must skip the HWM scan: {forced:?}");
@@ -2995,7 +3565,13 @@ mod tests {
         let exec = ExecutionId::new();
         {
             let config = load_config_or_default(&config_path);
-            let hwm_keys = load_write_hwm_key(&config).unwrap();
+            let vault_root = zeph_core::vault::default_vault_dir();
+            let hwm_keys = load_write_hwm_key(
+                &config,
+                &vault_root.join("vault-key.txt"),
+                &vault_root.join("secrets.age"),
+            )
+            .unwrap();
             let slot = hwm_keys.current.expect("ZEPH_DURABLE_KEY is seeded");
             assert_eq!(
                 slot.epoch, 0,
@@ -3040,6 +3616,9 @@ mod tests {
                 force: false,
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         )
         .await
         .unwrap();
@@ -3047,7 +3626,13 @@ mod tests {
         let rotated = load_config_or_default(&config_path);
         assert_eq!(rotated.durable.key_id, 1);
         assert_eq!(rotated.durable.previous_key_id, Some(0));
-        let hwm_keys = load_write_hwm_key(&rotated).unwrap();
+        let vault_root = zeph_core::vault::default_vault_dir();
+        let hwm_keys = load_write_hwm_key(
+            &rotated,
+            &vault_root.join("vault-key.txt"),
+            &vault_root.join("secrets.age"),
+        )
+        .unwrap();
         let current = hwm_keys.current.expect("current HWM slot must resolve");
         assert_eq!(current.epoch, 1, "epoch must follow key_id after rotation");
         let previous = hwm_keys

--- a/src/commands/scheduler_daemon.rs
+++ b/src/commands/scheduler_daemon.rs
@@ -16,28 +16,88 @@ use crate::bootstrap::{load_config_or_default, resolve_config_path};
 ///
 /// Starts the scheduler daemon. Without `--foreground`, re-execs with
 /// `--foreground` to detach without forking a live tokio runtime.
+///
+/// `vault_override`/`vault_key_override`/`vault_path_override` are the `--vault`/`--vault-key`/
+/// `--vault-path` CLI flags. Resolved once via [`crate::bootstrap::resolve_vault_paths`] (the
+/// same resolution `doctor.rs`/`vault.rs` use post-#6499) for the `--foreground` path, and
+/// forwarded verbatim as CLI args to the re-exec'd child on the detach path — the child otherwise
+/// falls back to `ZEPH_VAULT_*` env vars (inherited) or `default_vault_dir()`, silently ignoring
+/// an operator-supplied override for the long-running daemon process (#6547/#6548).
 pub(crate) async fn handle_serve(
     config_path: Option<&std::path::Path>,
     foreground: bool,
     catch_up: bool,
+    vault_override: Option<&str>,
+    vault_key_override: Option<&std::path::Path>,
+    vault_path_override: Option<&std::path::Path>,
 ) -> anyhow::Result<()> {
     let config_file = resolve_config_path(config_path);
     let config = load_config_or_default(&config_file);
     let daemon_cfg = build_daemon_config(&config);
 
     if foreground {
-        run_foreground(daemon_cfg, &config).await
+        let (vault_key_path, vault_secrets_path) = crate::bootstrap::resolve_vault_paths(
+            &config,
+            vault_override,
+            vault_key_override,
+            vault_path_override,
+        );
+        run_foreground(daemon_cfg, &config, &vault_key_path, &vault_secrets_path).await
     } else {
         // Build args for the re-exec child. Pass --config so the child resolves
         // the same config file, then `serve --foreground` with catch-up flag.
         let config_str = config_file.to_string_lossy();
-        let mut extra: Vec<&str> = vec!["--config", &config_str, "serve", "--foreground"];
-        if !catch_up {
-            extra.push("--no-catch-up");
-        }
-        zeph_scheduler::detach_and_run(&daemon_cfg, &extra)
+        let extra = build_detach_args(
+            &config_str,
+            catch_up,
+            vault_override,
+            vault_key_override,
+            vault_path_override,
+        );
+        let extra_refs: Vec<&str> = extra.iter().map(String::as_str).collect();
+        zeph_scheduler::detach_and_run(&daemon_cfg, &extra_refs)
             .context("failed to detach scheduler daemon")
     }
+}
+
+/// Build the CLI argument vector for the detached `--foreground` child process (the
+/// non-foreground path of [`handle_serve`]).
+///
+/// Split out from `handle_serve` so the argument-construction logic — in particular, forwarding
+/// `--vault`/`--vault-key`/`--vault-path` to the re-exec'd child — is independently testable
+/// without actually spawning/detaching a process. The child otherwise only inherits `ZEPH_VAULT_*`
+/// env vars automatically; the CLI-flag form of an override is lost across `std::process::Command`
+/// unless explicitly forwarded here, silently dropping an operator-supplied override for the
+/// long-running daemon process (#6547/#6548).
+fn build_detach_args(
+    config_str: &str,
+    catch_up: bool,
+    vault_override: Option<&str>,
+    vault_key_override: Option<&std::path::Path>,
+    vault_path_override: Option<&std::path::Path>,
+) -> Vec<String> {
+    let mut extra: Vec<String> = vec![
+        "--config".to_owned(),
+        config_str.to_owned(),
+        "serve".to_owned(),
+        "--foreground".to_owned(),
+    ];
+    if !catch_up {
+        extra.push("--no-catch-up".to_owned());
+    }
+    if let Some(backend) = vault_override {
+        extra.push("--vault".to_owned());
+        extra.push(backend.to_owned());
+    }
+    if let Some(key_path) = vault_key_override {
+        extra.push("--vault-key".to_owned());
+        extra.push(key_path.to_string_lossy().into_owned());
+    }
+    if let Some(vault_path) = vault_path_override {
+        extra.push("--vault-path".to_owned());
+        extra.push(vault_path.to_string_lossy().into_owned());
+    }
+    extra
 }
 
 /// Handle `zeph stop [--timeout-secs N]`.
@@ -94,6 +154,8 @@ fn build_daemon_config(config: &zeph_core::config::Config) -> zeph_scheduler::Da
 async fn run_foreground(
     daemon_cfg: zeph_scheduler::DaemonConfig,
     config: &zeph_core::config::Config,
+    vault_key_path: &std::path::Path,
+    vault_secrets_path: &std::path::Path,
 ) -> anyhow::Result<()> {
     let db_url = crate::db_url::resolve_db_url(config);
     let store = zeph_scheduler::JobStore::open(db_url)
@@ -145,7 +207,14 @@ async fn run_foreground(
         config.scheduler.security.attenuate_after_external_read,
     );
 
-    if let Some(adapter) = build_durable_adapter(config, &sched_supervisor).await? {
+    if let Some(adapter) = build_durable_adapter(
+        config,
+        &sched_supervisor,
+        vault_key_path,
+        vault_secrets_path,
+    )
+    .await?
+    {
         scheduler = scheduler.with_durable(adapter);
     }
 
@@ -191,6 +260,8 @@ async fn run_foreground(
 async fn build_durable_adapter(
     config: &zeph_core::config::Config,
     sched_supervisor: &zeph_common::TaskSupervisor,
+    vault_key_path: &std::path::Path,
+    vault_secrets_path: &std::path::Path,
 ) -> anyhow::Result<Option<zeph_scheduler::durable::SchedulerDurableAdapter>> {
     if !(config.durable.enabled && config.durable.scheduler) {
         return Ok(None);
@@ -199,9 +270,12 @@ async fn build_durable_adapter(
     // control-entry HMAC key (#6043/#6044), and the high-water-mark key (addendum to #6451)
     // before opening the backend, so a forbidden config fails closed without creating a stray
     // empty journal file on disk first.
-    let cipher = crate::commands::durable::load_write_cipher(config)?;
-    let hmac_keys = crate::commands::durable::load_write_hmac_key(config)?;
-    let hwm_keys = crate::commands::durable::load_write_hwm_key(config)?;
+    let cipher =
+        crate::commands::durable::load_write_cipher(config, vault_key_path, vault_secrets_path)?;
+    let hmac_keys =
+        crate::commands::durable::load_write_hmac_key(config, vault_key_path, vault_secrets_path)?;
+    let hwm_keys =
+        crate::commands::durable::load_write_hwm_key(config, vault_key_path, vault_secrets_path)?;
     let durable_url = crate::commands::durable::resolve_durable_db_url(config);
     let local = zeph_durable::LocalBackend::open(&durable_url, config.durable.max_payload_bytes)
         .await
@@ -317,6 +391,87 @@ mod tests {
     use super::*;
     use zeph_durable::Journal as _;
 
+    // --- build_detach_args (#6547/#6548, tester follow-up) ---
+    //
+    // `handle_serve`'s non-foreground path re-execs itself as a detached `--foreground` child;
+    // these tests isolate the argv-construction logic without actually spawning/detaching a
+    // process, covering the exact gap the tester flagged: zero coverage existed for whether
+    // `--vault`/`--vault-key`/`--vault-path` actually reach the re-exec'd child's argv.
+
+    #[test]
+    fn build_detach_args_forwards_all_three_vault_overrides_when_present() {
+        let args = build_detach_args(
+            "/some/config.toml",
+            true,
+            Some("age"),
+            Some(std::path::Path::new("/override/vault-key.txt")),
+            Some(std::path::Path::new("/override/secrets.age")),
+        );
+        assert!(args.iter().any(|a| a == "--vault"));
+        assert!(args.iter().any(|a| a == "age"));
+        assert!(args.iter().any(|a| a == "--vault-key"));
+        assert!(args.iter().any(|a| a == "/override/vault-key.txt"));
+        assert!(args.iter().any(|a| a == "--vault-path"));
+        assert!(args.iter().any(|a| a == "/override/secrets.age"));
+        // --vault-key must be immediately followed by its value (argv parsing depends on
+        // adjacency), not just present anywhere in the vector.
+        let key_idx = args.iter().position(|a| a == "--vault-key").unwrap();
+        assert_eq!(args[key_idx + 1], "/override/vault-key.txt");
+        let path_idx = args.iter().position(|a| a == "--vault-path").unwrap();
+        assert_eq!(args[path_idx + 1], "/override/secrets.age");
+    }
+
+    #[test]
+    fn build_detach_args_omits_vault_flags_when_no_override_given() {
+        let args = build_detach_args("/some/config.toml", true, None, None, None);
+        assert!(
+            !args.iter().any(|a| a == "--vault"),
+            "no --vault override must not appear in the child argv: {args:?}"
+        );
+        assert!(
+            !args.iter().any(|a| a == "--vault-key"),
+            "no --vault-key override must not appear in the child argv: {args:?}"
+        );
+        assert!(
+            !args.iter().any(|a| a == "--vault-path"),
+            "no --vault-path override must not appear in the child argv: {args:?}"
+        );
+    }
+
+    #[test]
+    fn build_detach_args_forwards_single_override_independently() {
+        // --vault-key alone must not pull in --vault-path (and vice versa) — each override is
+        // forwarded independently, mirroring resolve_vault_paths' per-field resolution.
+        let args = build_detach_args(
+            "/some/config.toml",
+            true,
+            None,
+            Some(std::path::Path::new("/override/vault-key.txt")),
+            None,
+        );
+        assert!(args.iter().any(|a| a == "--vault-key"));
+        assert!(!args.iter().any(|a| a == "--vault-path"));
+        assert!(!args.iter().any(|a| a == "--vault"));
+    }
+
+    #[test]
+    fn build_detach_args_always_includes_config_and_foreground() {
+        let args = build_detach_args("/x/config.toml", true, None, None, None);
+        assert_eq!(args[0], "--config");
+        assert_eq!(args[1], "/x/config.toml");
+        assert!(args.iter().any(|a| a == "serve"));
+        assert!(args.iter().any(|a| a == "--foreground"));
+    }
+
+    #[test]
+    fn build_detach_args_no_catch_up_flag_added_when_catch_up_false() {
+        let with_catch_up = build_detach_args("/x/config.toml", true, None, None, None);
+        assert!(!with_catch_up.iter().any(|a| a == "--no-catch-up"));
+
+        let without_catch_up = build_detach_args("/x/config.toml", false, None, None, None);
+        assert!(without_catch_up.iter().any(|a| a == "--no-catch-up"));
+    }
+
     /// #6264: `build_durable_adapter` must spawn the retention sweep (not just the journal
     /// writer) onto `sched_supervisor`, mirroring the P1/P2 coverage in
     /// `crates/zeph-core/src/agent/durable_bootstrap.rs`. `encrypt_payload = false` avoids a
@@ -335,9 +490,15 @@ mod tests {
         let cancel = tokio_util::sync::CancellationToken::new();
         let sched_supervisor = zeph_common::TaskSupervisor::new(cancel);
 
-        let adapter = build_durable_adapter(&config, &sched_supervisor)
-            .await
-            .expect("build_durable_adapter must succeed with a local, unencrypted backend");
+        let vault_dir = zeph_core::vault::default_vault_dir();
+        let adapter = build_durable_adapter(
+            &config,
+            &sched_supervisor,
+            &vault_dir.join("vault-key.txt"),
+            &vault_dir.join("secrets.age"),
+        )
+        .await
+        .expect("build_durable_adapter must succeed with a local, unencrypted backend");
         assert!(
             adapter.is_some(),
             "durable.enabled && durable.scheduler must produce an adapter"
@@ -371,9 +532,15 @@ mod tests {
         let cancel = tokio_util::sync::CancellationToken::new();
         let sched_supervisor = zeph_common::TaskSupervisor::new(cancel);
 
-        let adapter = build_durable_adapter(&config, &sched_supervisor)
-            .await
-            .expect("build_durable_adapter must succeed (returns None, not an error)");
+        let vault_dir = zeph_core::vault::default_vault_dir();
+        let adapter = build_durable_adapter(
+            &config,
+            &sched_supervisor,
+            &vault_dir.join("vault-key.txt"),
+            &vault_dir.join("secrets.age"),
+        )
+        .await
+        .expect("build_durable_adapter must succeed (returns None, not an error)");
         assert!(adapter.is_none());
         assert!(sched_supervisor.snapshot().is_empty());
     }
@@ -467,7 +634,13 @@ mod tests {
 
         let cancel = tokio_util::sync::CancellationToken::new();
         let sched_supervisor = zeph_common::TaskSupervisor::new(cancel);
-        let adapter = build_durable_adapter(&config, &sched_supervisor).await;
+        let adapter = build_durable_adapter(
+            &config,
+            &sched_supervisor,
+            &vault_root.join("vault-key.txt"),
+            &vault_root.join("secrets.age"),
+        )
+        .await;
         assert!(
             adapter.is_ok() && adapter.unwrap().is_some(),
             "build_durable_adapter must succeed with a consistent rotation window declared"
@@ -476,7 +649,12 @@ mod tests {
         // Re-derive the same keys `build_durable_adapter` resolved, and confirm the pre-rotation
         // entry is still readable through the window (the actual regression assertion) — still
         // under the guard's vault dir, before it is restored below.
-        let hmac_keys = crate::commands::durable::load_write_hmac_key(&config).unwrap();
+        let hmac_keys = crate::commands::durable::load_write_hmac_key(
+            &config,
+            &vault_root.join("vault-key.txt"),
+            &vault_root.join("secrets.age"),
+        )
+        .unwrap();
         let reader =
             zeph_durable::LocalBackend::open(&durable_url, config.durable.max_payload_bytes)
                 .await
@@ -588,7 +766,13 @@ mod tests {
 
         let cancel = tokio_util::sync::CancellationToken::new();
         let sched_supervisor = zeph_common::TaskSupervisor::new(cancel);
-        let adapter = build_durable_adapter(&config, &sched_supervisor).await;
+        let adapter = build_durable_adapter(
+            &config,
+            &sched_supervisor,
+            &vault_root.join("vault-key.txt"),
+            &vault_root.join("secrets.age"),
+        )
+        .await;
         assert!(
             adapter.is_ok() && adapter.unwrap().is_some(),
             "build_durable_adapter must succeed with a consistent rotation window declared"
@@ -597,7 +781,12 @@ mod tests {
         // Re-derive the same HWM keys `build_durable_adapter` resolved, and confirm the
         // pre-rotation execution still resumes cleanly through the window (the actual regression
         // assertion) -- still under the guard's vault dir, before it is restored below.
-        let hwm_keys = crate::commands::durable::load_write_hwm_key(&config).unwrap();
+        let hwm_keys = crate::commands::durable::load_write_hwm_key(
+            &config,
+            &vault_root.join("vault-key.txt"),
+            &vault_root.join("secrets.age"),
+        )
+        .unwrap();
         let current = hwm_keys.current.expect("current HWM slot must resolve");
         let previous = hwm_keys
             .previous

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -748,9 +748,11 @@ async fn resume_session_sink_fallback(
     }
 }
 
-/// Resolve `ZEPH_HISTORY_KEY` from the default vault location and configure hash-chain
-/// verification (issue #6360) for the `zeph-subagent` transcript and `zeph-session` event-log
-/// JSONL adapters, one key ring per subsystem (domain-separated per
+/// Resolve `ZEPH_HISTORY_KEY` from the CLI-resolved vault location (`--vault-key`/
+/// `--vault-path` overrides, falling back to `default_vault_dir()` — see
+/// [`crate::bootstrap::resolve_vault_paths`]) and configure hash-chain verification (issue
+/// #6360) for the `zeph-subagent` transcript and `zeph-session` event-log JSONL adapters, one
+/// key ring per subsystem (domain-separated per
 /// `zeph_core::history_integrity::derive_history_chain_key_b64`).
 ///
 /// Never fails the caller: an absent vault or an absent key both log at `debug`/`warn` and
@@ -759,12 +761,8 @@ async fn resume_session_sink_fallback(
 /// misconfiguration, and even that only disables chaining for the affected subsystem rather
 /// than aborting startup, since the primary command dispatch (which may not even touch
 /// transcripts/sessions, e.g. `zeph vault`) must not be blocked by it.
-fn configure_history_integrity_from_default_vault() {
-    let vault_dir = zeph_core::vault::default_vault_dir();
-    let Ok(provider) = zeph_core::vault::AgeVaultProvider::load(
-        &vault_dir.join("vault-key.txt"),
-        &vault_dir.join("secrets.age"),
-    ) else {
+fn configure_history_integrity(key_path: &std::path::Path, vault_path: &std::path::Path) {
+    let Ok(provider) = zeph_core::vault::AgeVaultProvider::load(key_path, vault_path) else {
         tracing::debug!(
             "history-chain integrity: vault not yet initialized; transcript/session log \
              chaining disabled for this run"
@@ -867,15 +865,29 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         );
     }
 
+    // CLI-resolved vault key/secrets-file paths (--vault-key/--vault-path overrides, falling
+    // back to default_vault_dir() — see `crate::bootstrap::resolve_vault_paths`), shared by every
+    // vault-key consumer below that resolves a key outside of the full `AppBuilder` vault
+    // construction: the history-chain integrity bootstrap immediately below (#6547) and the
+    // `zeph durable` key-material loaders further down this function (#6548). `config.vault.*` is
+    // a plain config value (not a secret), so resolving from `base_config` here — before
+    // `AppBuilder::new` resolves secrets — is equivalent to resolving from `app.config()` later.
+    let (vault_key_path, vault_secrets_path) = crate::bootstrap::resolve_vault_paths(
+        &base_config,
+        cli.vault.as_deref(),
+        cli.vault_key.as_deref(),
+        cli.vault_path.as_deref(),
+    );
+
     // History-chain integrity bootstrap (issue #6360): resolve ZEPH_HISTORY_KEY once and
     // configure hash-chain verification for both JSONL adapters before any entry point below
     // opens a transcript or session log — same ordering requirement as the migration step
     // above. Gracefully degrades to chaining-disabled (never a hard failure) when the vault or
     // the key itself is not yet provisioned (M2 bootstrap posture): a transient or first-run
-    // vault miss must never block ordinary CLI usage. Uses the default vault directory only
-    // (mirrors `crate::commands::durable::load_write_hwm_key`'s existing simplification) —
-    // `--vault-key`/`--vault-path` CLI overrides are not threaded through here yet.
-    configure_history_integrity_from_default_vault();
+    // vault miss must never block ordinary CLI usage. Resolves the vault location the same way
+    // `doctor.rs`/`vault.rs` do post-#6499 — `--vault-key`/`--vault-path` CLI overrides are
+    // honored, falling back to `default_vault_dir()` only when absent (#6547).
+    configure_history_integrity(&vault_key_path, &vault_secrets_path);
 
     // Flag aliases for the init / migrate-config subcommands (spec-076, #6277). Route to the exact
     // same handlers as the subcommand arms below — no forked logic. If both a flag and its
@@ -1027,6 +1039,9 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
             return crate::commands::durable::handle_durable_command(
                 durable_cmd,
                 cli.config.as_deref(),
+                cli.vault.as_deref(),
+                cli.vault_key.as_deref(),
+                cli.vault_path.as_deref(),
             )
             .await;
         }
@@ -1050,6 +1065,9 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
                 cli.config.as_deref(),
                 foreground,
                 !no_catch_up,
+                cli.vault.as_deref(),
+                cli.vault_key.as_deref(),
+                cli.vault_path.as_deref(),
             )
             .await;
         }
@@ -3293,10 +3311,26 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         let agent = agent.with_orchestration(config.orchestration.clone(), agents_config, mgr);
         let agent = if config.durable.enabled && config.durable.orchestration {
             let durable_url = crate::commands::durable::resolve_durable_db_url(config);
-            let cipher = crate::commands::durable::load_write_cipher(config)?;
-            let hmac_keys = crate::commands::durable::load_write_hmac_key(config)?;
-            let hwm_keys = crate::commands::durable::load_write_hwm_key(config)?;
-            let integrity_seal = crate::commands::durable::load_integrity_seal(config);
+            let cipher = crate::commands::durable::load_write_cipher(
+                config,
+                &vault_key_path,
+                &vault_secrets_path,
+            )?;
+            let hmac_keys = crate::commands::durable::load_write_hmac_key(
+                config,
+                &vault_key_path,
+                &vault_secrets_path,
+            )?;
+            let hwm_keys = crate::commands::durable::load_write_hwm_key(
+                config,
+                &vault_key_path,
+                &vault_secrets_path,
+            )?;
+            let integrity_seal = crate::commands::durable::load_integrity_seal(
+                config,
+                &vault_key_path,
+                &vault_secrets_path,
+            );
             agent.with_durable_orchestration(
                 config.durable.clone(),
                 durable_url,
@@ -3317,10 +3351,26 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         // lazily by `ensure_session_durable_ctx` on the first turn.
         let agent = if config.durable.enabled && config.durable.agent_turns {
             let durable_url = crate::commands::durable::resolve_durable_db_url(config);
-            let cipher = crate::commands::durable::load_write_cipher(config)?;
-            let hmac_keys = crate::commands::durable::load_write_hmac_key(config)?;
-            let hwm_keys = crate::commands::durable::load_write_hwm_key(config)?;
-            let integrity_seal = crate::commands::durable::load_integrity_seal(config);
+            let cipher = crate::commands::durable::load_write_cipher(
+                config,
+                &vault_key_path,
+                &vault_secrets_path,
+            )?;
+            let hmac_keys = crate::commands::durable::load_write_hmac_key(
+                config,
+                &vault_key_path,
+                &vault_secrets_path,
+            )?;
+            let hwm_keys = crate::commands::durable::load_write_hwm_key(
+                config,
+                &vault_key_path,
+                &vault_secrets_path,
+            )?;
+            let integrity_seal = crate::commands::durable::load_integrity_seal(
+                config,
+                &vault_key_path,
+                &vault_secrets_path,
+            );
             agent.with_durable_agent_turns(
                 config.durable.clone(),
                 durable_url,
@@ -3345,8 +3395,8 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
     // spawn the reconcile-and-cap sweep whenever `anchor = "vault"` (the default) and the age
     // vault is actually reachable. Degrades gracefully (never a hard failure) when the vault
     // isn't available yet — sessions/transcripts stay chain-verified (#6453) but not
-    // downgrade-resistant, exactly mirroring `configure_history_integrity_from_default_vault`'s
-    // own degrade posture.
+    // downgrade-resistant, exactly mirroring `configure_history_integrity`'s own degrade
+    // posture.
     if config.integrity.anchor == zeph_config::AnchorMode::Vault {
         if let Some(vault_arc) = app.age_vault_arc() {
             let store: std::sync::Arc<dyn zeph_common::anchor::AnchorStore> =
@@ -4595,6 +4645,62 @@ mod deep_link_tests {
 mod tests {
     use super::*;
     use clap::Parser;
+
+    // --- configure_history_integrity (#6547) ---
+    //
+    // `configure_history_integrity` mutates process-global state (via
+    // `zeph_subagent::transcript::configure_history_integrity`/
+    // `zeph_session::log::configure_history_integrity`), so this relies on cargo nextest's
+    // one-process-per-test model for isolation, the same precondition
+    // `crates/zeph-subagent/src/transcript.rs`'s own hash-chain tests document and depend on.
+    #[tokio::test]
+    async fn configure_history_integrity_resolves_key_from_explicit_path_not_default_vault_dir() {
+        let vault_dir = tempfile::tempdir().unwrap();
+        zeph_core::vault::AgeVaultProvider::init_vault(vault_dir.path()).unwrap();
+        let key_path = vault_dir.path().join("vault-key.txt");
+        let vault_path = vault_dir.path().join("secrets.age");
+        let mut provider = zeph_core::vault::AgeVaultProvider::load(&key_path, &vault_path)
+            .expect("age vault must load right after init");
+        provider
+            .set_secret_mut(
+                zeph_core::history_integrity::HISTORY_KEY_SECRET.to_owned(),
+                zeph_core::history_integrity::generate_history_key_b64(),
+                false,
+            )
+            .unwrap();
+        provider.save().unwrap();
+
+        // A path distinct from `vault_dir` that is never touched: proves the function reads
+        // from the explicit paths, not `zeph_core::vault::default_vault_dir()`.
+        configure_history_integrity(&key_path, &vault_path);
+
+        let transcript_dir = tempfile::tempdir().unwrap();
+        let transcript_path = transcript_dir.path().join("abc.jsonl");
+        let writer = zeph_subagent::transcript::TranscriptWriter::new(&transcript_path).unwrap();
+        writer
+            .append(
+                0,
+                &zeph_llm::provider::Message {
+                    role: zeph_llm::provider::Role::User,
+                    content: "hello".to_owned(),
+                    parts: vec![],
+                    metadata: zeph_llm::provider::MessageMetadata::default(),
+                },
+            )
+            .await
+            .unwrap();
+        drop(writer);
+
+        let raw = std::fs::read_to_string(&transcript_path).unwrap();
+        zeph_subagent::transcript::configure_history_integrity(None);
+        zeph_session::log::configure_history_integrity(None);
+
+        assert!(
+            raw.contains("\"chain\":"),
+            "chaining must be active once configure_history_integrity resolves \
+             ZEPH_HISTORY_KEY from the explicit vault path (#6547): {raw}"
+        );
+    }
 
     // --- warn_if_tui_requested_but_unavailable ---
 


### PR DESCRIPTION
## Summary

- `configure_history_integrity_from_default_vault` (`src/runner.rs`) and `durable.rs`'s key-material loaders (`load_write_cipher`, `load_write_hmac_key`, `load_write_hwm_key`, `load_integrity_seal`, rotate-key) hardcoded `zeph_core::vault::default_vault_dir()`, silently ignoring `--vault-key`/`--vault-path` CLI overrides already respected by `doctor.rs`/`vault.rs` post-#6499. This made `zeph doctor`'s `integrity.anchor` check report OK against the override vault while the real runtime writer read the default vault instead — hash-chain tamper-evidence was silently inactive with no warning.
- Added `bootstrap::resolve_vault_paths`, a shared wrapper around the existing `parse_vault_args` CLI resolution plus `doctor.rs`'s default-dir fallback, and threaded it through every affected call site:
  - `runner.rs`: history-chain integrity bootstrap (`configure_history_integrity`, renamed)
  - `commands/durable.rs`: all four named key-material loaders, `handle_durable_command`'s own vault-arg forwarding (previously missing entirely, unlike `zeph bench`), `handle_seal_integrity`, and the rotate-key write path (`handle_rotate_key`/`open_window`/`drop_previous`) — found during adversarial review to have the same asymmetry `seal-integrity` had just been fixed for
  - `commands/scheduler_daemon.rs`: `handle_serve`'s non-foreground detach re-exec, which dropped `--vault-key`/`--vault-path` for the long-running daemon process; extracted into a testable `build_detach_args` helper
- 15 new regression tests across `bootstrap/tests.rs`, `commands/durable.rs`, and `commands/scheduler_daemon.rs` proving each fixed path honors an explicit override and doesn't silently fall back to `default_vault_dir()`, plus unchanged-behavior coverage for the no-override case.
- `resolve_registry_token` (`registry_client.rs`) has the identical hardcoded pattern but is out of scope for this PR (different subsystem — plugin/skill registry auth, not history/durable); filed as a follow-up issue.

Closes #6547
Closes #6548

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 14885 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `gitleaks protect --staged` — no leaks
- [x] No real/default vault touched at any point; all new/modified tests use `tempfile`/`XDG_CONFIG_HOME` redirection with explicit override paths