### PR TITLE
fix: remove wall-clock-timing races from 3 flaky zeph-core tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   session — every event still queued at that point is provably an orphan from a prior turn —
   closing the whole inter-turn window instead of one snapshot; `Drop`'s drain remains as a cheap
   early filter.
+- `zeph-core`: fixed 3 flaky timing-based test assertions (issue #6679) that inferred
+  concurrency or non-blocking behavior from fixed wall-clock thresholds, which could
+  spuriously fail under CI load. `after_tool_hooks_run_concurrently_across_tier_indices`
+  now asserts a structural max-in-flight high-water mark (an atomic counter around
+  in-process `RuntimeLayer::after_tool` calls) instead of comparing elapsed time against
+  `N * per-task-delay`. `pre_tool_use_hooks_fire_concurrently_across_tier_indices` (subprocess-
+  based `PreToolUse` hooks, `#[cfg(unix)]`) uses a two-phase rendezvous barrier instead: every
+  hook invocation must individually observe all `N` markers present before creating a witness
+  file, which serial dispatch can never satisfy — this replaced an earlier marker-file-poller
+  draft that still raced a fixed sleep against subprocess-start spread (caught in review).
+  `dump_request_smoke_returns_promptly_and_write_still_lands` is replaced by
+  `dump_request_returns_before_blocking_write_completes`, which uses a test-only
+  `TestWriteGate` channel handshake (with a 30s bound so a regression to an inline write path
+  fails with a clear panic instead of hanging the CI shard) to prove `dump_request` returns
+  before its `spawn_blocking` write completes, with no timing race window at all.
 
 ## [0.22.3] - 2026-07-22
 ### Fixed

--- a/crates/zeph-core/src/agent/tool_execution/tests/apply_tier_results_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/apply_tier_results_tests.rs
@@ -6,8 +6,9 @@
 
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use zeph_llm::provider::ToolUseRequest;
 use zeph_tools::ToolError;
@@ -19,11 +20,16 @@ use crate::agent::agent_tests::{
 use crate::runtime_layer::{LayerContext, RuntimeLayer};
 
 /// `RuntimeLayer` whose `after_tool` sleeps and records every `tool_call_id` it observed, so
-/// tests can assert both concurrency (elapsed time) and per-index correctness (every index seen
-/// exactly once).
+/// tests can assert both concurrency (structurally, via a max-in-flight counter — see #6679)
+/// and per-index correctness (every index seen exactly once).
 struct DelayRecordingLayer {
     delay: Duration,
     seen: Arc<Mutex<Vec<String>>>,
+    /// Number of `after_tool` calls currently inside their sleep.
+    in_flight: AtomicUsize,
+    /// High-water mark of `in_flight`, i.e. the largest number of `after_tool` calls ever
+    /// observed running simultaneously.
+    max_in_flight: AtomicUsize,
 }
 
 impl RuntimeLayer for DelayRecordingLayer {
@@ -34,7 +40,10 @@ impl RuntimeLayer for DelayRecordingLayer {
         _result: &'a Result<Option<ToolOutput>, ToolError>,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
         Box::pin(async move {
+            let current = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            self.max_in_flight.fetch_max(current, Ordering::SeqCst);
             tokio::time::sleep(self.delay).await;
+            self.in_flight.fetch_sub(1, Ordering::SeqCst);
             self.seen.lock().unwrap().push(call.tool_call_id.clone());
         })
     }
@@ -49,13 +58,21 @@ fn make_tool_use_request(id: &str, name: &str) -> ToolUseRequest {
 }
 
 /// N tool results land in a single tier, each with a `RuntimeLayer::after_tool` that sleeps.
-/// Serial processing (the pre-#6128 behavior) would take N * delay; concurrent processing
-/// should stay close to a single delay regardless of N.
+/// Concurrency is proven structurally via a max-in-flight counter (#6679) rather than by
+/// racing wall-clock elapsed time against `N * delay`: serial processing (the pre-#6128
+/// behavior) could never observe more than 1 hook in flight at once, while concurrent
+/// processing must observe all N simultaneously in flight at some point.
 #[tokio::test]
 async fn after_tool_hooks_run_concurrently_across_tier_indices() {
     let n = 5;
-    let delay = Duration::from_millis(60);
+    let delay = Duration::from_millis(150);
     let seen: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let layer = Arc::new(DelayRecordingLayer {
+        delay,
+        seen: Arc::clone(&seen),
+        in_flight: AtomicUsize::new(0),
+        max_in_flight: AtomicUsize::new(0),
+    });
 
     let provider = mock_provider(vec![]);
     let channel = MockChannel::new(vec![]);
@@ -63,25 +80,17 @@ async fn after_tool_hooks_run_concurrently_across_tier_indices() {
     let executor = MockToolExecutor::new((0..n).map(|_| Ok(None)).collect());
     let mut agent = crate::agent::Agent::new(provider, channel, registry, None, 5, executor);
     agent.runtime.config.timeouts.max_parallel_tools = n;
-    agent
-        .runtime
-        .config
-        .layers
-        .push(Arc::new(DelayRecordingLayer {
-            delay,
-            seen: Arc::clone(&seen),
-        }));
+    let layer_dyn: Arc<dyn RuntimeLayer> = layer.clone();
+    agent.runtime.config.layers.push(layer_dyn);
 
     let tool_calls: Vec<ToolUseRequest> = (0..n)
         .map(|i| make_tool_use_request(&format!("id-{i}"), "noop"))
         .collect();
 
-    let start = Instant::now();
     agent
         .handle_native_tool_calls(None, &tool_calls)
         .await
         .unwrap();
-    let elapsed = start.elapsed();
 
     let seen = seen.lock().unwrap();
     assert_eq!(
@@ -95,9 +104,15 @@ async fn after_tool_hooks_run_concurrently_across_tier_indices() {
         n,
         "each tool result's after_tool call must carry its own tool_call_id, not a shared one"
     );
-    assert!(
-        elapsed < delay * u32::try_from(n).unwrap(),
-        "after_tool hooks appear to have run serially: took {elapsed:?} for {n} x {delay:?}"
+    // This proof assumes all n `after_tool` futures are polled within a single `join_all` pass
+    // on one task, with the semaphore permit count == n (#6679 review D2); revisit if the
+    // dispatch mechanism moves to a per-index `tokio::spawn`, or if the permit count is ever
+    // clamped below n (e.g. by available CPU count).
+    assert_eq!(
+        layer.max_in_flight.load(Ordering::SeqCst),
+        n,
+        "after_tool hooks must all be in flight simultaneously at some point — serial \
+         processing could never exceed 1 concurrent hook"
     );
 }
 

--- a/crates/zeph-core/src/agent/tool_execution/tests/pre_tool_use_concurrency_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/pre_tool_use_concurrency_tests.rs
@@ -6,8 +6,11 @@
 //! per-index gate-check loop (Phase 2). Mirrors `apply_tier_results_tests.rs`'s coverage of
 //! the already-fixed `PostToolUse`/`RuntimeLayer::after_tool` twin (#6128).
 
-use std::time::{Duration, Instant};
+#[cfg(unix)]
+use std::path::Path;
 
+#[cfg(unix)]
+use tempfile::tempdir;
 use zeph_config::{HookAction, HookDef, HookMatcher};
 use zeph_llm::provider::{Message, MessagePart, Role, ToolUseRequest};
 
@@ -23,26 +26,76 @@ fn make_tool_use_request(id: &str, name: &str) -> ToolUseRequest {
     }
 }
 
-fn sleep_hook(secs: f64) -> HookDef {
+/// Bound (in 50ms polling ticks) on each phase of the rendezvous barrier below: 60 ticks is
+/// at least ~3s of wall time — real duration scales up under load, since each tick forks a
+/// subshell to evaluate the glob.
+#[cfg(unix)]
+const BARRIER_PHASE_TICKS: u32 = 60;
+
+/// A `PreToolUse` hook that proves n-way concurrency via a two-phase rendezvous barrier
+/// (#6679) instead of racing a fixed sleep against subprocess-start spread. Each invocation:
+/// 1. creates a uniquely-named marker file under `marker_dir`;
+/// 2. spins (bounded by `BARRIER_PHASE_TICKS`) until it observes `n` markers — the arrival
+///    barrier, satisfiable only once every hook invocation has started;
+/// 3. on success, creates a uniquely-named witness file under `witness_dir`, then spins
+///    (bounded) until it observes `n` witnesses — the departure barrier, which keeps every
+///    marker alive until every invocation has individually confirmed the arrival barrier, so
+///    no marker can be removed out from under a still-spinning sibling;
+/// 4. removes its own marker and exits.
+///
+/// Serial dispatch can never satisfy the arrival barrier (hook 2..n are not scheduled until
+/// hook 1 returns), so a regressed hook exhausts its bound without creating a witness, and the
+/// test's `witness_count == n` assertion fails deterministically. Directory paths are quoted in
+/// the shell template (#6679 review M2). `mktemp "<dir>"/marker.XXXXXX` is portable to both GNU
+/// and BSD (macOS) `mktemp`; hooks run with `env_clear()` (hooks.rs), so the directory is passed
+/// explicitly rather than relying on `$TMPDIR`.
+#[cfg(unix)]
+fn rendezvous_hook(marker_dir: &Path, witness_dir: &Path, n: usize) -> HookDef {
+    let marker_dir = marker_dir.display();
+    let witness_dir = witness_dir.display();
+    let ticks = BARRIER_PHASE_TICKS;
     HookDef {
         action: HookAction::Command {
-            command: format!("sleep {secs}"),
+            command: format!(
+                "f=$(mktemp \"{marker_dir}\"/marker.XXXXXX) && \
+                 ok=0 && i=0 && \
+                 while [ \"$i\" -lt {ticks} ]; do \
+                   set -- \"{marker_dir}\"/marker.*; count=$#; \
+                   if [ \"$count\" -ge {n} ]; then ok=1; break; fi; \
+                   i=$((i + 1)); sleep 0.05; \
+                 done && \
+                 if [ \"$ok\" -eq 1 ]; then \
+                   mktemp \"{witness_dir}\"/witness.XXXXXX >/dev/null && \
+                   j=0 && \
+                   while [ \"$j\" -lt {ticks} ]; do \
+                     set -- \"{witness_dir}\"/witness.*; wcount=$#; \
+                     if [ \"$wcount\" -ge {n} ]; then break; fi; \
+                     j=$((j + 1)); sleep 0.05; \
+                   done; \
+                 fi; \
+                 rm -f \"$f\""
+            ),
         },
-        timeout_secs: 5,
+        timeout_secs: 25,
         fail_closed: false,
         r#if: None,
     }
 }
 
-/// N tool calls land in a single tier, each matching a `PreToolUse` hook that sleeps.
-/// Serial hook dispatch (the pre-#6259 behavior) would take N * delay; concurrent dispatch
-/// (Phase 1, bounded by the tier semaphore) should stay close to a single delay regardless
-/// of N.
+/// N tool calls land in a single tier, each matching a `PreToolUse` hook that runs the
+/// two-phase rendezvous barrier documented on [`rendezvous_hook`]. Concurrency is proven
+/// structurally: every hook invocation must individually observe all `n` markers present
+/// simultaneously to create its witness file, which is only reachable under concurrent
+/// dispatch (Phase 1, bounded by the tier semaphore) — serial hook dispatch (the pre-#6259
+/// behavior) can never satisfy it, since hook 2..n are not even scheduled until hook 1 returns.
+/// This removes the fixed-sleep-vs-subprocess-spawn-spread race the original marker-file-poller
+/// rewrite still carried (#6679 review, gap S1).
+#[cfg(unix)]
 #[tokio::test]
 async fn pre_tool_use_hooks_fire_concurrently_across_tier_indices() {
     let n = 4;
-    let delay_secs = 0.06;
-    let delay = Duration::from_millis(60);
+    let marker_dir = tempdir().unwrap();
+    let witness_dir = tempdir().unwrap();
 
     let provider = mock_provider(vec![]);
     let channel = MockChannel::new(vec![]);
@@ -52,7 +105,7 @@ async fn pre_tool_use_hooks_fire_concurrently_across_tier_indices() {
     agent.runtime.config.timeouts.max_parallel_tools = n;
     agent.services.session.hooks_config.pre_tool_use = vec![HookMatcher {
         matcher: "noop".to_owned(),
-        hooks: vec![sleep_hook(delay_secs)],
+        hooks: vec![rendezvous_hook(marker_dir.path(), witness_dir.path(), n)],
     }];
     agent
         .msg
@@ -63,16 +116,16 @@ async fn pre_tool_use_hooks_fire_concurrently_across_tier_indices() {
         .map(|i| make_tool_use_request(&format!("id-{i}"), "noop"))
         .collect();
 
-    let start = Instant::now();
     agent
         .handle_native_tool_calls(None, &tool_calls)
         .await
         .unwrap();
-    let elapsed = start.elapsed();
 
-    assert!(
-        elapsed < delay * u32::try_from(n).unwrap(),
-        "PreToolUse hooks appear to have fired serially: took {elapsed:?} for {n} x {delay:?}"
+    let witness_count = std::fs::read_dir(witness_dir.path()).map_or(0, std::iter::Iterator::count);
+    assert_eq!(
+        witness_count, n,
+        "every PreToolUse hook invocation must individually observe all {n} markers present \
+         simultaneously — serial dispatch can never satisfy this rendezvous barrier"
     );
 
     // Every call must still have proceeded to execution (hook is fail_open and succeeds).

--- a/crates/zeph-core/src/debug_dump/mod.rs
+++ b/crates/zeph-core/src/debug_dump/mod.rs
@@ -28,6 +28,11 @@ pub struct DebugDumper {
     counter: Arc<AtomicU32>,
     format: DumpFormat,
     include_raw_images: bool,
+    /// Test-only synchronization gate for [`Self::write`]'s blocking-pool task (#6679). Lets
+    /// tests prove "returns before the write completes" structurally via a channel handshake
+    /// instead of racing a wall-clock budget against real disk I/O.
+    #[cfg(test)]
+    test_write_gate: Option<Arc<TestWriteGate>>,
 }
 
 pub struct RequestDebugDump<'a> {
@@ -60,6 +65,8 @@ impl DebugDumper {
             counter: Arc::new(AtomicU32::new(0)),
             format,
             include_raw_images: false,
+            #[cfg(test)]
+            test_write_gate: None,
         })
     }
 
@@ -112,6 +119,8 @@ impl DebugDumper {
     fn write(&self, filename: &str, content: &[u8]) {
         let path = self.dir.join(filename);
         let content = content.to_vec();
+        #[cfg(test)]
+        let gate = self.test_write_gate.clone();
         // Ask-First exception to rust-code.md's Await Discipline rule #2 ("fire-and-forget
         // tasks MUST be tracked, never drop a JoinHandle"): this handle is deliberately
         // dropped, untracked. Rationale: this is a debug-only diagnostic path (opt-in,
@@ -123,6 +132,10 @@ impl DebugDumper {
         // for this fix. Recorded here per the exception clause in
         // .claude/rules/continuous-improvement.md rather than left as a silent deviation.
         tokio::task::spawn_blocking(move || {
+            #[cfg(test)]
+            if let Some(gate) = gate {
+                gate.block_until_released();
+            }
             if let Err(e) = zeph_common::fs_secure::atomic_write_private(&path, &content) {
                 tracing::warn!(path = %path.display(), error = %e, "debug dump write failed");
             }
@@ -1069,6 +1082,43 @@ fn part_to_block(part: &MessagePart, is_assistant: bool) -> Option<serde_json::V
     }
 }
 
+/// Test-only synchronization gate for [`DebugDumper::write`]'s blocking-pool task. Proves the
+/// "`dump_request` returns before its write completes" property structurally via a channel
+/// handshake (#6679) instead of racing a wall-clock budget against real disk I/O: the write
+/// task signals `started_tx` once dispatched, then blocks until the test releases it.
+///
+/// Single-release only: `block_until_released` calls `recv_timeout` exactly once per gated
+/// `write()` call. A second gated write in the same test (e.g. `dump_response`/
+/// `dump_tool_output` sharing this gate) would find `release_rx` already drained and park until
+/// the 30s timeout below, panicking rather than proceeding — construct a fresh `TestWriteGate`
+/// per gated write rather than reusing one across multiple writes.
+#[cfg(test)]
+struct TestWriteGate {
+    started_tx: std::sync::Mutex<Option<std::sync::mpsc::Sender<()>>>,
+    release_rx: std::sync::Mutex<std::sync::mpsc::Receiver<()>>,
+}
+
+#[cfg(test)]
+impl TestWriteGate {
+    fn block_until_released(&self) {
+        if let Some(tx) = self.started_tx.lock().unwrap().take() {
+            let _ = tx.send(());
+        }
+        // Bounded: a genuine regression to an inline (non-`spawn_blocking`) write path would
+        // otherwise call this on the test's own execution thread and block it forever (#6679
+        // review S2), hanging the CI shard up to the job-level timeout instead of failing
+        // cleanly. `recv_timeout` turns that into an explicit panic.
+        self.release_rx
+            .lock()
+            .unwrap()
+            .recv_timeout(std::time::Duration::from_secs(30))
+            .expect(
+                "TestWriteGate not released within 30s — possible regression to an inline \
+                 (non-spawn_blocking) write path",
+            );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1495,22 +1545,30 @@ mod tests {
         );
     }
 
-    /// Smoke test for #6029: `dump_request` returns promptly and the write still lands
-    /// afterward. NOT a strict regression guard — a revert to a synchronous single-file write
-    /// would typically also complete in 1-3ms on a tmpfs-backed tempdir and would still pass
-    /// the 50ms budget below. The write path isn't injectable/mockable here, so a tighter
-    /// assertion (e.g. proving the write is dispatched to a *different* thread than the
-    /// caller) isn't practical without adding test-only instrumentation to `DebugDumper`. Keep
-    /// this as a coarse sanity check plus the file-existence check below, not proof of
-    /// non-blocking behavior.
+    /// Structural replacement (#6679) for the former wall-clock-budget smoke test: proves
+    /// `dump_request` returns to the caller strictly before its `spawn_blocking` write task can
+    /// possibly complete, using a [`TestWriteGate`] channel handshake instead of racing a
+    /// millisecond threshold against real disk I/O. The write task is parked on the gate the
+    /// instant it is dispatched, so checking `request_path.exists()` right after `dump_request`
+    /// returns has no race window: it can only be `false` at that point.
     #[tokio::test]
-    async fn dump_request_smoke_returns_promptly_and_write_still_lands() {
+    async fn dump_request_returns_before_blocking_write_completes() {
         let dir = tempdir().unwrap();
-        let dumper = DebugDumper::new(dir.path(), DumpFormat::Json).unwrap();
+        let mut dumper = DebugDumper::new(dir.path(), DumpFormat::Json).unwrap();
+        let dump_dir = dumper.dir().to_path_buf();
+
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        dumper.test_write_gate = Some(Arc::new(TestWriteGate {
+            started_tx: std::sync::Mutex::new(Some(started_tx)),
+            release_rx: std::sync::Mutex::new(release_rx),
+        }));
+
         let messages = sample_messages();
         let tools = sample_tools();
 
-        let start = std::time::Instant::now();
+        // `dump_request` is a plain synchronous fn; reaching this point already proves it did
+        // not block on the gated write below.
         let _ = dumper.dump_request(&RequestDebugDump {
             model_name: "test-model",
             messages: &messages,
@@ -1518,14 +1576,26 @@ mod tests {
             provider_request: serde_json::json!({ "model": "test-model", "max_tokens": 1024 }),
             memcot_state: None,
         });
-        // Coarse budget only (see doc comment above) — not a strict non-blocking proof.
+
+        // Confirm the write was actually dispatched to the blocking pool. The timeout here is
+        // only a deadlock guard against a genuine regression — not the property under test.
+        started_rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("write task never reached the gate: spawn_blocking dispatch regressed");
+
+        // The write task is parked on the gate, so the file cannot exist yet — proves the
+        // caller-visible return happened strictly before the write, with no timing race.
+        let request_path = dump_dir.join("0000-request.json");
         assert!(
-            start.elapsed() < std::time::Duration::from_millis(50),
-            "dump_request must return without waiting on the blocking write"
+            !request_path.exists(),
+            "write must still be gated: file must not exist before release"
         );
 
-        // The write still completes shortly afterward (fire-and-forget, not dropped).
-        let _ = read_request_dump(dir.path()).await;
+        // Release the gate and confirm the write still lands afterward (fire-and-forget, not
+        // dropped).
+        release_tx.send(()).unwrap();
+        let payload = read_request_dump(dir.path()).await;
+        assert_eq!(payload["model"], "test-model");
     }
 
     // --- Image redaction (#6306) ---


### PR DESCRIPTION
## Summary

Three tests inferred concurrency or non-blocking behavior from fixed wall-clock thresholds, which spuriously failed under CI load (confirmed on two consecutive GitHub Actions runs of the same commit on PR #6678):

- `after_tool_hooks_run_concurrently_across_tier_indices` (`apply_tier_results_tests.rs`) — replaced the elapsed-time-vs-`N*delay` comparison with an atomic max-in-flight high-water mark around the in-process `RuntimeLayer::after_tool` calls. Serial execution can never exceed 1, so `max_in_flight == n` is a sound structural proof.
- `pre_tool_use_hooks_fire_concurrently_across_tier_indices` (`pre_tool_use_concurrency_tests.rs`, `#[cfg(unix)]`) — `PreToolUse` hooks run as real subprocesses with no shared in-process memory, so this uses a two-phase rendezvous/witness barrier instead: every hook must individually observe all `N` markers present before creating a witness file, which serial dispatch can never satisfy. This replaced an earlier marker-file-poller draft that still raced a fixed sleep against subprocess-start spread (caught in review — the original CI failure showed ~980ms spread for 4x60ms hooks, exactly the kind of assumption this rewrite removes).
- `dump_request_smoke_returns_promptly_and_write_still_lands` -> `dump_request_returns_before_blocking_write_completes` (`debug_dump/mod.rs`) — replaced a 50ms wall-clock budget with a test-only `TestWriteGate` channel handshake (30s bound, so a regression to an inline write path fails with a clear panic instead of hanging the CI shard) that proves `dump_request` returns before its `spawn_blocking` write completes, with no timing race window at all.

No production behavior changed — only test assertions/instrumentation, plus a `#[cfg(test)]`-only field on `DebugDumper`.

Closes #6679

## Test plan

- [x] Targeted 10x+ repeated loop for the 3 rewritten tests, multiple rounds across the iteration cycle (final count: 0 flakes across 100+ combined runs)
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (15154 passed, 0 failed)
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`)
- [x] Independent adversarial review confirmed the barrier logic is sound (no false-pass path under serial dispatch, no hang path on regression) and the `#[cfg(unix)]` gating is complete