### PR TITLE
refactor(memory): enforce VectorStore search clamp via template method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   methods now called across the new file boundaries — no behavior change, no field ownership
   change (all 25 fields stay on the coordinator struct), all existing tests pass unchanged
   (issue #6546).
+- `zeph-memory`: `VectorStore::search` is now a trait-provided template method that clamps
+  `limit` to `[1, MAX_SEARCH_LIMIT]` and delegates to a new required `search_clamped` method,
+  instead of every implementor calling the shared `clamp_search_limit` helper by convention.
+  The clamp is now structurally reached by every call path through `search` regardless of
+  implementor, rather than relying on each of `QdrantOps`, `DbVectorStore`, and
+  `InMemoryVectorStore` remembering to call the helper first (issue #6616 had already shown
+  one implementor — a test mock — skip the clamp). The public `search` signature and behavior
+  are unchanged for all ~10 external callers. Diagnostic-only behavior delta: the one-shot
+  clamp `warn!` now fires once per process instead of once per store type, and its log site
+  label lost the per-implementor suffix (e.g. `[QdrantOps]`), now reading plain
+  `"VectorStore::search"` (issue #6623).
 - `zeph-mcp`: **breaking** — `McpClient::connect` no longer takes two adjacent positional
   `bool` parameters (`suppress_stderr`, `env_isolation`); it now takes `StderrPolicy`
   (`Forward`/`Suppress`) and `EnvPolicy` (`InheritAll`/`Isolated`) instead. `McpClient::connect_url`,

--- a/crates/zeph-memory/src/db_vector_store.rs
+++ b/crates/zeph-memory/src/db_vector_store.rs
@@ -161,21 +161,14 @@ impl VectorStore for DbVectorStore {
         fut
     }
 
-    fn search(
+    fn search_clamped(
         &self,
         collection: &str,
         vector: Vec<f32>,
         limit: u64,
         filter: Option<VectorFilter>,
     ) -> BoxFuture<'_, Result<Vec<ScoredVectorPoint>, VectorStoreError>> {
-        static CLAMP_WARNED: std::sync::atomic::AtomicBool =
-            std::sync::atomic::AtomicBool::new(false);
         let collection = collection.to_owned();
-        let limit = crate::vector_store::clamp_search_limit(
-            "VectorStore::search[DbVectorStore]",
-            limit,
-            &CLAMP_WARNED,
-        );
         #[cfg(feature = "profiling")]
         let span = tracing::info_span!(
             "memory.vector_store",

--- a/crates/zeph-memory/src/in_memory_store.rs
+++ b/crates/zeph-memory/src/in_memory_store.rs
@@ -149,21 +149,14 @@ impl VectorStore for InMemoryVectorStore {
         })
     }
 
-    fn search(
+    fn search_clamped(
         &self,
         collection: &str,
         vector: Vec<f32>,
         limit: u64,
         filter: Option<VectorFilter>,
     ) -> BoxFuture<'_, Result<Vec<ScoredVectorPoint>, VectorStoreError>> {
-        static CLAMP_WARNED: std::sync::atomic::AtomicBool =
-            std::sync::atomic::AtomicBool::new(false);
         let collection = collection.to_owned();
-        let limit = crate::vector_store::clamp_search_limit(
-            "VectorStore::search[InMemoryVectorStore]",
-            limit,
-            &CLAMP_WARNED,
-        );
         Box::pin(async move {
             let cols = self.collections.read();
             let col = cols.get(&collection).ok_or_else(|| {

--- a/crates/zeph-memory/src/qdrant_ops.rs
+++ b/crates/zeph-memory/src/qdrant_ops.rs
@@ -553,21 +553,14 @@ impl crate::vector_store::VectorStore for QdrantOps {
         })
     }
 
-    fn search(
+    fn search_clamped(
         &self,
         collection: &str,
         vector: Vec<f32>,
         limit: u64,
         filter: Option<crate::VectorFilter>,
     ) -> BoxFuture<'_, Result<Vec<crate::ScoredVectorPoint>, crate::VectorStoreError>> {
-        static CLAMP_WARNED: std::sync::atomic::AtomicBool =
-            std::sync::atomic::AtomicBool::new(false);
         let collection = collection.to_owned();
-        let limit = crate::vector_store::clamp_search_limit(
-            "VectorStore::search[QdrantOps]",
-            limit,
-            &CLAMP_WARNED,
-        );
         Box::pin(async move {
             let qdrant_filter = filter.map(vector_filter_to_qdrant);
             let results = self

--- a/crates/zeph-memory/src/semantic/tests/summarization.rs
+++ b/crates/zeph-memory/src/semantic/tests/summarization.rs
@@ -49,7 +49,7 @@ impl VectorStore for FailingSearchStore {
         self.0.upsert(collection, points)
     }
 
-    fn search(
+    fn search_clamped(
         &self,
         _collection: &str,
         _vector: Vec<f32>,

--- a/crates/zeph-memory/src/vector_store.rs
+++ b/crates/zeph-memory/src/vector_store.rs
@@ -111,11 +111,12 @@ pub type ScrollWithIdsResult = Vec<(String, HashMap<String, String>)>;
 /// The wrapper methods in `embedding_store`, `embedding_registry`, and `reasoning` already
 /// clamp before forwarding to a [`VectorStore`] implementor (issue #6553), but any caller
 /// that reaches an implementor directly — e.g. `zeph-index`'s `CodeStore::search` or a
-/// generic `V: VectorStore` pipeline step — bypasses those wrappers entirely. Every
-/// [`VectorStore::search`] implementation in this crate calls this helper first, so the
-/// bound holds regardless of the call path. Clamping an already-clamped value is a no-op,
-/// so enforcing it at both the wrapper and the trait-impl layer is safe.
-pub(crate) fn clamp_search_limit(site: &'static str, limit: u64, warned: &AtomicBool) -> u64 {
+/// generic `V: VectorStore` pipeline step — bypasses those wrappers entirely. The
+/// trait-provided [`VectorStore::search`] calls this once before delegating to
+/// [`VectorStore::search_clamped`], so the bound holds regardless of the call path.
+/// Clamping an already-clamped value is a no-op, so enforcing it at both the wrapper and
+/// the trait layer is safe.
+fn clamp_search_limit(site: &'static str, limit: u64, warned: &AtomicBool) -> u64 {
     if let Ok(requested) = usize::try_from(limit) {
         crate::warn_if_search_limit_clamped(site, requested, warned);
     }
@@ -164,7 +165,31 @@ pub trait VectorStore: Send + Sync {
     ///
     /// Returns results in descending similarity order.  An optional [`VectorFilter`]
     /// restricts the search space to points matching the payload conditions.
+    ///
+    /// `limit` is clamped to `[1, MAX_SEARCH_LIMIT]` before delegating to
+    /// [`Self::search_clamped`] — this is the sole choke point where the clamp is
+    /// enforced, regardless of which implementor handles the call. Implementors MUST
+    /// implement [`Self::search_clamped`], not override this method; overriding
+    /// `search` bypasses the clamp.
     fn search(
+        &self,
+        collection: &str,
+        vector: Vec<f32>,
+        limit: u64,
+        filter: Option<VectorFilter>,
+    ) -> BoxFuture<'_, Result<Vec<ScoredVectorPoint>, VectorStoreError>> {
+        static CLAMP_WARNED: AtomicBool = AtomicBool::new(false);
+        let limit = clamp_search_limit("VectorStore::search", limit, &CLAMP_WARNED);
+        self.search_clamped(collection, vector, limit, filter)
+    }
+
+    /// Backend-specific search implementation invoked by [`Self::search`].
+    ///
+    /// Do not call directly — call [`Self::search`], which clamps `limit` before
+    /// delegating here. Implementors MUST NOT re-clamp `limit`; it is guaranteed to
+    /// already be within `[1, MAX_SEARCH_LIMIT]`. Never call `Self::search` from here —
+    /// it re-enters this method (infinite recursion).
+    fn search_clamped(
         &self,
         collection: &str,
         vector: Vec<f32>,
@@ -237,5 +262,123 @@ pub trait VectorStore: Send + Sync {
                 "get_points not implemented for this backend".into(),
             ))
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// Minimal [`VectorStore`] whose `search_clamped` records the `limit` it was given
+    /// instead of performing a real search, to prove the trait-provided `search` clamp
+    /// is structurally reached regardless of implementor.
+    struct RecordingStore {
+        last_limit: Arc<AtomicU64>,
+    }
+
+    impl VectorStore for RecordingStore {
+        fn ensure_collection(
+            &self,
+            _collection: &str,
+            _vector_size: u64,
+        ) -> BoxFuture<'_, Result<(), VectorStoreError>> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn collection_exists(
+            &self,
+            _collection: &str,
+        ) -> BoxFuture<'_, Result<bool, VectorStoreError>> {
+            Box::pin(async { Ok(true) })
+        }
+
+        fn delete_collection(
+            &self,
+            _collection: &str,
+        ) -> BoxFuture<'_, Result<(), VectorStoreError>> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn upsert(
+            &self,
+            _collection: &str,
+            _points: Vec<VectorPoint>,
+        ) -> BoxFuture<'_, Result<(), VectorStoreError>> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn search_clamped(
+            &self,
+            _collection: &str,
+            _vector: Vec<f32>,
+            limit: u64,
+            _filter: Option<VectorFilter>,
+        ) -> BoxFuture<'_, Result<Vec<ScoredVectorPoint>, VectorStoreError>> {
+            self.last_limit.store(limit, Ordering::SeqCst);
+            Box::pin(async { Ok(vec![]) })
+        }
+
+        fn delete_by_ids(
+            &self,
+            _collection: &str,
+            _ids: Vec<String>,
+        ) -> BoxFuture<'_, Result<(), VectorStoreError>> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn scroll_all(
+            &self,
+            _collection: &str,
+            _key_field: &str,
+        ) -> BoxFuture<'_, Result<ScrollResult, VectorStoreError>> {
+            Box::pin(async { Ok(ScrollResult::new()) })
+        }
+
+        fn scroll_all_with_point_ids(
+            &self,
+            _collection: &str,
+            _key_field: &str,
+        ) -> BoxFuture<'_, Result<ScrollWithIdsResult, VectorStoreError>> {
+            Box::pin(async { Ok(Vec::new()) })
+        }
+
+        fn health_check(&self) -> BoxFuture<'_, Result<bool, VectorStoreError>> {
+            Box::pin(async { Ok(true) })
+        }
+    }
+
+    #[tokio::test]
+    async fn search_clamps_oversized_limit_before_delegating() {
+        let last_limit = Arc::new(AtomicU64::new(0));
+        let store = RecordingStore {
+            last_limit: last_limit.clone(),
+        };
+
+        store
+            .search("collection", vec![0.0], u64::MAX, None)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            last_limit.load(Ordering::SeqCst),
+            crate::MAX_SEARCH_LIMIT as u64
+        );
+    }
+
+    #[tokio::test]
+    async fn search_passes_small_limit_through_unclamped() {
+        let last_limit = Arc::new(AtomicU64::new(0));
+        let store = RecordingStore {
+            last_limit: last_limit.clone(),
+        };
+
+        store
+            .search("collection", vec![0.0], 5, None)
+            .await
+            .unwrap();
+
+        assert_eq!(last_limit.load(Ordering::SeqCst), 5);
     }
 }


### PR DESCRIPTION
## Summary

- Converts `VectorStore::search` from a single required trait method into a template-method pair: `search` is now trait-provided (clamps `limit`, then delegates), and a new required `search_clamped` is what implementors supply.
- Migrates all 4 implementors (`QdrantOps`, `DbVectorStore`, `InMemoryVectorStore`, and the `FailingSearchStore` test mock) to the new contract, removing their per-impl clamp calls.
- Makes the `MAX_SEARCH_LIMIT` clamp (added in #6622 for #6616/#6553) structurally reached by every call path through `search`, instead of relying on each implementor remembering to call `clamp_search_limit` — the exact convention gap flagged in #6623 (the `FailingSearchStore` test mock had already silently skipped it).
- Public `search` API and behavior are unchanged for all ~10 external callers.

Closes #6623

## Test plan

- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-memory` — 1702 passed, 31 skipped, 0 failed (includes 2 new clamp-enforcement tests)
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 15033 passed, 36 skipped, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo test --doc -p zeph-memory` — 61 passed
- [x] `gitleaks protect --staged`