### PR TITLE
fix(memory): correct ring-hop distance computation in WaterCircles retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-memory`: `graph_recall_watercircles`'s ring-hop filter dropped every edge regardless of
+  `ring_limit`, returning empty results for any typical seed-outward graph (#6596). `hop_dist`
+  was computed by preferring the edge's source-node depth (falling back to target only when
+  source was absent); since BFS discovers edges in either direction, source was almost always
+  present but one ring shallower than the edge's true ring, so `dist != hop` never matched.
+  Fixed by computing `hop_dist = max(source_depth, target_depth)` — the edge's farther endpoint
+  from the seed — which correctly identifies its ring regardless of discovery orientation. Also
+  fixed a `zeph-agent-context` test that had pinned the old buggy empty-result behavior as
+  expected, and added regression coverage for multi-ring (`ring_limit > 1`) bucketing.
+
 - `zeph-sanitizer`/`zeph-subagent`/`zeph-core`: a generic secret-shaped string (e.g. an
   `sk-test-...`-prefixed API key) fabricated or echoed by a sub-agent in its own response text
   passed through unmasked on two operator-visible surfaces (#6571). The two sanitize layers

--- a/crates/zeph-agent-context/src/memory_backend.rs
+++ b/crates/zeph-agent-context/src/memory_backend.rs
@@ -1293,27 +1293,11 @@ mod tests {
     /// (a genuinely different code path than `Bfs`), rather than proving a specific pruning
     /// outcome.
     ///
-    /// **Pre-existing bug found while writing this test (unrelated to #6566's dispatch
-    /// wiring, tracked separately — see tester handoff)**: `graph_recall_watercircles`'s
-    /// per-ring hop filter (`retrieval_watercircles.rs`, "Only include edges that belong
-    /// exactly to this hop ring") computes `hop_dist` by looking up
-    /// `depth_map.get(&edge.source_entity_id)` first, falling back to the target only if the
-    /// source is absent. Since the BFS depth map always contains the seed itself at depth 0,
-    /// and a normal forward-directed edge's `source_entity_id` is the node *closer* to the
-    /// seed, `hop_dist` resolves to one less than the ring actually being tested — so
-    /// `dist != hop` is true for every ordinary edge and the ring is emptied every time. This
-    /// was confirmed independently by instrumenting the existing (pre-#6566)
-    /// `watercircles_ring_limit_auto_respects_limit` test in
-    /// `crates/zeph-memory/src/graph/retrieval_watercircles.rs`, which returns `len() == 0`
-    /// for a 10-edge, one-hop fixture — its assertion (`result.len() <= 5`) never checks
-    /// non-emptiness, so the bug went undetected. As a result, `graph_recall_watercircles`
-    /// currently returns an empty result set for any typical seed-outward-directed graph,
-    /// regardless of `ring_limit`. This test asserts the current (buggy) empty-result
-    /// behavior — which still validly proves the dispatch reaches `recall_graph_watercircles`
-    /// specifically, since a fallthrough to plain BFS would have produced non-empty results
-    /// identical to `bfs_facts` — but the empty result itself is a defect, not a feature, and
-    /// should be re-tightened to assert `watercircles_facts` is non-empty once the hop-filter
-    /// bug is fixed in a follow-up PR.
+    /// The fixture seeds two depth-1 edges from `watercircleseed`: `strong` (confidence 0.95)
+    /// and `weak` (confidence 0.2). With `ring_limit = 1`, `WaterCircles` caps ring 1 to its
+    /// single highest-scoring edge (`strong`), while plain `Bfs` returns both edges
+    /// unfiltered — the length divergence (1 vs 2) proves the dispatch reaches
+    /// `recall_graph_watercircles` rather than falling through to BFS.
     #[tokio::test]
     async fn recall_graph_facts_dispatches_bfs_and_watercircles_to_different_results() {
         let backend = seeded_watercircles_ring_backend().await;
@@ -1361,10 +1345,10 @@ mod tests {
             2,
             "expected plain BFS to return both edges; facts={bfs_facts:?}"
         );
-        assert!(
-            watercircles_facts.is_empty(),
-            "documents the pre-existing hop-filter bug in graph_recall_watercircles (see doc \
-             comment above) — expected empty due to the bug, not due to correct ring pruning; \
+        assert_eq!(
+            watercircles_facts.len(),
+            1,
+            "WaterCircles ring_limit=1 should keep only the higher-scoring edge (strong); \
              facts={watercircles_facts:?}"
         );
         assert_ne!(

--- a/crates/zeph-memory/src/graph/retrieval_watercircles.rs
+++ b/crates/zeph-memory/src/graph/retrieval_watercircles.rs
@@ -102,11 +102,19 @@ pub async fn graph_recall_watercircles(
             let traversed_ids: Vec<i64> = edges.iter().map(|e| e.id).collect();
 
             for edge in &edges {
-                // Only include edges that belong exactly to this hop ring.
-                let hop_dist = depth_map
-                    .get(&edge.source_entity_id)
-                    .or_else(|| depth_map.get(&edge.target_entity_id))
-                    .copied();
+                // An edge's ring is determined by its farther endpoint from the seed: `bfs_fetch_results`
+                // returns every edge between two visited entities regardless of traversal direction, so
+                // taking only one side's depth (e.g. always source) misclassifies edges discovered in the
+                // opposite orientation. `max` correctly identifies the newly-reached ring on either side.
+                let hop_dist = match (
+                    depth_map.get(&edge.source_entity_id).copied(),
+                    depth_map.get(&edge.target_entity_id).copied(),
+                ) {
+                    (Some(source_depth), Some(target_depth)) => {
+                        Some(source_depth.max(target_depth))
+                    }
+                    (source_depth, target_depth) => source_depth.or(target_depth),
+                };
                 let Some(dist) = hop_dist else { continue };
                 if dist != hop {
                     continue;
@@ -302,6 +310,68 @@ mod tests {
         )
         .await
         .unwrap();
+        assert!(
+            !result.is_empty(),
+            "ring-1 edges must be returned, not silently dropped by the hop-ring filter"
+        );
         assert!(result.len() <= 5, "limit must be respected");
+    }
+
+    #[tokio::test]
+    async fn watercircles_two_ring_hop_distance_matches_target_depth() {
+        let store = setup_store().await;
+        let root = store
+            .upsert_entity("Root", "root", EntityType::Concept, None, None)
+            .await
+            .unwrap()
+            .0;
+        let a = store
+            .upsert_entity("A", "A", EntityType::Concept, None, None)
+            .await
+            .unwrap()
+            .0;
+        let b = store
+            .upsert_entity("B", "B", EntityType::Concept, None, None)
+            .await
+            .unwrap()
+            .0;
+        store
+            .insert_edge(root, a, "has", "Root has A", 0.9, None, None)
+            .await
+            .unwrap();
+        store
+            .insert_edge(a, b, "has", "A has B", 0.9, None, None)
+            .await
+            .unwrap();
+
+        let provider = mock_provider();
+        let result = graph_recall_watercircles(
+            &store,
+            None,
+            &provider,
+            "Root",
+            10,
+            2,
+            10,
+            &[],
+            0.0,
+            false,
+            0.0,
+            std::time::Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+
+        let ring1 = result
+            .iter()
+            .find(|f| f.target_name == "A")
+            .expect("ring-1 edge Root->A must be present");
+        assert_eq!(ring1.hop_distance, 1, "Root->A must be assigned to ring 1");
+
+        let ring2 = result
+            .iter()
+            .find(|f| f.target_name == "B")
+            .expect("ring-2 edge A->B must be present");
+        assert_eq!(ring2.hop_distance, 2, "A->B must be assigned to ring 2");
     }
 }


### PR DESCRIPTION
## Summary

`graph_recall_watercircles` computed each edge's `hop_dist` by preferring the edge's *source*-node depth, falling back to the target only when source was absent from the depth map. Since BFS discovers edges regardless of traversal direction, the source was almost always present but one ring shallower than the edge's true ring, so the `dist != hop` filter never matched — every edge was dropped for any typical seed-outward graph, regardless of `ring_limit`.

Fixed by computing `hop_dist = max(source_depth, target_depth)` — the edge's farther endpoint from the seed — which correctly identifies its ring regardless of discovery orientation.

Also fixes a `zeph-agent-context` test that had pinned the old buggy empty-result behavior as the expected outcome, and adds regression coverage asserting `hop_distance` across multiple rings (`ring_limit > 1`).

Closes #6596

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 14927 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `gitleaks protect --staged --no-banner --redact`
- [x] Added regression test for multi-ring (`ring_limit > 1`) `hop_distance` bucketing
- [x] Verified the strengthened tests fail against the pre-fix source-depth-first logic