### PR TITLE
fix(cli,vault): honor --vault-key/--vault-path overrides in registry token resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   appears as a standalone word in unrelated prose (e.g. "the id was ok") still satisfies the
   check — this is a disclosed partial mitigation, not a full close of all accidental matches
   (issue #6575).
+- `src/commands/registry_client.rs`: `resolve_registry_token` no longer hardcodes `default_vault_dir()`
+  for the `Age` vault backend, ignoring any `--vault`/`--vault-key`/`--vault-path` CLI
+  overrides — every sibling vault-backed CLI path (`durable.rs`, `scheduler_daemon.rs`, per
+  #6590) already resolved these overrides, but the registry token lookup silently fell back to
+  the default vault directory even when the user pointed at a different vault (issue #6591).
+  `crate::bootstrap::resolve_vault_paths` is now threaded through `handle_skill_command` and
+  `handle_plugin_command` (`src/commands/skill.rs`, `src/commands/plugin.rs`) and their
+  registry search/get helpers, so registry authentication resolves against the same vault as
+  the rest of the command.
 - `zeph-channels`: Telegram guest-mode responses (`TelegramChannel::flush_chunks`) are now
   formatted through the same `markdown_to_telegram` renderer used by regular messages, and
   sent with `parse_mode = "MarkdownV2"` instead of an unconverted `"HTML"` call — raw LLM

--- a/src/commands/plugin.rs
+++ b/src/commands/plugin.rs
@@ -54,9 +54,13 @@ fn print_overlay_section(plugins_dir: &std::path::Path) -> anyhow::Result<()> {
 // `async` regardless, since `runner.rs` always `.await`s this call and the feature is a
 // caller-invisible build-time choice (M1, critic handoff).
 #[allow(clippy::unused_async)]
+#[allow(clippy::too_many_lines)]
 pub(crate) async fn handle_plugin_command(
     cmd: PluginCommand,
     config_path: Option<&std::path::Path>,
+    vault_override: Option<&str>,
+    vault_key_override: Option<&std::path::Path>,
+    vault_path_override: Option<&std::path::Path>,
 ) -> anyhow::Result<()> {
     use crate::bootstrap::{load_config_or_default, resolve_config_path};
 
@@ -136,7 +140,14 @@ pub(crate) async fn handle_plugin_command(
         PluginCommand::Search { query } => {
             #[cfg(feature = "registry")]
             {
-                registry_search(&config, &query).await?;
+                registry_search(
+                    &config,
+                    &query,
+                    vault_override,
+                    vault_key_override,
+                    vault_path_override,
+                )
+                .await?;
             }
             #[cfg(not(feature = "registry"))]
             {
@@ -155,11 +166,24 @@ pub(crate) async fn handle_plugin_command(
                 // they get the same reputation check (spec-043, #5864). No `--strict-reputation`
                 // flag on `get` — config's `enforcement` applies as-is.
                 let mgr = mgr.with_reputation_config(&config.plugins.reputation, false);
-                registry_get(&config, &mgr, &registry_id).await?;
+                registry_get(
+                    &config,
+                    &mgr,
+                    &registry_id,
+                    vault_override,
+                    vault_key_override,
+                    vault_path_override,
+                )
+                .await?;
             }
             #[cfg(not(feature = "registry"))]
             {
-                let _ = &registry_id;
+                let _ = (
+                    &registry_id,
+                    vault_override,
+                    vault_key_override,
+                    vault_path_override,
+                );
                 println!(
                     "This zeph build was compiled without the `registry` feature; rebuild \
                      with `--features registry` (or `full`) to use `zeph plugin get`."
@@ -179,7 +203,13 @@ pub(crate) async fn handle_plugin_command(
 /// [`registry_search_with`] — see that fn's tests for `MockRegistryClient`-driven coverage.
 #[cfg(feature = "registry")]
 #[tracing::instrument(name = "plugin.registry_search", skip(config), fields(query))]
-async fn registry_search(config: &zeph_core::config::Config, query: &str) -> anyhow::Result<()> {
+async fn registry_search(
+    config: &zeph_core::config::Config,
+    query: &str,
+    vault_override: Option<&str>,
+    vault_key_override: Option<&std::path::Path>,
+    vault_path_override: Option<&std::path::Path>,
+) -> anyhow::Result<()> {
     use crate::commands::registry_client::{
         REGISTRY_NOT_CONFIGURED_MSG, build_registry_client, resolve_registry_token,
     };
@@ -189,7 +219,13 @@ async fn registry_search(config: &zeph_core::config::Config, query: &str) -> any
         anyhow::bail!("{REGISTRY_NOT_CONFIGURED_MSG}");
     }
 
-    let token = resolve_registry_token(config).await?;
+    let token = resolve_registry_token(
+        config,
+        vault_override,
+        vault_key_override,
+        vault_path_override,
+    )
+    .await?;
     let client = build_registry_client(config, token);
     registry_search_with(client.as_ref(), query).await
 }
@@ -226,6 +262,9 @@ async fn registry_get(
     config: &zeph_core::config::Config,
     mgr: &zeph_plugins::PluginManager,
     registry_id: &str,
+    vault_override: Option<&str>,
+    vault_key_override: Option<&std::path::Path>,
+    vault_path_override: Option<&std::path::Path>,
 ) -> anyhow::Result<()> {
     use crate::commands::registry_client::{
         REGISTRY_NOT_CONFIGURED_MSG, build_registry_client, resolve_registry_token,
@@ -236,7 +275,13 @@ async fn registry_get(
         anyhow::bail!("{REGISTRY_NOT_CONFIGURED_MSG}");
     }
 
-    let token = resolve_registry_token(config).await?;
+    let token = resolve_registry_token(
+        config,
+        vault_override,
+        vault_key_override,
+        vault_path_override,
+    )
+    .await?;
     let client = build_registry_client(config, token);
     registry_get_with(client.as_ref(), mgr, registry_id).await
 }
@@ -400,7 +445,9 @@ mod registry_tests {
         let config = zeph_core::config::Config::default();
         assert!(!config.skills.registry.enabled);
 
-        let err = registry_search(&config, "query").await.unwrap_err();
+        let err = registry_search(&config, "query", None, None, None)
+            .await
+            .unwrap_err();
         assert_eq!(err.to_string(), REGISTRY_NOT_CONFIGURED_MSG);
     }
 
@@ -414,7 +461,9 @@ mod registry_tests {
         let config = zeph_core::config::Config::default();
         assert!(!config.skills.registry.enabled);
 
-        let err = registry_get(&config, &mgr, "acme/x").await.unwrap_err();
+        let err = registry_get(&config, &mgr, "acme/x", None, None, None)
+            .await
+            .unwrap_err();
         assert_eq!(err.to_string(), REGISTRY_NOT_CONFIGURED_MSG);
     }
 }

--- a/src/commands/registry_client.rs
+++ b/src/commands/registry_client.rs
@@ -9,11 +9,11 @@
 //! `src/commands/skill.rs`/`plugin.rs` stay compilable with the feature off (M1, critic
 //! handoff `.local/handoff/2026-07-10T19-29-13-critic.md`).
 
+use std::path::Path;
+
 use zeph_config::RegistryBackendKind;
 use zeph_core::config::Config;
-use zeph_core::vault::{
-    AgeVaultProvider, EnvVaultProvider, Secret, VaultProvider, default_vault_dir,
-};
+use zeph_core::vault::{AgeVaultProvider, EnvVaultProvider, Secret, VaultProvider};
 use zeph_plugins::marketplace::RegistryClient;
 use zeph_plugins::marketplace::skills_sh::{DEFAULT_BASE_URL, SkillsShClient};
 
@@ -29,12 +29,22 @@ use zeph_plugins::marketplace::skills_sh::{DEFAULT_BASE_URL, SkillsShClient};
 /// not registered with the LLM-context secret-mask registry; low risk, since a one-shot CLI
 /// invocation never feeds this value into an LLM-bound context.
 ///
+/// `vault_override`/`vault_key_override`/`vault_path_override` are the `--vault`/`--vault-key`/
+/// `--vault-path` CLI overrides, threaded through via [`crate::bootstrap::resolve_vault_paths`]
+/// (#6591) — without them the `Age` backend silently ignored the overrides and always loaded
+/// `default_vault_dir()`, diverging from every other vault-backed CLI command.
+///
 /// # Errors
 ///
 /// Returns an error if the configured vault backend cannot be loaded (e.g. missing age key
 /// file) or the lookup itself fails.
 #[tracing::instrument(name = "registry_client.resolve_token", skip(config))]
-pub(crate) async fn resolve_registry_token(config: &Config) -> anyhow::Result<Option<Secret>> {
+pub(crate) async fn resolve_registry_token(
+    config: &Config,
+    vault_override: Option<&str>,
+    vault_key_override: Option<&Path>,
+    vault_path_override: Option<&Path>,
+) -> anyhow::Result<Option<Secret>> {
     let reg = &config.skills.registry;
     if !reg.enabled {
         return Ok(None);
@@ -46,11 +56,15 @@ pub(crate) async fn resolve_registry_token(config: &Config) -> anyhow::Result<Op
     let vault: Box<dyn VaultProvider> = match config.vault.backend {
         zeph_config::VaultBackend::Env => Box::new(EnvVaultProvider),
         zeph_config::VaultBackend::Age => {
-            let dir = default_vault_dir();
-            let provider =
-                AgeVaultProvider::load_async(&dir.join("vault-key.txt"), &dir.join("secrets.age"))
-                    .await
-                    .map_err(|e| anyhow::anyhow!("failed to load vault: {e}"))?;
+            let (vault_key_path, vault_secrets_path) = crate::bootstrap::resolve_vault_paths(
+                config,
+                vault_override,
+                vault_key_override,
+                vault_path_override,
+            );
+            let provider = AgeVaultProvider::load_async(&vault_key_path, &vault_secrets_path)
+                .await
+                .map_err(|e| anyhow::anyhow!("failed to load vault: {e}"))?;
             Box::new(provider)
         }
         zeph_config::VaultBackend::Keyring => {
@@ -154,7 +168,9 @@ mod tests {
         config.skills.registry.enabled = false;
         config.skills.registry.auth_vault_key = Some("ZEPH_SKILL_REGISTRY_TOKEN".to_owned());
 
-        let result = resolve_registry_token(&config).await.unwrap();
+        let result = resolve_registry_token(&config, None, None, None)
+            .await
+            .unwrap();
         assert!(result.is_none());
     }
 
@@ -164,7 +180,9 @@ mod tests {
         config.skills.registry.enabled = true;
         config.skills.registry.auth_vault_key = None;
 
-        let result = resolve_registry_token(&config).await.unwrap();
+        let result = resolve_registry_token(&config, None, None, None)
+            .await
+            .unwrap();
         assert!(result.is_none());
     }
 
@@ -181,7 +199,9 @@ mod tests {
         config.skills.registry.auth_vault_key = Some(key.to_owned());
         config.vault.backend = zeph_config::VaultBackend::Env;
 
-        let result = resolve_registry_token(&config).await.unwrap();
+        let result = resolve_registry_token(&config, None, None, None)
+            .await
+            .unwrap();
 
         #[allow(unsafe_code)]
         unsafe {
@@ -191,6 +211,89 @@ mod tests {
         assert_eq!(
             result.map(|s| s.expose().to_owned()),
             Some("test-token-value".to_owned())
+        );
+    }
+
+    /// #6591: proves the `Age` backend actually reads from the CLI `--vault-key`/`--vault-path`
+    /// override, not from `default_vault_dir()`. `XDG_CONFIG_HOME` is pointed at an empty
+    /// tempdir with no vault files, so a silent fallback to the default dir would surface as an
+    /// `Err` here rather than resolving the secret — proving the override path was actually
+    /// used to read it, not merely accepted and ignored.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn resolve_registry_token_age_backend_uses_vault_override_paths() {
+        let override_dir = tempfile::tempdir().expect("override tempdir");
+        let default_dir = tempfile::tempdir().expect("default tempdir");
+        let key_path = override_dir.path().join("vault-key.txt");
+        let vault_path = override_dir.path().join("secrets.age");
+
+        AgeVaultProvider::init_vault_at(&key_path, &vault_path, false).expect("init vault");
+        let mut vault = AgeVaultProvider::load_async(&key_path, &vault_path)
+            .await
+            .expect("load fresh vault");
+        vault
+            .set_secret_mut(
+                "ZEPH_TEST_REGISTRY_TOKEN_AGE".to_owned(),
+                "override-token-value".to_owned(),
+                false,
+            )
+            .expect("seed secret");
+        vault.save_async().await.expect("persist vault");
+
+        #[allow(unsafe_code)] // scoped env mutation; #[serial] avoids cross-test races
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", default_dir.path());
+        }
+
+        let mut config = Config::default();
+        config.skills.registry.enabled = true;
+        config.skills.registry.auth_vault_key = Some("ZEPH_TEST_REGISTRY_TOKEN_AGE".to_owned());
+        config.vault.backend = zeph_config::VaultBackend::Age;
+
+        let result =
+            resolve_registry_token(&config, None, Some(&key_path), Some(&vault_path)).await;
+
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::remove_var("XDG_CONFIG_HOME");
+        }
+
+        let secret = result
+            .expect("override vault must load successfully")
+            .expect("secret must resolve from the override path");
+        assert_eq!(secret.expose(), "override-token-value");
+    }
+
+    /// Companion sanity check: with no `--vault-key`/`--vault-path` override, resolution must
+    /// still attempt `default_vault_dir()` (pointed at an empty tempdir via `XDG_CONFIG_HOME`)
+    /// rather than silently succeeding some other way — a missing vault there must surface as
+    /// an `Err`, matching pre-#6591 default-path behavior.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn resolve_registry_token_age_backend_falls_back_to_default_vault_dir_without_override() {
+        let default_dir = tempfile::tempdir().expect("default tempdir");
+
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", default_dir.path());
+        }
+
+        let mut config = Config::default();
+        config.skills.registry.enabled = true;
+        config.skills.registry.auth_vault_key = Some("ZEPH_TEST_REGISTRY_TOKEN_AGE".to_owned());
+        config.vault.backend = zeph_config::VaultBackend::Age;
+
+        let result = resolve_registry_token(&config, None, None, None).await;
+
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::remove_var("XDG_CONFIG_HOME");
+        }
+
+        assert!(
+            result.is_err(),
+            "no vault at default_vault_dir() must surface as an error, proving the default \
+             path (not a silent override bypass) was exercised"
         );
     }
 

--- a/src/commands/skill.rs
+++ b/src/commands/skill.rs
@@ -568,6 +568,7 @@ async fn registry_search_with(
 /// tests for `MockRegistryClient`-driven coverage.
 #[cfg(feature = "registry")]
 #[tracing::instrument(name = "skill.registry_get", skip(config, mgr), fields(registry_id))]
+#[allow(clippy::too_many_arguments)]
 async fn registry_get(
     config: &zeph_core::config::Config,
     mgr: &zeph_skills::manager::SkillManager,

--- a/src/commands/skill.rs
+++ b/src/commands/skill.rs
@@ -7,6 +7,9 @@ use crate::cli::SkillCommand;
 pub(crate) async fn handle_skill_command(
     cmd: SkillCommand,
     config_path: Option<&std::path::Path>,
+    vault_override: Option<&str>,
+    vault_key_override: Option<&std::path::Path>,
+    vault_path_override: Option<&std::path::Path>,
 ) -> anyhow::Result<()> {
     use crate::bootstrap::{load_config_or_default, managed_skills_dir, resolve_config_path};
     use std::collections::HashMap;
@@ -449,7 +452,14 @@ pub(crate) async fn handle_skill_command(
         SkillCommand::Search { query } => {
             #[cfg(feature = "registry")]
             {
-                registry_search(&config, &query).await?;
+                registry_search(
+                    &config,
+                    &query,
+                    vault_override,
+                    vault_key_override,
+                    vault_path_override,
+                )
+                .await?;
             }
             #[cfg(not(feature = "registry"))]
             {
@@ -464,11 +474,26 @@ pub(crate) async fn handle_skill_command(
         SkillCommand::Get { registry_id } => {
             #[cfg(feature = "registry")]
             {
-                registry_get(&config, &mgr, &managed_dir, &sqlite_path, &registry_id).await?;
+                registry_get(
+                    &config,
+                    &mgr,
+                    &managed_dir,
+                    &sqlite_path,
+                    &registry_id,
+                    vault_override,
+                    vault_key_override,
+                    vault_path_override,
+                )
+                .await?;
             }
             #[cfg(not(feature = "registry"))]
             {
-                let _ = &registry_id;
+                let _ = (
+                    &registry_id,
+                    vault_override,
+                    vault_key_override,
+                    vault_path_override,
+                );
                 println!(
                     "This zeph build was compiled without the `registry` feature; rebuild \
                      with `--features registry` (or `full`) to use `zeph skill get`."
@@ -489,7 +514,13 @@ pub(crate) async fn handle_skill_command(
 /// coverage.
 #[cfg(feature = "registry")]
 #[tracing::instrument(name = "skill.registry_search", skip(config), fields(query))]
-async fn registry_search(config: &zeph_core::config::Config, query: &str) -> anyhow::Result<()> {
+async fn registry_search(
+    config: &zeph_core::config::Config,
+    query: &str,
+    vault_override: Option<&str>,
+    vault_key_override: Option<&std::path::Path>,
+    vault_path_override: Option<&std::path::Path>,
+) -> anyhow::Result<()> {
     use crate::commands::registry_client::{
         REGISTRY_NOT_CONFIGURED_MSG, build_registry_client, resolve_registry_token,
     };
@@ -499,7 +530,13 @@ async fn registry_search(config: &zeph_core::config::Config, query: &str) -> any
         anyhow::bail!("{REGISTRY_NOT_CONFIGURED_MSG}");
     }
 
-    let token = resolve_registry_token(config).await?;
+    let token = resolve_registry_token(
+        config,
+        vault_override,
+        vault_key_override,
+        vault_path_override,
+    )
+    .await?;
     let client = build_registry_client(config, token);
     registry_search_with(client.as_ref(), query).await
 }
@@ -537,6 +574,9 @@ async fn registry_get(
     managed_dir: &std::path::Path,
     sqlite_path: &str,
     registry_id: &str,
+    vault_override: Option<&str>,
+    vault_key_override: Option<&std::path::Path>,
+    vault_path_override: Option<&std::path::Path>,
 ) -> anyhow::Result<()> {
     use crate::commands::registry_client::{
         REGISTRY_NOT_CONFIGURED_MSG, build_registry_client, resolve_registry_token,
@@ -547,7 +587,13 @@ async fn registry_get(
         anyhow::bail!("{REGISTRY_NOT_CONFIGURED_MSG}");
     }
 
-    let token = resolve_registry_token(config).await?;
+    let token = resolve_registry_token(
+        config,
+        vault_override,
+        vault_key_override,
+        vault_path_override,
+    )
+    .await?;
     let client = build_registry_client(config, token);
     registry_get_with(client.as_ref(), mgr, managed_dir, sqlite_path, registry_id).await
 }
@@ -741,7 +787,9 @@ mod registry_tests {
         let config = zeph_core::config::Config::default();
         assert!(!config.skills.registry.enabled);
 
-        let err = registry_search(&config, "query").await.unwrap_err();
+        let err = registry_search(&config, "query", None, None, None)
+            .await
+            .unwrap_err();
         assert_eq!(err.to_string(), REGISTRY_NOT_CONFIGURED_MSG);
     }
 
@@ -763,6 +811,9 @@ mod registry_tests {
             &managed_dir,
             sqlite_path.to_str().unwrap(),
             "acme/x",
+            None,
+            None,
+            None,
         )
         .await
         .unwrap_err();
@@ -818,6 +869,9 @@ mod trust_promotion_tests {
                 source: skill_src.to_string_lossy().into_owned(),
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         ))
         .await
         .unwrap();
@@ -848,6 +902,9 @@ mod trust_promotion_tests {
                 no_require_check: false,
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         ))
         .await;
 
@@ -881,6 +938,9 @@ mod trust_promotion_tests {
                 no_require_check: true,
             },
             Some(&config_path),
+            None,
+            None,
+            None,
         ))
         .await;
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -912,7 +912,14 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
             );
         }
         Some(Command::Skill { command: skill_cmd }) => {
-            return handle_skill_command(skill_cmd, cli.config.as_deref()).await;
+            return handle_skill_command(
+                skill_cmd,
+                cli.config.as_deref(),
+                cli.vault.as_deref(),
+                cli.vault_key.as_deref(),
+                cli.vault_path.as_deref(),
+            )
+            .await;
         }
         Some(Command::Plugin {
             command: plugin_cmd,
@@ -920,6 +927,9 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
             return crate::commands::plugin::handle_plugin_command(
                 plugin_cmd,
                 cli.config.as_deref(),
+                cli.vault.as_deref(),
+                cli.vault_key.as_deref(),
+                cli.vault_path.as_deref(),
             )
             .await;
         }


### PR DESCRIPTION
## Summary

- `resolve_registry_token` (`src/commands/registry_client.rs`) hardcoded `default_vault_dir()` for the `Age` vault backend, ignoring `--vault`/`--vault-key`/`--vault-path` CLI overrides already respected by every sibling vault-backed CLI path (`durable.rs`, `scheduler_daemon.rs`, per #6590).
- Threads `vault_override`/`vault_key_override`/`vault_path_override` from `runner.rs`'s CLI dispatch through `handle_skill_command`/`registry_search`/`registry_get` (`src/commands/skill.rs`) and `handle_plugin_command`/`registry_search`/`registry_get` (`src/commands/plugin.rs`) into `resolve_registry_token`, which now resolves the vault key/secrets paths via `crate::bootstrap::resolve_vault_paths` instead of the hardcoded default.
- Adds Age-backend regression coverage (`registry_client.rs`) proving the override path is actually read from, with a companion test confirming the no-override fallback behavior is unchanged.
- Adds `#[allow(clippy::too_many_lines)]` to `handle_plugin_command`, which crossed the threshold after the parameter growth (mirrors the existing allow already on `handle_skill_command`).

Closes #6591

## Test plan

- [x] `cargo build --features full`
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph --features full` — 1136 passed, 15 skipped, 0 failed
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo +nightly fmt --check` — clean
- [x] `gitleaks protect --staged --no-banner --redact` — no leaks
- [x] New Age-backend override tests exercise the actual bug (fallback to `default_vault_dir()` verified via `XDG_CONFIG_HOME`-scoped tempdir isolation, `#[serial_test::serial]`)