### PR TITLE
fix: remove wall-clock defect from performance_agent_integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -269,6 +269,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   A genuine hang is not caught by nextest's `slow-timeout` (warn-only, no `terminate-after`
   configured); it surfaces only coarsely, as CI's job-level `timeout-minutes: 10` killing the
   whole shard.
+- `tests/performance_agent_integration.rs`: removed the same flaky wall-clock defect class from
+  `agent_throughput_multiple_responses` (issue #6690, same class as #6687/#6679) — a fixed
+  `elapsed.as_secs() < 10` budget around a fully-mocked `Agent::run()` call, plus an unasserted
+  per-message throughput `println!`. Kept the structural `outputs.len() >= 5` assertion, which
+  proves all 5 mocked responses were actually processed and sent.
+- `tests/performance_agent_integration.rs`: fixed `tool_executor_overhead_is_minimal` (issue
+  #6689), which measured `Instant::now()`/`.elapsed()` around two adjacent statements with no
+  work between them, so its `< 10ms` assertion passed unconditionally regardless of any real
+  regression, and its `if let Some(time) = ...` guard meant the assertion was silently skipped
+  entirely whenever the mocked tool call never fired. Widening the timed region to cover the
+  mock's own bookkeeping (mutex locks, struct construction) was considered and rejected: it
+  still only measures test-scaffolding overhead, not a real tool-executor dispatch path, so it
+  can never catch a genuine regression — only widen the flake surface for no benefit, the same
+  defect class the sibling #6690/#6687/#6688 fixes exist to remove. Real dispatch/pattern-
+  matching overhead (production `ShellExecutor`, not a mock) is already covered separately by
+  `tool_executor_pattern_matching_overhead` (left unchanged, out of scope for this issue).
+  Replaced the vacuous timing assertion with `assert_eq!(executor.get_call_count(), 1)` — the
+  same unconditional load-bearing-dispatch pattern already used by the sibling
+  `agent_integration_with_safe_bash_blocks` test in this file — so the test now fails whenever
+  the tool call is never dispatched instead of silently passing with zero assertions executed.
 - `zeph-acp`: fixed a session-turn race where a closed/deleted session's agent-loop task could
   keep running and emit events/notifications under a `SessionId` reused by a later
   `session/load`/`session/resume` (issue #6674). `do_close_session`/`do_delete_session` previously

--- a/tests/performance_agent_integration.rs
+++ b/tests/performance_agent_integration.rs
@@ -91,10 +91,9 @@ impl Channel for MockChannel {
     }
 }
 
-// Instrumented mock tool executor to track timing and execution
+// Instrumented mock tool executor to track dispatch and execution
 #[derive(Clone)]
 struct InstrumentedMockExecutor {
-    execution_time: Arc<Mutex<Option<Duration>>>,
     call_count: Arc<Mutex<u32>>,
     execution_log: Arc<Mutex<Vec<String>>>,
 }
@@ -102,7 +101,6 @@ struct InstrumentedMockExecutor {
 impl InstrumentedMockExecutor {
     fn new() -> Self {
         Self {
-            execution_time: Arc::new(Mutex::new(None)),
             call_count: Arc::new(Mutex::new(0)),
             execution_log: Arc::new(Mutex::new(Vec::new())),
         }
@@ -110,10 +108,6 @@ impl InstrumentedMockExecutor {
 
     fn get_call_count(&self) -> u32 {
         *self.call_count.lock().unwrap()
-    }
-
-    fn get_execution_time(&self) -> Option<Duration> {
-        *self.execution_time.lock().unwrap()
     }
 }
 
@@ -123,15 +117,11 @@ impl ToolExecutor for InstrumentedMockExecutor {
     }
 
     async fn execute_tool_call(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
-        let start = Instant::now();
-        let elapsed = start.elapsed();
-
-        *self.execution_time.lock().unwrap() = Some(elapsed);
         *self.call_count.lock().unwrap() += 1;
-        self.execution_log.lock().unwrap().push(format!(
-            "execute_tool_call() called, tool={}, elapsed={elapsed:?}",
-            call.tool_id,
-        ));
+        self.execution_log
+            .lock()
+            .unwrap()
+            .push(format!("execute_tool_call() called, tool={}", call.tool_id));
 
         Ok(Some(ToolOutput {
             tool_name: call.tool_id.clone(),
@@ -253,14 +243,12 @@ async fn tool_executor_overhead_is_minimal() {
 
     let _ = agent.run().await;
 
-    // Check that tool executor overhead is minimal (just mock, no real bash)
-    if let Some(time) = executor.get_execution_time() {
-        // Mock executor should take < 10ms (CI runners have high mutex/scheduling jitter)
-        assert!(
-            time.as_millis() < 10,
-            "Tool executor mock call overhead should be minimal: {time:?}",
-        );
-    }
+    // No wall-clock budget here (see #6689): timing the mock's own bookkeeping can never catch
+    // a real tool-executor dispatch regression — that coverage lives in
+    // `tool_executor_pattern_matching_overhead` below, which drives the production
+    // `ShellExecutor`. This assertion fires unconditionally instead of being silently skipped
+    // when `execute_tool_call` is never invoked.
+    assert_eq!(executor.get_call_count(), 1);
 }
 
 // ==========================
@@ -431,10 +419,12 @@ async fn agent_throughput_multiple_responses() {
         executor.clone(),
     );
 
-    let start = Instant::now();
     let _ = agent.run().await;
-    let elapsed = start.elapsed();
 
+    // No wall-clock budget here (see #6690, same defect class as #6687/#6688): this is a
+    // fully-mocked Agent::run() call with no real I/O, so a fixed elapsed-time assertion races
+    // CI load rather than catching a genuine regression. A hang is caught only coarsely, at the
+    // shard level, by CI's job-level `timeout-minutes: 10` (.github/workflows/ci.yml).
     // Should process 5 messages — each produces a text response sent to channel
     let outputs = output_sent.lock().unwrap();
     assert!(
@@ -442,16 +432,6 @@ async fn agent_throughput_multiple_responses() {
         "expected at least 5 outputs, got {}",
         outputs.len()
     );
-
-    // Sanity check: should complete in reasonable time
-    assert!(
-        elapsed.as_secs() < 10,
-        "5 responses should complete: {elapsed:?}",
-    );
-
-    let total_ms = elapsed.as_millis() as u64;
-    let per_msg = total_ms as f64 / 5.0;
-    println!("5-message throughput: {total_ms}ms total ({per_msg:.0}ms per message)");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- `agent_throughput_multiple_responses` asserted `elapsed < 10s` around a fully-mocked `Agent::run()` call — the same flaky-wall-clock defect class already fixed for its two sibling tests in this file (#6687, PR #6688) and for 3 `zeph-core` unit tests (#6679, PR #6685). Dropped the timing assertion; kept the structural `outputs.len() >= 5` check, which proves all 5 mocked responses were actually processed and sent.
- `tool_executor_overhead_is_minimal` timed `Instant::now()`/`.elapsed()` around two adjacent statements with no work in between, so its `< 10ms` assertion passed unconditionally regardless of any real regression, and its `if let Some(time) = ...` guard meant the assertion was silently skipped whenever the mocked tool call never fired. Real dispatch/pattern-matching overhead coverage already exists in `tool_executor_pattern_matching_overhead`, which drives the production `ShellExecutor` — left untouched. Replaced the vacuous timing check with `assert_eq!(executor.get_call_count(), 1)`, the same unconditional load-bearing-dispatch pattern already used by `agent_integration_with_safe_bash_blocks` in this file, and removed the now-dead `execution_time`/`get_execution_time()` machinery from `InstrumentedMockExecutor`.

Closes #6690
Closes #6689

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (15155 passed, 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo nextest run --test performance_agent_integration` (13/13 pass)
- [x] `gitleaks protect --staged`