### PR TITLE
fix(subagent)!: reject unknown keys in nested tools/permissions frontmatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   been revoked (mirroring the existing `Secret`-path TTL re-check). A sub-agent with no
   `GrantKind::Tool` grants — the universal case today, since no caller creates one yet — sees no
   behavior change (issue #6567).
+- `zeph-subagent`: `tools:`/`permissions:` nested frontmatter sections in sub-agent
+  definitions now reject unknown keys instead of silently ignoring them. `RawSubAgentDef`
+  has carried `#[serde(deny_unknown_fields)]` since #1183, but serde does not propagate that
+  attribute into nested structs, so `RawToolPolicy` and `RawPermissions` still silently
+  swallowed typos (e.g. `pemission_mode:`, `alow:`) and fell back to defaults. Since
+  `permissions:` carries the security/isolation-relevant `permission_mode` and `worktree`
+  fields, this masked misconfiguration rather than an exploitable privilege escalation (all
+  defaults are already fail-safe) (issue #6583).
+  - **Breaking (pre-1.0)**: any sub-agent frontmatter file with a misspelled key inside its
+    `tools:` or `permissions:` section now fails to load instead of silently falling back to
+    defaults for that section.
 - `zeph-core`/`zeph-skills`: the failure-driven self-learning path (`store_improved_version`)
   wrote LLM-regenerated skill bodies straight to the live `SKILL.md` with no injection scan,
   and the new `"auto"`-sourced skill version silently inherited the parent skill's trust tier

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -2714,6 +2714,123 @@ mod tests {
         );
     }
 
+    fn spawn_wiring_test_tool_def(id: &str) -> zeph_tools::registry::ToolDef {
+        use zeph_tools::registry::{InvocationHint, ToolDef};
+        ToolDef {
+            id: id.to_owned().into(),
+            description: format!("{id} tool").into(),
+            schema: schemars::Schema::default(),
+            invocation: InvocationHint::ToolCall,
+            output_schema: None,
+            server_id: None,
+        }
+    }
+
+    /// Regression test for issue #6539: `composes_with_parent_floor_via_intersect_allowlists`
+    /// above only proves that `zeph_subagent::intersect_allowlists` and
+    /// `task_tool_allowlist_for_task` compose correctly in isolation — it never drives the
+    /// real `handle_scheduler_spawn_action` call site (`spawn_ctx.inherited_tool_allowlist =
+    /// self.intersect_task_tool_allowlist(...)`) that wires the parent-permission-derived
+    /// floor (`build_spawn_context`, #6527) together with the per-task planner-emitted
+    /// allowlist (#6526). This test spawns a real `InheritAll` sub-agent through
+    /// `run_scheduler_loop`'s actual `Spawn` action dispatch and asserts on the tool
+    /// definitions actually sent to the sub-agent's LLM (via `MockProvider::with_tool_recording`),
+    /// which reflect `apply_constraint_propagation` (`zeph-subagent/src/manager/spawn.rs`)
+    /// replacing `InheritAll` with the composed `SpawnContext::inherited_tool_allowlist`.
+    #[tokio::test]
+    async fn handle_scheduler_spawn_action_composes_parent_floor_and_task_allowlist() {
+        use crate::agent::agent_tests::*;
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+        use zeph_orchestration::{DagScheduler, GraphStatus, RuleBasedRouter, TaskGraph, TaskNode};
+        use zeph_subagent::{SubAgentDef, SubAgentManager};
+
+        // Parent-permission-derived floor (#6527): wholesale-deny "grep" so
+        // `build_spawn_context` narrows the parent's own tool universe {bash, read, write,
+        // grep} down to {bash, read, write}.
+        let mut rules = std::collections::HashMap::new();
+        rules.insert(
+            "grep".to_owned(),
+            vec![zeph_config::tools::PermissionRule {
+                pattern: "*".to_owned(),
+                action: zeph_config::tools::PermissionAction::Deny,
+            }],
+        );
+
+        // Per-task planner-emitted allowlist (#6526): {bash, write, grep} — "grep" is a
+        // valid tool name so it survives `task_tool_allowlist_for_task`'s universe filter,
+        // but must still be dropped once intersected against the parent floor above.
+        let mut graph = TaskGraph::new("goal");
+        let mut task = TaskNode::new(0, "t", "do a task");
+        task.tool_allowlist = Some(vec!["bash".into(), "write".into(), "grep".into()]);
+        graph.tasks.push(task);
+
+        let def =
+            SubAgentDef::parse("---\nname: worker\ndescription: A worker\n---\n\nDo things.\n")
+                .unwrap();
+
+        let config = zeph_config::OrchestrationConfig::default();
+        let mut scheduler = DagScheduler::new(
+            graph,
+            &config,
+            Box::new(RuleBasedRouter),
+            vec![def.clone()],
+            None,
+        )
+        .unwrap();
+
+        let (mock, recorded_tools) =
+            MockProvider::with_responses(vec!["done".into()]).with_tool_recording();
+        let provider = AnyProvider::Mock(mock);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let executor = MockToolExecutor::no_tools().with_definitions(vec![
+            spawn_wiring_test_tool_def("bash"),
+            spawn_wiring_test_tool_def("read"),
+            spawn_wiring_test_tool_def("write"),
+            spawn_wiring_test_tool_def("grep"),
+        ]);
+        let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
+        agent.services.orchestration.orchestration_config = config;
+        agent.runtime.config.permission_policy = zeph_tools::PermissionPolicy::new(rules)
+            .with_autonomy(zeph_config::tools::AutonomyLevel::Supervised);
+
+        let mut mgr = SubAgentManager::new(4);
+        mgr.definitions_mut().push(def);
+        agent.services.orchestration.subagent_manager = Some(mgr);
+
+        let token = tokio_util::sync::CancellationToken::new();
+        let status = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            agent.run_scheduler_loop(&mut scheduler, 1, token),
+        )
+        .await
+        .expect("run_scheduler_loop must not hang")
+        .unwrap();
+        assert_eq!(status, GraphStatus::Completed);
+
+        // A plain-text first turn triggers `handle_no_tool_response`'s one-time nudge
+        // (zeph-subagent's `agent_loop.rs`), so the mock provider is called twice before
+        // the loop breaks — the composed tool set must be identical (computed once in
+        // `init_loop_state`, not re-derived per turn), so every recorded call is checked.
+        let calls = recorded_tools.lock().unwrap();
+        assert!(
+            !calls.is_empty(),
+            "sub-agent must call the LLM at least once"
+        );
+        for (i, call) in calls.iter().enumerate() {
+            let sent: std::collections::HashSet<&str> =
+                call.iter().map(|t| t.name.as_str()).collect();
+            assert_eq!(
+                sent,
+                std::collections::HashSet::from(["bash", "write"]),
+                "call #{i}: must be the TRUE intersection of the parent floor \
+                 {{bash,read,write}} and the task allowlist {{bash,write,grep}} — not a \
+                 union, and not an overwrite of one by the other; got: {sent:?}"
+            );
+        }
+    }
+
     /// Regression test for issue #6288: `collect_finished_subagents()` must be a no-op (not
     /// panic) when orchestration is not spawning any sub-agents this session, i.e.
     /// `subagent_manager` is `None`. `run_scheduler_loop` calls it unconditionally every tick

--- a/crates/zeph-subagent/src/def.rs
+++ b/crates/zeph-subagent/src/def.rs
@@ -240,13 +240,13 @@ struct RawSubAgentDef {
     memory: Option<MemoryScope>,
 }
 
-// Note: `RawToolPolicy` and `RawPermissions` intentionally do not carry
-// `#[serde(deny_unknown_fields)]`. They are nested under `RawSubAgentDef` (which does have
-// `deny_unknown_fields`), but serde does not propagate that attribute into nested structs.
-// Adding it here would reject currently-valid frontmatter that omits optional fields via
-// serde's default mechanism. A follow-up issue should evaluate whether strict rejection of
-// unknown nested keys is desirable before adding it.
+// Note: `RawToolPolicy` and `RawPermissions` are nested under `RawSubAgentDef` (which also
+// carries `deny_unknown_fields`), but serde does not propagate that attribute into nested
+// structs — each struct must declare it independently. Both structs already mark every field
+// `#[serde(default = ...)]`, so `deny_unknown_fields` only rejects genuinely unknown keys
+// (e.g. typos) and does not affect omission of optional fields.
 #[derive(Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct RawToolPolicy {
     allow: Option<Vec<String>>,
     deny: Option<Vec<String>>,
@@ -257,6 +257,7 @@ struct RawToolPolicy {
 }
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 struct RawPermissions {
     #[serde(default)]
     secrets: Vec<String>,
@@ -1613,6 +1614,24 @@ mod tests {
     fn parse_yaml_unknown_top_level_field_is_error() {
         // deny_unknown_fields on RawSubAgentDef: typos like "permisions:" must be rejected.
         let content = "---\nname: a\ndescription: b\npermisions:\n  max_turns: 5\n---\n\nbody\n";
+        let err = SubAgentDef::parse(content).unwrap_err();
+        assert_matches!(err, SubAgentError::Parse { .. });
+    }
+
+    #[test]
+    fn parse_yaml_unknown_permissions_field_is_error() {
+        // deny_unknown_fields on RawPermissions (#6583): a typo like "pemission_mode:" inside
+        // the nested `permissions:` section must be rejected, not silently ignored.
+        let content = "---\nname: a\ndescription: b\npermissions:\n  pemission_mode: bypass_permissions\n---\n\nbody\n";
+        let err = SubAgentDef::parse(content).unwrap_err();
+        assert_matches!(err, SubAgentError::Parse { .. });
+    }
+
+    #[test]
+    fn parse_yaml_unknown_tools_field_is_error() {
+        // deny_unknown_fields on RawToolPolicy (#6583): a typo like "alow:" inside the nested
+        // `tools:` section must be rejected, not silently ignored.
+        let content = "---\nname: a\ndescription: b\ntools:\n  alow:\n    - shell\n---\n\nbody\n";
         let err = SubAgentDef::parse(content).unwrap_err();
         assert_matches!(err, SubAgentError::Parse { .. });
     }


### PR DESCRIPTION
## Summary

- `RawToolPolicy` and `RawPermissions` (the `tools:`/`permissions:` nested sections of sub-agent frontmatter) did not propagate `RawSubAgentDef`'s `#[serde(deny_unknown_fields)]` into their own structs, so a typo inside either section (e.g. `pemission_mode:`, `alow:`) was silently ignored and fell back to the section's fail-safe default instead of failing to load. Both structs now carry `deny_unknown_fields` directly.
- Adds a regression test that drives the real `handle_scheduler_spawn_action`/`intersect_task_tool_allowlist` wiring end-to-end through `run_scheduler_loop`, asserting the tool definitions delivered to a spawned sub-agent's LLM are the true intersection of the parent-permission floor and the per-task planner-emitted allowlist. The existing composition test only exercised the decomposed `zeph_subagent::intersect_allowlists`/`task_tool_allowlist_for_task` helpers in isolation, never the actual call site.

## Breaking change

A sub-agent frontmatter file with a misspelled key inside its `tools:` or `permissions:` section now fails to load instead of silently falling back to defaults for that section. Not an exploitable privilege escalation (every existing default is already conservative/restrictive) — this closes a silent-misconfiguration trap where an operator's intended tool/permission restriction never took effect.

Closes #6583
Closes #6539

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (2736/2736 in touched crates, full workspace clean)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `gitleaks protect --staged --no-banner --redact`
- [x] 2 new `#6583` tests independently verified as genuine regression guards (temporarily removed `deny_unknown_fields`, confirmed both new tests fail, restored)
- [x] New `#6539` test independently verified as a genuine regression guard (temporarily reverted `intersect_allowlists` to a naive overwrite, confirmed the test fails with the expected leaked-tool mismatch, restored)
- [x] CHANGELOG.md updated under `[Unreleased]/Fixed` with breaking-change note