### PR TITLE
fix(memory): clamp VectorStore::search trait method directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `[1, 20]`, unaffected). Defense-in-depth: no exploitable path today, but closes a gap where
   a future caller forwarding an externally-supplied limit without its own clamp could trigger
   an oversized Qdrant result-set allocation (issue #6553).
+- `zeph-memory`: moved the `MAX_SEARCH_LIMIT` clamp down to the `VectorStore::search` trait
+  method itself — the `QdrantOps`, `DbVectorStore`, and `InMemoryVectorStore` implementations
+  now all clamp `limit` via a shared `clamp_search_limit` helper before touching the backend.
+  The #6553 wrapper-level clamps (`EmbeddingStore`/`EmbeddingRegistry`/`ReasoningMemory`) only
+  covered callers that went through those wrappers; a caller reaching a `VectorStore`
+  implementor directly — e.g. `zeph-index`'s `CodeStore::search` (no clamp at all) or a
+  generic `V: VectorStore` pipeline step (`RetrievalStep`) — still forwarded an unclamped
+  `limit` straight to the backend. Clamping twice (wrapper, then trait impl) is a no-op on an
+  already-clamped value, so the existing wrapper clamps are unchanged (issue #6616).
 - `zeph-config`: `Config::validate` now logs a `tracing::warn!` when `memory.qdrant_url`
   resolves to a non-loopback host without TLS (`https://`) and/or `memory.qdrant_api_key`
   configured — memory content would otherwise travel in plaintext with no server

--- a/crates/zeph-memory/src/db_vector_store.rs
+++ b/crates/zeph-memory/src/db_vector_store.rs
@@ -168,7 +168,14 @@ impl VectorStore for DbVectorStore {
         limit: u64,
         filter: Option<VectorFilter>,
     ) -> BoxFuture<'_, Result<Vec<ScoredVectorPoint>, VectorStoreError>> {
+        static CLAMP_WARNED: std::sync::atomic::AtomicBool =
+            std::sync::atomic::AtomicBool::new(false);
         let collection = collection.to_owned();
+        let limit = crate::vector_store::clamp_search_limit(
+            "VectorStore::search[DbVectorStore]",
+            limit,
+            &CLAMP_WARNED,
+        );
         #[cfg(feature = "profiling")]
         let span = tracing::info_span!(
             "memory.vector_store",
@@ -407,6 +414,34 @@ mod tests {
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].id, "a");
         assert!((results[0].score - 1.0).abs() < 1e-5);
+    }
+
+    /// Issue #6616: `VectorStore::search` must clamp an oversized `limit` at the trait-impl
+    /// choke point itself, not only in the wrapper methods added for issue #6553 — a caller
+    /// reaching `DbVectorStore` directly must still get the same bound.
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn search_clamps_oversized_limit() {
+        let (vs, _) = setup().await;
+        vs.ensure_collection("c", 4).await.unwrap();
+        let points: Vec<VectorPoint> = (0..(crate::MAX_SEARCH_LIMIT + 10))
+            .map(|i| VectorPoint {
+                id: format!("p{i}"),
+                vector: vec![1.0, 0.0, 0.0, 0.0],
+                payload: HashMap::new(),
+            })
+            .collect();
+        vs.upsert("c", points).await.unwrap();
+
+        let results = vs
+            .search("c", vec![1.0, 0.0, 0.0, 0.0], u64::MAX, None)
+            .await
+            .unwrap();
+        assert_eq!(results.len(), crate::MAX_SEARCH_LIMIT);
+        assert!(
+            logs_contain("requested search limit exceeds MAX_SEARCH_LIMIT"),
+            "expected a one-shot warn when the trait-impl clamp actually reduces the requested limit"
+        );
     }
 
     #[tokio::test]

--- a/crates/zeph-memory/src/in_memory_store.rs
+++ b/crates/zeph-memory/src/in_memory_store.rs
@@ -156,7 +156,14 @@ impl VectorStore for InMemoryVectorStore {
         limit: u64,
         filter: Option<VectorFilter>,
     ) -> BoxFuture<'_, Result<Vec<ScoredVectorPoint>, VectorStoreError>> {
+        static CLAMP_WARNED: std::sync::atomic::AtomicBool =
+            std::sync::atomic::AtomicBool::new(false);
         let collection = collection.to_owned();
+        let limit = crate::vector_store::clamp_search_limit(
+            "VectorStore::search[InMemoryVectorStore]",
+            limit,
+            &CLAMP_WARNED,
+        );
         Box::pin(async move {
             let cols = self.collections.read();
             let col = cols.get(&collection).ok_or_else(|| {
@@ -493,5 +500,35 @@ mod tests {
         let store = InMemoryVectorStore::new();
         let dbg = format!("{store:?}");
         assert!(dbg.contains("InMemoryVectorStore"));
+    }
+
+    /// Issue #6616: `VectorStore::search` must clamp an oversized `limit` at the trait-impl
+    /// choke point itself, not only in the `EmbeddingStore`/`EmbeddingRegistry`/`ReasoningMemory`
+    /// wrapper methods (issue #6553) — a caller reaching this implementor directly (e.g. a
+    /// generic `V: VectorStore` pipeline step) must still get the same bound.
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn search_clamps_oversized_limit() {
+        let store = InMemoryVectorStore::new();
+        store.ensure_collection("test", 3).await.unwrap();
+
+        let points: Vec<VectorPoint> = (0..(crate::MAX_SEARCH_LIMIT + 10))
+            .map(|i| VectorPoint {
+                id: format!("p{i}"),
+                vector: vec![1.0, 0.0, 0.0],
+                payload: HashMap::new(),
+            })
+            .collect();
+        store.upsert("test", points).await.unwrap();
+
+        let results = store
+            .search("test", vec![1.0, 0.0, 0.0], u64::MAX, None)
+            .await
+            .unwrap();
+        assert_eq!(results.len(), crate::MAX_SEARCH_LIMIT);
+        assert!(
+            logs_contain("requested search limit exceeds MAX_SEARCH_LIMIT"),
+            "expected a one-shot warn when the trait-impl clamp actually reduces the requested limit"
+        );
     }
 }

--- a/crates/zeph-memory/src/qdrant_ops.rs
+++ b/crates/zeph-memory/src/qdrant_ops.rs
@@ -560,7 +560,14 @@ impl crate::vector_store::VectorStore for QdrantOps {
         limit: u64,
         filter: Option<crate::VectorFilter>,
     ) -> BoxFuture<'_, Result<Vec<crate::ScoredVectorPoint>, crate::VectorStoreError>> {
+        static CLAMP_WARNED: std::sync::atomic::AtomicBool =
+            std::sync::atomic::AtomicBool::new(false);
         let collection = collection.to_owned();
+        let limit = crate::vector_store::clamp_search_limit(
+            "VectorStore::search[QdrantOps]",
+            limit,
+            &CLAMP_WARNED,
+        );
         Box::pin(async move {
             let qdrant_filter = filter.map(vector_filter_to_qdrant);
             let results = self
@@ -1001,5 +1008,25 @@ mod tests {
         );
 
         ops.delete_collection(collection).await.unwrap();
+    }
+
+    /// Issue #6616: the `VectorStore::search` trait impl on `QdrantOps` must clamp an
+    /// oversized `limit` itself, not rely on `EmbeddingStore`/`EmbeddingRegistry` wrapper
+    /// methods (issue #6553) to clamp before forwarding. `QdrantOps` has no test seam
+    /// (concrete gRPC client), so — matching the pattern in `embedding_registry.rs`'s
+    /// `search_raw_oversized_limit_does_not_panic` — this connects to an unreachable
+    /// endpoint and asserts the one-shot `tracing::warn!` fired before the network call was
+    /// attempted, rather than the clamped result count.
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn vector_store_search_clamps_oversized_limit() {
+        use crate::vector_store::VectorStore;
+
+        let ops = QdrantOps::new("http://127.0.0.1:1", None).unwrap(); // unreachable — forces network error
+        let _ = VectorStore::search(&ops, "col", vec![1.0, 0.0], u64::MAX, None).await;
+        assert!(
+            logs_contain("requested search limit exceeds MAX_SEARCH_LIMIT"),
+            "expected the one-shot clamp warning to fire for an oversized limit"
+        );
     }
 }

--- a/crates/zeph-memory/src/vector_store.rs
+++ b/crates/zeph-memory/src/vector_store.rs
@@ -14,6 +14,7 @@
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::atomic::AtomicBool;
 
 /// Error type for [`VectorStore`] operations.
 #[derive(Debug, thiserror::Error)]
@@ -103,6 +104,23 @@ pub type ScrollResult = HashMap<String, HashMap<String, String>>;
 ///
 /// Only points whose payload contains `key_field` as a `StringValue` are included.
 pub type ScrollWithIdsResult = Vec<(String, HashMap<String, String>)>;
+
+/// Clamp a caller-supplied `search` `limit` to `[1, MAX_SEARCH_LIMIT]` at the
+/// [`VectorStore::search`] trait method itself (issue #6616).
+///
+/// The wrapper methods in `embedding_store`, `embedding_registry`, and `reasoning` already
+/// clamp before forwarding to a [`VectorStore`] implementor (issue #6553), but any caller
+/// that reaches an implementor directly — e.g. `zeph-index`'s `CodeStore::search` or a
+/// generic `V: VectorStore` pipeline step — bypasses those wrappers entirely. Every
+/// [`VectorStore::search`] implementation in this crate calls this helper first, so the
+/// bound holds regardless of the call path. Clamping an already-clamped value is a no-op,
+/// so enforcing it at both the wrapper and the trait-impl layer is safe.
+pub(crate) fn clamp_search_limit(site: &'static str, limit: u64, warned: &AtomicBool) -> u64 {
+    if let Ok(requested) = usize::try_from(limit) {
+        crate::warn_if_search_limit_clamped(site, requested, warned);
+    }
+    limit.clamp(1, crate::MAX_SEARCH_LIMIT as u64)
+}
 
 /// Abstraction over a vector database backend.
 ///


### PR DESCRIPTION
## Summary
- Moves the `MAX_SEARCH_LIMIT` clamp added in #6553/PR #6615 down from the wrapper methods (`EmbeddingStore`/`EmbeddingRegistry`/`ReasoningMemory`) to the `VectorStore::search` trait method itself, via a shared `clamp_search_limit` helper called first-thing inside `search` in all three production implementors (`QdrantOps`, `DbVectorStore`, `InMemoryVectorStore`).
- Closes two confirmed real bypasses where a caller reached a `VectorStore` implementor directly and forwarded an unclamped `limit`: `zeph-index`'s `CodeStore::search` (no clamp at all) and `zeph-core`'s generic `RetrievalStep<P, V: VectorStore>` pipeline step.
- Wrapper-level clamps are left in place; re-clamping an already-clamped value is a no-op and each wrapper's warn `site` string remains independently useful.

Closes #6616

## Test plan
- [x] `cargo build -p zeph-memory`
- [x] `cargo clippy -p zeph-memory --all-targets --features "profiling,jsonschema,pdf,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-memory --features "profiling,jsonschema,pdf,testing"` (1700 passed)
- [x] `cargo +nightly fmt --check`
- [x] Rustdoc gate clean
- [x] 3 new unit tests added (one per implementor), each asserting both the clamped result and the one-shot warn log
- [x] Adversarial critique (impl-critic) — verdict `minor`, no blockers; one non-blocking structural-durability observation deferred to a follow-up issue rather than expanded scope
- [x] Code review — verdict `approved`, independently re-verified checks and both bypass fixes