### PR TITLE
fix(acp): align test cfg gate with build_combined_deps' own feature gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 ### Fixed
 
+- `src/acp.rs`: the test `build_combined_deps_wires_equivalent_security_pipeline_from_config`
+  was gated `#[cfg(feature = "acp-http")]` while the function it exercises, `build_combined_deps`,
+  requires `#[cfg(all(feature = "acp-http", feature = "session"))]` — since the `ide` feature
+  bundle enables `acp-http` without `session`, `cargo check --workspace --all-targets --features
+  ide` failed to compile (`error[E0425]: cannot find function build_combined_deps in this scope`).
+  Aligned the test's cfg gate with the function's (issue #6607).
 - `zeph-channels`: Telegram guest-mode responses (`TelegramChannel::flush_chunks`) are now
   formatted through the same `markdown_to_telegram` renderer used by regular messages, and
   sent with `parse_mode = "MarkdownV2"` instead of an unconverted `"HTML"` call — raw LLM

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -4887,7 +4887,7 @@ mod tests {
     /// struct defaults. This is the parity test that closes the gap meta-issue #6581 tracks (a
     /// 24th instance of the wire-X-into-serve defect class): a future PR that drops one of these
     /// fields from `assemble_serve_deps` fails this test instead of shipping unnoticed.
-    #[cfg(feature = "acp-http")]
+    #[cfg(all(feature = "acp-http", feature = "session"))]
     #[tokio::test]
     #[allow(clippy::too_many_lines)] // exhaustive field-by-field assertions across 2 deps structs
     async fn build_combined_deps_wires_equivalent_security_pipeline_from_config() {


### PR DESCRIPTION
## Summary
- The test `build_combined_deps_wires_equivalent_security_pipeline_from_config` in `src/acp.rs` was gated `#[cfg(feature = "acp-http")]` while the function it exercises, `build_combined_deps`, requires `#[cfg(all(feature = "acp-http", feature = "session"))]`.
- Since the `ide` feature bundle (`ide = ["acp", "acp-http"]`) enables `acp-http` without `session`, `cargo check --workspace --all-targets --features ide` failed to compile with `error[E0425]: cannot find function build_combined_deps in this scope`.
- Aligned the test's cfg gate with the function's own gate. Confirmed this was the sole instance of the pattern in the file — `mod acp` compiles unconditionally while the sibling `mod serve` is itself gated on `session`, so no other `acp-http`-only gate inside `serve/` can hit this bug class.

Fixes #6607

## Test plan
- [x] `cargo check --workspace --all-targets --features ide` — now passes (previously failed with E0425), verified twice including after a forced recompile
- [x] `cargo nextest run -p zeph --features full -E 'test(build_combined_deps_wires_equivalent_security_pipeline_from_config)'` — test still compiles and passes under a feature set with both `acp-http` and `session`
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 14981 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] CHANGELOG.md updated under `[Unreleased]/### Fixed`