### PR TITLE
fix: remove unused tar-slip-vulnerable extract_archive dead code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   bar; a second `Ctrl+C` within that window quits, a later press re-arms instead. `q` and
   `/quit` are unaffected.
 
+### Removed
+
+- `zeph-plugins`: removed the unused, test-only `extract_archive` helper (issue #6467).
+  It was `#[cfg(test)]`-gated with zero production call sites — all real extraction paths
+  already used the hardened `extract_archive_safe`, which rejects absolute paths, `..`
+  components, and symlink entries. This is dead-code hygiene, not a vulnerability fix; the
+  4 tests that exercised `extract_archive` now call `extract_archive_safe` instead.
+
 ### Fixed
 
 - `zeph-acp`: fixed a deadlock on every permission-gated tool call (issue #6656). `handle_prompt`

--- a/crates/zeph-plugins/src/manager/mod.rs
+++ b/crates/zeph-plugins/src/manager/mod.rs
@@ -306,8 +306,6 @@ mod store;
 mod tests;
 
 pub use registry::{MAX_ARCHIVE_BYTES, download_and_extract};
-#[cfg(test)]
-pub(crate) use security::extract_archive;
 pub use security::validate_url_scheme_ephemeral;
 pub(crate) use security::{
     check_allowed_commands_overlay_effect, extract_archive_safe, scan_skill_entries,

--- a/crates/zeph-plugins/src/manager/security.rs
+++ b/crates/zeph-plugins/src/manager/security.rs
@@ -530,36 +530,10 @@ pub(crate) fn scan_skill_entries(
     }
 }
 
-/// Extract a `.tar.gz` plugin archive into `dest`.
-///
-/// Only gzip-compressed tar archives are supported. The format is detected by the gzip magic
-/// bytes (`0x1f 0x8b`); any other format returns [`PluginError::InvalidSource`].
-///
-/// # Errors
-///
-/// Returns [`PluginError::InvalidSource`] when the archive format is unrecognized or extraction
-/// fails.
-#[cfg(test)]
-pub(crate) fn extract_archive(bytes: &[u8], dest: &Path, url: &str) -> Result<(), PluginError> {
-    if !bytes.starts_with(&[0x1f, 0x8b]) {
-        return Err(PluginError::InvalidSource {
-            path: url.to_owned(),
-            reason: "unsupported archive format: only .tar.gz is supported".to_owned(),
-        });
-    }
-    let gz = flate2::read::GzDecoder::new(bytes);
-    let mut archive = tar::Archive::new(gz);
-    archive
-        .unpack(dest)
-        .map_err(|e| PluginError::InvalidSource {
-            path: url.to_owned(),
-            reason: format!("tar.gz extraction failed: {e}"),
-        })
-}
-
 /// Extract a `.tar.gz` archive with tar-slip protection.
 ///
-/// Unlike [`extract_archive`], this function rejects:
+/// Only gzip-compressed tar archives are supported (gzip magic `0x1f 0x8b`). Beyond plain
+/// extraction, this function rejects:
 /// - Absolute paths inside the archive.
 /// - Entries with `..` path components.
 /// - Symbolic link entries (prevent symlink-based traversal).

--- a/crates/zeph-plugins/src/manager/tests.rs
+++ b/crates/zeph-plugins/src/manager/tests.rs
@@ -804,13 +804,14 @@ fn collect_skill_dirs_returns_installed_skill_paths() {
     );
 }
 
-// --- extract_archive tests ---
+// --- extract_archive_safe tests ---
 
 #[test]
-fn extract_archive_rejects_non_gz_bytes() {
+fn extract_archive_safe_rejects_non_gz_bytes() {
     let fake_bytes = b"PK\x03\x04not a tar.gz";
     let tmp = tempfile::tempdir().unwrap();
-    let err = extract_archive(fake_bytes, tmp.path(), "http://example.com/plugin.zip").unwrap_err();
+    let err =
+        extract_archive_safe(fake_bytes, tmp.path(), "http://example.com/plugin.zip").unwrap_err();
     assert!(
         matches!(err, PluginError::InvalidSource { .. }),
         "non-gz archive must return InvalidSource, got {err:?}"
@@ -2103,7 +2104,7 @@ path = "skills/injected"
     // download_and_extract + scan path directly using a local TempDir.
     let dest = tempfile::tempdir().unwrap();
     let bytes = build_tar_gz(tmp_src.path());
-    extract_archive(&bytes, dest.path(), "https://test/plugin.tar.gz").unwrap();
+    extract_archive_safe(&bytes, dest.path(), "https://test/plugin.tar.gz").unwrap();
 
     let manifest_path = dest.path().join("plugin.toml");
     let manifest_str = std::fs::read_to_string(&manifest_path).unwrap();
@@ -2738,7 +2739,7 @@ fn ephemeral_reputation_check_warns_on_near_match_advisory() {
     );
     let archive = build_tar_gz(&src);
     let dest = tempfile::tempdir().unwrap();
-    extract_archive(&archive, dest.path(), "https://test/github-pr.tar.gz").unwrap();
+    extract_archive_safe(&archive, dest.path(), "https://test/github-pr.tar.gz").unwrap();
 
     let manifest_str = std::fs::read_to_string(dest.path().join("plugin.toml")).unwrap();
     let manifest: crate::manifest::PluginManifest = toml::from_str(&manifest_str).unwrap();
@@ -2776,7 +2777,7 @@ fn ephemeral_reputation_check_block_mode_yields_reputation_blocked() {
     );
     let archive = build_tar_gz(&src);
     let dest = tempfile::tempdir().unwrap();
-    extract_archive(&archive, dest.path(), "https://test/github-pr.tar.gz").unwrap();
+    extract_archive_safe(&archive, dest.path(), "https://test/github-pr.tar.gz").unwrap();
 
     let manifest_str = std::fs::read_to_string(dest.path().join("plugin.toml")).unwrap();
     let manifest: crate::manifest::PluginManifest = toml::from_str(&manifest_str).unwrap();


### PR DESCRIPTION
## Summary
- Removes `extract_archive` from `crates/zeph-plugins/src/manager/security.rs` — a `#[cfg(test)]`-gated tar.gz extraction helper with no tar-slip protection (CWE-22) and zero production call sites. All real extraction paths already use the hardened `extract_archive_safe`, which rejects absolute paths, `..` traversal components, and symlink entries.
- This is dead-code hygiene, not a vulnerability fix — the unsafe function was never reachable outside tests, so there is no live exploit being patched.
- Migrates the 4 tests that exercised `extract_archive` onto `extract_archive_safe` (verified to be a strict superset for all current test fixtures) and drops the now-dead `pub(crate)` re-export in `manager/mod.rs`.
- Rewrites `extract_archive_safe`'s doc comment to remove its now-broken intra-doc link to the deleted function.

Closes #6467

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (15111 passed, 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `gitleaks protect --staged`
- [x] Repo-wide grep confirms zero remaining `extract_archive` (non-`_safe`) references outside the CHANGELOG