### PR TITLE
fix(acp): abort orphaned agent loops and deliver /review output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `TestWriteGate` channel handshake (with a 30s bound so a regression to an inline write path
   fails with a clear panic instead of hanging the CI shard) to prove `dump_request` returns
   before its `spawn_blocking` write completes, with no timing race window at all.
+- `zeph-acp`: fixed a session-turn race where a closed/deleted session's agent-loop task could
+  keep running and emit events/notifications under a `SessionId` reused by a later
+  `session/load`/`session/resume` (issue #6674). `do_close_session`/`do_delete_session` previously
+  only fired a bare `cancel_signal.notify_one()` and removed the session's map entry, without
+  waiting for or aborting the still-running loop task. `SessionEntry` now carries the loop task's
+  `JoinHandle`; close/delete abort and await it (bounded by a 5s timeout) before proceeding, and
+  `Drop for SessionEntry` also aborts it unconditionally as a safety net covering the LRU-eviction
+  removal path in `do_fork_session`/`do_resume_session`.
+- `zeph-acp`: fixed `/review` silently discarding its own output (issue #6673, regression
+  surfaced by #6666/#6667's fix above). `handle_review_command` dispatched the expanded review
+  prompt via a fire-and-forget `input_tx.try_send` and returned `EndTurn` immediately, without
+  ever calling `acquire_prompt_channels`/acquiring `output_rx` — before #6666/#6667, the agent
+  loop's resulting events leaked into the *next* unrelated `session/prompt` call's drain; after
+  that fix, `acquire_prompt_channels`'s new inter-turn drain discards them outright, so `/review`
+  produced no client-visible output either way. `/review` is now intercepted in `do_prompt` and
+  expanded into a real prompt that flows through the same `acquire_prompt_channels`/drain turn
+  path as any other prompt, so its output is actually delivered. Client-visible behavior change:
+  `/review` now participates in the same per-session turn contention check as any other prompt
+  — it can be rejected with "prompt already in progress" if another turn is already in flight
+  on the session (previously always accepted and silently dropped its own output) — and its
+  expanded prompt text is now persisted/replayed as part of the session's conversation history
+  like a normal turn, rather than never being recorded anywhere.
 
 ## [0.22.3] - 2026-07-22
 ### Fixed

--- a/crates/zeph-acp/src/agent/mod.rs
+++ b/crates/zeph-acp/src/agent/mod.rs
@@ -22,7 +22,6 @@ use parking_lot::{Mutex, RwLock};
 
 use agent_client_protocol as acp;
 use tokio::sync::{mpsc, oneshot};
-#[cfg(feature = "unstable-elicitation")]
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use zeph_common::task_supervisor::TaskSupervisor;
@@ -318,6 +317,20 @@ pub(crate) struct SessionEntry {
     /// after `tool_call_update` notifications are sent (ACP requires the terminal to
     /// remain alive until after the notification that embeds it).
     pub(crate) shell_executor: Option<AcpShellExecutor>,
+    /// Join handle for this session's agent-loop task (`spawn_local`, spawned in
+    /// `do_new_session`/`do_load_session`/`do_fork_session`/`do_resume_session`).
+    ///
+    /// `Mutex`-wrapped (unlike `elicitation_bridge_handle` below) because it is attached
+    /// *after* the entry is already behind `self.sessions`' lock — the loop task is spawned
+    /// once `session_ctx` is ready, which depends on async work (conversation resolution)
+    /// that happens after the entry is constructed — so it needs interior mutability to be
+    /// set through a shared reference (see `set_agent_loop_handle`). `do_close_session` and
+    /// `do_delete_session` `take()` and abort+await it (bounded) before removing the entry,
+    /// so a subsequent reload/resume can never race a still-running loop left over from a
+    /// closed/deleted session generation (#6674). `Drop` also aborts it unconditionally as a
+    /// safety net for the other entry-removal path (LRU eviction in `do_fork_session`/
+    /// `do_resume_session`), mirroring `elicitation_bridge_handle`'s existing pattern.
+    pub(crate) agent_loop_handle: Mutex<Option<JoinHandle<()>>>,
     /// Join handle for the elicitation bridge task spawned in `do_new_session`.
     ///
     /// Aborted on session close / reap for clean shutdown. `None` when the IDE
@@ -331,6 +344,9 @@ pub(crate) struct SessionEntry {
 
 impl Drop for SessionEntry {
     fn drop(&mut self) {
+        if let Some(handle) = self.agent_loop_handle.lock().take() {
+            handle.abort();
+        }
         #[cfg(feature = "unstable-elicitation")]
         if let Some(handle) = self.elicitation_bridge_handle.take() {
             handle.abort();
@@ -850,13 +866,16 @@ fn session_event_to_updates(
 /// Returns `true` when `trimmed_text` is an ACP-native slash command that should
 /// be handled by [`ZephAcpAgentState::handle_slash_command`] rather than forwarded
 /// to the agent loop.
+///
+/// `/review` is deliberately absent: `do_prompt` (`turn.rs`) intercepts it before this check
+/// even runs, expanding it into a real prompt that flows through the normal turn machinery
+/// instead of `handle_slash_command`'s synchronous short-circuit reply (#6673).
 fn is_acp_native_slash_command(trimmed_text: &str) -> bool {
     trimmed_text == "/help"
         || trimmed_text.starts_with("/help ")
         || trimmed_text == "/mode"
         || trimmed_text.starts_with("/mode ")
         || trimmed_text == "/clear"
-        || trimmed_text.starts_with("/review")
         || trimmed_text == "/model"
         || trimmed_text.starts_with("/model ")
 }

--- a/crates/zeph-acp/src/agent/reaper.rs
+++ b/crates/zeph-acp/src/agent/reaper.rs
@@ -86,10 +86,13 @@ impl ZephAcpAgentState {
     /// Evict the oldest idle session when the session limit is reached.
     ///
     /// Idle is defined as: `output_rx` is `Some` (no prompt in flight).
-    /// The lock-drop-and-reacquire pattern is intentional: the first lock
-    /// guard must be released before removing the entry to avoid a potential
-    /// deadlock if `cancel_signal.notify_one()` ever triggers reentrant
-    /// session-map access.
+    /// The two separate `self.sessions.lock()` calls below are intentional: the first is
+    /// scoped to just the `.iter()` scan + `min_by_key` that picks the victim, so the lock
+    /// isn't held for that O(n) work any longer than necessary; the second (re-)acquires it to
+    /// remove the victim. That second guard, via `if let`'s temporary lifetime extension, stays
+    /// held for the rest of the block — including `entry.cancel_signal.notify_one()` and
+    /// `entry`'s `Drop` (which now also aborts its agent-loop `JoinHandle`, #6674) — which is
+    /// safe only because nothing on either path touches `self.sessions` again.
     pub(crate) fn evict_oldest_idle_session_if_full(&self) -> acp::Result<()> {
         if self.sessions.lock().len() < self.max_sessions {
             return Ok(());

--- a/crates/zeph-acp/src/agent/session.rs
+++ b/crates/zeph-acp/src/agent/session.rs
@@ -40,6 +40,16 @@ use super::{
 
 const LOOPBACK_CHANNEL_CAPACITY: usize = 64;
 
+/// Bound on how long `do_close_session`/`do_delete_session` wait for a session's agent-loop
+/// task to stop after it is aborted (#6674).
+///
+/// `abort()` only takes effect at the task's next `.await` point, so a task deep in a long
+/// synchronous section could take a moment to unwind. This timeout bounds *the handler's*
+/// latency, not the correctness guarantee: the entry is removed from `self.sessions` either
+/// way once this returns, so a subsequent reload/resume still gets a fresh, generation-stamped
+/// entry regardless of whether the old task has actually finished unwinding by then.
+const AGENT_LOOP_SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
 /// Look up the `ConversationId` for an existing ACP session, creating one for legacy
 /// sessions that predate migration 026 (where `conversation_id` is `NULL`).
 ///
@@ -114,6 +124,65 @@ impl ZephAcpAgentState {
             }
             Ok(())
         })
+    }
+
+    /// Attach `handle` — the just-spawned agent-loop task's `JoinHandle` — to `session_id`'s
+    /// entry, so `do_close_session`/`do_delete_session` can later abort and await it (#6674).
+    ///
+    /// Called as a follow-up step after `tokio::task::spawn_local`, not at `make_session_entry`
+    /// construction time: the loop task is spawned once `session_ctx` is ready, which depends
+    /// on async work (conversation resolution, MCP server registration) that happens after the
+    /// entry already exists in `self.sessions`. That gap is exactly the race #6674 is about: if
+    /// a `session/close`/`session/delete` for this `SessionId` lands while the entry exists but
+    /// this call hasn't run yet, `stop_agent_loop` finds `agent_loop_handle == None` and aborts
+    /// nothing — `cancel_signal.notify_one()` alone does not stop a loop that isn't checking it
+    /// yet, or ever. So when the entry is no longer present here (removed by that close/delete),
+    /// `handle` must be aborted directly rather than silently dropped — `JoinHandle::drop` does
+    /// not abort the task on its own, and without this the loop this call was meant to track
+    /// would run untracked and unabortable under a `SessionId` that is now free to be reloaded.
+    fn set_agent_loop_handle(
+        &self,
+        session_id: &acp::schema::v1::SessionId,
+        handle: tokio::task::JoinHandle<()>,
+    ) {
+        match self.sessions.lock().get(session_id) {
+            Some(entry) => *entry.agent_loop_handle.lock() = Some(handle),
+            None => handle.abort(),
+        }
+    }
+
+    /// Abort and await (bounded) `entry`'s agent-loop task before it is dropped, so a
+    /// subsequent `session/load` or `session/resume` reusing the same `SessionId` can never
+    /// race a still-running loop left over from a closed/deleted session generation (#6674).
+    ///
+    /// `cancel_signal` is notified first — the same signal `do_cancel` (`mod.rs`) uses to
+    /// interrupt an in-flight turn — but this is *not* a graceful wait: there is no `.await`
+    /// between the `notify_one()` and the `abort()` immediately below to give the loop any
+    /// chance to observe the signal and unwind on its own. For `do_close_session` specifically
+    /// (unlike `do_delete_session`, which discards session state outright), this is a known,
+    /// accepted risk: an `abort()` landing mid-write could tear an in-flight persistence write.
+    /// This is the same abort-only shape the issue's own suggested fix direction describes; a
+    /// graceful-then-abort shutdown (mirroring `TaskSupervisor::shutdown_all(timeout)`) is
+    /// tracked as a follow-up, out of scope here. Whichever future implementation lands: the
+    /// grace period must be inserted *before* the entry leaves `self.sessions` (i.e. before
+    /// `stop_agent_loop` is even called), not between `notify_one()` and `abort()` here —
+    /// inserting it here would reopen #6674's exact race, since the entry is already removed
+    /// by the time this runs and a concurrent `session/load`/`session/resume` could build a new
+    /// generation while the old loop is still alive and ungraced.
+    async fn stop_agent_loop(entry: &SessionEntry) {
+        entry.cancel_signal.notify_one();
+        let Some(handle) = entry.agent_loop_handle.lock().take() else {
+            return;
+        };
+        handle.abort();
+        if tokio::time::timeout(AGENT_LOOP_SHUTDOWN_TIMEOUT, handle)
+            .await
+            .is_err()
+        {
+            tracing::warn!(
+                "session agent-loop task did not stop within {AGENT_LOOP_SHUTDOWN_TIMEOUT:?} after abort"
+            );
+        }
     }
 
     /// Assemble the `NewSessionResponse` with config options and project rule metadata.
@@ -254,12 +323,13 @@ impl ZephAcpAgentState {
 
         let spawner = Arc::clone(&self.spawner);
         let span = tracing::info_span!("acp.session.agent_loop", session_id = %session_id);
-        tokio::task::spawn_local(
+        let agent_loop_handle = tokio::task::spawn_local(
             async move {
                 (spawner)(channel, Some(acp_ctx), session_ctx).await;
             }
             .instrument(span),
         );
+        self.set_agent_loop_handle(&session_id, agent_loop_handle);
 
         let resp = self.build_new_session_response(session_id.clone(), &initial_model);
         self.send_commands_update_nowait(&session_id);
@@ -300,7 +370,10 @@ impl ZephAcpAgentState {
         }
         let removed = self.sessions.lock().remove(&args.session_id);
         if let Some(entry) = removed {
-            entry.cancel_signal.notify_one();
+            // #6674: abort and await (bounded) the session's agent-loop task before doing
+            // anything else with the removed entry, so it can never keep running — and
+            // emitting events/notifications under this `SessionId` — past this point.
+            Self::stop_agent_loop(&entry).await;
             // Snapshot the session's config fields (#5373) so a later `session/resume` or
             // `session/fork` of this now-evicted session can inherit them instead of
             // resetting to configured defaults.
@@ -339,8 +412,16 @@ impl ZephAcpAgentState {
         // silent failure here would let a transient DB error (lock/disk full/pool exhaustion)
         // report success to the client while the persisted row — and the resurrection risk it
         // carries — survives.
-        if let Some(entry) = self.sessions.lock().remove(&args.session_id) {
-            entry.cancel_signal.notify_one();
+        // Lock released before the `.await` below (the `MutexGuard` temporary from `.lock()`
+        // would otherwise be kept alive for the whole `if let` block, which is not `Send` and
+        // fails to compile under the `acp::on_receive_request!()` dispatcher — see
+        // do_close_session's identical two-statement split above for the same reason).
+        let removed = self.sessions.lock().remove(&args.session_id);
+        if let Some(entry) = removed {
+            // #6674: abort and await (bounded) the agent-loop task before proceeding, so it
+            // can never outlive this handler under a `SessionId` that may be reused by a
+            // later `session/load`/`session/resume`.
+            Self::stop_agent_loop(&entry).await;
         }
         if let Some(ref store) = self.store
             && let Err(e) = store
@@ -447,12 +528,13 @@ impl ZephAcpAgentState {
 
         let spawner = Arc::clone(&self.spawner);
         let span = tracing::info_span!("acp.session.agent_loop", session_id = %args.session_id);
-        tokio::task::spawn_local(
+        let agent_loop_handle = tokio::task::spawn_local(
             async move {
                 (spawner)(channel, Some(acp_ctx), session_ctx).await;
             }
             .instrument(span),
         );
+        self.set_agent_loop_handle(&args.session_id, agent_loop_handle);
 
         self.replay_session_events(&args.session_id, events).await;
 
@@ -704,12 +786,13 @@ impl ZephAcpAgentState {
 
         let spawner = Arc::clone(&self.spawner);
         let span = tracing::info_span!("acp.session.agent_loop", session_id = %new_id);
-        tokio::task::spawn_local(
+        let agent_loop_handle = tokio::task::spawn_local(
             async move {
                 (spawner)(channel, Some(acp_ctx), session_ctx).await;
             }
             .instrument(span),
         );
+        self.set_agent_loop_handle(&new_id, agent_loop_handle);
 
         let available_models = self.available_models_snapshot();
         let config_options = build_config_options(
@@ -835,12 +918,13 @@ impl ZephAcpAgentState {
 
         let spawner = Arc::clone(&self.spawner);
         let span = tracing::info_span!("acp.session.agent_loop", session_id = %args.session_id);
-        tokio::task::spawn_local(
+        let agent_loop_handle = tokio::task::spawn_local(
             async move {
                 (spawner)(channel, Some(acp_ctx), session_ctx).await;
             }
             .instrument(span),
         );
+        self.set_agent_loop_handle(&args.session_id, agent_loop_handle);
 
         Ok(acp::schema::v1::ResumeSessionResponse::new())
     }
@@ -1271,6 +1355,7 @@ impl ZephAcpAgentState {
             auto_approve_level: Mutex::new(config.auto_approve_level),
             temperature_preset: Mutex::new(config.temperature_preset),
             shell_executor,
+            agent_loop_handle: Mutex::new(None),
             #[cfg(feature = "unstable-elicitation")]
             elicitation_bridge_handle: None,
             #[cfg(feature = "unstable-session-usage")]

--- a/crates/zeph-acp/src/agent/slash.rs
+++ b/crates/zeph-acp/src/agent/slash.rs
@@ -3,9 +3,12 @@
 
 //! ACP-native slash-command handlers for `ZephAcpAgentState`.
 //!
-//! Groups the `/help`, `/review`, `/mode`, `/clear`, and `/model` command dispatch and the
+//! Groups the `/help`, `/mode`, `/clear`, and `/model` command dispatch and the
 //! `AvailableCommandsUpdate` notification helper so the slash-command surface is isolated
-//! from session lifecycle and prompt-turn logic in [`super`].
+//! from session lifecycle and prompt-turn logic in [`super`]. `/review`'s prompt-text builder
+//! (`build_review_prompt`) also lives here, but its dispatch is handled by `do_prompt`
+//! (`turn.rs`) directly rather than by [`ZephAcpAgentState::handle_slash_command`] below
+//! (#6673 — see `is_acp_native_slash_command`'s doc in `mod.rs` for why).
 
 use agent_client_protocol as acp;
 use zeph_core::channel::ChannelMessage;
@@ -15,6 +18,36 @@ use super::{AgentSpawner, ProviderFactory, SessionConfigSeed, ZephAcpAgent};
 use super::{ZephAcpAgentState, build_available_commands};
 #[cfg(test)]
 use tokio::sync::mpsc;
+
+/// Build the expanded `/review [path]` prompt text, validating `arg` first.
+///
+/// Pure and side-effect-free — used by `do_prompt` (`turn.rs`) to expand `/review` into a real
+/// prompt that flows through the normal `acquire_prompt_channels`/drain turn machinery (#6673),
+/// rather than being dispatched fire-and-forget the way the other ACP-native slash commands are.
+pub(crate) fn build_review_prompt(arg: &str) -> acp::Result<String> {
+    // Validate arg to prevent prompt injection: allow only safe path characters.
+    if !arg.is_empty() {
+        let valid = arg
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '/' | ' ' | '-'));
+        if !valid || arg.len() > 512 {
+            return Err(acp::Error::invalid_request()
+                .data("invalid path argument: only alphanumeric, _, ., /, space, - allowed (max 512 chars)"));
+        }
+    }
+    Ok(if arg.is_empty() {
+        "Review the recent changes in this workspace. Show a plain-text diff summary. \
+         Use only read_file and list_directory tools. Do not execute any commands or \
+         write any files."
+            .to_owned()
+    } else {
+        format!(
+            "Review the following file or path: {arg}. Show a plain-text diff summary. \
+             Use only read_file and list_directory tools. Do not execute any commands or \
+             write any files."
+        )
+    })
+}
 
 impl ZephAcpAgentState {
     /// Dispatch a slash command, returning a short-circuit `PromptResponse`.
@@ -33,9 +66,6 @@ impl ZephAcpAgentState {
             // out of sync with the real command set (49 commands).
             "/help" => zeph_commands::render_help_text(),
             "/model" => self.handle_model_command(session_id, arg).await?,
-            "/review" => {
-                return self.handle_review_command(session_id, arg);
-            }
             "/mode" => {
                 let valid_ids: &[&str] = &["code", "architect", "ask"];
                 if !valid_ids.contains(&arg) {
@@ -108,61 +138,6 @@ impl ZephAcpAgentState {
         let notification = acp::schema::v1::SessionNotification::new(session_id.clone(), update);
         if let Err(e) = self.send_notification(session_id, notification).await {
             tracing::warn!(error = %e, "failed to send command reply");
-        }
-
-        Ok(acp::schema::v1::PromptResponse::new(
-            acp::schema::v1::StopReason::EndTurn,
-        ))
-    }
-
-    fn handle_review_command(
-        &self,
-        session_id: &acp::schema::v1::SessionId,
-        arg: &str,
-    ) -> acp::Result<acp::schema::v1::PromptResponse> {
-        // Validate arg to prevent prompt injection: allow only safe path characters.
-        if !arg.is_empty() {
-            let valid = arg
-                .chars()
-                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '/' | ' ' | '-'));
-            if !valid || arg.len() > 512 {
-                return Err(acp::Error::invalid_request()
-                    .data("invalid path argument: only alphanumeric, _, ., /, space, - allowed (max 512 chars)"));
-            }
-        }
-        let review_prompt = if arg.is_empty() {
-            "Review the recent changes in this workspace. Show a plain-text diff summary. \
-             Use only read_file and list_directory tools. Do not execute any commands or \
-             write any files."
-                .to_owned()
-        } else {
-            format!(
-                "Review the following file or path: {arg}. Show a plain-text diff summary. \
-                 Use only read_file and list_directory tools. Do not execute any commands or \
-                 write any files."
-            )
-        };
-
-        let tx = self
-            .sessions
-            .lock()
-            .get(session_id)
-            .map(|e| e.input_tx.clone());
-        let Some(tx) = tx else {
-            return Err(acp::Error::invalid_request().data("session not found"));
-        };
-        if tx
-            .try_send(ChannelMessage {
-                text: review_prompt,
-                attachments: vec![],
-                is_guest_context: false,
-                is_from_bot: false,
-                // #6419: see do_prompt above.
-                owner_key: Some(self.owner_key.clone()),
-            })
-            .is_err()
-        {
-            tracing::warn!(%session_id, "failed to forward /review to agent input");
         }
 
         Ok(acp::schema::v1::PromptResponse::new(
@@ -479,19 +454,47 @@ mod owner_key_threading_tests {
     async fn review_command_threads_connection_owner_key_into_channel_message() {
         let (agent, session_id, mut channel) = make_agent_with_owner_key("acp:alice");
 
+        let review_request = acp::schema::v1::PromptRequest::new(
+            session_id.clone(),
+            vec![acp::schema::v1::ContentBlock::Text(
+                acp::schema::v1::TextContent::new("/review".to_owned()),
+            )],
+        );
+
+        // #6673: `/review` is now routed through the normal `do_prompt` turn machinery, so a
+        // stand-in "agent loop" must receive the forwarded prompt and flush to end the turn —
+        // unlike the pre-#6673 fire-and-forget dispatch this test used to exercise directly.
+        let agent_loop = tokio::spawn(async move {
+            let msg = channel
+                .recv()
+                .await
+                .expect("recv must not error")
+                .expect("do_prompt must forward the expanded /review prompt");
+            channel.flush_chunks().await.unwrap();
+            msg
+        });
+
         agent
-            .handle_review_command(&session_id, "")
+            .do_prompt(review_request)
+            .await
             .expect("/review must succeed");
 
-        let msg = channel
-            .recv()
+        let msg = agent_loop
             .await
-            .expect("recv must not error")
-            .expect("handle_review_command must forward a ChannelMessage");
+            .expect("agent-loop stand-in must not panic");
         assert_eq!(
             msg.owner_key.as_deref(),
             Some("acp:alice"),
             "/review must carry the connection's owner_key, not fall back to None/local"
+        );
+        // Guards against a mutation that deletes the `build_review_prompt` expansion (e.g.
+        // forwarding the raw "/review" text unchanged): only the owner_key threading would
+        // still be exercised by the assertion above, since it doesn't depend on the prompt
+        // text at all.
+        assert_eq!(
+            msg.text,
+            build_review_prompt("").expect("empty arg must always build successfully"),
+            "do_prompt must forward /review's build_review_prompt expansion, not raw text"
         );
     }
 

--- a/crates/zeph-acp/src/agent/turn.rs
+++ b/crates/zeph-acp/src/agent/turn.rs
@@ -329,11 +329,9 @@ impl ZephAcpAgentState {
     /// event still queued at this point is provably an orphan left over from a prior turn, not
     /// something the turn about to start could have produced yet. A late post-flush `Usage`
     /// event discarded this way is intentional, not a bug: attributing it to the *next* turn's
-    /// accounting would misattribute cost/tokens to the wrong prompt. Note this drain is not
-    /// side-effect-free in every case: `/review` (`handle_review_command`) dispatches via
-    /// `input_tx.try_send` and returns `EndTurn` immediately without ever calling this method,
-    /// so its live output events — not leftovers from an aborted turn, but genuine outputs of
-    /// a fire-and-forget prompt that never had a reader — are silently discarded here too.
+    /// accounting would misattribute cost/tokens to the wrong prompt. `/review` (#6673) is routed
+    /// through this same method like any other prompt, so it no longer has the fire-and-forget
+    /// gap this note used to describe.
     fn acquire_prompt_channels(
         &self,
         session_id: &acp::schema::v1::SessionId,
@@ -386,11 +384,27 @@ impl ZephAcpAgentState {
             .await?;
 
         let trimmed_text = text.trim_start();
-        if trimmed_text.starts_with('/') && is_acp_native_slash_command(trimmed_text) {
+        // #6673: `/review` must go through the normal acquire_prompt_channels/drain turn path
+        // below like any other prompt, so its output is actually delivered to the client —
+        // unlike the other ACP-native slash commands, which reply synchronously via
+        // `handle_slash_command`'s short-circuit `EndTurn` and never touch the agent loop's
+        // real output channel. Parsed the same way `handle_slash_command` splits cmd/arg —
+        // including trimming the command token on *both* ends, not just leading whitespace
+        // via `trim_start` above, so trailing whitespace (`"/review\n"`, `"/review\t"`) still
+        // matches `/review` exactly like it does for `handle_slash_command`'s other commands,
+        // instead of falling through as a raw prompt. `/reviewfoo` (no separating space) is
+        // still correctly left as an ordinary prompt, not mistaken for `/review`.
+        let mut review_parts = trimmed_text.splitn(2, ' ');
+        let text = if review_parts.next().map(str::trim) == Some("/review") {
+            let arg = review_parts.next().unwrap_or("").trim();
+            super::slash::build_review_prompt(arg)?
+        } else if trimmed_text.starts_with('/') && is_acp_native_slash_command(trimmed_text) {
             return self
                 .handle_slash_command(&args.session_id, trimmed_text)
                 .await;
-        }
+        } else {
+            text
+        };
 
         let (input_tx, output_rx, generation) = self.acquire_prompt_channels(&args.session_id)?;
         let mut channel_guard =
@@ -1126,5 +1140,51 @@ mod output_rx_leak_regression_tests {
             !agent.sessions.lock().contains_key(&session_id),
             "Drop must not re-insert a session entry that was removed while the turn was in flight"
         );
+    }
+
+    /// Regression test for #6673: `/review` must go through the same
+    /// `acquire_prompt_channels` contention check as every other prompt, instead of bypassing
+    /// it via the old fire-and-forget `handle_review_command` dispatch (which never took
+    /// `output_rx`, so it could run concurrently with an in-flight turn and its own output
+    /// would go nowhere). The sharpest observable proof the routing actually changed: with a
+    /// turn already holding the receiver, `/review` must now fail with the same "prompt
+    /// already in progress" error `acquire_prompt_channels` raises for any other prompt —
+    /// before the fix, it would have short-circuited to `EndTurn` regardless.
+    #[tokio::test]
+    async fn review_command_rejects_when_a_turn_is_already_in_progress() {
+        // Also covers the trailing-whitespace regression fixed alongside this test: `"/review"`
+        // is only leading-trimmed by `do_prompt` before the command-token split, so a naive
+        // `review_parts.next() == Some("/review")` comparison (without `.map(str::trim)` on the
+        // extracted token) would fail to recognize `"/review\n"`/`"/review\t"` as the command at
+        // all, falling through as an ordinary prompt instead of hitting this contention check —
+        // silently *passing* this test for the wrong reason (the contention error would never
+        // fire, but only because the command wasn't recognized, not because it was rejected).
+        for text in ["/review", "/review\n", "/review\t"] {
+            let spawner: AgentSpawner = Arc::new(|_ch, _ctx, _sc| Box::pin(async {}));
+            let agent = ZephAcpAgent::new(spawner, 4, 1800, None);
+            let (session_id, _channel) =
+                register_test_session(&agent, &format!("review-contention-session-{text:?}"));
+
+            // Simulate a turn already in flight by taking the receiver out directly, exactly
+            // what `do_prompt`'s own `acquire_prompt_channels` call would have done.
+            let _held = agent
+                .acquire_prompt_channels(&session_id)
+                .expect("first acquire must succeed");
+
+            let err = match agent.do_prompt(text_prompt_request(session_id, text)).await {
+                Ok(resp) => panic!(
+                    "{text:?} must be rejected while another turn is in progress, not silently \
+                     accepted as an ordinary prompt (got {:?})",
+                    resp.stop_reason
+                ),
+                Err(e) => e,
+            };
+            assert_eq!(
+                err.data.as_ref().and_then(serde_json::Value::as_str),
+                Some("prompt already in progress"),
+                "expected the same contention error acquire_prompt_channels raises for any \
+                 other prompt for input {text:?}, got: {err}"
+            );
+        }
     }
 }

--- a/crates/zeph-acp/tests/integration.rs
+++ b/crates/zeph-acp/tests/integration.rs
@@ -53,6 +53,38 @@ fn multi_turn_echo_spawner() -> AgentSpawner {
     })
 }
 
+/// Spawner that never completes on its own — awaits `pending()` forever, ignoring the
+/// channel and `cancel_signal` entirely — so the only way this task ever stops is via
+/// `JoinHandle::abort()` (#6674 regression coverage).
+///
+/// `started` is notified once the task begins running (so tests can wait for it before
+/// racing a close/delete against it); `alive` flips to `false` only when the task's future
+/// is actually dropped — by the runtime unwinding an aborted task, or (if the fix regresses)
+/// never, if nothing ever aborts it. Checking `alive` right after `session/close` or
+/// `session/delete` completes is a direct, non-flaky proof that the loop task was joined
+/// before the response went out, not just signaled and left to run.
+fn hanging_spawner(
+    started: Arc<tokio::sync::Notify>,
+    alive: Arc<std::sync::atomic::AtomicBool>,
+) -> AgentSpawner {
+    Arc::new(move |_channel, _ctx, _session| {
+        let started = Arc::clone(&started);
+        let alive = Arc::clone(&alive);
+        Box::pin(async move {
+            struct ClearOnDrop(Arc<std::sync::atomic::AtomicBool>);
+            impl Drop for ClearOnDrop {
+                fn drop(&mut self) {
+                    self.0.store(false, std::sync::atomic::Ordering::SeqCst);
+                }
+            }
+            alive.store(true, std::sync::atomic::Ordering::SeqCst);
+            let _clear_on_drop = ClearOnDrop(alive);
+            started.notify_one();
+            std::future::pending::<()>().await;
+        })
+    })
+}
+
 /// Spawner that sends N text chunks then flushes.
 fn text_chunks_spawner(chunks: Vec<&'static str>) -> AgentSpawner {
     Arc::new(move |mut channel, _ctx, _session| {
@@ -601,6 +633,90 @@ async fn drain_until_stop_collects_text_chunks() {
         .await;
 }
 
+/// Regression test for #6673: `/review`'s output must actually reach the client, not be
+/// silently discarded. `close_session_aborts_agent_loop_task`-style unit tests already prove
+/// `/review` is *dispatched* correctly, but that alone doesn't prove the client ever *sees*
+/// the agent's response — before this fix, `handle_review_command` bypassed
+/// `acquire_prompt_channels` entirely, so the agent loop's `AgentMessageChunk` notifications
+/// either leaked into the next unrelated turn (pre-#6666/#6667) or were silently drained and
+/// discarded by the next turn's `acquire_prompt_channels` (post-#6666/#6667) — either way, the
+/// client issuing `/review` never received its own output. This test registers a real
+/// `session/update` notification handler (mirroring the ACP client examples' pattern) so it can
+/// assert on content actually delivered over the wire, not just on `PromptResponse.stop_reason`.
+#[tokio::test(flavor = "current_thread")]
+async fn review_command_output_is_delivered_to_client() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let workdir = temp_workdir();
+            let (sw, sr, cw, cr) = duplex_pair();
+            let server_fut = serve_connection(
+                text_chunks_spawner(vec!["review", " ", "output"]),
+                test_config("test-agent"),
+                sw,
+                sr,
+                "acp-local".to_owned(),
+            );
+            let collected = Arc::new(std::sync::Mutex::new(String::new()));
+            let collected_for_handler = Arc::clone(&collected);
+            let client_fut = acp::Client
+                .builder()
+                .on_receive_notification(
+                    move |notification: acp::schema::v1::SessionNotification, _cx| {
+                        let collected = Arc::clone(&collected_for_handler);
+                        async move {
+                            if let acp::schema::v1::SessionUpdate::AgentMessageChunk(chunk) =
+                                notification.update
+                                && let acp::schema::v1::ContentBlock::Text(text) = chunk.content
+                            {
+                                collected.lock().unwrap().push_str(&text.text);
+                            }
+                            Ok(())
+                        }
+                    },
+                    acp::on_receive_notification!(),
+                )
+                .connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                    cx.send_request(acp::schema::v1::InitializeRequest::new(
+                        acp::schema::ProtocolVersion::LATEST,
+                    ))
+                    .block_task()
+                    .await?;
+
+                    let session_id = cx
+                        .send_request(acp::schema::v1::NewSessionRequest::new(workdir.path()))
+                        .block_task()
+                        .await?
+                        .session_id;
+
+                    let content = vec![acp::schema::v1::ContentBlock::Text(
+                        acp::schema::v1::TextContent::new("/review"),
+                    )];
+                    let resp = cx
+                        .send_request(acp::schema::v1::PromptRequest::new(session_id, content))
+                        .block_task()
+                        .await?;
+
+                    assert_eq!(resp.stop_reason, acp::schema::v1::StopReason::EndTurn);
+                    Ok(())
+                });
+            tokio::select! {
+                res = server_fut => panic!("server exited before client: {res:?}"),
+                result = client_fut => {
+                    assert!(result.is_ok(), "review round-trip test failed: {result:?}");
+                }
+            }
+            assert_eq!(
+                *collected.lock().unwrap(),
+                "review output",
+                "the spawner's chunks must have reached the client as AgentMessageChunk \
+                 notifications — before #6673 this would be empty since /review never called \
+                 acquire_prompt_channels"
+            );
+        })
+        .await;
+}
+
 /// AC #10: `session/cancel` prior to prompt causes the prompt to complete with
 /// `StopReason::Cancelled`.
 ///
@@ -962,6 +1078,115 @@ async fn delete_session_removes_session_from_list() {
                     .await
                     .expect("acp_session_exists query failed"),
                 "deleted session must not survive in the persistence store"
+            );
+        })
+        .await;
+}
+
+/// `session/close` must abort and await the session's agent-loop task before returning, so a
+/// task left running past the close can never keep emitting events/notifications under a
+/// `SessionId` that may be reused by a later `session/load`/`session/resume` (#6674).
+#[tokio::test(flavor = "current_thread")]
+async fn close_session_aborts_agent_loop_task() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let workdir = temp_workdir();
+            let started = Arc::new(tokio::sync::Notify::new());
+            let alive = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let (sw, sr, cw, cr) = duplex_pair();
+            let server_fut = serve_connection(
+                hanging_spawner(Arc::clone(&started), Arc::clone(&alive)),
+                test_config("test-agent"),
+                sw,
+                sr,
+                "acp-local".to_owned(),
+            );
+            let started_for_client = Arc::clone(&started);
+            let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                cx.send_request(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .block_task()
+                .await?;
+
+                let session_id = cx
+                    .send_request(acp::schema::v1::NewSessionRequest::new(workdir.path()))
+                    .block_task()
+                    .await?
+                    .session_id;
+
+                // Wait for the agent-loop task to actually start running before racing close
+                // against it — otherwise a close that lands before the task is even polled
+                // once would pass vacuously.
+                started_for_client.notified().await;
+
+                cx.send_request(acp::schema::v1::CloseSessionRequest::new(session_id))
+                    .block_task()
+                    .await?;
+                Ok(())
+            });
+            tokio::select! {
+                res = server_fut => panic!("server exited before client: {res:?}"),
+                result = client_fut => {
+                    assert!(result.is_ok(), "close_session test failed: {result:?}");
+                }
+            }
+            assert!(
+                !alive.load(std::sync::atomic::Ordering::SeqCst),
+                "agent-loop task must be aborted and joined before session/close returns"
+            );
+        })
+        .await;
+}
+
+/// Same guarantee as `close_session_aborts_agent_loop_task`, for `session/delete` (#6674).
+#[tokio::test(flavor = "current_thread")]
+async fn delete_session_aborts_agent_loop_task() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let workdir = temp_workdir();
+            let started = Arc::new(tokio::sync::Notify::new());
+            let alive = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let (sw, sr, cw, cr) = duplex_pair();
+            let server_fut = serve_connection(
+                hanging_spawner(Arc::clone(&started), Arc::clone(&alive)),
+                test_config("test-agent"),
+                sw,
+                sr,
+                "acp-local".to_owned(),
+            );
+            let started_for_client = Arc::clone(&started);
+            let client_fut = acp::Client.connect_with(acp::ByteStreams::new(cw, cr), async |cx| {
+                cx.send_request(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .block_task()
+                .await?;
+
+                let session_id = cx
+                    .send_request(acp::schema::v1::NewSessionRequest::new(workdir.path()))
+                    .block_task()
+                    .await?
+                    .session_id;
+
+                started_for_client.notified().await;
+
+                cx.send_request(acp::schema::v1::DeleteSessionRequest::new(session_id))
+                    .block_task()
+                    .await?;
+                Ok(())
+            });
+            tokio::select! {
+                res = server_fut => panic!("server exited before client: {res:?}"),
+                result = client_fut => {
+                    assert!(result.is_ok(), "delete_session test failed: {result:?}");
+                }
+            }
+            assert!(
+                !alive.load(std::sync::atomic::Ordering::SeqCst),
+                "agent-loop task must be aborted and joined before session/delete returns"
             );
         })
         .await;


### PR DESCRIPTION
## Summary

- `do_close_session`/`do_delete_session` previously only fired `cancel_signal.notify_one()` without joining or aborting the session's agent-loop task, so a `session/load`/`session/resume` reusing the same `SessionId` could race a still-running old loop and corrupt the new turn's event stream. `SessionEntry` now tracks the loop's `JoinHandle`; close/delete abort and await it (5s bounded timeout) before the entry is dropped, and `Drop for SessionEntry` also aborts it unconditionally as a safety net covering the LRU-eviction/reaper removal paths.
- `/review` previously dispatched fire-and-forget via `input_tx.try_send` and returned `EndTurn` immediately, bypassing `acquire_prompt_channels`. After PR #6672's inter-turn drain fix, `/review`'s output was silently discarded instead of leaking into the next turn. `/review` is now intercepted in `do_prompt` and routed through the normal `acquire_prompt_channels`/drain turn path like any other prompt, so its output actually reaches the client. This is a client-visible behavior change: `/review` now participates in the same turn-contention check as any other prompt (can be rejected with "prompt already in progress") and its expanded prompt is persisted/replayed as part of session history.

Both issues were follow-up findings from PR #6672's review. Went through two rounds of adversarial critique: the first found a real gap where `set_agent_loop_handle` could silently drop a `JoinHandle` if the session entry was removed before the loop was fully wired up (fixed: aborts immediately instead), and a `/review` trailing-whitespace parsing regression (fixed: trim both ends to match `handle_slash_command`'s existing parity). The second round re-verified both fixes and found no new gaps.

Closes #6674
Closes #6673

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler"` (zeph-acp, zeph-common, zeph-core scopes) — 2736 passed
- [x] `cargo nextest run` full `zeph-acp` package scope (including `tests/integration.rs`, not just `--lib --bins`) — 235/235 passed, including all 5 new/changed regression tests:
  - `close_session_aborts_agent_loop_task`, `delete_session_aborts_agent_loop_task` (prove the old loop is actually aborted+joined, not just signaled)
  - `review_command_output_is_delivered_to_client` (positive round-trip proving `/review`'s output reaches the client)
  - `review_command_rejects_when_a_turn_is_already_in_progress` (loops over `["/review", "/review\n", "/review\t"]` to lock in the trim fix)
  - `review_command_threads_connection_owner_key_into_channel_message` (now also asserts the forwarded text matches the expanded review prompt)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `gitleaks protect --staged`
- [x] `CHANGELOG.md` updated under `[Unreleased]`/`Fixed`