### PR TITLE
docs: fix local trace jq recipes matching zero events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `.claude/rules/continuous-improvement.md`: fixed the "Local Trace Analysis" jq recipes, which
+  matched zero events against every real local trace file (issue #6676). `tracing-chrome` 0.7.2
+  writes a bare top-level JSON array (not `{"traceEvents": [...]}`) and never emits `ph:"X"`
+  complete events with a `dur` field under either `TraceStyle` — verified against the crate
+  source, ruling out switching `build_chrome_layer` to `TraceStyle::Async` as a fix, since that
+  style still only emits paired `ph:"b"`/`"e"` duration events, not `"X"`. The recipes now
+  reconstruct synthetic complete events by pairing `ph:"B"`/`"E"` per-thread with a stack-based
+  jq helper (the same LIFO matching Perfetto/`chrome://tracing` use internally) and no longer
+  assume the `.traceEvents` wrapper. Also fixed an unrelated pre-existing jq syntax error in the
+  "total time per span name" recipe (`{total_ms: (map(.dur) | add) / 1000, ...}` — jq's grammar
+  requires the division parenthesized inside an object literal). Documented two further caveats
+  found in review: reconstructed `dur` is per-poll on-CPU time rather than wall-clock span
+  lifetime for any span with an internal `.await` (`TraceStyle::Threaded` re-fires enter/exit on
+  every poll — confirmed on a real 127s session where the top-level span fragmented into 209
+  pieces totalling 234ms), so the "spans > 500ms" recipe only reliably catches spans with no
+  internal await; and a trace file left open when the process was killed (e.g. via `pkill`, which
+  skips `FlushGuard`'s closing write) fails to parse outright, with a one-line recovery command
+  now documented. No source code change; the trace format was already correct for
+  Perfetto/`chrome://tracing` and the OTLP/Jaeger backend.
 - `zeph-acp`: fixed a deadlock on every permission-gated tool call (issue #6656). `handle_prompt`
   awaited the entire agent turn inline inside the ACP SDK's `on_receive_request` callback, holding
   the SDK's strictly serial dispatch loop for the whole turn; since that same loop demultiplexes


### PR DESCRIPTION
## Summary

Fixes the "Local Trace Analysis" jq recipes in `.claude/rules/continuous-improvement.md`, which matched zero events against every real local trace file.

Root cause: `tracing-chrome` 0.7.2 never emits `ph:"X"` complete events with a `dur` field under either `TraceStyle` (confirmed by reading the crate source directly — `Threaded` emits paired `"B"`/`"E"`, `Async` emits paired `"b"`/`"e"`, neither ever emits `"X"`), and writes a bare top-level JSON array rather than a `{"traceEvents": [...]}` wrapper. Switching `build_chrome_layer` to `TraceStyle::Async` was evaluated and ruled out — it does not fix the missing-`dur` problem, so no source code change was made.

The recipes now reconstruct synthetic complete events from real `B`/`E` pairs via a per-thread stack, drop the `.traceEvents` wrapper assumption, and fix an unrelated pre-existing jq syntax error (unparenthesized division inside an object literal). Adversarial review (impl-critic) surfaced and this PR now documents two further caveats, verified against real trace files:

- Reconstructed `dur` is per-poll on-CPU time, not wall-clock span lifetime, for any span with an internal `.await` — confirmed on a real 127s session where a top-level span fragmented into 209 pieces totaling 234ms instead of the true ~127,236ms. The "spans > 500ms" recipe is only reliable for await-free spans.
- A trace file left open when the process is killed (e.g. via `pkill`, which skips `FlushGuard`'s closing write) fails to parse outright; a verified one-line recovery command is now documented (2 of 7 sampled trace files were found in this state).

## Important: this fix does not ship via this PR's diff

`.claude/` is excluded by this environment's global `~/.gitignore_global` and has never been tracked in this repository's git history — `git ls-files .claude/` returns zero files. The actual jq-recipe fix lives entirely in `.claude/rules/continuous-improvement.md`, which is real on disk in the branch's worktree but **cannot appear in this PR's diff** and will not propagate to other clones via merge. Only the `CHANGELOG.md` entry below is git-visible. This is expected, pre-existing repo behavior, not an omission — flagging explicitly so a reviewer isn't confused seeing a CHANGELOG entry with no corresponding file diff.

## Follow-ups (to be filed separately)

- Evaluate a source-side fix for true wall-clock span durations (`TraceStyle::Async`'s `on_new_span`/`on_close` fire once per span lifetime instead of per-poll, but its `id` field groups by root span rather than uniquely per instance, so the jq pairing logic would need rework from per-tid LIFO to `(id, name)`-based pairing).
- Root-cause fix for trace files truncated by `pkill`-based teardown skipping `FlushGuard`'s closing write.

Closes #6676

## Test plan
- [x] All 3 jq recipes independently re-verified against multiple real trace files under `.local/traces/` (team-lead, tester, and reviewer each ran them independently)
- [x] Stack-pairing logic (`to_complete`) stress-tested against nested same-thread spans, cross-thread interleaving, and orphan B/E events (unbalanced/truncated traces) — degrades gracefully, no jq errors
- [x] Truncation recovery one-liner verified against a real 392MB truncated trace file (1,712,067 events recovered)
- [x] `git status --porcelain`: only `CHANGELOG.md` modified, zero `.rs` files — docs-only exception in branching.md applies
- [x] `gitleaks protect --staged` clean
- [x] impl-critic adversarial review: initial `significant` verdict resolved in a fix round; reviewer approved with zero remaining findings