### PR TITLE
fix(index,core): add depth-cap guards against unbounded recursion DoS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   sub-agents not being viewed are unaffected, since their completion is already surfaced via
   the existing plain-text notice in Main chat.
 
+- `zeph-index`/`zeph-core`: two independent uncontrolled-recursion stack-overflow DoS bugs
+  (CWE-674) — `chunk_children` (`crates/zeph-index/src/chunker.rs`) recursed into AST child
+  nodes with no depth limit, and `collect_strings` (`crates/zeph-core/src/agent/tool_execution/
+  tool_call_dag.rs`) recursed over tool-call JSON `input` with no depth limit — either could
+  exhaust the native call stack and abort the whole process (uncatchably — a stack overflow
+  cannot be caught by `catch_unwind`, `Result`, or any async task boundary) on adversarially
+  deep input: a crafted source file placed in a watched/indexed project directory (#6551), or
+  a deeply nested tool-call `input` payload originating from LLM output influenced by untrusted
+  content, e.g. a prompt-injected web page or MCP result (#6554). Both functions now take an
+  explicit `depth: usize` parameter bounded by a module-level const (`MAX_CHUNK_DEPTH = 512`,
+  `MAX_JSON_DEPTH = 256`); at the bound, `chunk_children` emits the oversized subtree as a
+  single leaf chunk instead of recursing further, and `collect_strings` stops descending into
+  that branch — both degrade gracefully rather than crashing, and log a `tracing::warn!` when
+  the bound is hit so operators get a signal that adversarial nesting was encountered. Added 11
+  regression tests (4 chunker, 7 DAG walker) covering the depth boundary, graceful degradation
+  under attacker-scale nesting, and that nesting *depth* (not element count/width) is what's
+  bounded.
+
 - `zeph-core`: `handle_compress_context` (the `compress_context`/`request_compaction` tool path,
   `crates/zeph-core/src/agent/tool_execution/focus.rs`) appended the compression LLM's summary
   directly to the pinned Knowledge block with no sanitizer pass, unlike its sibling

--- a/crates/zeph-core/src/agent/tool_execution/tool_call_dag.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tool_call_dag.rs
@@ -166,6 +166,13 @@ impl ToolCallDag {
     }
 }
 
+/// Maximum JSON nesting depth walked by [`collect_strings`].
+///
+/// Guards against stack overflow on adversarially deep tool-call input (e.g. from
+/// prompt-injected LLM output). Beyond this depth, further descent is simply skipped —
+/// dependency detection just misses strings past the bound rather than crashing.
+const MAX_JSON_DEPTH: usize = 256;
+
 /// Recursively collect all leaf string values from a JSON value.
 ///
 /// Only leaf nodes (strings) are collected; object keys are ignored. Arrays and
@@ -174,21 +181,28 @@ impl ToolCallDag {
 /// (IMP-02 prerequisite failure propagation in `native.rs`).
 pub(super) fn extract_string_values(value: &Value) -> Vec<String> {
     let mut out = Vec::new();
-    collect_strings(value, &mut out);
+    collect_strings(value, &mut out, 0);
     out
 }
 
-fn collect_strings(value: &Value, out: &mut Vec<String>) {
+fn collect_strings(value: &Value, out: &mut Vec<String>, depth: usize) {
+    if depth >= MAX_JSON_DEPTH {
+        tracing::warn!(
+            depth,
+            "collect_strings: max JSON nesting depth reached, skipping further descent"
+        );
+        return;
+    }
     match value {
         Value::String(s) => out.push(s.clone()),
         Value::Array(arr) => {
             for item in arr {
-                collect_strings(item, out);
+                collect_strings(item, out, depth + 1);
             }
         }
         Value::Object(map) => {
             for v in map.values() {
-                collect_strings(v, out);
+                collect_strings(v, out, depth + 1);
             }
         }
         // Numbers, booleans, null — not strings, skip.
@@ -389,5 +403,94 @@ mod tests {
         let calls = [make_call("id_self", json!({"ref": "id_self"}))];
         let dag = ToolCallDag::build(&calls);
         assert!(dag.is_trivial());
+    }
+
+    /// Wraps `leaf` in `depth` nested single-element arrays, e.g. `[[["leaf"]]]`.
+    fn nested_array(depth: usize, leaf: &str) -> Value {
+        let mut v = json!(leaf);
+        for _ in 0..depth {
+            v = Value::Array(vec![v]);
+        }
+        v
+    }
+
+    /// Wraps `leaf` in `depth` nested single-key objects, e.g. `{"k":{"k":"leaf"}}`.
+    fn nested_object(depth: usize, leaf: &str) -> Value {
+        let mut v = json!(leaf);
+        for _ in 0..depth {
+            let mut map = serde_json::Map::new();
+            map.insert("k".to_string(), v);
+            v = Value::Object(map);
+        }
+        v
+    }
+
+    #[test]
+    fn collect_strings_shallow_nesting_unaffected() {
+        let value = nested_array(5, "target");
+        assert_eq!(extract_string_values(&value), vec!["target".to_string()]);
+    }
+
+    #[test]
+    fn collect_strings_array_beyond_depth_bound_drops_leaf_without_panicking() {
+        let value = nested_array(MAX_JSON_DEPTH + 44, "unreachable");
+        assert!(
+            extract_string_values(&value).is_empty(),
+            "leaf string beyond the depth bound must not be collected"
+        );
+    }
+
+    #[test]
+    fn collect_strings_object_beyond_depth_bound_drops_leaf_without_panicking() {
+        let value = nested_object(MAX_JSON_DEPTH + 44, "unreachable");
+        assert!(
+            extract_string_values(&value).is_empty(),
+            "leaf string beyond the depth bound must not be collected"
+        );
+    }
+
+    #[test]
+    fn collect_strings_exact_depth_boundary() {
+        // Leaf's own call depth == MAX_JSON_DEPTH - 1: still inside the bound
+        // (`depth >= MAX_JSON_DEPTH` is false), so it must be collected.
+        let just_inside = nested_array(MAX_JSON_DEPTH - 1, "just_inside");
+        assert_eq!(
+            extract_string_values(&just_inside),
+            vec!["just_inside".to_string()]
+        );
+
+        // Leaf's own call depth == MAX_JSON_DEPTH: guard fires, must be dropped.
+        let just_outside = nested_array(MAX_JSON_DEPTH, "just_outside");
+        assert!(extract_string_values(&just_outside).is_empty());
+    }
+
+    #[test]
+    fn collect_strings_adversarial_scale_does_not_crash() {
+        // Attacker-scale nesting, far beyond the bound — must not overflow the
+        // stack; the depth guard caps real recursion depth at MAX_JSON_DEPTH
+        // regardless of how deeply the input is actually nested.
+        let value = nested_array(2_000, "deep");
+        assert!(extract_string_values(&value).is_empty());
+    }
+
+    #[test]
+    fn collect_strings_wide_flat_array_is_not_bounded_by_width() {
+        // MAX_JSON_DEPTH bounds nesting depth, not array width — a wide flat
+        // array must collect every element regardless of count.
+        let n = 10_000;
+        let arr: Vec<Value> = (0..n).map(|i| json!(format!("item{i}"))).collect();
+        let value = Value::Array(arr);
+        assert_eq!(extract_string_values(&value).len(), n);
+    }
+
+    #[test]
+    fn collect_strings_wide_flat_object_is_not_bounded_by_width() {
+        let n = 10_000;
+        let mut map = serde_json::Map::new();
+        for i in 0..n {
+            map.insert(format!("k{i}"), json!(format!("item{i}")));
+        }
+        let value = Value::Object(map);
+        assert_eq!(extract_string_values(&value).len(), n);
     }
 }

--- a/crates/zeph-index/src/chunker.rs
+++ b/crates/zeph-index/src/chunker.rs
@@ -161,7 +161,7 @@ pub fn chunk_file(
         imports: &imports,
         config,
     };
-    chunk_children(&ctx, &root, "", &mut chunks);
+    chunk_children(&ctx, &root, "", &mut chunks, 0);
     merge_small_chunks(&mut chunks, config);
 
     // Fallback: if AST chunking produced nothing but source has content,
@@ -173,11 +173,19 @@ pub fn chunk_file(
     Ok(chunks)
 }
 
+/// Maximum AST descent depth for [`chunk_children`].
+///
+/// Guards against stack overflow on adversarially deep source files (e.g. thousands of
+/// nested brackets). Chosen well below typical thread stack sizes while comfortably
+/// exceeding any legitimate nesting depth seen in real-world code.
+const MAX_CHUNK_DEPTH: usize = 512;
+
 fn chunk_children(
     ctx: &ChunkCtx<'_>,
     parent: &Node,
     parent_scope: &str,
     output: &mut Vec<CodeChunk>,
+    depth: usize,
 ) {
     let mut batch: Vec<Node> = Vec::new();
     let mut batch_size: usize = 0;
@@ -196,7 +204,19 @@ fn chunk_children(
             batch_size = 0;
 
             let scope = extend_scope(parent_scope, &child, ctx.source);
-            chunk_children(ctx, &child, &scope, output);
+            if depth >= MAX_CHUNK_DEPTH {
+                // Depth limit reached: emit the oversized node as a single leaf chunk
+                // instead of recursing further.
+                tracing::warn!(
+                    file_path = ctx.file_path,
+                    scope = %scope,
+                    depth,
+                    "chunk_children: max AST depth reached, emitting oversized node as a leaf chunk"
+                );
+                flush_batch(ctx, &[child], &scope, output);
+            } else {
+                chunk_children(ctx, &child, &scope, output, depth + 1);
+            }
             continue;
         }
 
@@ -589,6 +609,141 @@ class Greeter:
             cursor,
             originals.len(),
             "every original chunk must appear exactly once, in order"
+        );
+    }
+
+    /// Builds `fn f() { {{{...}}} let x = 1; ...}` with `nesting` levels of nested
+    /// block expressions wrapping a single statement — a real tree-sitter-parseable
+    /// fixture (not a naive repeated-char string) that produces `nesting` genuine
+    /// `block` AST nodes chained via single-child recursion.
+    fn nested_blocks_source(nesting: usize) -> String {
+        let mut source = String::from("fn f() {\n");
+        for _ in 0..nesting {
+            source.push_str("{\n");
+        }
+        source.push_str("let x = 1;\n");
+        for _ in 0..nesting {
+            source.push_str("}\n");
+        }
+        source.push_str("}\n");
+        source
+    }
+
+    #[test]
+    fn flush_batch_singular_node_type_has_no_count_suffix() {
+        let config = ChunkerConfig {
+            target_size: 600,
+            max_size: 1200,
+            min_size: 5,
+        };
+        let chunks = chunk_file("fn solo() { 1 }", "src/solo.rs", Lang::Rust, &config).unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].node_type, "function_item");
+    }
+
+    // Each nested-block level in `nested_blocks_source` parses as
+    // `expression_statement(block(...))` (confirmed via `to_sexp()`), i.e. each level
+    // costs 2 AST-descent levels, not 1. With `function_item` + the body `block` as
+    // fixed overhead (2 more descent levels), the depth guard — checked against the
+    // *parent* frame's own depth before it would recurse into a MAX_CHUNK_DEPTH-deep
+    // child — always fires while processing the frame at nesting level
+    // `MAX_CHUNK_DEPTH / 2 - 1`, flushing that frame's child (nesting level
+    // `MAX_CHUNK_DEPTH / 2`, an `expression_statement` node) as a single leaf chunk.
+    const FALLBACK_LEVEL: usize = MAX_CHUNK_DEPTH / 2;
+
+    #[test]
+    fn chunk_deeply_nested_blocks_triggers_depth_guard_without_crashing() {
+        let nesting = MAX_CHUNK_DEPTH + 100; // comfortably past the guard
+        let source = nested_blocks_source(nesting);
+        let config = ChunkerConfig {
+            target_size: 600,
+            max_size: 10,
+            min_size: 0,
+        };
+
+        let chunks = chunk_file(&source, "src/deep.rs", Lang::Rust, &config)
+            .expect("deeply nested source must parse and chunk without panicking");
+        assert!(!chunks.is_empty());
+
+        // Once the depth guard fires, the remaining oversized subtree is emitted as
+        // a single leaf chunk whose node_type is the child's own kind (not the
+        // "<kind>xN" batch form) instead of recursing further.
+        let fallback = chunks
+            .iter()
+            .find(|c| c.node_type == "expression_statement" && c.code.contains("let x = 1;"))
+            .expect("expected a leaf-fallback chunk covering the depth-limited subtree");
+
+        // The fallback chunk must still hold a large slice of the leftover nesting,
+        // proving consolidation happened rather than continued per-level recursion.
+        let remaining_levels = nesting - FALLBACK_LEVEL + 1;
+        assert_eq!(fallback.code.matches('{').count(), remaining_levels);
+        assert!(remaining_levels > 50);
+    }
+
+    #[test]
+    fn chunk_shallow_nested_blocks_unaffected_by_depth_guard() {
+        let nesting = 20; // far below MAX_CHUNK_DEPTH — guard must never engage
+        let source = nested_blocks_source(nesting);
+        let config = ChunkerConfig {
+            target_size: 600,
+            max_size: 10,
+            min_size: 0,
+        };
+
+        let chunks = chunk_file(&source, "src/shallow.rs", Lang::Rust, &config).unwrap();
+        assert!(!chunks.is_empty());
+        assert!(
+            chunks.iter().any(|c| c.code.contains("let x = 1;")),
+            "innermost statement must still be reachable via normal (non-fallback) recursion"
+        );
+    }
+
+    #[test]
+    fn depth_guard_fallback_respects_min_size_and_can_silently_drop_content() {
+        // Nesting depth exactly at FALLBACK_LEVEL: the leaf-fallback fires on the
+        // innermost expression_statement/block pair itself, so the leftover subtree
+        // is tiny (just that one block wrapping the statement). flush_batch's
+        // existing min_size check applies here too — this is pre-existing
+        // flush_batch behavior, now reachable via the new depth-limited path, and it
+        // can silently drop the whole leftover subtree with no chunk emitted for it
+        // and no panic.
+        //
+        // 20 leading sibling statements are included so the function body produces
+        // other, normal-sized surviving chunks — otherwise chunk_children would
+        // yield an empty chunk list and chunk_file's own whole-file fallback (for
+        // files with no AST chunks at all) would re-introduce the dropped content
+        // via a different, coarser path, masking the behavior under test.
+        use std::fmt::Write as _;
+
+        let nesting = FALLBACK_LEVEL;
+        let mut source = String::from("fn f() {\n");
+        for i in 0..20 {
+            let _ = writeln!(source, "let v{i} = {i};");
+        }
+        for _ in 0..nesting {
+            source.push_str("{\n");
+        }
+        source.push_str("let x = 1;\n");
+        for _ in 0..nesting {
+            source.push_str("}\n");
+        }
+        source.push_str("}\n");
+
+        let config = ChunkerConfig {
+            target_size: 600,
+            max_size: 10,
+            min_size: 100, // comfortably larger than the tiny leftover subtree
+        };
+
+        let chunks = chunk_file(&source, "src/tiny-leftover.rs", Lang::Rust, &config).unwrap();
+        assert!(
+            chunks.iter().any(|c| c.code.contains("let v0 = 0;")),
+            "the 20 leading statements must survive as their own batch"
+        );
+        assert!(
+            chunks.iter().all(|c| !c.code.contains("let x = 1;")),
+            "tiny leftover subtree below min_size must be silently dropped by flush_batch, \
+             same as any other undersized batch"
         );
     }
 }


### PR DESCRIPTION
## Summary

Two independent uncontrolled-recursion stack-overflow DoS bugs (CWE-674), same defect class and fix pattern, fixed together:

- `chunk_children` (`crates/zeph-index/src/chunker.rs`) recursed into AST child nodes with no depth limit — an attacker-crafted deeply-nested source file placed in a watched/indexed project directory could exhaust the native call stack and abort the whole process.
- `collect_strings` (`crates/zeph-core/src/agent/tool_execution/tool_call_dag.rs`) recursed over a tool call's `input` JSON with no depth limit — a deeply nested LLM-generated tool-call argument (e.g. steered by prompt-injected content the model read) could do the same on a more directly reachable surface.

A Rust stack overflow aborts the process uncatchably — it cannot be caught by `catch_unwind`, `Result`, or any async task boundary — so both are genuine full-DoS vectors, not just failures of the triggering task.

## Fix

Both functions now take an explicit `depth: usize` parameter bounded by a module-level const:
- `MAX_CHUNK_DEPTH = 512` — at the bound, `chunk_children` emits the oversized subtree as a single leaf chunk instead of recursing further (no content lost, just coarser chunk granularity for that subtree).
- `MAX_JSON_DEPTH = 256` — at the bound, `collect_strings` stops descending into that branch (dependency detection just misses strings past the bound rather than crashing).

Neither path panics when the bound is hit; both log a `tracing::warn!` so operators get a signal that adversarial nesting was encountered in production.

## Test plan

- [x] 11 new regression tests (4 chunker, 7 DAG walker): depth-boundary exactness, graceful degradation under attacker-scale nesting (2000 levels / 612-level real tree-sitter-parseable fixture), and that nesting *depth* (not element count/width) is what's bounded — a 10,000-element flat array/object is unaffected.
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 14909 passed, 36 skipped, no regressions
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] `gitleaks protect --staged` — no leaks

## Follow-up

Filed #6594 to track the same unguarded-recursion pattern in two sibling functions (`zeph-sanitizer/src/exfiltration.rs`, `zeph-tools/src/verifier.rs`) that are out of scope for this PR — currently bounded in practice by `serde_json`'s own default recursion limit on the upstream parse, but latent risk if that ever changes.

Closes #6551
Closes #6554