### PR TITLE
refactor(core): consolidate security-relevant AgentBuilder wiring across entry points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   activation) if the trust write itself errors. Retroactive re-scan of pre-existing `"auto"`
   versions and per-version (rather than per-skill-name) trust restoration on rollback are
   deferred as follow-ups (issue #6568).
+- `src/agent_setup.rs`: consolidated every security-relevant `AgentBuilder` setter (risk-chain
+  accumulator, MAGE trajectory-risk gate, typed-page CAM fidelity, trajectory risk
+  slot/signal queue/config, write-time memory-consent trust slot, `ShadowSentinel`, VIGIL,
+  hooks, the MCP tool-id registry handle, and the ML injection classifier + its enforcement
+  mode) into one `apply_security_pipeline` call site shared by `src/runner.rs`,
+  `src/daemon.rs`, `src/acp.rs`, and `src/serve/agent_factory.rs`, superseding the narrower
+  `apply_entrypoint_security_controls`. This closes three real divergences: `serve-sessions`
+  never wired `[hooks]` at all; `serve/agent_factory.rs` built a `TrustGateExecutor` MCP
+  tool-id handle but never attached it to the `Agent` (only fed it to
+  `register_mcp_tool_ids`); and `acp.rs`/`serve/agent_factory.rs` set the injection-classifier
+  enforcement mode inline instead of through the shared helper, bypassing the documented
+  "must follow the injection classifier" ordering constraint (still correct by luck of call
+  order, now enforced structurally). Added `Agent::security_wiring_snapshot()` and two
+  binary-crate guardrail tests (a structural inline-call scan across the four entry points,
+  and a behavioral test asserting `apply_security_pipeline` populates every field) so a future
+  entry point cannot silently reintroduce this class of drift (issue #6581).
 - `zeph-core`: `build_compression_prompt` (`agent/tool_execution/focus.rs`) now repairs
   spotlight-wrapper integrity when its existing 500-char truncation cuts off the closing tag
   of an already-applied untrusted-content wrapper (`<tool-output>`/`<external-data>`, added

--- a/crates/zeph-core/src/agent/builder.rs
+++ b/crates/zeph-core/src/agent/builder.rs
@@ -113,6 +113,41 @@ pub struct SkillConfigParams {
     pub semantic_scan_provider_name: String,
 }
 
+/// Bool snapshot of which security-relevant `AgentBuilder` setters have been applied.
+///
+/// Returned by [`Agent::security_wiring_snapshot`] — see that method's doc comment for which
+/// setters are (and are deliberately not) represented here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(clippy::struct_excessive_bools)] // independent wiring flags, one per setter; mirrors serve/deps.rs's ServeAgentDeps
+pub struct SecurityWiringSnapshot {
+    /// `true` when [`Agent::with_risk_chain_accumulator`] has been called.
+    pub risk_chain_accumulator: bool,
+    /// `true` when [`Agent::with_mage_accumulator_config`] installed a live (non-noop)
+    /// accumulator.
+    pub mage_accumulator_enabled: bool,
+    /// `true` when [`Agent::with_typed_pages_state`] was called with `Some`.
+    pub typed_pages_state: bool,
+    /// `true` when [`Agent::with_shadow_sentinel`] has been called.
+    pub shadow_sentinel: bool,
+    /// `true` when [`Agent::with_vigil_config`] attached a `VigilGate`.
+    pub vigil_config: bool,
+    /// `true` when [`Agent::with_hooks_config`] was called with a non-empty `HooksConfig`.
+    pub hooks_config: bool,
+    /// `true` when [`Agent::with_mcp_tool_ids_handle`] has been called.
+    pub mcp_tool_ids_handle: bool,
+    /// `true` when [`Agent::with_llm_classifier`] has been called.
+    pub llm_classifier: bool,
+    /// `true` when [`Agent::with_injection_classifier`] attached a classifier backend.
+    #[cfg(feature = "classifiers")]
+    pub injection_classifier: bool,
+    /// `true` when [`Agent::with_enforcement_mode`] set `InjectionEnforcementMode::Block`.
+    #[cfg(feature = "classifiers")]
+    pub enforcement_mode_blocking: bool,
+    /// `true` when [`Agent::with_scan_user_input`] set `scan_user_input = true`.
+    #[cfg(feature = "classifiers")]
+    pub scan_user_input: bool,
+}
+
 /// Extracts the fields [`Agent::with_skill_config`] needs from a full `[skills]` config
 /// section — the shape available at `src/runner.rs`'s and `src/daemon.rs`'s call sites, which
 /// hold the whole `Config` rather than pre-extracted scalars.
@@ -1787,6 +1822,40 @@ impl<C: Channel> Agent<C> {
     #[must_use]
     pub fn has_code_retriever(&self) -> bool {
         self.services.index.retriever.is_some()
+    }
+
+    /// Reports which security-relevant setters (issue #6581) have been applied to this `Agent`.
+    ///
+    /// Primarily used by the binary crate's structural + behavioral guardrail tests
+    /// (`src/agent_setup.rs`) to assert wiring without accessing the `pub(crate)`
+    /// `SecurityState`/`FeedbackState` fields directly, mirroring [`Self::has_code_retriever`].
+    ///
+    /// `with_trajectory_risk_slot`, `with_trajectory_config`, `with_memory_consent_trust_slot`,
+    /// and `with_signal_queue` are deliberately not represented here: those fields are
+    /// always-present (non-`Option`, `Arc`-shared or plain owned state) rather than toggled, so
+    /// "was it wired" is only meaningfully observable via `Arc::strong_count` on the caller's
+    /// own clone — see `apply_security_pipeline`'s behavioral test, which follows the same
+    /// convention as the pre-existing
+    /// `wire_risk_chain_attaches_the_returned_accumulator_to_the_executor` test.
+    #[must_use]
+    pub fn security_wiring_snapshot(&self) -> SecurityWiringSnapshot {
+        SecurityWiringSnapshot {
+            risk_chain_accumulator: self.services.security.risk_chain_accumulator.is_some(),
+            mage_accumulator_enabled: self.services.security.mage_accumulator.is_enabled(),
+            typed_pages_state: self.services.compression.typed_pages_state.is_some(),
+            shadow_sentinel: self.services.security.shadow_sentinel.is_some(),
+            vigil_config: self.services.security.vigil.is_some(),
+            hooks_config: !self.services.session.hooks_config.is_empty(),
+            mcp_tool_ids_handle: self.services.security.mcp_tool_ids.is_some(),
+            llm_classifier: self.services.feedback.llm_classifier.is_some(),
+            #[cfg(feature = "classifiers")]
+            injection_classifier: self.services.security.sanitizer.has_classifier_backend(),
+            #[cfg(feature = "classifiers")]
+            enforcement_mode_blocking: self.services.security.sanitizer.enforcement_mode()
+                == zeph_config::InjectionEnforcementMode::Block,
+            #[cfg(feature = "classifiers")]
+            scan_user_input: self.services.security.sanitizer.scan_user_input(),
+        }
     }
 
     // ---- Debug & Diagnostics ----

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -7,7 +7,7 @@ pub(crate) mod agent_supervisor;
 mod autodream;
 mod autonomous_turn;
 mod builder;
-pub use builder::SkillConfigParams;
+pub use builder::{SecurityWiringSnapshot, SkillConfigParams};
 #[cfg(feature = "cocoon")]
 mod cocoon_cmd;
 mod command_context_impls;

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -1100,6 +1100,19 @@ pub(crate) struct HooksConfigSnapshot {
     pub(crate) post_tool_use: Vec<zeph_config::HookMatcher>,
 }
 
+impl HooksConfigSnapshot {
+    /// Returns `true` when no hooks are configured in any section — mirrors
+    /// `zeph_config::HooksConfig::is_empty()` for the post-`with_hooks_config` snapshot shape.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.cwd_changed.is_empty()
+            && self.file_changed_hooks.is_empty()
+            && self.permission_denied.is_empty()
+            && self.turn_complete.is_empty()
+            && self.pre_tool_use.is_empty()
+            && self.post_tool_use.is_empty()
+    }
+}
+
 // Groups message buffering and image staging state.
 pub(crate) struct MessageState {
     pub(crate) messages: Vec<Message>,

--- a/crates/zeph-core/src/lib.rs
+++ b/crates/zeph-core/src/lib.rs
@@ -116,6 +116,7 @@ pub mod testing;
 
 pub use agent::Agent;
 pub use agent::DurableKeyMaterial;
+pub use agent::SecurityWiringSnapshot;
 pub use agent::SkillConfigParams;
 pub use agent::error::AgentError;
 pub use agent::session_config::{AgentSessionConfig, CONTEXT_BUDGET_RESERVE_RATIO};

--- a/crates/zeph-sanitizer/src/sanitizer.rs
+++ b/crates/zeph-sanitizer/src/sanitizer.rs
@@ -222,6 +222,13 @@ impl ContentSanitizer {
         self
     }
 
+    /// Returns the currently configured injection-classifier enforcement mode.
+    #[cfg(feature = "classifiers")]
+    #[must_use]
+    pub fn enforcement_mode(&self) -> zeph_config::InjectionEnforcementMode {
+        self.enforcement_mode
+    }
+
     /// Attach a three-class classifier backend for `AlignSentinel` refinement.
     ///
     /// When attached, content flagged by the binary classifier is passed to this model.

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -606,12 +606,11 @@ pub(crate) struct SharedAgentDeps {
     /// Typed-page CAM fidelity state (#6574), built once per connection via
     /// `agent_setup::build_typed_pages_state` since `[memory.compression.typed_pages]` is static
     /// config. `spawn_acp_agent` clones the `Arc` into every session via
-    /// `agent_setup::apply_entrypoint_security_controls` — mirrors `src/runner.rs` and
-    /// `src/daemon.rs`.
+    /// `agent_setup::apply_security_pipeline` — mirrors `src/runner.rs` and `src/daemon.rs`.
     typed_pages_state: Option<std::sync::Arc<zeph_context::typed_page::TypedPagesState>>,
     /// `config.memory.shadow_memory` (#6579), wired into `Agent::with_mage_accumulator_config`
-    /// per session via `agent_setup::apply_entrypoint_security_controls` — mirrors
-    /// `src/runner.rs` and `src/daemon.rs`. Replaces the noop `TrajectoryRiskAccumulator` set by
+    /// per session via `agent_setup::apply_security_pipeline` — mirrors `src/runner.rs` and
+    /// `src/daemon.rs`. Replaces the noop `TrajectoryRiskAccumulator` set by
     /// `SecurityState::default()`.
     shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig,
 
@@ -2194,18 +2193,33 @@ async fn spawn_acp_agent(
         memory.sqlite().pool().clone(),
     );
 
-    // #5958: wire the trajectory risk slot/signal queue built above (spec 050 Invariant 2) plus
-    // the TrajectorySentinel state machine itself into the agent, matching src/runner.rs and
-    // src/daemon.rs.
-    agent = agent
-        .with_trajectory_risk_slot(trajectory_risk_slot)
-        .with_signal_queue(trajectory_signal_queue)
-        .with_trajectory_config(d.trajectory_sentinel_config.clone())
-        .0;
-    // Write-time memory-consent gate (issue #6490, MemGhost): share the same slot with
-    // `memory_executor` (wired above) so sanitize_tool_output's ratcheting is visible to
-    // MemoryToolExecutor's confirmation check.
-    agent = agent.with_memory_consent_trust_slot(memory_consent_trust_slot);
+    // Security-relevant AgentBuilder setters — risk-chain accumulator (#6578), MAGE
+    // trajectory-risk gate (#6579), typed-page CAM fidelity (#6574), trajectory risk
+    // slot/signal queue/config (spec 050 Invariant 2), write-time memory-consent trust slot
+    // (#6490), ShadowSentinel (spec 050 Phase 2), VIGIL, hooks, the MCP tool-id registry
+    // handle (#5747), and (when `classifiers` is enabled) the ML injection classifier +
+    // enforcement mode — shared with src/runner.rs/src/daemon.rs/src/serve/agent_factory.rs
+    // via one call site so these controls cannot silently drop out of sync across entry
+    // points again (#6581).
+    agent = agent_setup::apply_security_pipeline(
+        agent,
+        agent_setup::SecurityWiringInputs {
+            risk_chain_accumulator,
+            mage_accumulator_config,
+            typed_pages_state: d.typed_pages_state.clone(),
+            trajectory_risk_slot,
+            trajectory_signal_queue,
+            trajectory_config: d.trajectory_sentinel_config.clone(),
+            memory_consent_trust_slot,
+            shadow_sentinel: shadow_sentinel_arc,
+            vigil_config,
+            hooks_config: (!safe_mode).then_some(hooks_config),
+            mcp_tool_ids_handle: mcp_ids_handle,
+            #[cfg(feature = "classifiers")]
+            classifiers_config: classifiers_config.clone(),
+            llm_classifier: feedback_classifier,
+        },
+    );
 
     // SkillOrchestra: wire the RL routing head, if enabled (#5921). `d.rl_head` is loaded/
     // cold-started exactly once in `build_shared_core` and cloned (cheap `Arc` clone) into every
@@ -2278,9 +2292,6 @@ async fn spawn_acp_agent(
     if let Some(jp) = judge_provider {
         agent = agent.with_judge_provider(jp);
     }
-    if let Some(fc) = feedback_classifier {
-        agent = agent.with_llm_classifier(fc);
-    }
 
     if let Some(pp) = probe_provider {
         agent = agent.with_probe_provider(pp);
@@ -2310,10 +2321,6 @@ async fn spawn_acp_agent(
     }
     #[cfg(feature = "classifiers")]
     {
-        agent = agent_setup::apply_injection_classifier_with_cfg(agent, &classifiers_config);
-        if classifiers_config.enabled {
-            agent = agent.with_enforcement_mode(classifiers_config.enforcement_mode);
-        }
         agent = agent_setup::apply_three_class_classifier_with_cfg(agent, &classifiers_config);
         agent = agent_setup::apply_pii_classifier_with_cfg(agent, &classifiers_config);
         agent = agent_setup::apply_pii_ner_classifier_with_cfg(
@@ -2337,18 +2344,6 @@ async fn spawn_acp_agent(
         secret_registry.as_ref(),
     );
     agent = agent_setup::apply_secret_masking(agent, secret_registry);
-    agent = agent_setup::apply_vigil(agent, &vigil_config);
-    // Risk-chain accumulator (#6561/#6588: this session's own instance, built alongside its
-    // `ShellExecutor` above — see the comment there), MAGE trajectory-risk gate (#6579),
-    // typed-page CAM fidelity (#6574) — shared with src/runner.rs/src/daemon.rs/
-    // src/serve/agent_factory.rs via one call site so the three controls cannot silently drop
-    // out of sync across entry points again (#6581).
-    agent = agent_setup::apply_entrypoint_security_controls(
-        agent,
-        risk_chain_accumulator,
-        mage_accumulator_config.clone(),
-        d.typed_pages_state.clone(),
-    );
 
     if debug_config.enabled {
         // Use session_id as a subdirectory prefix so concurrent sessions never share the same
@@ -2364,18 +2359,6 @@ async fn spawn_acp_agent(
         )
         .0;
     }
-
-    if !safe_mode {
-        agent = agent.with_hooks_config(&hooks_config);
-    }
-    // Spec 050 Phase 2 (#5913): wire ShadowSentinel into the agent so begin_turn() calls
-    // advance_turn(), matching src/runner.rs.
-    if let Some(sentinel) = shadow_sentinel_arc {
-        agent = agent.with_shadow_sentinel(sentinel);
-    }
-    // Keep TrustGateExecutor's MCP tool-id registry in sync with MCP servers connected after
-    // startup (#5747) — without this, check_tool_refresh has no handle to update.
-    agent = agent.with_mcp_tool_ids_handle(mcp_ids_handle);
 
     drop(d);
 

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -701,7 +701,7 @@ pub(crate) async fn build_tool_setup(
 /// detector (`SensitiveRead` -> `NetworkEgress`, e.g. `exfil_read_then_send`) is actually
 /// enforced — without it, `ShellExecutor::execute`'s risk-chain check is silently skipped
 /// (#6578). Pass the returned `Arc` to `Agent::with_risk_chain_accumulator` (via
-/// [`apply_entrypoint_security_controls`]) so `begin_turn()` advances it (prunes calls older
+/// [`apply_security_pipeline`]) so `begin_turn()` advances it (prunes calls older
 /// than its cross-turn window and recomputes the score — see
 /// [`zeph_tools::risk_chain::RiskChainAccumulator::advance_turn`]) at each turn boundary.
 ///
@@ -1028,41 +1028,114 @@ pub(crate) async fn build_typed_pages_state(
     }))
 }
 
-/// Apply the three security/fidelity controls that must stay identical across every entry point:
-/// the shell risk-chain accumulator (#6578), the MAGE trajectory-risk gate (#6579), and typed-page
-/// CAM fidelity enforcement (#6574). Previously each was wired only in `runner.rs`'s CLI/TUI
-/// bootstrap and silently skipped by `daemon.rs`, `acp.rs`, and `serve/agent_factory.rs` — this
-/// helper is the single call site all four entry points share so the three controls cannot drift
-/// out of sync again (tracked defect class: `#6581`).
+/// Decomposed inputs for [`apply_security_pipeline`] — the single call site all four entry
+/// points (`runner.rs`, `daemon.rs`, `acp.rs`, `serve/agent_factory.rs`) use to wire every
+/// security-relevant `AgentBuilder` setter in one place, in the correct order, so a future entry
+/// point cannot silently omit one (tracked defect class: `#6581`).
 ///
-/// `risk_chain_accumulator` is the `Arc` returned by [`wire_risk_chain`] — the same instance
-/// attached to the entry point's `ShellExecutor`. `mage_accumulator_config` is
-/// `config.memory.shadow_memory.clone()`. `typed_pages_state` is the result of
-/// [`build_typed_pages_state`]. Takes the decomposed config value rather than `&Config` because
-/// `acp.rs`'s `SharedAgentDeps` never holds a full `Config` (it decomposes config into
-/// per-session fields at connection-build time) — matching that convention keeps the call site
-/// identical across all four entry points.
-pub(crate) fn apply_entrypoint_security_controls<C: Channel>(
-    agent: Agent<C>,
-    risk_chain_accumulator: Arc<zeph_tools::RiskChainAccumulator>,
-    mage_accumulator_config: zeph_config::TrajectoryRiskAccumulatorConfig,
-    typed_pages_state: Option<Arc<zeph_context::typed_page::TypedPagesState>>,
-) -> Agent<C> {
-    agent
-        .with_risk_chain_accumulator(risk_chain_accumulator)
-        .with_mage_accumulator_config(mage_accumulator_config)
-        .with_typed_pages_state(typed_pages_state)
+/// Takes decomposed values rather than `&Config` because `acp.rs`'s `SharedAgentDeps` and
+/// `serve/deps.rs`'s `ServeAgentDeps` never hold a full `Config` — they decompose config into
+/// per-session fields at connection/session-build time (matching [`apply_vigil`]'s and
+/// `apply_injection_classifier_with_cfg`'s existing convention).
+pub(crate) struct SecurityWiringInputs {
+    /// The `Arc` returned by [`wire_risk_chain`] — the same instance attached to the entry
+    /// point's `ShellExecutor` (#6578).
+    pub(crate) risk_chain_accumulator: Arc<zeph_tools::RiskChainAccumulator>,
+    /// `config.memory.shadow_memory.clone()` (#6579).
+    pub(crate) mage_accumulator_config: zeph_config::TrajectoryRiskAccumulatorConfig,
+    /// The result of [`build_typed_pages_state`] (#6574).
+    pub(crate) typed_pages_state: Option<Arc<zeph_context::typed_page::TypedPagesState>>,
+    /// Shared risk slot (spec 050 Invariant 2) — same `Arc` passed to
+    /// `PolicyGateExecutor`/`ScopedToolExecutor`.
+    pub(crate) trajectory_risk_slot: zeph_tools::TrajectoryRiskSlot,
+    /// Shared signal queue (spec 050 §2) — same `Arc` passed to
+    /// `PolicyGateExecutor`/`ScopedToolExecutor`.
+    pub(crate) trajectory_signal_queue: zeph_tools::RiskSignalQueue,
+    /// `config.security.trajectory.clone()`.
+    pub(crate) trajectory_config: zeph_config::TrajectorySentinelConfig,
+    /// Write-time memory-consent trust slot (#6490), shared with the memory tool executor.
+    pub(crate) memory_consent_trust_slot: zeph_core::memory_tools::MemoryConsentTrustSlot,
+    /// `Some` when `security.shadow_sentinel.enabled = true` for this session (spec 050 Phase 2).
+    pub(crate) shadow_sentinel: Option<Arc<zeph_core::agent::shadow_sentinel::ShadowSentinel>>,
+    /// `config.security.vigil.clone()`.
+    pub(crate) vigil_config: zeph_config::VigilConfig,
+    /// `Some(config.hooks.clone())` to wire hooks; `None` to skip (bare/safe-mode gate) —
+    /// mirrors the existing `if !bare/safe_mode { with_hooks_config }` pattern.
+    pub(crate) hooks_config: Option<zeph_config::HooksConfig>,
+    /// Handle into `TrustGateExecutor`'s MCP tool-id registry (#5747).
+    pub(crate) mcp_tool_ids_handle: McpToolIdsHandle,
+    /// `config.classifiers.clone()` — drives both the injection classifier (#6580) and the
+    /// enforcement mode (D3, #6581); the pipeline applies enforcement mode AFTER the injection
+    /// classifier (verified ordering constraint).
+    #[cfg(feature = "classifiers")]
+    pub(crate) classifiers_config: zeph_config::ClassifiersConfig,
+    /// `config.skills.learning` feedback/reward-signal classifier (`detector_mode = "model"`).
+    pub(crate) llm_classifier: Option<zeph_llm::classifier::llm::LlmClassifier>,
 }
 
-/// Wire the `CandleClassifier` injection backend into the agent's sanitizer.
+/// Wires every security-relevant `AgentBuilder` setter onto `agent` in one call — the shell
+/// risk-chain accumulator (#6578), the MAGE trajectory-risk gate (#6579), typed-page CAM
+/// fidelity enforcement (#6574), the trajectory sentinel risk slot/signal queue/config, the
+/// write-time memory-consent trust slot (#6490), `ShadowSentinel` (spec 050 Phase 2), VIGIL
+/// (#6581), hooks (D1), the MCP tool-id registry handle (D2), and — when the `classifiers`
+/// feature is enabled — the ML injection classifier followed by its enforcement mode (D3).
 ///
-/// Only active when `classifiers.enabled = true` in config.
-#[cfg(feature = "classifiers")]
-pub(crate) fn apply_injection_classifier<C: Channel>(
-    agent: zeph_core::agent::Agent<C>,
-    config: &Config,
-) -> zeph_core::agent::Agent<C> {
-    apply_injection_classifier_with_cfg(agent, &config.classifiers)
+/// Supersedes the narrower `apply_entrypoint_security_controls` (#6574/#6578/#6579): that helper
+/// only covered 3 of these setters, leaving the rest to drift independently across
+/// `runner.rs`/`daemon.rs`/`acp.rs`/`serve/agent_factory.rs` — `with_hooks_config` was missing
+/// entirely from `serve`, `with_enforcement_mode` was inlined (bypassing the ordering
+/// constraint) in `acp.rs`/`serve/agent_factory.rs`, and the MCP tool-id handle built in
+/// `serve/agent_factory.rs` was never attached to the `Agent` at all.
+///
+/// # Ordering
+///
+/// The injection classifier is applied before `with_enforcement_mode` — `with_enforcement_mode`
+/// is a no-op unless a classifier is already attached to the sanitizer. This function encodes
+/// that ordering internally so no call site can get it wrong.
+pub(crate) fn apply_security_pipeline<C: Channel>(
+    agent: Agent<C>,
+    inputs: SecurityWiringInputs,
+) -> Agent<C> {
+    let agent = agent
+        .with_risk_chain_accumulator(inputs.risk_chain_accumulator)
+        .with_mage_accumulator_config(inputs.mage_accumulator_config)
+        .with_typed_pages_state(inputs.typed_pages_state);
+
+    let agent = agent
+        .with_trajectory_risk_slot(inputs.trajectory_risk_slot)
+        .with_signal_queue(inputs.trajectory_signal_queue)
+        .with_trajectory_config(inputs.trajectory_config)
+        .0;
+
+    let agent = agent.with_memory_consent_trust_slot(inputs.memory_consent_trust_slot);
+
+    let agent = if let Some(sentinel) = inputs.shadow_sentinel {
+        agent.with_shadow_sentinel(sentinel)
+    } else {
+        agent
+    };
+
+    let agent = apply_vigil(agent, &inputs.vigil_config);
+
+    let agent = if let Some(ref hooks) = inputs.hooks_config {
+        agent.with_hooks_config(hooks)
+    } else {
+        agent
+    };
+
+    let agent = agent.with_mcp_tool_ids_handle(inputs.mcp_tool_ids_handle);
+
+    #[cfg(feature = "classifiers")]
+    let agent = {
+        let agent = apply_injection_classifier_with_cfg(agent, &inputs.classifiers_config);
+        apply_enforcement_mode_with_cfg(agent, &inputs.classifiers_config)
+    };
+
+    if let Some(fc) = inputs.llm_classifier {
+        agent.with_llm_classifier(fc)
+    } else {
+        agent
+    }
 }
 
 /// Wire the `CandleClassifier` injection backend into the agent's sanitizer (takes `ClassifiersConfig` directly).
@@ -1195,19 +1268,21 @@ pub(crate) fn apply_pii_ner_classifier_with_cfg<C: Channel>(
     )
 }
 
-/// Wire `enforcement_mode` from config into the agent's injection classifier.
+/// Wire `enforcement_mode` from config into the agent's injection classifier (takes
+/// `ClassifiersConfig` directly).
 ///
-/// Must be called AFTER `apply_injection_classifier` so the sanitizer already has
-/// a classifier attached. Safe to call when classifiers are disabled (no-op).
+/// Must be called AFTER `apply_injection_classifier_with_cfg` so the sanitizer already has a
+/// classifier attached — [`apply_security_pipeline`] encodes this ordering. Safe to call when
+/// classifiers are disabled (no-op).
 #[cfg(feature = "classifiers")]
-pub(crate) fn apply_enforcement_mode<C: Channel>(
+pub(crate) fn apply_enforcement_mode_with_cfg<C: Channel>(
     agent: zeph_core::agent::Agent<C>,
-    config: &Config,
+    classifiers: &zeph_core::config::ClassifiersConfig,
 ) -> zeph_core::agent::Agent<C> {
-    if !config.classifiers.enabled {
+    if !classifiers.enabled {
         return agent;
     }
-    agent.with_enforcement_mode(config.classifiers.enforcement_mode)
+    agent.with_enforcement_mode(classifiers.enforcement_mode)
 }
 
 /// Wire the three-class `AlignSentinel` refinement model into the agent's sanitizer.
@@ -4503,20 +4578,20 @@ mod tests {
         );
     }
 
-    // --- #6578/#6579/#6574 entry-point security wiring regressions ---
+    // --- #6578/#6579/#6574/#6581 entry-point security wiring regressions ---
     //
     // `Agent::services` (where `risk_chain_accumulator`/`mage_accumulator`/`typed_pages_state`
     // actually live) is `pub(crate)` to `zeph-core`, not visible from this binary crate, so
     // these tests cannot assert "the Agent now contains X" directly the way zeph-core's own
     // `agent/tests/mage_signal_mapping_tests.rs` does. Instead they prove wiring via `Arc`
-    // strong-count: `wire_risk_chain`/`apply_entrypoint_security_controls` must retain a live
-    // clone of the accumulator/typed-pages `Arc`, not merely construct-and-discard it — the
-    // exact failure mode of the original bug (`ShellExecutor.risk_chain`/`AgentBuilder`'s
-    // security services silently staying `None`/noop when a call site is missing). Full
-    // integration coverage across daemon/acp/serve is impractical here (heavy bootstrap); the
-    // architectural defense is that all 4 entry points now call the same
-    // `apply_entrypoint_security_controls`/`wire_risk_chain` functions tested below, so a future
-    // dropped call site is a one-line diff against a shared, tested helper rather than a
+    // strong-count (`wire_risk_chain`/`apply_security_pipeline` must retain a live clone of
+    // each `Arc`-backed field, not merely construct-and-discard it — the exact failure mode of
+    // the original bug: `ShellExecutor.risk_chain`/`AgentBuilder`'s security services silently
+    // staying `None`/noop when a call site is missing) and, for non-`Arc` fields,
+    // `Agent::security_wiring_snapshot()`. Full integration coverage across daemon/acp/serve is
+    // impractical here (heavy bootstrap); the architectural defense is that all 4 entry points
+    // now call the same `apply_security_pipeline`/`wire_risk_chain` functions tested below, so a
+    // future dropped call site is a one-line diff against a shared, tested helper rather than a
     // silently-incomplete duplicated wiring block.
 
     /// #6578: `wire_risk_chain` must hand `ShellExecutor::with_risk_chain` a live clone of the
@@ -4543,47 +4618,210 @@ mod tests {
         );
     }
 
-    /// #6578/#6574: `apply_entrypoint_security_controls` — the single call site all 4 entry
-    /// points (`runner.rs`, `daemon.rs`, `acp.rs`, `serve/agent_factory.rs`) now share — must
-    /// actually forward `risk_chain_accumulator` and `typed_pages_state` onto the `Agent` via
-    /// `with_risk_chain_accumulator`/`with_typed_pages_state`, not drop them on the floor.
-    /// `with_mage_accumulator_config` (#6579) constructs a fresh, non-`Arc` accumulator from the
-    /// config value, so it has no refcount to assert on here; exercising it below is a
-    /// panic/compile smoke check that the call happens at all — the accumulator's own
-    /// enabled/disabled behavior is covered by zeph-core's `mage_signal_mapping_tests.rs`.
+    /// #6581: structural guardrail — none of the 12 security-relevant `AgentBuilder` setters
+    /// consolidated by `apply_security_pipeline` may be called inline (bypassing the pipeline)
+    /// from any of the four agent entry points. A future entry point (or a regression in an
+    /// existing one) that reaches for e.g. `.with_shadow_sentinel(...)` directly, instead of
+    /// going through `apply_security_pipeline`, defeats the single-call-site guarantee this
+    /// consolidation establishes.
+    ///
+    /// `with_signal_queue`, `with_enforcement_mode`, and `with_scan_user_input` are
+    /// intentionally excluded from `SETTER_NAMES` — those method names are also defined on
+    /// `ScopedToolExecutor`/`PolicyGateExecutor`/`ContentSanitizer` (multi-receiver), so a
+    /// name-only scan would false-positive on those legitimate non-`Agent` call sites (e.g.
+    /// `scoped.with_signal_queue(...)`). Covered instead by the behavioral snapshot test below.
+    ///
+    /// KNOWN LIMITATION: this proves the four entry points don't inline these setters; it does
+    /// NOT prove an entry point actually calls `apply_security_pipeline` with populated
+    /// (non-default/non-`None`) inputs — an entry point could theoretically call the pipeline
+    /// with an empty/default `SecurityWiringInputs` and still pass this test while wiring
+    /// nothing. This mirrors the project's `tokio::spawn` awk-scan "known limitation"
+    /// convention (`.claude/rules/continuous-improvement.md`) and is an accepted, documented
+    /// limitation, not a defect to fix here.
     #[test]
-    fn apply_entrypoint_security_controls_attaches_risk_chain_and_typed_pages() {
+    fn entry_points_never_inline_security_setters() {
+        const SETTER_NAMES: &[&str] = &[
+            "with_risk_chain_accumulator",
+            "with_mage_accumulator_config",
+            "with_typed_pages_state",
+            "with_shadow_sentinel",
+            "with_vigil_config",
+            "with_hooks_config",
+            "with_mcp_tool_ids_handle",
+            "with_trajectory_risk_slot",
+            "with_trajectory_config",
+            "with_memory_consent_trust_slot",
+            "with_llm_classifier",
+            "with_injection_classifier",
+        ];
+        let entry_points: &[&str] = &[
+            concat!(env!("CARGO_MANIFEST_DIR"), "/src/runner.rs"),
+            concat!(env!("CARGO_MANIFEST_DIR"), "/src/daemon.rs"),
+            concat!(env!("CARGO_MANIFEST_DIR"), "/src/acp.rs"),
+            concat!(env!("CARGO_MANIFEST_DIR"), "/src/serve/agent_factory.rs"),
+        ];
+
+        let mut violations = Vec::new();
+        for path in entry_points {
+            let content = std::fs::read_to_string(path)
+                .unwrap_or_else(|e| panic!("failed to read {path}: {e}"));
+            for name in SETTER_NAMES {
+                // Word/`.`-anchored: a leading `.` excludes the setter's own `pub fn` definition
+                // (never in these 4 files anyway) and requiring `(` immediately after `name`
+                // excludes longer identifiers like `with_shadow_sentinel_sets_field(`.
+                let needle = format!(".{name}(");
+                if content.contains(&needle) {
+                    violations.push(format!("{path}: inline `{needle}` call"));
+                }
+            }
+        }
+
+        assert!(
+            violations.is_empty(),
+            "security setters must only be called through apply_security_pipeline, found \
+             inline calls bypassing it:\n{violations:#?}"
+        );
+    }
+
+    /// #6581: `apply_security_pipeline` — the single call site all 4 entry points now share —
+    /// must actually forward every field of a fully-populated `SecurityWiringInputs` onto the
+    /// `Agent`, not drop any of them on the floor. This is the exact failure mode the
+    /// consolidation defends against: D1 (`with_hooks_config` missing from serve), D2
+    /// (`mcp_tool_ids_handle` built but never attached in serve), D3 (`with_enforcement_mode`
+    /// inlined, bypassing the injection-classifier ordering constraint, in acp/serve).
+    ///
+    /// `Agent::services` is `pub(crate)` to `zeph-core`, so `Arc`-backed always-present fields
+    /// (`trajectory_risk_slot`/`trajectory_signal_queue`/`memory_consent_trust_slot`, which have
+    /// no `Option` to observe) are verified via `Arc::strong_count` — mirrors
+    /// `wire_risk_chain_attaches_the_returned_accumulator_to_the_executor` above — and every
+    /// other field via `Agent::security_wiring_snapshot()`.
+    #[tokio::test]
+    #[allow(clippy::too_many_lines)] // exhaustively constructs + asserts every field once
+    async fn apply_security_pipeline_wires_every_field() {
         let agent = make_agent();
+
         let risk_chain_accumulator = Arc::new(zeph_tools::RiskChainAccumulator::new(None));
         let typed_pages_state = Arc::new(zeph_context::typed_page::TypedPagesState {
             registry: zeph_context::typed_page::InvariantRegistry::default(),
             audit_sink: None,
             is_active: false,
         });
-        assert_eq!(Arc::strong_count(&risk_chain_accumulator), 1);
-        assert_eq!(Arc::strong_count(&typed_pages_state), 1);
+        let trajectory_risk_slot: zeph_tools::TrajectoryRiskSlot =
+            Arc::new(parking_lot::RwLock::new(0u8));
+        let trajectory_signal_queue: zeph_tools::RiskSignalQueue =
+            Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let memory_consent_trust_slot: zeph_core::memory_tools::MemoryConsentTrustSlot =
+            Arc::new(parking_lot::RwLock::new(0u8));
+        let mcp_tool_ids_handle: McpToolIdsHandle =
+            Arc::new(parking_lot::RwLock::new(std::collections::HashSet::new()));
 
-        let agent = apply_entrypoint_security_controls(
-            agent,
-            Arc::clone(&risk_chain_accumulator),
-            zeph_config::TrajectoryRiskAccumulatorConfig::default(),
-            Some(Arc::clone(&typed_pages_state)),
+        let store = zeph_core::agent::shadow_sentinel::ShadowEventStore::new(memory_pool().await);
+        let probe = zeph_core::agent::shadow_sentinel::LlmSafetyProbe::new(
+            Arc::new(offline_provider()),
+            1_000,
+            false,
         );
+        let shadow_sentinel = Arc::new(zeph_core::agent::shadow_sentinel::ShadowSentinel::new(
+            store,
+            Box::new(probe),
+            zeph_config::ShadowSentinelConfig::default(),
+            "test-session",
+        ));
+
+        #[cfg(feature = "classifiers")]
+        let classifiers_config = zeph_core::config::ClassifiersConfig {
+            enabled: true,
+            scan_user_input: true,
+            enforcement_mode: zeph_config::InjectionEnforcementMode::Block,
+            ..Default::default()
+        };
+
+        let inputs = SecurityWiringInputs {
+            risk_chain_accumulator: Arc::clone(&risk_chain_accumulator),
+            mage_accumulator_config: zeph_config::TrajectoryRiskAccumulatorConfig {
+                enabled: true,
+                ..Default::default()
+            },
+            typed_pages_state: Some(Arc::clone(&typed_pages_state)),
+            trajectory_risk_slot: Arc::clone(&trajectory_risk_slot),
+            trajectory_signal_queue: Arc::clone(&trajectory_signal_queue),
+            trajectory_config: zeph_config::TrajectorySentinelConfig::default(),
+            memory_consent_trust_slot: Arc::clone(&memory_consent_trust_slot),
+            shadow_sentinel: Some(Arc::clone(&shadow_sentinel)),
+            vigil_config: zeph_config::VigilConfig::default(),
+            hooks_config: Some(zeph_config::HooksConfig {
+                turn_complete: vec![zeph_config::HookDef {
+                    action: zeph_config::HookAction::Command {
+                        command: "true".to_owned(),
+                    },
+                    timeout_secs: 30,
+                    fail_closed: false,
+                    r#if: None,
+                }],
+                ..Default::default()
+            }),
+            mcp_tool_ids_handle: Arc::clone(&mcp_tool_ids_handle),
+            #[cfg(feature = "classifiers")]
+            classifiers_config,
+            llm_classifier: Some(zeph_llm::classifier::llm::LlmClassifier::new(Arc::new(
+                offline_provider(),
+            ))),
+        };
+
+        let agent = apply_security_pipeline(agent, inputs);
 
         assert_eq!(
             Arc::strong_count(&risk_chain_accumulator),
             2,
-            "apply_entrypoint_security_controls must store the accumulator on the Agent via \
-             with_risk_chain_accumulator (#6578) — a count that never rises above 1 reproduces \
-             the bug where 3 of 4 entry points silently skipped this wiring"
+            "apply_security_pipeline must store the accumulator via with_risk_chain_accumulator"
         );
         assert_eq!(
             Arc::strong_count(&typed_pages_state),
             2,
-            "apply_entrypoint_security_controls must store the state on the Agent via \
-             with_typed_pages_state (#6574) — a count that never rises above 1 reproduces the \
-             bug where 3 of 4 entry points silently skipped typed-page CAM fidelity enforcement"
+            "apply_security_pipeline must store the state via with_typed_pages_state"
         );
+        assert_eq!(
+            Arc::strong_count(&trajectory_risk_slot),
+            2,
+            "apply_security_pipeline must store the slot via with_trajectory_risk_slot"
+        );
+        assert_eq!(
+            Arc::strong_count(&trajectory_signal_queue),
+            2,
+            "apply_security_pipeline must store the queue via with_signal_queue"
+        );
+        assert_eq!(
+            Arc::strong_count(&memory_consent_trust_slot),
+            2,
+            "apply_security_pipeline must store the slot via with_memory_consent_trust_slot"
+        );
+        assert_eq!(
+            Arc::strong_count(&mcp_tool_ids_handle),
+            2,
+            "apply_security_pipeline must store the handle via with_mcp_tool_ids_handle"
+        );
+        assert_eq!(
+            Arc::strong_count(&shadow_sentinel),
+            2,
+            "apply_security_pipeline must store the sentinel via with_shadow_sentinel"
+        );
+
+        let snapshot = agent.security_wiring_snapshot();
+        assert!(snapshot.risk_chain_accumulator);
+        assert!(snapshot.mage_accumulator_enabled);
+        assert!(snapshot.typed_pages_state);
+        assert!(snapshot.shadow_sentinel);
+        assert!(snapshot.vigil_config);
+        assert!(snapshot.hooks_config);
+        assert!(snapshot.mcp_tool_ids_handle);
+        assert!(snapshot.llm_classifier);
+        #[cfg(feature = "classifiers")]
+        {
+            assert!(snapshot.injection_classifier);
+            assert!(snapshot.enforcement_mode_blocking);
+            assert!(snapshot.scan_user_input);
+        }
+
         drop(agent);
         assert_eq!(
             Arc::strong_count(&risk_chain_accumulator),
@@ -4594,6 +4832,31 @@ mod tests {
             Arc::strong_count(&typed_pages_state),
             1,
             "dropping the Agent must release its clone of the typed-pages state"
+        );
+        assert_eq!(
+            Arc::strong_count(&trajectory_risk_slot),
+            1,
+            "dropping the Agent must release its clone of the trajectory risk slot"
+        );
+        assert_eq!(
+            Arc::strong_count(&trajectory_signal_queue),
+            1,
+            "dropping the Agent must release its clone of the trajectory signal queue"
+        );
+        assert_eq!(
+            Arc::strong_count(&memory_consent_trust_slot),
+            1,
+            "dropping the Agent must release its clone of the memory-consent trust slot"
+        );
+        assert_eq!(
+            Arc::strong_count(&mcp_tool_ids_handle),
+            1,
+            "dropping the Agent must release its clone of the MCP tool-id handle"
+        );
+        assert_eq!(
+            Arc::strong_count(&shadow_sentinel),
+            1,
+            "dropping the Agent must release its clone of the shadow sentinel"
         );
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -363,8 +363,8 @@ impl zeph_a2a::TaskProcessor for AgentTaskProcessor {
 /// never wires session-sink, compression, autosave, shutdown-summary, compaction-provider,
 /// tiered-retrieval, or bare-mode config at all. Typed-pages state, the risk-chain accumulator,
 /// and the MAGE trajectory-risk gate are wired post-`build_daemon_agent` via
-/// `agent_setup::apply_entrypoint_security_controls`, not through this struct (#6574/#6578/
-/// #6579). Forcing both paths into one struct would need `None`/default placeholders for
+/// `agent_setup::apply_security_pipeline`, not through this struct (#6574/#6578/#6579/#6581).
+/// Forcing both paths into one struct would need `None`/default placeholders for
 /// whichever fields the other path doesn't use, reintroducing the exact default-vs-omitted
 /// wiring-regression defect class this issue exists to catch.
 struct BuildDaemonAgentDeps<'a, F>
@@ -1139,15 +1139,32 @@ pub(crate) async fn run_daemon(
     };
     let agent = Box::pin(build_daemon_agent(deps, loopback_channel)).await;
 
-    // Risk-chain accumulator (#6578), MAGE trajectory-risk gate (#6579), typed-page CAM fidelity
-    // (#6574) — shared with src/runner.rs/src/acp.rs/src/serve/agent_factory.rs via one call
-    // site so the three controls cannot silently drop out of sync across entry points again
-    // (#6581).
-    let agent = agent_setup::apply_entrypoint_security_controls(
+    // Security-relevant AgentBuilder setters — risk-chain accumulator (#6578), MAGE
+    // trajectory-risk gate (#6579), typed-page CAM fidelity (#6574), trajectory risk
+    // slot/signal queue/config (spec 050 Invariant 2), write-time memory-consent trust slot
+    // (#6490), ShadowSentinel (spec 050 Phase 2), VIGIL, hooks, the MCP tool-id registry
+    // handle (#5747), and (when `classifiers` is enabled) the ML injection classifier +
+    // enforcement mode — shared with src/runner.rs/src/acp.rs/src/serve/agent_factory.rs via
+    // one call site so these controls cannot silently drop out of sync across entry points
+    // again (#6581).
+    let agent = agent_setup::apply_security_pipeline(
         agent,
-        risk_chain_accumulator,
-        config.memory.shadow_memory.clone(),
-        typed_pages_state,
+        agent_setup::SecurityWiringInputs {
+            risk_chain_accumulator,
+            mage_accumulator_config: config.memory.shadow_memory.clone(),
+            typed_pages_state,
+            trajectory_risk_slot,
+            trajectory_signal_queue,
+            trajectory_config: config.security.trajectory.clone(),
+            memory_consent_trust_slot,
+            shadow_sentinel: shadow_sentinel_arc,
+            vigil_config: config.security.vigil.clone(),
+            hooks_config: (!config.cli.safe_mode).then(|| config.hooks.clone()),
+            mcp_tool_ids_handle: mcp_ids_handle,
+            #[cfg(feature = "classifiers")]
+            classifiers_config: config.classifiers.clone(),
+            llm_classifier: app.build_feedback_classifier(&provider),
+        },
     );
 
     // #6022: wire code-RAG retrieval (static repo-map/IndexMcpServer injection plus automatic
@@ -1236,10 +1253,6 @@ pub(crate) async fn run_daemon(
     let agent = agent_setup::apply_quarantine_provider(agent, app.build_quarantine_provider());
     let agent = agent_setup::apply_guardrail(agent, app.build_guardrail_provider());
     #[cfg(feature = "classifiers")]
-    let agent = agent_setup::apply_injection_classifier(agent, config);
-    #[cfg(feature = "classifiers")]
-    let agent = agent_setup::apply_enforcement_mode(agent, config);
-    #[cfg(feature = "classifiers")]
     let agent = agent_setup::apply_three_class_classifier(agent, config);
     #[cfg(feature = "classifiers")]
     let agent = agent_setup::apply_pii_classifier(agent, config);
@@ -1257,7 +1270,6 @@ pub(crate) async fn run_daemon(
         config,
         app.secret_registry().as_ref(),
     );
-    let agent = agent_setup::apply_vigil(agent, &config.security.vigil);
 
     let judge_provider = app.build_judge_provider();
     let agent = if let Some(jp) = judge_provider {
@@ -1270,11 +1282,6 @@ pub(crate) async fn run_daemon(
     // masking is structural, not per-call-site. judge_provider is the last provider setter in
     // this chain, so secret masking is wired here, not earlier alongside the other classifiers.
     let agent = agent_setup::apply_secret_masking(agent, app.secret_registry());
-    let agent = if let Some(fc) = app.build_feedback_classifier(&provider) {
-        agent.with_llm_classifier(fc)
-    } else {
-        agent
-    };
 
     let agent = agent_setup::apply_cost_tracker(agent, config);
 
@@ -1288,35 +1295,7 @@ pub(crate) async fn run_daemon(
         agent
     };
 
-    let agent = agent.with_document_config(config.memory.documents.clone());
-    // Safe-mode gate (#6031): daemon had no prior bare-mode gate on hooks (unlike
-    // `runner.rs`'s `exec_mode.bare`) — this is a fresh gate, safe-mode only.
-    let agent = if config.cli.safe_mode {
-        agent
-    } else {
-        agent.with_hooks_config(&config.hooks)
-    };
-    // Keep TrustGateExecutor's MCP tool-id registry in sync with MCP servers connected
-    // after startup (#5747) — without this, check_tool_refresh has no handle to update.
-    let mut agent = agent.with_mcp_tool_ids_handle(mcp_ids_handle);
-
-    // Spec 050 Phase 2 (#5913): wire ShadowSentinel into the agent so begin_turn() calls
-    // advance_turn(), matching src/runner.rs and src/acp.rs.
-    if let Some(sentinel) = shadow_sentinel_arc {
-        agent = agent.with_shadow_sentinel(sentinel);
-    }
-
-    // #5958: wire the trajectory risk slot/signal queue built above (spec 050 Invariant 2) plus
-    // the TrajectorySentinel state machine itself into the agent, matching src/runner.rs.
-    agent = agent
-        .with_trajectory_risk_slot(trajectory_risk_slot)
-        .with_signal_queue(trajectory_signal_queue)
-        .with_trajectory_config(config.security.trajectory.clone())
-        .0;
-    // Write-time memory-consent gate (issue #6490, MemGhost): share the same slot with
-    // `memory_executor` (wired above) so sanitize_tool_output's ratcheting is visible to
-    // MemoryToolExecutor's confirmation check.
-    agent = agent.with_memory_consent_trust_slot(memory_consent_trust_slot);
+    let mut agent = agent.with_document_config(config.memory.documents.clone());
 
     // #5951: wire the self-check quality pipeline, matching src/runner.rs.
     agent = agent.with_quality_pipeline(agent_setup::build_quality_pipeline(

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2642,8 +2642,8 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
 
     // Build TypedPagesState if enabled (#3630). Done before the builder chain because
     // CompactionAuditSink::open is async. Applied post-`build_agent` via
-    // `agent_setup::apply_entrypoint_security_controls`, alongside the risk-chain and MAGE
-    // accumulator wiring, so all 4 entry points share one call site (#6574/#6578/#6579).
+    // `agent_setup::apply_security_pipeline`, alongside the risk-chain and MAGE accumulator
+    // wiring, so all 4 entry points share one call site (#6574/#6578/#6579/#6581).
     let typed_pages_state = agent_setup::build_typed_pages_state(config, Some(&*supervisor)).await;
 
     // Precompute before moving into `BuildAgentDeps` — mirrors the inline chain's prior
@@ -2767,34 +2767,32 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
     } else {
         agent
     };
-    // Wire the trajectory risk slot and signal queue (spec 050 Invariant 2).
-    let agent = agent
-        .with_trajectory_risk_slot(trajectory_risk_slot)
-        .with_signal_queue(trajectory_signal_queue)
-        .with_trajectory_config(config.security.trajectory.clone())
-        .0;
-    // Write-time memory-consent gate (issue #6490, MemGhost): share the same slot with
-    // `memory_executor` (wired above) so sanitize_tool_output's ratcheting is visible to
-    // MemoryToolExecutor's confirmation check.
-    let agent = agent.with_memory_consent_trust_slot(memory_consent_trust_slot);
-    // Risk-chain accumulator (#6578), MAGE trajectory-risk gate (#6579), typed-page CAM fidelity
-    // (#6574) — shared with daemon.rs/acp.rs/serve/agent_factory.rs via one call site so the
-    // three controls cannot silently drop out of sync across entry points again (#6581).
-    let agent = agent_setup::apply_entrypoint_security_controls(
+    // Security-relevant AgentBuilder setters — risk-chain accumulator (#6578), MAGE
+    // trajectory-risk gate (#6579), typed-page CAM fidelity (#6574), trajectory risk
+    // slot/signal queue/config (spec 050 Invariant 2), write-time memory-consent trust slot
+    // (#6490), ShadowSentinel (spec 050 Phase 2), VIGIL, hooks, the MCP tool-id registry
+    // handle (#5747), and (when `classifiers` is enabled) the ML injection classifier +
+    // enforcement mode — shared with daemon.rs/acp.rs/serve/agent_factory.rs via one call site
+    // so these controls cannot silently drop out of sync across entry points again (#6581).
+    let agent = agent_setup::apply_security_pipeline(
         agent,
-        tool_setup.risk_chain_accumulator,
-        config.memory.shadow_memory.clone(),
-        typed_pages_state,
+        agent_setup::SecurityWiringInputs {
+            risk_chain_accumulator: tool_setup.risk_chain_accumulator,
+            mage_accumulator_config: config.memory.shadow_memory.clone(),
+            typed_pages_state,
+            trajectory_risk_slot,
+            trajectory_signal_queue,
+            trajectory_config: config.security.trajectory.clone(),
+            memory_consent_trust_slot,
+            shadow_sentinel: shadow_sentinel_arc,
+            vigil_config: config.security.vigil.clone(),
+            hooks_config: (!(exec_mode.bare || exec_mode.safe_mode)).then(|| config.hooks.clone()),
+            mcp_tool_ids_handle: mcp_ids_handle,
+            #[cfg(feature = "classifiers")]
+            classifiers_config: config.classifiers.clone(),
+            llm_classifier: app.build_feedback_classifier(&provider),
+        },
     );
-    // Spec 050 Phase 2: wire ShadowSentinel into agent so begin_turn() calls advance_turn().
-    let agent = if let Some(sentinel) = shadow_sentinel_arc {
-        agent.with_shadow_sentinel(sentinel)
-    } else {
-        agent
-    };
-    // Keep TrustGateExecutor's MCP tool-id registry in sync with MCP servers connected after
-    // startup (#5747) — without this, check_tool_refresh has no handle to update.
-    let agent = agent.with_mcp_tool_ids_handle(mcp_ids_handle);
 
     // Load provider-specific and explicit instruction files.
     // base_dir is the process CWD at startup — the most natural project root for local tools.
@@ -2969,10 +2967,6 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
     let agent = agent_setup::apply_guardrail(agent, app.build_guardrail_provider());
     let agent = agent.with_notifications(config.notifications.clone());
     #[cfg(feature = "classifiers")]
-    let agent = agent_setup::apply_injection_classifier(agent, config);
-    #[cfg(feature = "classifiers")]
-    let agent = agent_setup::apply_enforcement_mode(agent, config);
-    #[cfg(feature = "classifiers")]
     let agent = agent_setup::apply_three_class_classifier(agent, config);
     #[cfg(feature = "classifiers")]
     let agent = agent_setup::apply_pii_classifier(agent, config);
@@ -2990,7 +2984,6 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         config,
         app.secret_registry().as_ref(),
     );
-    let agent = agent_setup::apply_vigil(agent, &config.security.vigil);
 
     let (_index_watcher, index_progress_rx) = if exec_mode.bare {
         (None, None)
@@ -3070,11 +3063,6 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         agent.with_lsp_hooks(runner)
     } else {
         agent
-    };
-    let agent = if exec_mode.bare || exec_mode.safe_mode {
-        agent
-    } else {
-        agent.with_hooks_config(&config.hooks)
     };
     let agent = agent.with_channel_skills(channel_skills_config);
     let agent = agent.with_channel_tool_allowlist(channel_tool_allowlist);
@@ -3159,11 +3147,6 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
     // masking is structural, not per-call-site. judge_provider is the last provider setter in
     // this chain, so secret masking is wired here, not earlier alongside the other classifiers.
     let agent = agent_setup::apply_secret_masking(agent, app.secret_registry());
-    let agent = if let Some(fc) = app.build_feedback_classifier(&provider) {
-        agent.with_llm_classifier(fc)
-    } else {
-        agent
-    };
 
     let agent = if config.tools.anomaly.enabled {
         agent.with_anomaly_detector(zeph_tools::AnomalyDetector::new(

--- a/src/serve/agent_factory.rs
+++ b/src/serve/agent_factory.rs
@@ -229,7 +229,7 @@ pub(crate) async fn build_agent_factory(
     // (base + skill_loader + skill_invoke + memory + overflow, #6046) — see
     // `gate_serve_session_executor`'s doc comment for the full rationale and the INVARIANT that
     // binds future serve tool-executor changes.
-    let gated_executor = gate_serve_session_executor(
+    let (gated_executor, mcp_ids_handle) = gate_serve_session_executor(
         composed_base,
         &deps.permission_policy,
         &deps.policy_gate_pieces,
@@ -371,13 +371,6 @@ pub(crate) async fn build_agent_factory(
         agent = crate::agent_setup::apply_guardrail(agent, deps.guardrail_provider);
         #[cfg(feature = "classifiers")]
         {
-            agent = crate::agent_setup::apply_injection_classifier_with_cfg(
-                agent,
-                &deps.classifiers_config,
-            );
-            if deps.classifiers_config.enabled {
-                agent = agent.with_enforcement_mode(deps.classifiers_config.enforcement_mode);
-            }
             agent = crate::agent_setup::apply_three_class_classifier_with_cfg(
                 agent,
                 &deps.classifiers_config,
@@ -405,40 +398,35 @@ pub(crate) async fn build_agent_factory(
             deps.secret_registry.as_ref(),
         );
         agent = crate::agent_setup::apply_secret_masking(agent, deps.secret_registry);
-        agent = crate::agent_setup::apply_vigil(agent, &deps.vigil_config);
-        if let Some(fc) = deps.feedback_classifier {
-            agent = agent.with_llm_classifier(fc);
-        }
         if !preloaded_messages.is_empty() {
             agent = agent.with_preloaded_messages(preloaded_messages);
         }
-        // Spec 050 Phase 2 (#5913): wire ShadowSentinel into the agent so begin_turn() calls
-        // advance_turn(), matching src/runner.rs/src/acp.rs/src/daemon.rs.
-        if let Some(sentinel) = shadow_sentinel_arc {
-            agent = agent.with_shadow_sentinel(sentinel);
-        }
-        // #5958: wire the trajectory risk slot/signal queue built above (spec 050 Invariant 2)
-        // plus the TrajectorySentinel state machine itself into the agent, matching
-        // src/runner.rs/src/acp.rs/src/daemon.rs.
-        agent = agent
-            .with_trajectory_risk_slot(trajectory_risk_slot)
-            .with_signal_queue(trajectory_signal_queue)
-            .with_trajectory_config(deps.trajectory_sentinel_config)
-            .0;
-        // Write-time memory-consent gate (issue #6490, MemGhost): share the same slot with
-        // `memory_executor` (wired above via compose_session_tool_tree) so
-        // sanitize_tool_output's ratcheting is visible to MemoryToolExecutor's confirmation
-        // check.
-        agent = agent.with_memory_consent_trust_slot(memory_consent_trust_slot);
-        // Risk-chain accumulator (#6561/#6588: this session's own instance, built alongside its
-        // `ShellExecutor` above), MAGE trajectory-risk gate (#6579), typed-page CAM fidelity
-        // (#6574) — shared with src/runner.rs/src/daemon.rs/src/acp.rs via one call site so the
-        // three controls cannot silently drop out of sync across entry points again (#6581).
-        agent = crate::agent_setup::apply_entrypoint_security_controls(
+        // Security-relevant AgentBuilder setters — risk-chain accumulator (#6578), MAGE
+        // trajectory-risk gate (#6579), typed-page CAM fidelity (#6574), trajectory risk
+        // slot/signal queue/config (spec 050 Invariant 2), write-time memory-consent trust slot
+        // (#6490), ShadowSentinel (spec 050 Phase 2), VIGIL, hooks (D1, #6581), the MCP tool-id
+        // registry handle (D2, #6581, built by `gate_serve_session_executor` above), and (when
+        // `classifiers` is enabled) the ML injection classifier + enforcement mode (D3, #6581)
+        // — shared with src/runner.rs/src/daemon.rs/src/acp.rs via one call site so these
+        // controls cannot silently drop out of sync across entry points again.
+        agent = crate::agent_setup::apply_security_pipeline(
             agent,
-            risk_chain_accumulator,
-            deps.shadow_memory_config,
-            deps.typed_pages_state,
+            crate::agent_setup::SecurityWiringInputs {
+                risk_chain_accumulator,
+                mage_accumulator_config: deps.shadow_memory_config,
+                typed_pages_state: deps.typed_pages_state,
+                trajectory_risk_slot,
+                trajectory_signal_queue,
+                trajectory_config: deps.trajectory_sentinel_config,
+                memory_consent_trust_slot,
+                shadow_sentinel: shadow_sentinel_arc,
+                vigil_config: deps.vigil_config,
+                hooks_config: (!deps.safe_mode).then_some(deps.hooks_config),
+                mcp_tool_ids_handle: mcp_ids_handle,
+                #[cfg(feature = "classifiers")]
+                classifiers_config: deps.classifiers_config,
+                llm_classifier: deps.feedback_classifier,
+            },
         );
         if let Some(head) = rl_head {
             agent = agent.with_rl_head(head);
@@ -485,6 +473,13 @@ pub(crate) async fn build_agent_factory(
 /// the same signal queue too, but that wrap happens separately, per session, in
 /// `wrap_capability_scope` (called by `build_agent_factory` after this function returns) — see
 /// its doc comment for why.
+///
+/// Also returns the `TrustGateExecutor` MCP tool-id handle built internally (D2, #6581): before
+/// this fix the handle was constructed here, fed once to `register_mcp_tool_ids`, and then
+/// dropped — never attached to the `Agent` via `with_mcp_tool_ids_handle`, so MCP servers
+/// connected after startup could never refresh it (#5747, though moot until serve actually
+/// connects MCP tools — see the "Known gap" in `serve::deps`'s module docs). The caller now
+/// threads this handle into [`crate::agent_setup::apply_security_pipeline`].
 fn gate_serve_session_executor(
     tool_executor: Arc<dyn zeph_tools::ErasedToolExecutor>,
     permission_policy: &zeph_tools::PermissionPolicy,
@@ -494,7 +489,10 @@ fn gate_serve_session_executor(
         &zeph_tools::TrajectoryRiskSlot,
         &zeph_tools::RiskSignalQueue,
     )>,
-) -> zeph_tools::DynExecutor {
+) -> (
+    zeph_tools::DynExecutor,
+    crate::agent_setup::McpToolIdsHandle,
+) {
     let (trust_gated, mcp_ids_handle) = crate::agent_setup::apply_common_tool_gating(
         zeph_tools::DynExecutor(tool_executor),
         permission_policy,
@@ -502,12 +500,13 @@ fn gate_serve_session_executor(
     // R7: serve has no MCP-provided tools yet (deps.rs's "Known gap") — this empty-slice call
     // is the exact seam a future MCP-wiring PR must populate with the connected tool list.
     crate::agent_setup::register_mcp_tool_ids(&mcp_ids_handle, &[]);
-    crate::agent_setup::apply_policy_gate_chain(
+    let gated = crate::agent_setup::apply_policy_gate_chain(
         trust_gated,
         policy_gate_pieces,
         audit_logger,
         trajectory,
-    )
+    );
+    (gated, mcp_ids_handle)
 }
 
 /// Wraps `tool_executor` (the already trust/policy/adversarial-gated tree from
@@ -1070,6 +1069,7 @@ mod tests {
             feedback_classifier: None,
             typed_pages_state: None,
             shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
+            hooks_config: zeph_config::HooksConfig::default(),
         };
 
         let (_, build_agent) =
@@ -1177,6 +1177,7 @@ mod tests {
             feedback_classifier: None,
             typed_pages_state: None,
             shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
+            hooks_config: zeph_config::HooksConfig::default(),
         };
 
         let (resume_banner, build_agent) =
@@ -1281,6 +1282,7 @@ mod tests {
             feedback_classifier: None,
             typed_pages_state: None,
             shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
+            hooks_config: zeph_config::HooksConfig::default(),
         };
 
         let (_, build_agent) =
@@ -1411,6 +1413,7 @@ mod tests {
             feedback_classifier: None,
             typed_pages_state: None,
             shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
+            hooks_config: zeph_config::HooksConfig::default(),
         };
 
         let (_, build_agent) =
@@ -1440,6 +1443,7 @@ mod tests {
     /// and asserts the exact values echoed by `/skills injection`'s `Display` output, not just
     /// "non-default", so a swapped argument in `with_skill_group_config` would also be caught.
     #[tokio::test]
+    #[allow(clippy::too_many_lines)] // pushed over the limit by the new hooks_config fixture field (#6581)
     async fn build_agent_factory_wires_skill_group_config() {
         use zeph_commands::SkillAccess as _;
 
@@ -1530,6 +1534,7 @@ mod tests {
             feedback_classifier: None,
             typed_pages_state: None,
             shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
+            hooks_config: zeph_config::HooksConfig::default(),
         };
 
         let (_, build_agent) =
@@ -1648,6 +1653,7 @@ mod tests {
             feedback_classifier: None,
             typed_pages_state: None,
             shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
+            hooks_config: zeph_config::HooksConfig::default(),
         };
 
         let (_, build_agent) =
@@ -1763,6 +1769,7 @@ mod tests {
             feedback_classifier: None,
             typed_pages_state: None,
             shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
+            hooks_config: zeph_config::HooksConfig::default(),
         };
 
         let (_, build_agent) =
@@ -1861,6 +1868,7 @@ mod tests {
             feedback_classifier: None,
             typed_pages_state: None,
             shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
+            hooks_config: zeph_config::HooksConfig::default(),
         }
     }
 
@@ -2041,7 +2049,7 @@ mod tests {
         let trajectory_signal_queue: zeph_tools::RiskSignalQueue =
             Arc::new(parking_lot::Mutex::new(Vec::new()));
 
-        let gated = gate_serve_session_executor(
+        let (gated, _mcp_ids_handle) = gate_serve_session_executor(
             Arc::new(zeph_tools::SetCwdExecutor::new(vec![])),
             &zeph_tools::PermissionPolicy::default().with_autonomy(zeph_tools::AutonomyLevel::Full),
             &policy_gate_pieces,
@@ -2132,7 +2140,7 @@ mod tests {
         ));
         let policy =
             zeph_tools::PermissionPolicy::default().with_autonomy(zeph_tools::AutonomyLevel::Full);
-        let gated = gate_serve_session_executor(
+        let (gated, _mcp_ids_handle) = gate_serve_session_executor(
             composite,
             &policy,
             &crate::agent_setup::PolicyGatePieces::default(),

--- a/src/serve/deps.rs
+++ b/src/serve/deps.rs
@@ -215,14 +215,23 @@ pub(crate) struct ServeAgentDeps {
     /// Typed-page CAM fidelity state (#6574), built once at startup via
     /// `agent_setup::build_typed_pages_state` since `[memory.compression.typed_pages]` is static
     /// config. `agent_factory` clones the `Arc` into every session via
-    /// `agent_setup::apply_entrypoint_security_controls` — mirrors `src/runner.rs`,
-    /// `src/daemon.rs`, and `src/acp.rs`.
+    /// `agent_setup::apply_security_pipeline` — mirrors `src/runner.rs`, `src/daemon.rs`, and
+    /// `src/acp.rs`.
     pub(crate) typed_pages_state: Option<Arc<zeph_context::typed_page::TypedPagesState>>,
     /// `config.memory.shadow_memory` (#6579), wired into `Agent::with_mage_accumulator_config`
-    /// per session via `agent_setup::apply_entrypoint_security_controls` — mirrors
-    /// `src/runner.rs`, `src/daemon.rs`, and `src/acp.rs`. Replaces the noop
-    /// `TrajectoryRiskAccumulator` set by `SecurityState::default()`.
+    /// per session via `agent_setup::apply_security_pipeline` — mirrors `src/runner.rs`,
+    /// `src/daemon.rs`, and `src/acp.rs`. Replaces the noop `TrajectoryRiskAccumulator` set by
+    /// `SecurityState::default()`.
     pub(crate) shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig,
+    /// `config.hooks.clone()` (D1, #6581), wired into every session's `Agent` via
+    /// `Agent::with_hooks_config` per session via `agent_setup::apply_security_pipeline`,
+    /// mirroring `src/runner.rs`/`src/daemon.rs`/`src/acp.rs`. Previously `/sessions*` agents
+    /// had no hooks wired at all — the `false` passed for `no_mcp_media` in
+    /// [`build_serve_deps`] is unrelated (serve still has no MCP tools connected, see the
+    /// "Known gap" above; only the media-passthrough gate, not hooks, depends on that flag).
+    /// Gated on `safe_mode` at the `apply_security_pipeline` call site, matching the other three
+    /// entry points.
+    pub(crate) hooks_config: zeph_config::HooksConfig,
 }
 
 /// Assemble [`ServeAgentDeps`] once at `zeph serve-sessions` startup, plus the resolved bearer
@@ -247,8 +256,11 @@ pub(crate) async fn build_serve_deps(
 ) -> anyhow::Result<(ServeAgentDeps, Option<String>)> {
     use crate::bootstrap::AppBuilder;
 
-    // Serve wires no hooks or MCP tools today (see `ServeSessionsArgs::safe_mode` doc), so
-    // there is no media-passthrough surface to gate here — pass `false` unconditionally.
+    // `no_mcp_media` only gates MCP image-passthrough sanitization (`build_tool_setup`'s
+    // `no_mcp_media` param) — unrelated to hooks (D1, #6581: serve now wires hooks, see
+    // `ServeAgentDeps::hooks_config`). Serve still has no MCP tools connected (see the "Known
+    // gap" in this module's docs), so there is no media-passthrough surface to gate either way
+    // — pass `false` unconditionally.
     let app = AppBuilder::new(
         config_path,
         vault_backend,
@@ -287,7 +299,8 @@ pub(crate) async fn assemble_serve_deps(
     if config.cli.safe_mode {
         tracing::info!(
             "safe mode active: plugins and skills are disabled for every session built from \
-             this serve-sessions process (serve wires no hooks or MCP tools yet)"
+             this serve-sessions process (hooks are also gated off under safe mode, matching \
+             runner.rs/daemon.rs/acp.rs; serve still has no MCP tools connected)"
         );
     }
     let (tool_executor, permission_policy, audit_logger, shell_ingredients) =
@@ -638,6 +651,7 @@ pub(crate) async fn assemble_serve_deps(
         tools_enabled: config.tools.enabled,
         typed_pages_state,
         shadow_memory_config: config.memory.shadow_memory.clone(),
+        hooks_config: config.hooks.clone(),
     })
 }
 

--- a/src/serve/handlers.rs
+++ b/src/serve/handlers.rs
@@ -624,6 +624,7 @@ mod tests {
             feedback_classifier: None,
             typed_pages_state: None,
             shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
+            hooks_config: zeph_config::HooksConfig::default(),
         };
         AppState {
             registry: Arc::new(LiveSessionRegistry::new()),

--- a/src/serve/test_support.rs
+++ b/src/serve/test_support.rs
@@ -170,6 +170,7 @@ impl ServeTestHarness {
             feedback_classifier: None,
             typed_pages_state: None,
             shadow_memory_config: zeph_config::TrajectoryRiskAccumulatorConfig::default(),
+            hooks_config: zeph_config::HooksConfig::default(),
         };
 
         let state = AppState {


### PR DESCRIPTION
## Summary

- Extract `apply_security_pipeline` in `src/agent_setup.rs` to replace the independently-maintained `AgentBuilder::with_*` chains previously duplicated across `src/runner.rs`, `src/daemon.rs`, `src/acp.rs`, and `src/serve/agent_factory.rs`. Each entry point now makes exactly one call with a `SecurityWiringInputs` struct.
- Fixes three concrete divergences found during review: `serve` now wires `hooks_config` (gated on `safe_mode`, previously never wired at all); `serve`'s MCP tool-ids handle is now attached to the `Agent` and not just passed to `register_mcp_tool_ids`; `acp`/`serve` now apply `enforcement_mode` through the shared `apply_enforcement_mode_with_cfg` helper instead of inlining it, guaranteeing it always runs after the injection classifier.
- Adds `Agent::security_wiring_snapshot()` and two guardrail tests: a structural scan that fails if any of the 12 Agent-only security setters are called inline in an entry point instead of through the pipeline, and a behavioral test asserting the pipeline wires every field. Setters also defined on non-Agent receivers (`with_signal_queue`, `with_enforcement_mode`, `with_scan_user_input`) are excluded from the structural scan and covered only by the behavioral test.

Note: the issue's original 23-instance-drift framing was found to be mostly stale during architecture review — prior PRs (#6574, #6578, #6579, #6580) already fixed most of it. The real remaining scope was the three divergences above plus the missing guardrail test itself.

Wiring hooks into `serve` (Telegram/Discord/Slack) is a deliberate security-posture decision, not mechanical dedup — hooks now execute on zeph's only network-facing, multi-tenant channel. This was reviewed explicitly: gating is exact parity with the other three entry points (`safe_mode`), hook commands come from operator config (not chat-user input), and the media-passthrough gate in `src/serve/deps.rs` was independently verified to need no change (serve's tool executor wires no MCP executor regardless of hooks, so there is no media surface to gate).

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo clippy --profile ci -p zeph --features classifiers -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (15013 passed, 0 failed, 36 skipped)
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph --features classifiers` (new classifiers-gated assertions)
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`)
- [x] Adversarial mutation test: removed `with_hooks_config` from the pipeline, confirmed the guardrail test fails with the expected assertion panic, reverted
- [x] `.local/testing/playbooks/agentbuilder-security-pipeline-consolidation-6581.md` and a `coverage-status.md` row added (main repo) — marked `Untested` pending a live session
- [ ] Live-session verification of hooks firing under serve / safe-mode gating them off / enforcement-mode block behavior (playbook scenarios 3-5) — not yet run this cycle

Closes #6581