### PR TITLE
docs(zeph-common): add anchor_key doctest, instrument vault-anchor ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   reason — including a transient `ConcurrencyLimit` the orchestration scheduler retries —
   never burns budget it never used. `--migrate-config` populates the new key on existing
   configs; `/agent status` and `/agent list` surface the running count.
+- `zeph-common`: `# Examples` doctest on `anchor_key`, covering both the ASCII-safe encoding
+  and the `hex:`-prefixed fallback, each round-tripped through `parse_anchor_key` (issue #6465).
+- `zeph-core`: dedicated `core.anchor.put`/`core.anchor.get`/`core.anchor.get_sync`/
+  `core.anchor.delete`/`core.anchor.sweep` tracing spans on `AgeVaultAnchorStore`'s vault-anchor
+  operations and the reconcile-and-cap sweep (issue #6464). Observability-only, no behavior
+  change.
 
 ### Changed
 

--- a/crates/zeph-common/src/anchor.rs
+++ b/crates/zeph-common/src/anchor.rs
@@ -269,6 +269,35 @@ fn decode_file_id(segment: &str) -> Option<Vec<u8>> {
 ///
 /// Format: `ZEPH_HISTORY_ANCHOR_<SUBSYSTEM>_<file_id>` (ASCII-safe-encoded, falling back to a
 /// `hex:`-prefixed hex encoding for any byte outside `[A-Za-z0-9._-]`).
+///
+/// # Examples
+///
+/// The common, ASCII-safe path:
+///
+/// ```
+/// use zeph_common::anchor::{AnchorSubsystem, anchor_key, parse_anchor_key};
+///
+/// let key = anchor_key(AnchorSubsystem::SubagentTranscript, b"task-42");
+/// assert_eq!(key, "ZEPH_HISTORY_ANCHOR_SUBAGENT_task-42");
+///
+/// let (subsystem, file_id) = parse_anchor_key(&key).unwrap();
+/// assert_eq!(subsystem, AnchorSubsystem::SubagentTranscript);
+/// assert_eq!(file_id, b"task-42");
+/// ```
+///
+/// A `file_id` containing a byte outside `[A-Za-z0-9._-]` falls back to the `hex:`-prefixed
+/// encoding, which round-trips through [`parse_anchor_key`] the same way:
+///
+/// ```
+/// use zeph_common::anchor::{AnchorSubsystem, anchor_key, parse_anchor_key};
+///
+/// let key = anchor_key(AnchorSubsystem::SessionLog, b"a/b");
+/// assert_eq!(key, "ZEPH_HISTORY_ANCHOR_SESSION_hex:612f62");
+///
+/// let (subsystem, file_id) = parse_anchor_key(&key).unwrap();
+/// assert_eq!(subsystem, AnchorSubsystem::SessionLog);
+/// assert_eq!(file_id, b"a/b");
+/// ```
 #[must_use]
 pub fn anchor_key(subsystem: AnchorSubsystem, file_id: &[u8]) -> String {
     format!(

--- a/crates/zeph-core/src/anchor_store.rs
+++ b/crates/zeph-core/src/anchor_store.rs
@@ -61,6 +61,7 @@ use std::pin::Pin;
 use std::sync::{Arc, RwLock as StdRwLock};
 use std::time::Duration;
 
+use tracing::Instrument as _;
 use zeph_common::anchor::{Anchor, AnchorError, AnchorStore, AnchorSubsystem, parse_anchor_key};
 use zeph_common::task_supervisor::{RestartPolicy, TaskDescriptor, TaskSupervisor};
 
@@ -118,6 +119,12 @@ impl AgeVaultAnchorStore {
         timeout: Duration,
     ) -> Result<Option<Anchor>, AnchorError> {
         let key = zeph_common::anchor::anchor_key(subsystem, file_id);
+        let _span = tracing::info_span!(
+            "core.anchor.get_sync",
+            subsystem = subsystem.key_segment(),
+            key = %key
+        )
+        .entered();
         let deadline = std::time::Instant::now() + timeout;
         loop {
             match self.vault.try_read() {
@@ -151,20 +158,28 @@ impl AnchorStore for AgeVaultAnchorStore {
         // suspension point to race against, and the timeout can never fire (issue #6449 M1
         // regression: a prior version called `get_sync` here directly).
         let key = zeph_common::anchor::anchor_key(subsystem, file_id);
+        let span = tracing::info_span!(
+            "core.anchor.get",
+            subsystem = subsystem.key_segment(),
+            key = %key
+        );
         let vault = Arc::clone(&self.vault);
         let supervisor = self.supervisor.clone();
-        Box::pin(async move {
-            let handle = supervisor.spawn_blocking(Arc::from("anchor-get"), move || {
-                let guard = vault
-                    .read()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner);
-                decode_anchor(guard.get(&key))
-            });
-            handle
-                .join()
-                .await
-                .map_err(|e| AnchorError::Store(format!("spawn_blocking: {e}")))?
-        })
+        Box::pin(
+            async move {
+                let handle = supervisor.spawn_blocking(Arc::from("anchor-get"), move || {
+                    let guard = vault
+                        .read()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    decode_anchor(guard.get(&key))
+                });
+                handle
+                    .join()
+                    .await
+                    .map_err(|e| AnchorError::Store(format!("spawn_blocking: {e}")))?
+            }
+            .instrument(span),
+        )
     }
 
     fn get_sync(
@@ -182,28 +197,36 @@ impl AnchorStore for AgeVaultAnchorStore {
         anchor: Anchor,
     ) -> Pin<Box<dyn Future<Output = Result<(), AnchorError>> + Send + '_>> {
         let key = zeph_common::anchor::anchor_key(subsystem, file_id);
+        let span = tracing::info_span!(
+            "core.anchor.put",
+            subsystem = subsystem.key_segment(),
+            key = %key
+        );
         let vault = Arc::clone(&self.vault);
         let supervisor = self.supervisor.clone();
-        Box::pin(async move {
-            let json = serde_json::to_string(&anchor)
-                .map_err(|e| AnchorError::Store(format!("anchor JSON encode failed: {e}")))?;
-            let handle = supervisor.spawn_blocking(Arc::from("anchor-put"), move || {
-                let mut guard = vault
-                    .write()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner);
-                // An anchor is our own managed entry, always overwritten on re-finalize —
-                // mirrors the OAuth store's `set_secret_mut(.., true)` rationale.
-                guard
-                    .set_secret_mut(key, json, true)
-                    .map_err(|e| e.to_string())?;
-                guard.save().map_err(|e| e.to_string())
-            });
-            handle
-                .join()
-                .await
-                .map_err(|e| AnchorError::Store(format!("spawn_blocking: {e}")))?
-                .map_err(AnchorError::Store)
-        })
+        Box::pin(
+            async move {
+                let json = serde_json::to_string(&anchor)
+                    .map_err(|e| AnchorError::Store(format!("anchor JSON encode failed: {e}")))?;
+                let handle = supervisor.spawn_blocking(Arc::from("anchor-put"), move || {
+                    let mut guard = vault
+                        .write()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    // An anchor is our own managed entry, always overwritten on re-finalize —
+                    // mirrors the OAuth store's `set_secret_mut(.., true)` rationale.
+                    guard
+                        .set_secret_mut(key, json, true)
+                        .map_err(|e| e.to_string())?;
+                    guard.save().map_err(|e| e.to_string())
+                });
+                handle
+                    .join()
+                    .await
+                    .map_err(|e| AnchorError::Store(format!("spawn_blocking: {e}")))?
+                    .map_err(AnchorError::Store)
+            }
+            .instrument(span),
+        )
     }
 
     fn delete(
@@ -212,24 +235,32 @@ impl AnchorStore for AgeVaultAnchorStore {
         file_id: &[u8],
     ) -> Pin<Box<dyn Future<Output = Result<(), AnchorError>> + Send + '_>> {
         let key = zeph_common::anchor::anchor_key(subsystem, file_id);
+        let span = tracing::info_span!(
+            "core.anchor.delete",
+            subsystem = subsystem.key_segment(),
+            key = %key
+        );
         let vault = Arc::clone(&self.vault);
         let supervisor = self.supervisor.clone();
-        Box::pin(async move {
-            let handle = supervisor.spawn_blocking(Arc::from("anchor-delete"), move || {
-                let mut guard = vault
-                    .write()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner);
-                if !guard.remove_secret_mut(&key) {
-                    return Ok(()); // absent — a no-op, not an error
-                }
-                guard.save().map_err(|e| e.to_string())
-            });
-            handle
-                .join()
-                .await
-                .map_err(|e| AnchorError::Store(format!("spawn_blocking: {e}")))?
-                .map_err(AnchorError::Store)
-        })
+        Box::pin(
+            async move {
+                let handle = supervisor.spawn_blocking(Arc::from("anchor-delete"), move || {
+                    let mut guard = vault
+                        .write()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    if !guard.remove_secret_mut(&key) {
+                        return Ok(()); // absent — a no-op, not an error
+                    }
+                    guard.save().map_err(|e| e.to_string())
+                });
+                handle
+                    .join()
+                    .await
+                    .map_err(|e| AnchorError::Store(format!("spawn_blocking: {e}")))?
+                    .map_err(AnchorError::Store)
+            }
+            .instrument(span),
+        )
     }
 }
 
@@ -417,6 +448,8 @@ pub fn run_anchor_sweep(
     max_session_anchors: usize,
     now: u64,
 ) -> Result<AnchorSweepReport, String> {
+    let _span = tracing::info_span!("core.anchor.sweep", max_session_anchors).entered();
+
     // Step 1: snapshot every anchor key + raw value under a brief READ lock — no I/O here.
     let snapshot: Vec<(String, String)> = {
         let guard = vault


### PR DESCRIPTION
## Summary
- Adds an `# Examples` doctest on `anchor_key` in `crates/zeph-common/src/anchor.rs`, covering both the ASCII-safe encoding and the `hex:`-prefixed fallback, each round-tripped through `parse_anchor_key`.
- Adds `core.anchor.put`/`core.anchor.get`/`core.anchor.get_sync`/`core.anchor.delete`/`core.anchor.sweep` tracing spans to `AgeVaultAnchorStore`'s vault-anchor operations and the reconcile-and-cap sweep in `crates/zeph-core/src/anchor_store.rs`, per the project's `<crate>.<subsystem>.<operation>` span naming convention. `get_sync_bounded` — the dominant production read path, previously uninstrumented even by the generic `spawn_blocking` baseline — is now covered too.
- Observability and documentation only; no behavior change.
- `.local/testing/coverage-status.md` (existing anchor row amended in place) and `.local/testing/playbooks/transcript-integrity.md` (scenario A15 added) updated in the main repo per project convention.

Closes #6465
Closes #6464

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 15141 passed, 0 failed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `gitleaks protect --staged`