### PR TITLE
test(core): add discriminating test for classify_tool_result's [stderr] branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   tokio-rs/tokio#7172). Latent since Guest Mode's original implementation; unreachable in
   tests or production until the `guest_mode` wiring fix above made this code path actually
   run — without this fix, enabling `guest_mode = true` would have crashed the process.
+- `zeph-core`: `classify_tool_result`'s `"[stderr]"` branch (`agent/tool_execution/tool_result.rs`)
+  had no test that could actually distinguish `AnomalyOutcome::Error` from `::Success`
+  classification — the only existing test drove it through `AnomalyDetector`'s windowed
+  aggregation (window=20, thresholds 0.5/0.7), where a single `[stderr]` call never crosses
+  either threshold regardless of its classification, so the assertion passed either way. Added
+  two focused unit tests that call `classify_tool_result` directly and assert on the returned
+  `anomaly_outcome` (issue #6618, follow-up from #6617/#6560).
 
 ### Changed
 

--- a/crates/zeph-core/src/agent/tool_execution/tests/parallel_and_handle_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/parallel_and_handle_tests.rs
@@ -667,10 +667,9 @@ async fn process_one_tool_result_error_prefix_records_tool_failure_outcome() {
     );
 }
 
-// classify_tool_result's "[stderr]" branch (tool_result.rs:295) currently has no test that can
-// distinguish Error from Success classification for it — a pre-existing gap, not introduced by
-// this PR (the removed legacy-harness test was equally non-discriminating). Follow-up test-
-// coverage issue to be filed separately.
+// classify_tool_result's "[stderr]" branch (tool_result.rs:295) is now covered directly by
+// classify_tool_result_stderr_marker_yields_error_outcome and its Success-side contrast test
+// in tafc_and_record_outcomes_tests.rs (R-AN-3b/3c, #6618).
 
 #[tokio::test]
 async fn buffered_preserves_order() {

--- a/crates/zeph-core/src/agent/tool_execution/tests/tafc_and_record_outcomes_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/tafc_and_record_outcomes_tests.rs
@@ -1809,6 +1809,74 @@ async fn native_anomaly_stderr_output_records_error() {
     );
 }
 
+// R-AN-3b: classify_tool_result itself must classify a "[stderr]"-marked summary as
+// AnomalyOutcome::Error. R-AN-3 above drives this through AnomalyDetector, but a single
+// [stderr] call in a 20-window never crosses either threshold regardless of how it was
+// classified, so it cannot catch a regression in classify_tool_result. This test calls
+// classify_tool_result directly and asserts on the returned anomaly_outcome (#6618).
+#[test]
+fn classify_tool_result_stderr_marker_yields_error_outcome() {
+    use crate::agent::agent_tests::{MockChannel, create_test_registry, mock_provider};
+
+    let executor = FixedOutputExecutor {
+        summary: String::new(),
+        is_err: false,
+    };
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+
+    let tc = make_tool_use_request("id-stderr", "bash");
+    let result = agent.classify_tool_result(
+        &tc,
+        Ok(Some(zeph_tools::ToolOutput {
+            tool_name: "bash".into(),
+            summary: "[stderr] something went wrong".into(),
+            ..Default::default()
+        })),
+    );
+
+    assert!(
+        matches!(result.anomaly_outcome, super::super::AnomalyOutcome::Error),
+        "a [stderr]-marked summary must classify as AnomalyOutcome::Error"
+    );
+}
+
+// R-AN-3c: contrast case — a plain-success summary (no [error]/[stderr] markers) must
+// classify as AnomalyOutcome::Success, proving the test above actually discriminates.
+#[test]
+fn classify_tool_result_plain_success_yields_success_outcome() {
+    use crate::agent::agent_tests::{MockChannel, create_test_registry, mock_provider};
+
+    let executor = FixedOutputExecutor {
+        summary: String::new(),
+        is_err: false,
+    };
+    let provider = mock_provider(vec![]);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+
+    let tc = make_tool_use_request("id-success", "bash");
+    let result = agent.classify_tool_result(
+        &tc,
+        Ok(Some(zeph_tools::ToolOutput {
+            tool_name: "bash".into(),
+            summary: "hello world".into(),
+            ..Default::default()
+        })),
+    );
+
+    assert!(
+        matches!(
+            result.anomaly_outcome,
+            super::super::AnomalyOutcome::Success
+        ),
+        "a plain-success summary must classify as AnomalyOutcome::Success"
+    );
+}
+
 // R-AN-4: executor Err records an error outcome.
 #[tokio::test]
 async fn native_anomaly_executor_error_records_error() {

--- a/crates/zeph-core/src/agent/tool_execution/tool_result.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tool_result.rs
@@ -284,7 +284,7 @@ impl<C: Channel> Agent<C> {
         }
     }
 
-    fn classify_tool_result(
+    pub(super) fn classify_tool_result(
         &mut self,
         tc: &zeph_llm::provider::ToolUseRequest,
         tool_result: Result<Option<zeph_tools::ToolOutput>, zeph_tools::ToolError>,


### PR DESCRIPTION
## Summary

- `Agent::classify_tool_result`'s `"[stderr]"` branch (`crates/zeph-core/src/agent/tool_execution/tool_result.rs:295`) had no test that could actually distinguish `AnomalyOutcome::Error` from `::Success` classification. The only existing test, `native_anomaly_stderr_output_records_error` (R-AN-3), drove classification through `AnomalyDetector`'s windowed aggregation (window=20, thresholds 0.5/0.7) — a single `[stderr]` call in a 20-window never crosses either threshold regardless of how it was classified, so the assertion passed either way.
- Adds two focused unit tests (`classify_tool_result_stderr_marker_yields_error_outcome`, `classify_tool_result_plain_success_yields_success_outcome`) that call `classify_tool_result` directly and assert on the returned `anomaly_outcome`, independent of the detector.
- Required a `pub(super)` visibility bump on `classify_tool_result` (was private) since the test module tree is a sibling subtree, not a descendant, of `tool_result.rs`'s defining module.
- Updates the stale gap-documenting comment in `parallel_and_handle_tests.rs` to point at the new tests.

## Test plan

- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-core --features scheduler -E 'test(classify_tool_result_stderr_marker_yields_error_outcome) or test(classify_tool_result_plain_success_yields_success_outcome)'` — 2/2 passed
- [x] Flip-and-revert sanity check: swapping the `Error`/`Success` arms makes both new tests fail; reverted, both pass again — confirms genuine discrimination
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-core --features scheduler -E 'test(tool_execution)'` — 340/340 passed
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 15027/15027 passed
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean

Closes #6618