### PR TITLE
feat(zeph-tui): move busy status from status bar to input separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `zeph-tui`: moved the busy spinner and humanized activity verb from the bottom status
+  bar to the input separator row, next to the existing interrupt hint (issue #6649). The
+  variable-width verb (`thinking`, `compacting · context`, …) no longer shifts the status
+  bar's trailing segments (skills, tokens, api, cost, …) horizontally on every status
+  change, and the spinner is no longer duplicated between the two rows. The spinner,
+  interrupt hint, and a minimum-width slice for the verb all outrank the row's idle
+  elements (mode hint, token estimate, queue badges) for space, which are what gets
+  dropped first under width pressure.
 - `zeph-tui`: unified `Ctrl+C` semantics in the TUI (issue #6646). `Ctrl+C` now cancels the
   current agent turn immediately when the agent is busy (moved from `Esc`, which no longer
   cancels anything in Normal mode). When idle, a single `Ctrl+C` no longer quits outright —

--- a/crates/zeph-tui/src/widgets/input.rs
+++ b/crates/zeph-tui/src/widgets/input.rs
@@ -9,34 +9,69 @@ use unicode_width::UnicodeWidthStr;
 use zeph_config::Motion;
 
 use crate::app::{App, InputMode};
+use crate::layout::truncate_to_width;
 use crate::theme::Theme;
 use crate::widgets::spinner::breeze_frame;
+use crate::widgets::status_verbs::humanize;
 use zeph_common::text::format_tokens;
 
 /// Prompt glyph shown at the beginning of the separator line.
 const PROMPT_GLYPH: &str = "you ▸";
 
-/// Append the animated spinner glyph and interrupt hint to a busy separator row.
+/// Upper bound on the humanized verb's display width, so one abnormally long or
+/// unrecognized status label (`humanize` passes unknown strings through verbatim)
+/// cannot crowd out the interrupt hint.
+const VERB_MAX_WIDTH: u16 = 24;
+
+/// Below this width, a truncated verb (e.g. `"thinki…"`) is less legible than showing
+/// no verb at all, so it is dropped entirely instead.
+const VERB_MIN_WIDTH: u16 = 6;
+
+/// The width always reserved for the verb (its minimum useful width, plus the leading
+/// `"  "`) before the row's optional idle elements are admitted. The verb is
+/// rule-mandated (Spinner Rule, spec 011-tui: "a visible spinner **with a short status
+/// message**"), while the mode hint / token estimate / queue badges are convenience
+/// text, so the verb must outrank them for space — otherwise, as the terminal widens,
+/// an idle element can suddenly become admissible and starve the verb back down to
+/// nothing, making verb visibility non-monotonic in width.
+const VERB_RESERVED_WIDTH: u16 = VERB_MIN_WIDTH + 2;
+
+/// The interrupt hint shown at the end of a busy separator row.
+const INTERRUPT_HINT: &str = "  ctrl+c to interrupt";
+
+/// Append the spinner glyph, humanized activity verb, and interrupt hint to a busy
+/// separator row.
 ///
-/// No activity label is shown here — the busy verb already lives in the bottom
-/// status bar ([`crate::widgets::status`]) and the wave equalizer in the side
-/// panel, so duplicating it on this row would be redundant.
-///
-/// Used by `Motion::Minimal` (breeze spinner) and `Motion::Off` (static `·`).
+/// This is the canonical on-screen location for the busy spinner + activity verb (see
+/// spec 011-tui); the bottom status bar no longer duplicates it. The spinner and
+/// interrupt hint are mandatory (Spinner Rule, #6646) and their width is reserved by
+/// the caller before `verb_budget` is computed — see [`build_spinner_busy_sep`] — so
+/// only the verb is truncated (and, below [`VERB_MIN_WIDTH`], dropped) under pressure;
+/// the spinner and hint themselves always render in full.
 fn push_busy_tail<'a>(
     spans: &mut Vec<Span<'a>>,
-    spinner_idx: u8,
+    spinner_span: String,
+    verb_budget: u16,
     app: &App,
     theme: &'a Theme,
-    animated: bool,
 ) {
-    let symbol = if animated {
-        breeze_frame(u64::from(spinner_idx), app.is_ascii_only())
+    spans.push(Span::styled(spinner_span, theme.highlight));
+
+    let phrase = humanize(app.status_label().unwrap_or("thinking"));
+    let verb = if phrase.detail.is_empty() {
+        phrase.verb
     } else {
-        "·"
+        format!("{} · {}", phrase.verb, phrase.detail)
     };
-    spans.push(Span::styled(format!("  {symbol}"), theme.highlight));
-    spans.push(Span::styled("  ctrl+c to interrupt", theme.system_message));
+    if !verb.is_empty() {
+        let budget = verb_budget.saturating_sub(2).min(VERB_MAX_WIDTH); // leading "  "
+        if budget >= VERB_MIN_WIDTH {
+            let truncated = truncate_to_width(&verb, budget as usize);
+            spans.push(Span::styled(format!("  {truncated}"), theme.system_message));
+        }
+    }
+
+    spans.push(Span::styled(INTERRUPT_HINT, theme.system_message));
 }
 
 /// Mode hint shown on the separator row, accurate to what the keys actually do.
@@ -52,36 +87,80 @@ fn mode_hint(app: &App) -> &'static str {
 
 /// Build the busy separator row for `Motion::Minimal` (animated) and `Motion::Off` (static).
 ///
-/// Layout: prompt glyph + mode hint + token estimate + queued badge + spinner +
+/// Layout: prompt glyph + mode hint + token estimate + queued badge + spinner + verb +
 /// interrupt hint. The only difference between modes is whether the spinner glyph
 /// animates (`animated = true`).
+///
+/// The spinner, interrupt hint, and a minimum-width slice for the verb
+/// ([`VERB_RESERVED_WIDTH`]) are all mandatory and reserved up front; the row's other,
+/// merely convenient elements (mode hint, token estimate, queue badges) are dropped
+/// first under pressure — each is only included if it still fits in what's left, so
+/// neither the spinner nor the verb is ever pushed out by them. Whatever width remains
+/// after that is added back on top of the verb's reserved slice (see
+/// [`push_busy_tail`]), letting it grow past the floor when there's slack.
 fn build_spinner_busy_sep<'a>(
     spinner_idx: u8,
     app: &'a App,
     theme: &'a Theme,
     animated: bool,
+    max_width: u16,
 ) -> Vec<Span<'a>> {
-    let estimate = app.context_token_estimate();
-    let meta = if estimate > 0 {
-        format!("  ~{} tokens", format_tokens(estimate as u64))
+    let symbol = if animated {
+        breeze_frame(u64::from(spinner_idx), app.is_ascii_only())
     } else {
-        String::new()
+        "·"
     };
-    let mut spans: Vec<Span<'_>> = vec![
-        Span::styled(format!("{PROMPT_GLYPH} "), theme.system_message),
-        Span::styled(mode_hint(app), theme.system_message),
-        Span::styled(meta, theme.system_message),
-    ];
+    let spinner_span = format!("  {symbol}");
+    let spinner_width = u16::try_from(spinner_span.width()).unwrap_or(u16::MAX);
+    let hint_width = u16::try_from(INTERRUPT_HINT.width()).unwrap_or(u16::MAX);
+
+    let prompt_span = format!("{PROMPT_GLYPH} ");
+    let prompt_width = u16::try_from(prompt_span.width()).unwrap_or(u16::MAX);
+
+    let mut spans: Vec<Span<'_>> = vec![Span::styled(prompt_span, theme.system_message)];
+    let mut budget = max_width
+        .saturating_sub(prompt_width)
+        .saturating_sub(spinner_width)
+        .saturating_sub(hint_width)
+        .saturating_sub(VERB_RESERVED_WIDTH);
+
+    let mode = mode_hint(app);
+    let mode_width = u16::try_from(mode.width()).unwrap_or(u16::MAX);
+    if mode_width <= budget {
+        spans.push(Span::styled(mode, theme.system_message));
+        budget -= mode_width;
+    }
+
+    let estimate = app.context_token_estimate();
+    if estimate > 0 {
+        let meta = format!("  ~{} tokens", format_tokens(estimate as u64));
+        let meta_width = u16::try_from(meta.width()).unwrap_or(u16::MAX);
+        if meta_width <= budget {
+            budget -= meta_width;
+            spans.push(Span::styled(meta, theme.system_message));
+        }
+    }
+
     if app.queued_count() > 0 {
-        spans.push(Span::styled(
-            format!("  [+{} queued]", app.queued_count()),
-            theme.highlight,
-        ));
+        let queued = format!("  [+{} queued]", app.queued_count());
+        let queued_width = u16::try_from(queued.width()).unwrap_or(u16::MAX);
+        if queued_width <= budget {
+            budget -= queued_width;
+            spans.push(Span::styled(queued, theme.highlight));
+        }
     }
+
     if app.editing_queued() {
-        spans.push(Span::styled("  [editing queued]", theme.highlight));
+        const EDITING_QUEUED: &str = "  [editing queued]";
+        let editing_width = u16::try_from(EDITING_QUEUED.width()).unwrap_or(u16::MAX);
+        if editing_width <= budget {
+            budget -= editing_width;
+            spans.push(Span::styled(EDITING_QUEUED, theme.highlight));
+        }
     }
-    push_busy_tail(&mut spans, spinner_idx, app, theme, animated);
+
+    let verb_budget = budget.saturating_add(VERB_RESERVED_WIDTH);
+    push_busy_tail(&mut spans, spinner_span, verb_budget, app, theme);
     spans
 }
 
@@ -191,8 +270,8 @@ pub fn render(
 
     let sep_spans: Vec<Span<'_>> = if busy {
         match motion {
-            Motion::Off => build_spinner_busy_sep(spinner_idx, app, theme, false),
-            _ => build_spinner_busy_sep(spinner_idx, app, theme, true),
+            Motion::Off => build_spinner_busy_sep(spinner_idx, app, theme, false, area.width),
+            _ => build_spinner_busy_sep(spinner_idx, app, theme, true, area.width),
         }
     } else {
         build_idle_sep(app, theme)
@@ -290,15 +369,39 @@ mod tests {
         let output = render_to_string(40, 5, |frame, area| {
             render_input(&app, frame, area, true, 0, zeph_config::Motion::Minimal);
         });
-        // The busy verb is NOT duplicated here (it lives in the status bar); the
-        // separator shows the prompt glyph + mode hint, which fit at width 40.
+        // Spinner + interrupt hint are mandatory (Spinner Rule) and reserved first,
+        // along with a minimum-width slice for the verb; the mode hint (a merely
+        // convenient idle element) is the first thing dropped under pressure, per
+        // spec 011-tui ("truncated before the hint under width pressure") — never the
+        // spinner or hint.
         assert!(
             output.contains("you ▸"),
             "prompt glyph must appear when busy; got: {output:?}"
         );
         assert!(
-            !output.contains("thinking"),
-            "activity label must NOT be duplicated in the input separator; got: {output:?}"
+            output.contains("ctrl+c to interrupt"),
+            "interrupt hint must always be fully visible, even under width pressure; got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn input_busy_width_45_shows_verb_without_mode_hint() {
+        // M6/M8 regression: the verb has a reserved minimum-width slice that outranks
+        // the mode hint, so verb visibility degrades monotonically with width instead
+        // of vanishing in a middle band (e.g. 51-58 cols) only to reappear once the
+        // terminal is wide enough to admit the mode hint too. At width 45 the mode hint
+        // ("esc for normal mode", 19 cols) does not fit, but the verb still must.
+        let app = make_app();
+        let output = render_to_string(45, 5, |frame, area| {
+            render_input(&app, frame, area, true, 0, zeph_config::Motion::Minimal);
+        });
+        assert!(
+            !output.contains("esc for normal mode"),
+            "mode hint must not fit at width 45 (test premise); got: {output:?}"
+        );
+        assert!(
+            output.contains("thinking"),
+            "verb must still render even though the mode hint was dropped; got: {output:?}"
         );
     }
 
@@ -311,6 +414,31 @@ mod tests {
         assert!(
             output.contains("ctrl+c to interrupt"),
             "spinner hint must appear on wide terminal"
+        );
+    }
+
+    #[test]
+    fn input_busy_narrow_with_queue_badge_keeps_spinner_and_hint_visible() {
+        // Spinner Rule (NON-NEGOTIABLE): the spinner and interrupt hint must always
+        // render, even when the queue badge and narrow width would otherwise crowd
+        // them out — the queue badge (or mode hint, or verb) is what gets dropped.
+        use crate::widgets::spinner::BREEZE_FRAMES;
+
+        let mut app = make_app();
+        app.handle_event(crate::event::AppEvent::Agent(
+            crate::event::AgentEvent::QueueCount(2),
+        ));
+        let output = render_to_string(40, 5, |frame, area| {
+            render_input(&app, frame, area, true, 0, zeph_config::Motion::Minimal);
+        });
+        assert!(
+            BREEZE_FRAMES.iter().any(|f| output.contains(f)),
+            "spinner must remain visible despite an active queue badge on a narrow \
+             terminal; got: {output:?}"
+        );
+        assert!(
+            output.contains("ctrl+c to interrupt"),
+            "interrupt hint must remain visible too; got: {output:?}"
         );
     }
 
@@ -421,6 +549,107 @@ mod tests {
         assert!(
             !output.contains('•'),
             "no dot-matrix bullet should appear under Motion::Off; got: {output:?}"
+        );
+        // Assert on the spinner's own span ("  ·", two leading spaces) rather than a
+        // bare '·' — `humanize` joins verb + detail with " · ", so a bare '·' check
+        // would pass by coincidence of the verb text, not because the spinner rendered.
+        assert!(
+            output.contains("  ·"),
+            "the static dot spinner must still render under Motion::Off; got: {output:?}"
+        );
+        assert!(
+            output.contains("thinking"),
+            "the activity verb must still render under Motion::Off; got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn input_busy_humanizes_label_with_detail() {
+        let mut app = make_app();
+        app.sessions.current_mut().status_label = Some("Loading skills...".to_owned());
+        let output = render_to_string(80, 5, |frame, area| {
+            render_input(&app, frame, area, true, 0, zeph_config::Motion::Minimal);
+        });
+        assert!(
+            output.contains("loading · skills"),
+            "raw label must be humanized to 'loading · skills'; got: {output:?}"
+        );
+        assert!(
+            !output.contains("Loading skills"),
+            "raw internal label must not leak into the rendered separator; got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn input_busy_unrecognized_label_passes_through() {
+        let mut app = make_app();
+        app.sessions.current_mut().status_label = Some("Some unknown operation...".to_owned());
+        let output = render_to_string(80, 5, |frame, area| {
+            render_input(&app, frame, area, true, 0, zeph_config::Motion::Minimal);
+        });
+        assert!(
+            output.contains("Some unknown operation"),
+            "humanize() fallback must pass through unrecognized labels verbatim; got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn input_busy_long_verb_is_capped_and_hint_still_shown() {
+        let mut app = make_app();
+        app.sessions.current_mut().status_label =
+            Some("This is a very long unrecognized status message".to_owned());
+        let output = render_to_string(200, 5, |frame, area| {
+            render_input(&app, frame, area, true, 0, zeph_config::Motion::Minimal);
+        });
+        assert!(
+            output.contains("ctrl+c to interrupt"),
+            "interrupt hint must still appear even with a very long verb; got: {output:?}"
+        );
+        assert!(
+            !output.contains("This is a very long unrecognized status message"),
+            "an abnormally long verb must be capped, not rendered in full; got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn input_busy_uses_breeze_spinner_not_braille() {
+        use crate::widgets::spinner::BREEZE_FRAMES;
+
+        let app = make_app();
+        let output = render_to_string(80, 5, |frame, area| {
+            render_input(&app, frame, area, true, 0, zeph_config::Motion::Minimal);
+        });
+        let contains_braille = output
+            .chars()
+            .any(|c| ('\u{2800}'..='\u{28FF}').contains(&c));
+        assert!(
+            !contains_braille,
+            "braille spinner must not appear; got: {output:?}"
+        );
+        assert!(
+            BREEZE_FRAMES.iter().any(|f| output.contains(f)),
+            "expected a breeze_frame glyph in the busy separator; got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn input_busy_ascii_fallback_uses_ascii_breeze_frames() {
+        use crate::widgets::spinner::{BREEZE_ASCII, BREEZE_FRAMES};
+
+        let mut app = make_app();
+        app.unicode_capable = false;
+        assert!(app.is_ascii_only());
+
+        let output = render_to_string(80, 5, |frame, area| {
+            render_input(&app, frame, area, true, 0, zeph_config::Motion::Minimal);
+        });
+        assert!(
+            BREEZE_ASCII.iter().any(|f| output.contains(f)),
+            "expected an ASCII breeze_frame glyph when unicode is unavailable; got: {output:?}"
+        );
+        assert!(
+            !BREEZE_FRAMES.iter().any(|f| output.contains(f)),
+            "Unicode breeze glyphs must not appear in ASCII fallback mode; got: {output:?}"
         );
     }
 }

--- a/crates/zeph-tui/src/widgets/status.rs
+++ b/crates/zeph-tui/src/widgets/status.rs
@@ -15,8 +15,6 @@ use crate::app::{App, InputMode};
 use crate::layout::truncate_to_width;
 use crate::metrics::MetricsSnapshot;
 use crate::theme::Theme;
-use crate::widgets::spinner::breeze_frame;
-use crate::widgets::status_verbs::humanize;
 
 /// Priority level for a status bar segment.
 ///
@@ -26,7 +24,6 @@ use crate::widgets::status_verbs::humanize;
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum Priority {
     Critical = 1,
-    High = 2,
     Medium = 3,
     Low = 4,
 }
@@ -279,9 +276,7 @@ fn build_segment_lists(
 
     push_mode_chip(&mut list, mode, theme);
 
-    if app.is_agent_busy() {
-        push_busy_segment(&mut list, app, theme);
-    } else if app.quit_hint_active() {
+    if app.quit_hint_active() {
         push_quit_hint_segment(&mut list, theme);
     }
 
@@ -319,36 +314,6 @@ fn push_mode_chip(list: &mut SegmentList, mode: InputMode, theme: &Theme) {
             Style::default().fg(surface_bg).bg(chip_bg),
         )],
     );
-}
-
-fn push_busy_segment(list: &mut SegmentList, app: &App, theme: &Theme) {
-    let phrase = humanize(app.status_label().unwrap_or("thinking"));
-    let verb = if phrase.detail.is_empty() {
-        phrase.verb
-    } else {
-        format!("{} · {}", phrase.verb, phrase.detail)
-    };
-    if app.motion == zeph_config::Motion::Off {
-        list.push(
-            Priority::High,
-            vec![
-                Span::styled(" · ", theme.system_message),
-                Span::styled("·", theme.system_message),
-                Span::styled(format!(" {verb}"), theme.system_message),
-            ],
-        );
-    } else {
-        let idx = usize::try_from(app.throbber_state().index().rem_euclid(6)).unwrap_or(0);
-        let spinner_char = breeze_frame(idx as u64, app.is_ascii_only());
-        list.push(
-            Priority::High,
-            vec![
-                Span::styled(" · ", theme.system_message),
-                Span::styled(spinner_char, theme.highlight),
-                Span::styled(format!(" {verb}"), theme.system_message),
-            ],
-        );
-    }
 }
 
 fn push_quit_hint_segment(list: &mut SegmentList, theme: &Theme) {
@@ -710,7 +675,7 @@ mod tests {
     }
 
     #[test]
-    fn segment_list_drops_low_before_high() {
+    fn segment_list_drops_low_before_medium() {
         let theme = Theme::default();
         let mut list = SegmentList::new();
         // Critical: 10 chars
@@ -718,9 +683,9 @@ mod tests {
             Priority::Critical,
             vec![Span::styled("0123456789", theme.status_bar)],
         );
-        // High: 10 chars
+        // Medium: 10 chars
         list.push(
-            Priority::High,
+            Priority::Medium,
             vec![Span::styled("ABCDEFGHIJ", theme.status_bar)],
         );
         // Low: 10 chars — should be dropped first
@@ -728,11 +693,11 @@ mod tests {
             Priority::Low,
             vec![Span::styled("xxxxxxxxxx", theme.status_bar)],
         );
-        // max_width = 20: Critical + High fit (20 chars), Low is dropped
+        // max_width = 20: Critical + Medium fit (20 chars), Low is dropped
         let spans = list.layout(20);
         let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(text.contains("0123456789"), "Critical must survive");
-        assert!(text.contains("ABCDEFGHIJ"), "High must survive");
+        assert!(text.contains("ABCDEFGHIJ"), "Medium must survive");
         assert!(!text.contains("xxxxxxxxxx"), "Low must be dropped");
     }
 
@@ -1151,7 +1116,10 @@ mod tests {
     }
 
     #[test]
-    fn motion_off_shows_static_busy_not_braille() {
+    fn motion_off_status_bar_omits_busy_verb() {
+        // The busy verb (spinner + humanized activity text) moved to the input
+        // separator row (#6649) — the status bar must not render it under any motion
+        // setting, including `Off`.
         use tokio::sync::mpsc;
 
         use crate::app::App;
@@ -1177,8 +1145,8 @@ mod tests {
             "motion=Off must not show braille spinner; got: {output:?}"
         );
         assert!(
-            output.contains("thinking"),
-            "motion=Off must still show verb; got: {output:?}"
+            !output.contains("thinking"),
+            "status bar must no longer show the busy verb; got: {output:?}"
         );
     }
 
@@ -1216,7 +1184,10 @@ mod tests {
     }
 
     #[test]
-    fn busy_segment_humanizes_label_with_detail() {
+    fn status_bar_omits_busy_verb_regardless_of_label() {
+        // The busy verb (spinner + humanized activity text) moved to the input
+        // separator row (#6649) — the status bar must never render it, whether the
+        // raw label is recognized by `humanize()` or passes through verbatim.
         use tokio::sync::mpsc;
 
         use crate::app::App;
@@ -1234,17 +1205,13 @@ mod tests {
         });
 
         assert!(
-            output.contains("loading · skills"),
-            "raw label must be humanized to 'loading · skills'; got: {output:?}"
-        );
-        assert!(
-            !output.contains("Loading skills"),
-            "raw internal label must not leak into the rendered status bar; got: {output:?}"
+            !output.contains("loading") && !output.contains("Loading skills"),
+            "busy verb must not appear in the status bar; got: {output:?}"
         );
     }
 
     #[test]
-    fn busy_segment_unrecognized_label_passes_through() {
+    fn status_bar_omits_unrecognized_busy_label() {
         use tokio::sync::mpsc;
 
         use crate::app::App;
@@ -1262,13 +1229,79 @@ mod tests {
         });
 
         assert!(
-            output.contains("Some unknown operation"),
-            "humanize() fallback must pass through unrecognized labels verbatim; got: {output:?}"
+            !output.contains("Some unknown operation"),
+            "busy label must not leak into the status bar; got: {output:?}"
         );
     }
 
     #[test]
-    fn busy_segment_uses_breeze_spinner_not_braille() {
+    fn status_bar_segment_positions_stable_across_verb_length_changes() {
+        // Regression test for #6649: the busy verb's variable width used to shift every
+        // segment to its right. Now that the verb lives only in the input separator,
+        // a short label and a long label must render the trailing segments at the same
+        // column in the status bar.
+        use tokio::sync::mpsc;
+
+        use crate::app::App;
+        use crate::metrics::MetricsSnapshot;
+        use crate::test_utils::render_to_string;
+
+        let metrics = MetricsSnapshot {
+            active_skills: vec!["web".into()],
+            total_skills: 3,
+            ..MetricsSnapshot::default()
+        };
+
+        let (user_tx, _) = mpsc::channel(1);
+        let (_, agent_rx) = mpsc::channel(1);
+        let mut app_short = App::new(user_tx, agent_rx);
+        app_short.sessions.current_mut().status_label = Some("thinking".to_owned());
+        assert!(
+            app_short.is_agent_busy(),
+            "test setup must actually exercise the busy path"
+        );
+        let output_short = render_to_string(120, 1, |frame, area| {
+            super::render(&app_short, &metrics, frame, area);
+        });
+
+        let (user_tx, _) = mpsc::channel(1);
+        let (_, agent_rx) = mpsc::channel(1);
+        let mut app_long = App::new(user_tx, agent_rx);
+        app_long.sessions.current_mut().status_label =
+            Some("compacting context in the background".to_owned());
+        assert!(
+            app_long.is_agent_busy(),
+            "test setup must actually exercise the busy path"
+        );
+        let output_long = render_to_string(120, 1, |frame, area| {
+            super::render(&app_long, &metrics, frame, area);
+        });
+
+        let pos_short = output_short
+            .find("skills")
+            .expect("skills segment must be present");
+        let pos_long = output_long
+            .find("skills")
+            .expect("skills segment must be present");
+        assert_eq!(
+            pos_short, pos_long,
+            "skills segment must not shift when the busy label length changes; \
+             short={output_short:?} long={output_long:?}"
+        );
+        // Compare everything from the skills segment onward, not just its start column,
+        // so a shift in a later segment (tokens, api, cost, …) would also be caught.
+        assert_eq!(
+            &output_short[pos_short..],
+            &output_long[pos_long..],
+            "no segment from `skills` onward may differ when only the busy label \
+             length changes; short={output_short:?} long={output_long:?}"
+        );
+    }
+
+    #[test]
+    fn status_bar_omits_spinner_glyph_when_busy() {
+        // The spinner also moved to the input separator row (#6649) — the status bar
+        // must not render any spinner glyph, braille or breeze, while busy.
         use tokio::sync::mpsc;
 
         use crate::app::App;
@@ -1291,11 +1324,11 @@ mod tests {
             .any(|c| ('\u{2800}'..='\u{28FF}').contains(&c));
         assert!(
             !contains_braille,
-            "the old hardcoded braille spinner must be gone; got: {output:?}"
+            "the old hardcoded braille spinner must stay gone; got: {output:?}"
         );
         assert!(
-            BREEZE_FRAMES.iter().any(|f| output.contains(f)),
-            "expected a breeze_frame() glyph in the busy segment; got: {output:?}"
+            !BREEZE_FRAMES.iter().any(|f| output.contains(f)),
+            "breeze spinner must not appear in the status bar; got: {output:?}"
         );
     }
 
@@ -1355,7 +1388,7 @@ mod tests {
     }
 
     #[test]
-    fn busy_segment_ascii_fallback_uses_ascii_breeze_frames() {
+    fn status_bar_omits_spinner_glyph_ascii_fallback() {
         use tokio::sync::mpsc;
 
         use crate::app::App;
@@ -1377,12 +1410,12 @@ mod tests {
         });
 
         assert!(
-            BREEZE_ASCII.iter().any(|f| output.contains(f)),
-            "expected an ASCII breeze_frame() glyph when unicode is unavailable; got: {output:?}"
+            !BREEZE_ASCII.iter().any(|f| output.contains(f)),
+            "ASCII breeze glyph must not appear in the status bar; got: {output:?}"
         );
         assert!(
             !BREEZE_FRAMES.iter().any(|f| output.contains(f)),
-            "Unicode breeze glyphs must not appear in ASCII fallback mode; got: {output:?}"
+            "Unicode breeze glyphs must not appear in the status bar; got: {output:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Removes `push_busy_segment()` and the bottom status bar's busy segment (breeze spinner + humanized activity verb) entirely. Its variable width was shifting every following bottom-bar segment (skills, tokens, api, cost, sh:N, cocoon, bg, goal, filters, GRD, tok/s + TTFT, mouse, durable) horizontally on every status change.
- Relocates the spinner + verb to the input separator row, where the spinner already lived (previously without the verb, duplicating the animation across two widgets).
- New width-budget admission order on the separator row: prompt + spinner + interrupt hint are a mandatory reserved core (always render in full — Spinner Rule compliance), the verb is next priority (renders down to a minimum width floor, dropped rather than shown as a truncated stub below that), then mode hint / token estimate / queue badges are shed first under width pressure.
- `Priority::High` removed from the bottom bar's `SegmentList` enum (dead after the busy segment's removal). The `Press Ctrl+C again to exit` hint (#6646) is unaffected — stays as `Priority::Critical`.

Closes #6649

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins -E 'package(zeph-tui)'` — 978/978 pass
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `gitleaks protect --staged --no-banner --redact` — clean
- [x] Went through two rounds of adversarial critique pre-merge (verb-vs-hint width priority inversion at narrow widths, unreserved spinner width, non-monotonic verb visibility band) — all fixed and re-verified
- [x] Independent code review — approved
- [ ] Live TUI session across the narrow-width scenarios (tracked in `.local/testing/playbooks/tui-visual-polish.md`, not part of this PR diff)