### PR TITLE
fix(sanitizer,tools): add depth guards to unbounded JSON recursion in collect_strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Security
 
+- `zeph-sanitizer`/`zeph-tools`: added explicit depth-cap guards (`MAX_JSON_DEPTH = 256`) to
+  three previously-unguarded recursive `serde_json::Value` walkers that traverse untrusted
+  tool-call arguments — `exfiltration::collect_strings` (`zeph-sanitizer`, recurses on
+  `Array`/`Object`), `FirewallVerifier::collect_strings` (`zeph-tools`, `Array`), and
+  `InjectionPatternVerifier::check_value`/`check_object` (`zeph-tools`, mutual recursion on
+  `Array`/`Object`, folded into this fix after adversarial review flagged the same defect
+  class in the same file). Same CWE-674 stack-overflow-DoS class as the recursion guards
+  added for #6551/#6554: not currently exploitable since `serde_json`'s default 128-deep
+  parse-time recursion limit already bounds these paths, but the fix removes the latent risk
+  should that upstream limit ever be disabled or the value originate from a non-`serde_json`
+  source (#6594).
+
 - `zeph-core`/`zeph-memory`/`zeph-llm`/`zeph-agent-context`: closed two TOCTOU bypasses of the
   write-time memory-consent gate shipped for #6490/MemGhost above, plus two related residual
   bypasses found during review — all in the same threat class (the gate reading a trust signal

--- a/crates/zeph-sanitizer/src/exfiltration.rs
+++ b/crates/zeph-sanitizer/src/exfiltration.rs
@@ -400,7 +400,7 @@ impl ExfiltrationGuard {
 
         let mut events = Vec::new();
         let mut strings = Vec::new();
-        collect_strings(&parsed, &mut strings);
+        collect_strings(&parsed, &mut strings, 0);
 
         for s in &strings {
             for url_match in URL_EXTRACT_RE.find_iter(s) {
@@ -597,18 +597,32 @@ pub fn normalize_url_for_matching(url: &str) -> &str {
     }
 }
 
+/// Maximum JSON nesting depth walked by [`collect_strings`].
+///
+/// Guards against stack overflow on adversarially deep tool-call input (e.g. from
+/// prompt-injected LLM output). Beyond this depth, further descent is simply skipped —
+/// URL detection just misses strings past the bound rather than crashing.
+const MAX_JSON_DEPTH: usize = 256;
+
 /// Recursively collect all string leaves from a JSON value.
-fn collect_strings<'a>(value: &'a serde_json::Value, out: &mut Vec<&'a str>) {
+fn collect_strings<'a>(value: &'a serde_json::Value, out: &mut Vec<&'a str>, depth: usize) {
+    if depth >= MAX_JSON_DEPTH {
+        tracing::warn!(
+            depth,
+            "collect_strings: max JSON nesting depth reached, skipping further descent"
+        );
+        return;
+    }
     match value {
         serde_json::Value::String(s) => out.push(s.as_str()),
         serde_json::Value::Array(arr) => {
             for v in arr {
-                collect_strings(v, out);
+                collect_strings(v, out, depth + 1);
             }
         }
         serde_json::Value::Object(map) => {
             for v in map.values() {
-                collect_strings(v, out);
+                collect_strings(v, out, depth + 1);
             }
         }
         _ => {}
@@ -1510,5 +1524,40 @@ mod tests {
             "//evil.com/x"
         );
         assert_eq!(normalize_url_for_matching("//evil.com/x"), "//evil.com/x");
+    }
+
+    // --- collect_strings depth guard ---
+
+    /// Wraps `leaf` in `depth` nested single-element arrays, e.g. `[[["leaf"]]]`.
+    fn nested_array(depth: usize, leaf: &str) -> serde_json::Value {
+        let mut v = serde_json::json!(leaf);
+        for _ in 0..depth {
+            v = serde_json::Value::Array(vec![v]);
+        }
+        v
+    }
+
+    #[test]
+    fn collect_strings_adversarial_scale_does_not_crash() {
+        // Attacker-scale nesting, far beyond MAX_JSON_DEPTH, built programmatically to
+        // bypass serde_json's own parse-time recursion limit — must not overflow the
+        // stack; the depth guard caps real recursion depth regardless of input nesting.
+        let value = nested_array(10_000, "deep");
+        let mut out = Vec::new();
+        collect_strings(&value, &mut out, 0);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn collect_strings_exact_depth_boundary() {
+        let just_inside = nested_array(MAX_JSON_DEPTH - 1, "just_inside");
+        let mut out = Vec::new();
+        collect_strings(&just_inside, &mut out, 0);
+        assert_eq!(out, vec!["just_inside"]);
+
+        let just_outside = nested_array(MAX_JSON_DEPTH, "just_outside");
+        let mut out = Vec::new();
+        collect_strings(&just_outside, &mut out, 0);
+        assert!(out.is_empty());
     }
 }

--- a/crates/zeph-tools/src/verifier.rs
+++ b/crates/zeph-tools/src/verifier.rs
@@ -539,9 +539,13 @@ impl InjectionPatternVerifier {
     }
 
     /// Walk all string leaf values in a JSON object, collecting field names for context.
-    fn check_object(&self, obj: &serde_json::Map<String, serde_json::Value>) -> VerificationResult {
+    fn check_object(
+        &self,
+        obj: &serde_json::Map<String, serde_json::Value>,
+        depth: usize,
+    ) -> VerificationResult {
         for (key, val) in obj {
-            let result = self.check_value(key, val);
+            let result = self.check_value(key, val, depth);
             if !matches!(result, VerificationResult::Allow) {
                 return result;
             }
@@ -549,19 +553,31 @@ impl InjectionPatternVerifier {
         VerificationResult::Allow
     }
 
-    fn check_value(&self, field: &str, val: &serde_json::Value) -> VerificationResult {
+    fn check_value(
+        &self,
+        field: &str,
+        val: &serde_json::Value,
+        depth: usize,
+    ) -> VerificationResult {
+        if depth >= MAX_JSON_DEPTH {
+            tracing::warn!(
+                depth,
+                "check_value: max JSON nesting depth reached, skipping further descent"
+            );
+            return VerificationResult::Allow;
+        }
         match val {
             serde_json::Value::String(s) => self.check_field_value(field, s),
             serde_json::Value::Array(arr) => {
                 for item in arr {
-                    let r = self.check_value(field, item);
+                    let r = self.check_value(field, item, depth + 1);
                     if !matches!(r, VerificationResult::Allow) {
                         return r;
                     }
                 }
                 VerificationResult::Allow
             }
-            serde_json::Value::Object(obj) => self.check_object(obj),
+            serde_json::Value::Object(obj) => self.check_object(obj, depth + 1),
             // Non-string primitives (numbers, booleans, null) cannot contain injection.
             _ => VerificationResult::Allow,
         }
@@ -575,7 +591,7 @@ impl PreExecutionVerifier for InjectionPatternVerifier {
 
     fn verify(&self, _tool_name: &str, args: &serde_json::Value) -> VerificationResult {
         match args {
-            serde_json::Value::Object(obj) => self.check_object(obj),
+            serde_json::Value::Object(obj) => self.check_object(obj, 0),
             // Flat string args (unusual but handle gracefully — treat as unnamed field).
             serde_json::Value::String(s) => self.check_field_value("_args", s),
             _ => VerificationResult::Allow,
@@ -733,6 +749,14 @@ static INSPECTED_FIELDS: &[&str] = &[
     "args",
 ];
 
+/// Maximum JSON nesting depth walked by this module's recursive tool-args scanners
+/// ([`FirewallVerifier::collect_strings`], [`InjectionPatternVerifier::check_value`]).
+///
+/// Guards against stack overflow on adversarially deep tool-call input (e.g. from
+/// prompt-injected LLM output). Beyond this depth, further descent is simply skipped —
+/// argument scanning just misses content past the bound rather than crashing.
+const MAX_JSON_DEPTH: usize = 256;
+
 impl FirewallVerifier {
     /// Build a `FirewallVerifier` from config.
     ///
@@ -778,7 +802,7 @@ impl FirewallVerifier {
             serde_json::Value::Object(map) => {
                 for field in INSPECTED_FIELDS {
                     if let Some(val) = map.get(*field) {
-                        Self::collect_strings(val, &mut out);
+                        Self::collect_strings(val, &mut out, 0);
                     }
                 }
             }
@@ -788,12 +812,19 @@ impl FirewallVerifier {
         out
     }
 
-    fn collect_strings(val: &serde_json::Value, out: &mut Vec<String>) {
+    fn collect_strings(val: &serde_json::Value, out: &mut Vec<String>, depth: usize) {
+        if depth >= MAX_JSON_DEPTH {
+            tracing::warn!(
+                depth,
+                "collect_strings: max JSON nesting depth reached, skipping further descent"
+            );
+            return;
+        }
         match val {
             serde_json::Value::String(s) => out.push(s.clone()),
             serde_json::Value::Array(arr) => {
                 for item in arr {
-                    Self::collect_strings(item, out);
+                    Self::collect_strings(item, out, depth + 1);
                 }
             }
             _ => {}
@@ -1775,5 +1806,78 @@ mod tests {
         assert!(cfg.blocked_paths.is_empty());
         assert!(cfg.blocked_env_vars.is_empty());
         assert!(cfg.exempt_tools.is_empty());
+    }
+
+    // --- FirewallVerifier::collect_strings depth guard ---
+
+    /// Wraps `leaf` in `depth` nested single-element arrays, e.g. `[[["leaf"]]]`.
+    fn nested_array(depth: usize, leaf: &str) -> serde_json::Value {
+        let mut v = json!(leaf);
+        for _ in 0..depth {
+            v = serde_json::Value::Array(vec![v]);
+        }
+        v
+    }
+
+    #[test]
+    fn collect_strings_adversarial_scale_does_not_crash() {
+        // Attacker-scale nesting, far beyond MAX_JSON_DEPTH, built programmatically to
+        // bypass serde_json's own parse-time recursion limit — must not overflow the
+        // stack; the depth guard caps real recursion depth regardless of input nesting.
+        let value = nested_array(10_000, "deep");
+        let mut out = Vec::new();
+        FirewallVerifier::collect_strings(&value, &mut out, 0);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn collect_strings_exact_depth_boundary() {
+        let just_inside = nested_array(MAX_JSON_DEPTH - 1, "just_inside");
+        let mut out = Vec::new();
+        FirewallVerifier::collect_strings(&just_inside, &mut out, 0);
+        assert_eq!(out, vec!["just_inside".to_string()]);
+
+        let just_outside = nested_array(MAX_JSON_DEPTH, "just_outside");
+        let mut out = Vec::new();
+        FirewallVerifier::collect_strings(&just_outside, &mut out, 0);
+        assert!(out.is_empty());
+    }
+
+    // --- InjectionPatternVerifier::check_value/check_object depth guard ---
+
+    /// Wraps `value` as `{"command": value}` without going through the `json!` macro's
+    /// non-literal-expression rule, which calls `serde_json::to_value` and would
+    /// re-serialize (and thus recursively re-walk) an already-deeply-nested `Value`.
+    fn wrap_command(value: serde_json::Value) -> serde_json::Value {
+        let mut map = serde_json::Map::new();
+        map.insert("command".to_string(), value);
+        serde_json::Value::Object(map)
+    }
+
+    #[test]
+    fn check_value_adversarial_scale_does_not_crash() {
+        // Attacker-scale nesting, far beyond MAX_JSON_DEPTH, built programmatically to
+        // bypass serde_json's own parse-time recursion limit — must not overflow the
+        // stack; the depth guard caps real recursion depth regardless of input nesting.
+        let args = wrap_command(nested_array(10_000, "; rm -rf /"));
+        let result = ipv().verify("shell", &args);
+        assert_matches!(result, VerificationResult::Allow);
+    }
+
+    #[test]
+    fn check_value_exact_depth_boundary() {
+        // Malicious leaf just inside the bound must still be reached and blocked.
+        let just_inside = wrap_command(nested_array(MAX_JSON_DEPTH - 1, "; rm -rf /"));
+        assert_matches!(
+            ipv().verify("shell", &just_inside),
+            VerificationResult::Block { .. }
+        );
+
+        // Malicious leaf just outside the bound is unreachable — guard fires, must Allow.
+        let just_outside = wrap_command(nested_array(MAX_JSON_DEPTH, "; rm -rf /"));
+        assert_matches!(
+            ipv().verify("shell", &just_outside),
+            VerificationResult::Allow
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Adversarial review of #6551/#6554's recursion depth-cap fix flagged two sibling `collect_strings` functions with the identical unguarded-recursion pattern in `zeph-sanitizer/src/exfiltration.rs` and `zeph-tools/src/verifier.rs`.
- Adds the same `MAX_JSON_DEPTH = 256` guard, threaded as a `depth` parameter with an early-return + `tracing::warn!` on breach, mirroring the merged precedent (commit `9522ec795`). No panic, fail-open (shallower-collected strings preserved).
- Also folds in a same-class fix for `InjectionPatternVerifier::check_value`/`check_object` (mutual recursion, same file as `FirewallVerifier::collect_strings`) — found by adversarial critique during this PR's own review pass, folded in rather than filed as a separate follow-up.
- Not currently exploitable (bounded today by `serde_json`'s default 128-deep parse-time recursion limit), but removes the latent CWE-674 stack-overflow-DoS risk should that upstream limit ever be disabled or the value originate from a non-`serde_json` source.

Closes #6594

## Test plan

- [x] 6 new regression tests (2 per guarded function): adversarial 10,000-deep nesting built programmatically (bypassing serde_json's own parse-time recursion limit) confirming no crash, plus an exact off-by-one boundary test (`MAX_JSON_DEPTH-1` reaches leaf, `MAX_JSON_DEPTH` stops descending)
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 14957 passed, 36 skipped, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] `gitleaks protect --staged --no-banner --redact` — no leaks