### PR TITLE
ci(bundle-check): add --all-targets to per-bundle cargo check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -532,7 +532,7 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.run-full-ci == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -548,9 +548,12 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: "ci"
+      # --all-targets compiles test/bench/example targets too, so per-bundle
+      # test-cfg-gate mismatches (e.g. #6607) are caught here, not just by the
+      # broader combined-feature jobs above (lint-clippy, msrv, release-build).
       - name: Check bundle
         continue-on-error: ${{ matrix.allow_failure == true }}
-        run: cargo check --features ${{ matrix.bundle }}
+        run: cargo check --all-targets --features ${{ matrix.bundle }}
 
   release-build:
     name: Release Build Check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   restores it into the session on `Drop`, covering every exit path; `drain_agent_events` borrows
   the receiver instead of consuming it so the guard never loses ownership across the drain loop's
   await points.
+- `ci`: the per-bundle `bundle-check` job in `ci.yml` now runs `cargo check --all-targets`
+  instead of a lib/bin-only check (issue #6609, follow-up to #6607/#6608). Every other
+  `--all-targets` job in CI (`lint-clippy`, `msrv`, `release-build`) always combines feature
+  strings that enable both `session` and `acp-http` together, so a narrower single bundle like
+  `ide` was never checked with `--all-targets` anywhere, letting test-only `#[cfg(...)]` gates
+  narrower than the production code they exercise ship and pass CI indefinitely.
 
 ## [0.22.3] - 2026-07-22
 ### Fixed


### PR DESCRIPTION
## Summary
- Bundle-check job in `.github/workflows/ci.yml` only compiled lib/bin targets per feature bundle via `cargo check --features <bundle>` (no `--all-targets`), so test-module compilation was never verified per-bundle.
- Every job that does use `--all-targets` (lint-clippy, msrv, release-build, postgres/sqlite parity) always combines feature strings that enable both `session` and `acp-http` together, or uses `full`, so a narrower bundle like `ide` was never checked with `--all-targets` in isolation.
- This let a test whose `#[cfg(...)]` gate is narrower than the production code it calls ship and pass CI indefinitely, as happened with #6607 (fixed in #6608).
- Adds `--all-targets` to the existing per-bundle `cargo check` step and bumps the job timeout 10 -> 15 minutes to account for compiling test/bench/example targets per bundle.
- `ci-non-linux.yml` has no bundle-check job, confirmed directly, left untouched.

Closes #6609

## Test plan
- [x] `fy lint .github/workflows/ci.yml` — 0 errors (30 pre-existing warnings, none on changed lines)
- [x] `gitleaks protect --staged` — no leaks
- [x] Reviewed diff scope: only `.github/workflows/ci.yml` and `CHANGELOG.md`, no `src/*.rs` touched
- [ ] CI run on this PR exercises the new `--all-targets` step for the `ide` bundle (and all other bundles) for the first time