### PR TITLE
fix(tools): audit declarative PolicyGateExecutor deny/allow decisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,6 +298,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   note sent when enabled and at/above threshold, suppressed when below threshold, and
   suppressed when `consent_gate.enabled = false` regardless of trust tier.
 
+- `zeph-tools`: declarative `PolicyGateExecutor` allow/deny decisions were silently unaudited
+  across all three agent entry points (CLI, ACP, daemon), while the LLM-judged
+  `AdversarialPolicyGateExecutor` gate's decisions were audited — an asymmetry that left
+  `[tools.policy]` policy blocks invisible to the tool audit log (#6565). The shared
+  `apply_policy_gate_chain` helper (`src/agent_setup.rs`) attached the audit logger to the
+  adversarial gate via `.with_audit(...)` but never did so for the declarative
+  `PolicyGateExecutor` branch immediately after it, even though `audit_logger` was already in
+  scope; `PolicyGateExecutor::check_policy`/`log_audit` silently no-op when `self.audit` is
+  `None` (the `PolicyGateExecutor::new()` default). Now `apply_policy_gate_chain` also calls
+  `.with_audit(Arc::clone(audit))` on the declarative gate when an audit logger is present,
+  matching the adversarial branch.
+
 - `zeph-sanitizer`/`zeph-subagent`/`zeph-core`: a generic secret-shaped string (e.g. an
   `sk-test-...`-prefixed API key) fabricated or echoed by a sub-agent in its own response text
   passed through unmasked on two operator-visible surfaces (#6571). The two sanitize layers

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -2267,6 +2267,9 @@ pub(crate) fn apply_policy_gate_chain(
             Arc::clone(enforcer),
             policy_context,
         );
+        if let Some(audit) = audit_logger {
+            gate = gate.with_audit(Arc::clone(audit));
+        }
         if let Some((slot, queue)) = trajectory {
             gate = gate
                 .with_trajectory_risk(Arc::clone(slot))
@@ -4172,6 +4175,10 @@ mod tests {
     /// a real `PolicyGateExecutor` when `pieces.policy_enforcer` is `Some`, and a deny rule must
     /// still block the call — this is the exact guardrail that pins the serve wiring fix (the
     /// pre-fix `serve/deps.rs::build_tool_executor` never called this function at all).
+    ///
+    /// #6565 regression: `apply_policy_gate_chain` must also forward `audit_logger` into the
+    /// declarative `PolicyGateExecutor` branch (it was previously only wired into the
+    /// adversarial branch), so both the deny and the allow decision land in the audit log.
     #[tokio::test]
     async fn apply_policy_gate_chain_blocks_denied_tool_when_policy_enforcer_present() {
         let policy_config = zeph_tools::PolicyConfig {
@@ -4198,18 +4205,51 @@ mod tests {
             policy_configured: true,
         };
 
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("audit.log");
+        let audit_config = zeph_tools::AuditConfig {
+            enabled: true,
+            destination: zeph_tools::AuditDestination::File(log_path.clone()),
+            ..Default::default()
+        };
+        let audit_logger = Arc::new(
+            zeph_tools::AuditLogger::from_config(&audit_config, false)
+                .await
+                .unwrap(),
+        );
+
         let inner: Arc<dyn zeph_tools::ErasedToolExecutor> = Arc::new(NoopExec);
         let policy =
             zeph_tools::PermissionPolicy::default().with_autonomy(zeph_tools::AutonomyLevel::Full);
         let (trust_gated, _handle) =
             apply_common_tool_gating(zeph_tools::DynExecutor(inner), &policy);
-        let executor = apply_policy_gate_chain(trust_gated, &pieces, None, None);
+        let executor = apply_policy_gate_chain(trust_gated, &pieces, Some(&audit_logger), None);
 
         let result = executor.execute_tool_call(&make_tool_call("shell")).await;
         assert!(
             matches!(result, Err(zeph_tools::ToolError::Blocked { .. })),
             "expected apply_policy_gate_chain to block a denied tool call through the full \
              trust+policy wrap, got {result:?}"
+        );
+
+        let allow_result = executor.execute_tool_call(&make_tool_call("read")).await;
+        assert!(
+            allow_result.is_ok(),
+            "expected an unmatched tool to fall through to the default Allow effect, got \
+             {allow_result:?}"
+        );
+
+        let content = tokio::fs::read_to_string(&log_path).await.unwrap();
+        assert!(
+            content.contains("\"type\":\"blocked\"")
+                && content.contains("\"error_category\":\"policy_blocked\""),
+            "declarative PolicyGateExecutor deny decision must be recorded in the audit log \
+             (#6565), got: {content}"
+        );
+        assert!(
+            content.contains("\"type\":\"success\""),
+            "declarative PolicyGateExecutor allow decision must also be recorded in the audit \
+             log, got: {content}"
         );
     }
 


### PR DESCRIPTION
## Summary

- `apply_policy_gate_chain` (`src/agent_setup.rs`) wired the audit logger into the LLM-judged `AdversarialPolicyGateExecutor` branch but never into the declarative `PolicyGateExecutor` branch immediately after it, even though `audit_logger` was already in scope at that point.
- `PolicyGateExecutor::check_policy`/`log_audit` silently no-op when `self.audit` is `None` (the constructor default), so every `[tools.policy]` allow/deny decision was invisible to the tool audit log across all three agent entry points (CLI, ACP, daemon) — while the adversarial gate's decisions were fully audited.
- Threads `audit_logger` into the declarative branch the same way it is already threaded into the adversarial branch (`.with_audit(Arc::clone(audit))`).
- Extends the existing `apply_policy_gate_chain_blocks_denied_tool_when_policy_enforcer_present` regression test to wire a real `AuditLogger` and assert both a deny (`"type":"blocked"` + `"error_category":"policy_blocked"`) and an allow (`"type":"success"`) decision land in the audit log.
- Adds `.local/testing/playbooks/policy-gate-audit-log.md` and a coverage-status.md row (main repo root) per project testing conventions.

Closes #6565

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (14950 passed, 0 failed)
- [x] rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`)
- [x] Extended regression test asserts declarative deny and allow decisions both land in the audit log