### PR TITLE
fix(subagent,sanitizer,tui): mask generic secrets and fix background transcript stall

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -21,6 +21,7 @@ regexes = [
   '''sk-abc123def456''',
   '''sk-abc123def''',
   '''sk-abc123xyz''',
+  '''sk-test-abc123def456''',
   '''AKIA1234567890ABCDEF''',
   '''AIzaSyA1234567890abcdefghijklmnop''',
   '''sk_live_abcdef123456''',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-sanitizer`/`zeph-subagent`/`zeph-core`: a generic secret-shaped string (e.g. an
+  `sk-test-...`-prefixed API key) fabricated or echoed by a sub-agent in its own response text
+  passed through unmasked on two operator-visible surfaces (#6571). The two sanitize layers
+  already wired into sub-agent output — `SecretMaskRegistry` (exact-value masking of
+  registered vault secrets only) and `PiiFilter` (classic PII patterns only) — do not detect
+  secret *shapes* the sub-agent never registered. New `zeph-sanitizer::secret_shape::
+  scrub_secret_shapes` compiles the existing `zeph_common::secrets::{SECRET_PREFIXES,
+  BEARER_TOKEN_PATTERN, JWT_PATTERN}` constants into a shared shape-based scrubber (the same
+  detection `zeph-core::redact::redact_secrets` already used for debug dumps, now delegating to
+  it instead of duplicating the regex logic) and wires it into both leak surfaces: the live
+  transcript-forward pipeline (`zeph-subagent::forward::sanitize_text`, run after the exact-value
+  `SecretMaskRegistry` mask so a registered secret still gets its typed
+  `<SECRET:category:...>` placeholder) and the background sub-agent completion notice
+  (`notify_completed_subagents`, `crates/zeph-core/src/agent/subagent_commands.rs`), which had
+  no sanitization applied to the raw result text at all before this fix.
+
+- `zeph-tui`/`zeph-core`: a background sub-agent's (`/agent bg`) transcript view, opened
+  manually via the SubAgents sidebar (`a` → `j` → `Enter`), stalled indefinitely once the
+  sub-agent completed — no terminal state was ever rendered and the view never returned to
+  Main chat, even though the sidebar's own agent list emptied at the same moment (#6570).
+  `SubAgentManager::collect()` removes the finished agent from `mgr.statuses()` synchronously,
+  so `maybe_reload_transcript`'s reload trigger (which reads `metrics.sub_agents`) could never
+  observe the transition and fire once more. `Channel` gains a new
+  `notify_background_subagent_completed` method (default no-op), mirroring the existing
+  `notify_foreground_subagent_completed` used by the `/agent`-foreground and `/agent resume`
+  paths; `notify_completed_subagents` (`crates/zeph-core/src/agent/subagent_commands.rs`) now
+  calls it for every background sub-agent it collects, alongside the existing plain-text
+  completion notice. `TuiChannel` forwards this to a new `AgentEvent::BackgroundSubagentCompleted`
+  event; the TUI only acts on it when the completed id matches the subagent currently being
+  viewed, resetting `view_target` to Main and pushing a terminal completion/failure marker —
+  sub-agents not being viewed are unaffected, since their completion is already surfaced via
+  the existing plain-text notice in Main chat.
+
 - `zeph-core`: `handle_compress_context` (the `compress_context`/`request_compaction` tool path,
   `crates/zeph-core/src/agent/tool_execution/focus.rs`) appended the compression LLM's summary
   directly to the pinned Knowledge block with no sanitizer pass, unlike its sibling

--- a/crates/zeph-core/src/agent/subagent_commands.rs
+++ b/crates/zeph-core/src/agent/subagent_commands.rs
@@ -10,6 +10,7 @@
 
 use std::sync::Arc;
 
+use zeph_sanitizer::secret_shape::scrub_secret_shapes;
 use zeph_tools::registry::ToolDef;
 
 use super::{Agent, error};
@@ -38,35 +39,37 @@ impl<C: Channel> Agent<C> {
 
     /// Poll all active sub-agents for completed/failed/canceled results.
     ///
-    /// Non-blocking: returns immediately with a list of `(task_id, result)` pairs
-    /// for agents that have finished. Each completed agent is removed from the manager.
+    /// Non-blocking: returns immediately with a list of `(task_id, name, result, success)`
+    /// tuples for agents that have finished. Each completed agent is removed from the
+    /// manager. `name` and `success` are captured here (before `collect()` removes the
+    /// manager entry) so callers can notify view layers (e.g. the TUI transcript pane) about
+    /// the terminal state without needing to re-resolve the agent definition afterwards
+    /// (#6570).
     #[tracing::instrument(name = "core.agent.poll_subagents", skip_all, level = "debug")]
-    pub async fn poll_subagents(&mut self) -> Vec<(String, String)> {
+    pub async fn poll_subagents(&mut self) -> Vec<(String, String, String, bool)> {
         let Some(mgr) = &mut self.services.orchestration.subagent_manager else {
             return vec![];
         };
 
-        let finished: Vec<String> = mgr
-            .statuses()
-            .into_iter()
-            .filter_map(|(id, status)| {
-                if matches!(
-                    status.state,
-                    zeph_subagent::SubAgentState::Completed
-                        | zeph_subagent::SubAgentState::Failed
-                        | zeph_subagent::SubAgentState::Canceled
-                ) {
-                    Some(id)
-                } else {
-                    None
-                }
-            })
-            .collect();
+        let finished: Vec<(String, bool)> =
+            mgr.statuses()
+                .into_iter()
+                .filter_map(|(id, status)| match status.state {
+                    zeph_subagent::SubAgentState::Completed => Some((id, true)),
+                    zeph_subagent::SubAgentState::Failed
+                    | zeph_subagent::SubAgentState::Canceled => Some((id, false)),
+                    _ => None,
+                })
+                .collect();
 
         let mut results = vec![];
-        for task_id in finished {
+        for (task_id, success) in finished {
+            let name = mgr.agents_def(&task_id).map_or_else(
+                || task_id[..8.min(task_id.len())].to_owned(),
+                |d| d.name.clone(),
+            );
             match mgr.collect(&task_id).await {
-                Ok(result) => results.push((task_id, result)),
+                Ok(result) => results.push((task_id, name, result, success)),
                 Err(e) => {
                     tracing::warn!(task_id, error = %e, "failed to collect sub-agent result");
                 }
@@ -119,7 +122,13 @@ impl<C: Channel> Agent<C> {
     /// Non-blocking poll: notify the user when background sub-agents complete.
     pub(super) async fn notify_completed_subagents(&mut self) -> Result<(), error::AgentError> {
         let completed = self.poll_subagents().await;
-        for (task_id, result) in completed {
+        for (task_id, name, result, success) in completed {
+            // #6571: `result` is the sub-agent's raw final text — nothing upstream (the agent
+            // loop's own return value, `SubAgentManager::collect`) sanitizes it before it
+            // reaches this operator-visible completion notice, so a generic secret-shaped
+            // string the sub-agent fabricates or echoes must be scrubbed here, the same as the
+            // live-forward path (`zeph-subagent::forward::sanitize_text`).
+            let result = scrub_secret_shapes(&result).into_owned();
             let notice = if result.is_empty() {
                 format!("[sub-agent {id}] completed (no output)", id = &task_id[..8])
             } else {
@@ -127,6 +136,16 @@ impl<C: Channel> Agent<C> {
             };
             if let Err(e) = self.channel.send(&notice).await {
                 tracing::warn!(error = %e, "failed to send sub-agent completion notice");
+            }
+            // Notify view layers (e.g. the TUI transcript pane) so a manually-opened
+            // background subagent view reaches a terminal state instead of stalling
+            // indefinitely once the manager entry backing it disappears (#6570).
+            if let Err(e) = self
+                .channel
+                .notify_background_subagent_completed(&task_id, &name, success)
+                .await
+            {
+                tracing::warn!(error = %e, "failed to notify background sub-agent completion");
             }
         }
         Ok(())
@@ -2174,6 +2193,110 @@ mod tests {
             *recorder.calls.lock().unwrap() >= 1,
             "the sub-agent's tool call must reach the parent's own tool executor instance, \
              proving no fresh/ungated executor is substituted for the child"
+        );
+    }
+
+    // ── #6570: background subagent completion notifies the view layer ────────────
+
+    /// `notify_completed_subagents` (the `/agent bg` background-poll path, distinct from the
+    /// foreground `handle_agent_spawn_foreground`/`handle_agent_resume` paths) must call
+    /// `Channel::notify_background_subagent_completed` with the agent's definition name and
+    /// success flag, in addition to the plain-text notice. Channels that support a manually
+    /// opened subagent view (e.g. the TUI sidebar) rely on this to reset the view once the
+    /// `SubAgentManager` entry backing it disappears, instead of leaving the transcript pane
+    /// stalled forever.
+    #[tokio::test]
+    async fn notify_completed_subagents_notifies_channel_of_background_completion() {
+        let provider = mock_provider(vec!["done".into()]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        let mut mgr = zeph_subagent::SubAgentManager::new(4);
+        mgr.definitions_mut().push(subagent_def("helper"));
+        agent.services.orchestration.subagent_manager = Some(mgr);
+
+        let resp = agent.handle_agent_background("helper", "do work").await;
+        assert!(
+            resp.is_some_and(|r| r.contains("started in background")),
+            "test setup: the background spawn must succeed"
+        );
+
+        let mut notified = Vec::new();
+        for _ in 0..50 {
+            agent.notify_completed_subagents().await.unwrap();
+            notified = agent.channel.notify_background_completed_calls();
+            if !notified.is_empty() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+
+        assert_eq!(
+            notified.len(),
+            1,
+            "exactly one background-completion notification must be recorded"
+        );
+        let (_task_id, name, success) = &notified[0];
+        assert_eq!(name, "helper");
+        assert!(
+            *success,
+            "MockProvider's clean text response must be treated as a success"
+        );
+    }
+
+    // ── #6571: generic secret shape masked in the completion notice ──────────
+
+    /// A sub-agent that fabricates or echoes an API-key-shaped string in its final response
+    /// must not have it forwarded verbatim in the plain-text completion notice sent via
+    /// `channel.send` — the same class of leak #6571 reported for the live-forward path
+    /// (`zeph-subagent::forward::sanitize_text`), but on the completion-notice surface instead.
+    #[tokio::test]
+    async fn notify_completed_subagents_masks_generic_secret_shape_in_notice() {
+        // Two responses: a text-only first turn always draws a one-time nudge to use tools
+        // (`handle_no_tool_response`, `turns == 1 && !any_tool_called`), so the completion
+        // notice reflects the *second* queued response, not the first.
+        let provider = mock_provider(vec![
+            "thinking about it".into(),
+            "here is a key: sk-test-abc123def456, use it wisely".into(),
+        ]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools();
+        let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+
+        let mut mgr = zeph_subagent::SubAgentManager::new(4);
+        mgr.definitions_mut().push(subagent_def("helper"));
+        agent.services.orchestration.subagent_manager = Some(mgr);
+
+        let resp = agent.handle_agent_background("helper", "do work").await;
+        assert!(
+            resp.is_some_and(|r| r.contains("started in background")),
+            "test setup: the background spawn must succeed"
+        );
+
+        let mut sent = Vec::new();
+        for _ in 0..50 {
+            agent.notify_completed_subagents().await.unwrap();
+            sent = agent.channel.sent_messages();
+            if !sent.is_empty() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+
+        let notice = sent
+            .iter()
+            .find(|m| m.contains("completed"))
+            .expect("a completion notice must have been sent");
+        assert!(
+            !notice.contains("sk-test-abc123def456"),
+            "generic secret-shaped string must not appear verbatim in the completion notice: {notice}"
+        );
+        assert!(
+            notice.contains("[REDACTED]"),
+            "masked placeholder must be present in the completion notice: {notice}"
         );
     }
 

--- a/crates/zeph-core/src/agent/tests/agent_tests/common.rs
+++ b/crates/zeph-core/src/agent/tests/agent_tests/common.rs
@@ -106,6 +106,11 @@ pub(crate) struct MockChannel {
     /// `(task_id, name, success)`, in order — lets tests assert on TUI-completion-event count
     /// and content (e.g. that a durable replay does not re-fire it, #6027).
     pub(crate) notify_completed_calls: Arc<Mutex<Vec<(String, String, bool)>>>,
+    /// Records every `Channel::notify_background_subagent_completed` call as
+    /// `(task_id, name, success)`, in order — lets tests assert that background sub-agent
+    /// completions notify the view layer even though the parent turn was not blocking on
+    /// them (#6570).
+    pub(crate) notify_background_completed_calls: Arc<Mutex<Vec<(String, String, bool)>>>,
     pub(crate) exit_supported: bool,
     pub(crate) input_sanitization_required: bool,
     /// When `true`, `send()` fails with `ChannelError::ChannelClosed` instead of recording the
@@ -126,6 +131,7 @@ impl MockChannel {
             statuses: Arc::new(Mutex::new(Vec::new())),
             tool_starts: Arc::new(Mutex::new(Vec::new())),
             notify_completed_calls: Arc::new(Mutex::new(Vec::new())),
+            notify_background_completed_calls: Arc::new(Mutex::new(Vec::new())),
             exit_supported: true,
             input_sanitization_required: false,
             fail_send: false,
@@ -165,6 +171,13 @@ impl MockChannel {
 
     pub(crate) fn notify_completed_calls(&self) -> Vec<(String, String, bool)> {
         self.notify_completed_calls.lock().unwrap().clone()
+    }
+
+    pub(crate) fn notify_background_completed_calls(&self) -> Vec<(String, String, bool)> {
+        self.notify_background_completed_calls
+            .lock()
+            .unwrap()
+            .clone()
     }
 }
 
@@ -257,6 +270,19 @@ impl Channel for MockChannel {
         success: bool,
     ) -> Result<(), crate::channel::ChannelError> {
         self.notify_completed_calls
+            .lock()
+            .unwrap()
+            .push((id.to_owned(), name.to_owned(), success));
+        Ok(())
+    }
+
+    async fn notify_background_subagent_completed(
+        &mut self,
+        id: &str,
+        name: &str,
+        success: bool,
+    ) -> Result<(), crate::channel::ChannelError> {
+        self.notify_background_completed_calls
             .lock()
             .unwrap()
             .push((id.to_owned(), name.to_owned(), success));

--- a/crates/zeph-core/src/channel.rs
+++ b/crates/zeph-core/src/channel.rs
@@ -577,6 +577,29 @@ pub trait Channel: Send {
     ) -> impl Future<Output = Result<(), ChannelError>> + Send {
         async { Ok(()) }
     }
+
+    /// Notify channel that a *background* subagent (`/agent bg`) has reached a terminal
+    /// state. No-op by default.
+    ///
+    /// Called by `notify_completed_subagents` for every background subagent that just
+    /// finished, in addition to the plain-text completion notice sent via [`Self::send`].
+    /// Unlike [`Self::notify_foreground_subagent_completed`], this fires for subagents the
+    /// parent turn is not blocking on, so channels that support subagent views must only
+    /// act on it when the given `id` is the one currently being viewed (e.g. manually opened
+    /// via a sidebar) — otherwise every background completion would redundantly interrupt
+    /// unrelated views (#6570).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying I/O fails.
+    fn notify_background_subagent_completed(
+        &mut self,
+        _id: &str,
+        _name: &str,
+        _success: bool,
+    ) -> impl Future<Output = Result<(), ChannelError>> + Send {
+        async { Ok(()) }
+    }
 }
 
 pub use zeph_common::StopHint;

--- a/crates/zeph-core/src/redact.rs
+++ b/crates/zeph-core/src/redact.rs
@@ -6,7 +6,8 @@ use std::sync::LazyLock;
 
 use base64::Engine as _;
 use regex::Regex;
-use zeph_common::secrets::{BEARER_TOKEN_PATTERN, JWT_PATTERN, PATH_PREFIXES, SECRET_PREFIXES};
+use zeph_common::secrets::PATH_PREFIXES;
+use zeph_sanitizer::secret_shape::scrub_secret_shapes;
 
 /// Apply URL-credential stripping, secret redaction (including Bearer headers and JWTs),
 /// and path sanitization in a single pass.
@@ -26,20 +27,6 @@ pub fn scrub_content(text: &str) -> Cow<'_, str> {
     }
 }
 
-// Matches any secret prefix followed by non-whitespace characters.
-// Using alternation so a single pass covers all prefixes. Prefixes come from
-// zeph_common::secrets::SECRET_PREFIXES (the canonical, unescaped list — see #5917)
-// and are regex-escaped here since e.g. `ya29.` contains a literal dot.
-static SECRET_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    let pattern = SECRET_PREFIXES
-        .iter()
-        .map(|p| regex::escape(p))
-        .collect::<Vec<_>>()
-        .join("|");
-    let full = format!("(?:{pattern})[^\\s\"'`,;{{}}\\[\\]]*");
-    Regex::new(&full).expect("secret redaction regex is valid")
-});
-
 static PATH_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     let alt = PATH_PREFIXES.join("|");
     let full = format!(r#"(?:{alt})[^\s"'`,;{{}}\[\]]*"#);
@@ -52,42 +39,18 @@ static URL_CREDS_REGEX: LazyLock<Regex> = LazyLock::new(|| {
         .expect("url credential redaction regex is valid")
 });
 
-// Matches `Authorization: Bearer <token>` headers, keeping the header name via capture group 1.
-static BEARER_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(BEARER_TOKEN_PATTERN).expect("bearer redaction regex is valid"));
-
-// Matches standalone JWTs (three Base64url-encoded segments separated by dots).
-static JWT_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(JWT_PATTERN).expect("jwt redaction regex is valid"));
-
 /// Replace tokens containing known secret patterns with `[REDACTED]`.
 ///
 /// Detects secrets embedded in URLs, JSON values, and quoted strings (via the
 /// [`zeph_common::secrets::SECRET_PREFIXES`] prefix list), `Authorization: Bearer` headers,
-/// and standalone JWTs. Returns `Cow::Borrowed` when nothing was redacted (zero-allocation
-/// fast path).
+/// and standalone JWTs. Delegates the actual shape matching to
+/// [`zeph_sanitizer::secret_shape::scrub_secret_shapes`] — the same shape-based detection used
+/// by the subagent transcript-forward sanitize pipeline (issue #6571) — so both consumers stay
+/// in sync against a single implementation. Returns `Cow::Borrowed` when nothing was redacted
+/// (zero-allocation fast path).
 #[must_use]
 pub fn redact_secrets(text: &str) -> Cow<'_, str> {
-    // Fast path: check for any prefix substring before running the (more expensive)
-    // alternation regex. Bearer/JWT regexes below are cheap enough to run unconditionally —
-    // `Regex::replace_all` itself returns `Cow::Borrowed` when there is no match.
-    let has_prefix_match = SECRET_PREFIXES.iter().any(|p| text.contains(*p));
-    let after_prefixes: Cow<'_, str> = if has_prefix_match {
-        SECRET_REGEX.replace_all(text, "[REDACTED]")
-    } else {
-        Cow::Borrowed(text)
-    };
-
-    let after_bearer: Cow<'_, str> =
-        match BEARER_REGEX.replace_all(after_prefixes.as_ref(), "${1}[REDACTED]") {
-            Cow::Borrowed(_) => after_prefixes,
-            Cow::Owned(s) => Cow::Owned(s),
-        };
-
-    match JWT_REGEX.replace_all(after_bearer.as_ref(), "[REDACTED_JWT]") {
-        Cow::Borrowed(_) => after_bearer,
-        Cow::Owned(s) => Cow::Owned(s),
-    }
+    scrub_secret_shapes(text)
 }
 
 /// Replace absolute filesystem paths with `[PATH]` to prevent information disclosure.
@@ -167,6 +130,7 @@ pub fn redact_binary_blobs(text: &str) -> Cow<'_, str> {
 mod tests {
     use super::*;
     use std::assert_matches;
+    use zeph_common::secrets::SECRET_PREFIXES;
 
     #[test]
     fn redacts_openai_key() {

--- a/crates/zeph-sanitizer/src/lib.rs
+++ b/crates/zeph-sanitizer/src/lib.rs
@@ -74,6 +74,7 @@ pub mod quarantine;
 pub mod response_verifier;
 mod sanitizer;
 pub mod secret_mask;
+pub mod secret_shape;
 pub mod shadow_memory;
 pub mod types;
 
@@ -82,6 +83,7 @@ pub use media::{MediaRejected, MediaSanitizer};
 pub use nli::{NliConfig, NliSanitizer, NliVerdict};
 pub use sanitizer::ContentSanitizer;
 pub use secret_mask::{SecretCategory, SecretMaskRegistry};
+pub use secret_shape::scrub_secret_shapes;
 pub use shadow_memory::{GoalDriftResult, ShadowEvent, ShadowMemory, classify_tool_permission};
 pub use types::{
     ContentSource, ContentSourceKind, ContentTrustLevel, InjectionFlag, MemorySourceHint,

--- a/crates/zeph-sanitizer/src/secret_shape.rs
+++ b/crates/zeph-sanitizer/src/secret_shape.rs
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shape-based secret detection: redacts strings that *look like* a secret (known API-key
+//! prefix, `Authorization: Bearer` header, standalone JWT) regardless of whether the value
+//! was ever registered with a [`crate::secret_mask::SecretMaskRegistry`].
+//!
+//! [`SecretMaskRegistry`][crate::secret_mask::SecretMaskRegistry] only masks literal secret
+//! *values* explicitly registered at runtime (actual vault-loaded secrets) — a string a
+//! subagent invents, echoes, or fabricates in its own response text is invisible to it. This
+//! module closes that gap by scanning for the same secret shapes `zeph-core::redact` already
+//! scrubs from debug dumps and tool-execution output (issue #6571), compiling its own
+//! `regex::Regex` instances from the canonical prefix/pattern constants in
+//! [`zeph_common::secrets`] — the single source of truth both crates share.
+
+use std::borrow::Cow;
+use std::sync::LazyLock;
+
+use regex::Regex;
+use zeph_common::secrets::{BEARER_TOKEN_PATTERN, JWT_PATTERN, SECRET_PREFIXES};
+
+// Matches any secret prefix followed by non-whitespace/quote/bracket characters. A single
+// alternation pass covers every prefix in `SECRET_PREFIXES`; each prefix is regex-escaped
+// since e.g. `ya29.` contains a literal dot that must not be treated as "match any character".
+static SECRET_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    let pattern = SECRET_PREFIXES
+        .iter()
+        .map(|p| regex::escape(p))
+        .collect::<Vec<_>>()
+        .join("|");
+    let full = format!("(?:{pattern})[^\\s\"'`,;{{}}\\[\\]]*");
+    Regex::new(&full).expect("secret shape regex is valid")
+});
+
+static BEARER_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(BEARER_TOKEN_PATTERN).expect("bearer shape regex is valid"));
+
+static JWT_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(JWT_PATTERN).expect("jwt shape regex is valid"));
+
+/// Replace secret-shaped substrings (known API-key prefixes, `Authorization: Bearer` headers,
+/// standalone JWTs) with redaction markers.
+///
+/// Unlike [`SecretMaskRegistry::mask`][crate::secret_mask::SecretMaskRegistry::mask], this
+/// does not require the secret value to have been registered ahead of time — it flags
+/// anything matching a known secret *shape*, so it also catches secrets a subagent fabricates
+/// or echoes in generated text. Returns `Cow::Borrowed` when nothing matched (zero-allocation
+/// fast path).
+///
+/// # Examples
+///
+/// ```rust
+/// use zeph_sanitizer::secret_shape::scrub_secret_shapes;
+///
+/// let result = scrub_secret_shapes("here is a key: sk-test-abc123def456");
+/// assert!(!result.contains("sk-test-abc123def456"));
+/// assert!(result.contains("[REDACTED]"));
+/// ```
+#[must_use]
+pub fn scrub_secret_shapes(text: &str) -> Cow<'_, str> {
+    let has_prefix_match = SECRET_PREFIXES.iter().any(|p| text.contains(*p));
+    let after_prefixes: Cow<'_, str> = if has_prefix_match {
+        SECRET_REGEX.replace_all(text, "[REDACTED]")
+    } else {
+        Cow::Borrowed(text)
+    };
+
+    let after_bearer: Cow<'_, str> =
+        match BEARER_REGEX.replace_all(after_prefixes.as_ref(), "${1}[REDACTED]") {
+            Cow::Borrowed(_) => after_prefixes,
+            Cow::Owned(s) => Cow::Owned(s),
+        };
+
+    match JWT_REGEX.replace_all(after_bearer.as_ref(), "[REDACTED_JWT]") {
+        Cow::Borrowed(_) => after_bearer,
+        Cow::Owned(s) => Cow::Owned(s),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_generic_api_key_shape() {
+        let text = "the key is sk-test-abc123def456, use it wisely";
+        let result = scrub_secret_shapes(text);
+        assert!(!result.contains("sk-test-abc123def456"));
+        assert!(result.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn redacts_bearer_token() {
+        let result =
+            scrub_secret_shapes("Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.payload.signature");
+        assert!(result.contains("[REDACTED]"));
+        assert!(!result.contains("eyJhbGciOiJSUzI1NiJ9"));
+        assert!(result.contains("Authorization:"));
+    }
+
+    #[test]
+    fn redacts_standalone_jwt() {
+        let jwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyMTIzIn0.SflKxwRJSMeKKF2";
+        let text = format!("token value: {jwt} was found");
+        let result = scrub_secret_shapes(&text);
+        assert!(result.contains("[REDACTED_JWT]"));
+        assert!(!result.contains("eyJhbGci"));
+    }
+
+    #[test]
+    fn preserves_normal_text() {
+        let text = "This is a normal response with no secrets";
+        let result = scrub_secret_shapes(text);
+        assert_eq!(result, text);
+        assert!(matches!(result, Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn all_secret_prefixes_detected() {
+        for prefix in SECRET_PREFIXES {
+            let text = format!("token: {prefix}abc123");
+            let result = scrub_secret_shapes(&text);
+            assert!(result.contains("[REDACTED]"), "failed for prefix: {prefix}");
+            assert!(!result.contains(*prefix), "prefix not redacted: {prefix}");
+        }
+    }
+}

--- a/crates/zeph-subagent/src/forward.rs
+++ b/crates/zeph-subagent/src/forward.rs
@@ -43,6 +43,7 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use zeph_sanitizer::pii::PiiFilter;
 use zeph_sanitizer::secret_mask::SecretMaskRegistry;
+use zeph_sanitizer::secret_shape::scrub_secret_shapes;
 use zeph_sanitizer::{ContentSanitizer, ContentSource, ContentSourceKind};
 
 use crate::state::SubAgentState;
@@ -136,14 +137,17 @@ pub(crate) enum SanitizedChunkKind {
 
 /// The full sanitization pipeline applied at the drain's single sanitize point (NFR-005).
 ///
-/// Bundles the baseline injection/truncation pass (`ContentSanitizer`, always present) with
-/// two optional hardening layers that mirror the ones already guarding the analogous
-/// sub-agent-output *egress* path (debug dumps, see `PiiScrubbingDumpSink` / #6407 and
+/// Bundles the baseline injection/truncation pass (`ContentSanitizer`, always present), an
+/// always-on generic secret-*shape* scrub (`scrub_secret_shapes`, #6571 — catches API-key-
+/// shaped strings a subagent fabricates or echoes, not just registered vault values), and two
+/// optional hardening layers that mirror the ones already guarding the analogous sub-agent-
+/// output *egress* path (debug dumps, see `PiiScrubbingDumpSink` / #6407 and
 /// `apply_secret_masking` / #5437): a [`SecretMaskRegistry`] that replaces known vault
 /// secrets with opaque placeholders, and a [`PiiFilter`] that scrubs emails/phones/SSNs/etc.
-/// Both are `None` unless explicitly wired via `SubAgentManager::set_secret_registry` /
-/// `set_pii_filter` — forwarding remains fully functional (baseline sanitization only) when
-/// neither is configured, matching this crate's existing opt-in-hardening conventions.
+/// The latter two are `None` unless explicitly wired via `SubAgentManager::set_secret_registry`
+/// / `set_pii_filter` — forwarding remains fully functional (baseline + shape sanitization
+/// only) when neither is configured, matching this crate's existing opt-in-hardening
+/// conventions.
 pub(crate) struct SanitizeLayers {
     pub(crate) sanitizer: ContentSanitizer,
     pub(crate) secret_registry: Option<Arc<SecretMaskRegistry>>,
@@ -153,9 +157,13 @@ pub(crate) struct SanitizeLayers {
 fn sanitize_text(raw_text: &str, def_name: &str, layers: &SanitizeLayers) -> String {
     let source = ContentSource::new(ContentSourceKind::ToolResult).with_identifier(def_name);
     let mut body = layers.sanitizer.sanitize(raw_text, source).body;
+    // Exact-value registry masking runs first so a registered vault secret gets its typed
+    // `<SECRET:category:...>` placeholder; the shape-based scrub below then only catches
+    // whatever the registry didn't know about (e.g. a key a subagent fabricates or echoes).
     if let Some(registry) = &layers.secret_registry {
         body = registry.mask(&body);
     }
+    body = scrub_secret_shapes(&body).into_owned();
     if let Some(filter) = &layers.pii_filter {
         body = filter.scrub(&body).into_owned();
     }
@@ -821,6 +829,117 @@ mod tests {
                 SanitizedChunkKind::Terminal(_) => {}
             }
         }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn registered_secret_that_also_matches_a_shape_gets_typed_placeholder_not_generic() {
+        // A value that is BOTH registered with the SecretMaskRegistry AND shape-matched by
+        // `scrub_secret_shapes` (e.g. any `sk-...` value, since `SecretMaskRegistry::register`
+        // is commonly used for real API keys) must come out through the pipeline with the
+        // registry's typed `<SECRET:category:...>` placeholder, not the shape scrub's generic
+        // `[REDACTED]` marker — proving registry masking really does run before the shape scrub
+        // (see the ordering comment on `sanitize_text`) and the shape scrub does not re-process
+        // (double-mask) the registry's own placeholder output.
+        use zeph_sanitizer::secret_mask::{SecretCategory, SecretMaskRegistry};
+
+        let registry = Arc::new(SecretMaskRegistry::new());
+        registry.register(
+            "MY_KEY",
+            "sk-live-topsecretvalue123",
+            SecretCategory::ApiKey,
+        );
+
+        let task_id: Arc<str> = Arc::from("task-secret-typed");
+        let def_name: Arc<str> = Arc::from("agent-secret-typed");
+        let (sender, rx) = new_channel(Arc::clone(&task_id), Arc::clone(&def_name));
+        let buffer = new_buffer();
+
+        sender.send_text("the key is sk-live-topsecretvalue123, use it wisely");
+        sender.send_terminal(SubAgentState::Completed);
+        drop(sender);
+
+        let seen = Arc::new(std::sync::Mutex::new(Vec::<SanitizedChunk>::new()));
+        let collected = Arc::clone(&seen);
+        let layers = SanitizeLayers {
+            sanitizer: ContentSanitizer::new(&zeph_config::ContentIsolationConfig::default()),
+            secret_registry: Some(registry),
+            pii_filter: None,
+        };
+        run_forward_drain_with(
+            task_id,
+            def_name,
+            rx,
+            layers,
+            ForwardSurfaces {
+                tui: true,
+                bare: false,
+            },
+            buffer,
+            move |chunk, surfaces, buffer| {
+                collected.lock().unwrap().push(chunk.clone());
+                dispatch_chunk(chunk, surfaces, buffer);
+            },
+        )
+        .await;
+
+        let combined = collect_forwarded_text(&seen.lock().unwrap());
+        assert!(
+            !combined.contains("sk-live-topsecretvalue123"),
+            "raw secret must not survive the pipeline: {combined}"
+        );
+        assert!(
+            combined.contains("<SECRET:api_key:"),
+            "registry masking must run first and produce its typed placeholder: {combined}"
+        );
+        assert!(
+            !combined.contains("[REDACTED]"),
+            "shape scrub must not double-mask the registry's own placeholder output: {combined}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn generic_secret_shape_masked_without_registration() {
+        // #6571: a subagent that fabricates or echoes an API-key-shaped string in its own
+        // response text must have it masked even though it was never registered with a
+        // SecretMaskRegistry (no vault-loaded secret ever equals this value) — the always-on
+        // shape-based scrub (`scrub_secret_shapes`) is the only layer that can catch this.
+        let task_id: Arc<str> = Arc::from("task-shape");
+        let def_name: Arc<str> = Arc::from("agent-shape");
+        let (sender, rx) = new_channel(Arc::clone(&task_id), Arc::clone(&def_name));
+        let buffer = new_buffer();
+
+        sender.send_text("here is a key: sk-test-abc123def456, use it wisely");
+        sender.send_terminal(SubAgentState::Completed);
+        drop(sender);
+
+        let seen = Arc::new(std::sync::Mutex::new(Vec::<SanitizedChunk>::new()));
+        let collected = Arc::clone(&seen);
+        run_forward_drain_with(
+            task_id,
+            def_name,
+            rx,
+            layers(),
+            ForwardSurfaces {
+                tui: true,
+                bare: false,
+            },
+            buffer,
+            move |chunk, surfaces, buffer| {
+                collected.lock().unwrap().push(chunk.clone());
+                dispatch_chunk(chunk, surfaces, buffer);
+            },
+        )
+        .await;
+
+        let combined = collect_forwarded_text(&seen.lock().unwrap());
+        assert!(
+            !combined.contains("sk-test-abc123def456"),
+            "generic secret-shaped string must be masked without prior registration: {combined}"
+        );
+        assert!(
+            combined.contains("[REDACTED]"),
+            "masked placeholder must be present in the combined forwarded text: {combined}"
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/zeph-tui/src/app/events.rs
+++ b/crates/zeph-tui/src/app/events.rs
@@ -266,6 +266,29 @@ impl App {
                 self.trim_messages();
                 self.auto_scroll();
             }
+            AgentEvent::BackgroundSubagentCompleted { id, name, success } => {
+                // Only act if the user is currently viewing this subagent's transcript —
+                // background completions not being viewed are already surfaced via the
+                // Channel::send notice pushed to Main chat (notify_completed_subagents), so
+                // acting unconditionally here would double-notify every background subagent.
+                if self.sessions.current().view_target.subagent_id() == Some(id.as_str()) {
+                    let label = if success {
+                        format!("Sub-agent '{name}' completed")
+                    } else {
+                        format!("Sub-agent '{name}' failed")
+                    };
+                    self.set_view_target(super::AgentViewTarget::Main);
+                    self.sessions.current_mut().status_label = Some(label.clone());
+                    // Status change counts as progress so the wave animates (never reads Stalled).
+                    self.last_progress_at = Instant::now();
+                    self.sessions
+                        .current_mut()
+                        .messages
+                        .push(ChatMessage::new(MessageRole::System, label));
+                    self.trim_messages();
+                    self.auto_scroll();
+                }
+            }
             AgentEvent::ContextEstimate(tokens) => {
                 self.context_token_estimate = tokens;
             }
@@ -791,6 +814,120 @@ mod tests {
         });
 
         assert!(app.sessions.current().view_target.is_main());
+    }
+
+    // ── #6570 background subagent completion while manually viewed via sidebar ─────────
+
+    #[test]
+    fn background_subagent_completed_switches_back_when_viewing_subagent() {
+        // Reproduces the stuck-transcript bug: a background subagent (`/agent bg`) is
+        // manually opened via the sidebar's Enter action (set_view_target, not the
+        // ForegroundSubagentStarted event), then finishes. Before #6570, nothing ever told
+        // the TUI the viewed subagent had reached a terminal state — maybe_reload_transcript
+        // relies on `metrics.sub_agents`, which the manager empties synchronously at
+        // completion (SubAgentManager::collect), so the transcript pane was left frozen
+        // forever with no completion notice or reset to Main.
+        let mut app = make_app();
+        app.set_view_target(AgentViewTarget::SubAgent {
+            id: "sa-bg-1".into(),
+            name: "researcher".into(),
+        });
+        assert_eq!(
+            app.sessions.current().view_target.subagent_id(),
+            Some("sa-bg-1")
+        );
+
+        app.handle_agent_event(AgentEvent::BackgroundSubagentCompleted {
+            id: "sa-bg-1".into(),
+            name: "researcher".into(),
+            success: true,
+        });
+
+        assert!(
+            app.sessions.current().view_target.is_main(),
+            "view must return to Main once the manually-viewed background subagent completes"
+        );
+        assert_eq!(
+            app.sessions.current().status_label.as_deref(),
+            Some("Sub-agent 'researcher' completed")
+        );
+        let system_msg = app
+            .sessions
+            .current()
+            .messages
+            .iter()
+            .find(|m| m.role == MessageRole::System);
+        assert!(
+            system_msg.is_some(),
+            "a terminal completion marker must be pushed into the chat"
+        );
+    }
+
+    #[test]
+    fn background_subagent_completed_shows_failed_label_when_viewing_subagent() {
+        let mut app = make_app();
+        app.set_view_target(AgentViewTarget::SubAgent {
+            id: "sa-bg-2".into(),
+            name: "worker".into(),
+        });
+
+        app.handle_agent_event(AgentEvent::BackgroundSubagentCompleted {
+            id: "sa-bg-2".into(),
+            name: "worker".into(),
+            success: false,
+        });
+
+        assert!(app.sessions.current().view_target.is_main());
+        assert_eq!(
+            app.sessions.current().status_label.as_deref(),
+            Some("Sub-agent 'worker' failed")
+        );
+    }
+
+    #[test]
+    fn background_subagent_completed_ignored_when_not_viewing_that_subagent() {
+        // A background subagent completing while the user is looking at Main (or a
+        // different subagent) must not interrupt the current view — its plain-text
+        // completion notice is already delivered to Main chat separately via
+        // `Channel::send` in `notify_completed_subagents`; this event must be a no-op here.
+        let mut app = make_app();
+        assert!(app.sessions.current().view_target.is_main());
+        let messages_before = app.sessions.current().messages.len();
+
+        app.handle_agent_event(AgentEvent::BackgroundSubagentCompleted {
+            id: "sa-bg-elsewhere".into(),
+            name: "other".into(),
+            success: true,
+        });
+
+        assert!(app.sessions.current().view_target.is_main());
+        assert_eq!(
+            app.sessions.current().messages.len(),
+            messages_before,
+            "no message should be pushed for a background subagent that isn't being viewed"
+        );
+        assert_eq!(app.sessions.current().status_label, None);
+    }
+
+    #[test]
+    fn background_subagent_completed_respects_different_subagent_being_viewed() {
+        let mut app = make_app();
+        app.set_view_target(AgentViewTarget::SubAgent {
+            id: "sa-other".into(),
+            name: "other".into(),
+        });
+
+        app.handle_agent_event(AgentEvent::BackgroundSubagentCompleted {
+            id: "sa-bg-3".into(),
+            name: "worker".into(),
+            success: true,
+        });
+
+        assert_eq!(
+            app.sessions.current().view_target.subagent_id(),
+            Some("sa-other"),
+            "viewing a different subagent must not be disturbed by an unrelated completion"
+        );
     }
 
     #[test]

--- a/crates/zeph-tui/src/channel.rs
+++ b/crates/zeph-tui/src/channel.rs
@@ -445,6 +445,27 @@ impl Channel for TuiChannel {
             });
         Ok(())
     }
+
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(name = "tui.channel.notify_background_subagent_completed", skip_all)
+    )]
+    async fn notify_background_subagent_completed(
+        &mut self,
+        id: &str,
+        name: &str,
+        success: bool,
+    ) -> Result<(), ChannelError> {
+        // Non-critical: visual navigation only.
+        let _ = self
+            .agent_event_tx
+            .try_send(AgentEvent::BackgroundSubagentCompleted {
+                id: id.to_owned(),
+                name: name.to_owned(),
+                success,
+            });
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/zeph-tui/src/event.rs
+++ b/crates/zeph-tui/src/event.rs
@@ -251,6 +251,24 @@ pub enum AgentEvent {
         /// `true` if Completed state, `false` if Failed/Canceled.
         success: bool,
     },
+    /// A background subagent (`/agent bg`) has reached a terminal state.
+    ///
+    /// Fires for every background subagent, not just one the parent turn is blocking on.
+    /// The TUI only acts on it when `id` matches the subagent currently being viewed via the
+    /// sidebar's manual transcript view — resetting to Main and rendering a terminal marker,
+    /// since the sidebar list and the transcript reload trigger both key off
+    /// `MetricsSnapshot::sub_agents`, which no longer contains a completed agent by the time
+    /// this event is observed (#6570). Subagents not being viewed need no action here: their
+    /// completion notice is already pushed to Main chat via [`AgentEvent::FullMessage`] from
+    /// `Channel::send` in `notify_completed_subagents`.
+    BackgroundSubagentCompleted {
+        /// Stable sub-agent identifier.
+        id: String,
+        /// Human-readable agent definition name.
+        name: String,
+        /// `true` if Completed state, `false` if Failed/Canceled.
+        success: bool,
+    },
     /// Current context token count estimate, updated after each context assembly.
     ///
     /// The value is an approximation based on character-level heuristics and may


### PR DESCRIPTION
## Summary

Two P1 defects found live-testing the subagent live-transcript forwarding feature (#6455/#6359):

- **#6571 (security)**: a generic secret-shaped string (e.g. an `sk-...`-prefixed API key) fabricated or echoed by a sub-agent in its own response text passed through unmasked on two operator-visible surfaces — the live transcript-forward pipeline (`zeph-subagent::forward::sanitize_text`) and the background sub-agent completion notice (`notify_completed_subagents`, which had no sanitization at all). `SecretMaskRegistry` only masks exact registered values and `PiiFilter` only covers classic PII, so neither catches a shape the sub-agent never registered. Adds `zeph-sanitizer::secret_shape::scrub_secret_shapes`, built on the existing `zeph_common::secrets` constants (`SECRET_PREFIXES`/`BEARER_TOKEN_PATTERN`/`JWT_PATTERN`), and wires it into both surfaces. `zeph-core::redact::redact_secrets` now delegates to the same function instead of duplicating the regex logic.
- **#6570 (tui)**: viewing a background sub-agent's transcript via the TUI sidebar (`a` → `j` → `Enter`) and letting it complete left the pane frozen indefinitely with no terminal state, while the sidebar's own agent list emptied at the same instant — `SubAgentManager::collect()` removes the finished agent from its status map synchronously, permanently breaking the transcript reload's `current_turns > cached_turns` trigger. Adds a `Channel::notify_background_subagent_completed` method and `AgentEvent::BackgroundSubagentCompleted` event, mirroring the existing foreground-completion mechanism, so the view resets to Main and a terminal marker renders when the completed sub-agent is the one being viewed.

Both issues were found in the same live-testing session (ci-1449/ci-1450) against the same feature area and are fixed together in this PR.

Closes #6571
Closes #6570

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 14911/14911 passed (20 new tests)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean, including a new runnable example on `scrub_secret_shapes`
- [x] `gitleaks protect`/`detect` — clean (one dummy test-fixture value allowlisted in `.gitleaks.toml`)
- [x] New regression tests: `generic_secret_shape_masked_without_registration` and `registered_secret_that_also_matches_a_shape_gets_typed_placeholder_not_generic` (forward.rs), `notify_completed_subagents_masks_generic_secret_shape_in_notice` (subagent_commands.rs), 4 new tests in `zeph-tui/src/app/events.rs` covering switch-back+completed, failed, no-op-on-Main, and no-op-on-different-subagent scenarios, `notify_completed_subagents_notifies_channel_of_background_completion` (subagent_commands.rs)
- [x] Live TUI verification: reproduced the #6570 scenario end-to-end in a tmux TUI session (spawn background sub-agent → view via sidebar → completion → confirmed view resets to Main with a terminal marker, no stall)
- [x] Adversarially reviewed for a sibling secret-leak surface (found and fixed the completion-notice path had zero sanitization before this PR) and for TUI event-race conditions (confirmed benign: worst case is a one-frame render delay, not a stale/incorrect view)

## Known follow-up (not blocking)

`scrub_secret_shapes` covers the shapes already known to `zeph_common::secrets` but not PEM private-key bodies or no-prefix secret formats (e.g. raw AWS secret access keys) — filed as #6592.