### PR TITLE
fix(testing): resolve parallel test isolation hazards across 4 crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,57 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   the gap that #6693 left open. Two sites sharing the same `std::process::exit` pattern
   (`Notify::Test`, `UrlScheme::Status`) plus 5 `deep-link`-feature-gated sites inside
   `handle_url_open` were intentionally left out of scope; tracked as a follow-up.
+- `zeph-memory`, `zeph-plugins`, `zeph-session`, `zeph-subagent`: fixed 4 independent
+  shared-process-state test-isolation hazards that made `cargo insta test`/plain `cargo test`
+  flaky under thread-parallel execution while passing under `cargo nextest`'s one-process-per-test
+  model (issue #6686). All are test-only defects — no production races.
+  - `zeph-memory`: `VectorStore::search`'s one-shot clamp-warning flag was a `static` declared
+    inside the shared default trait method body, so it was a single instance shared by every
+    implementor's tests regardless of dynamic dispatch. Replaced with a required
+    `search_clamp_diagnostics()` trait method so each implementor (`InMemoryVectorStore`,
+    `DbVectorStore`, `QdrantOps`, and the test-only mocks) gets its own flag *and* its own
+    diagnostic label (e.g. `"QdrantOps::search"`), matching the existing per-call-site static
+    pattern in `embedding_store.rs`/`embedding_registry.rs`/`reasoning.rs` and letting an
+    operator tell which backend logged the warning (review round: the first pass gave every
+    implementor the identical `"VectorStore::search"` label).
+  - `zeph-plugins`: a `skills_sh.rs` test mutated the process-wide `TMPDIR` env var to force a
+    tempdir-creation failure, racing every other test's `tempfile::tempdir()` call. Replaced
+    with a test-only `tmp_root` field injected directly into `SkillsShClient`, eliminating the
+    global env mutation entirely.
+  - `zeph-session`, `zeph-subagent`: `log.rs`/`transcript.rs`'s process-global
+    `HISTORY_INTEGRITY`/`ANCHOR_STORE` statics were reconfigured per-test with no
+    synchronization and a manual (panic-unsafe) reset at the end of each test body. Added an
+    `IntegrityConfigGuard` RAII type (resets both statics on drop, surviving panics) and
+    `#[serial_test::serial(...)]` on every test in `zeph-session`'s `log.rs`/`fork.rs`/
+    `replay.rs` and `zeph-subagent`'s `transcript.rs` that configures either static or opens a
+    `SessionEventLog`/`TranscriptWriter` while one could be configured — collateral damage
+    extended to tests that never touch the statics directly. Also fixed a secondary
+    poisoning-cascade defect in `zeph-subagent`: a panic during the primary race could leave a
+    `std::sync::Mutex`-backed mock anchor store poisoned for the rest of the process, cascading
+    `PoisonError` into unrelated tests; the Drop-guard fix resolves this as a side effect.
+    Review round: closed the same hazard's remaining direction in
+    `zeph-subagent::manager::tests` — the one test installing a real key ring could chain
+    another concurrently-spawned test's transcript, which would then hard-fail its own
+    `load_strict` chain verification once the guard reset the ring; joined the same serial
+    group instead of the (infeasible, since the relevant items are only `pub(super)`) option of
+    moving it to a separate integration-test binary. Also found and fixed the identical hazard,
+    self-contained within its own process, in the `zeph` binary crate's own test suite
+    (`src/runner.rs`'s `configure_history_integrity` test plus the `SessionEventLog`-opening
+    tests it shares a test binary with in `src/runner.rs`/`src/acp.rs`, in scope via the issue's
+    own `--bins` acceptance criterion) — new `zeph_bin_history_integrity` serial group and
+    `HistoryIntegrityTestGuard`.
+  - `zeph-subagent`: `memory.rs`'s `resolve_memory_dir`/`ensure_memory_dir` and 9 tests across
+    `memory.rs`/`manager/tests.rs` read or mutated the process-wide CWD
+    (`std::env::current_dir`/`set_current_dir`) with inconsistent or missing synchronization —
+    3 tests were missing the crate's existing (unnamed) `#[serial]` group entirely. Closed the
+    gap and added a test-only `cwd_guard::TestCwdGuard` RAII save/restore helper for panic-safety,
+    used by all CWD-mutating tests in the crate. Review round: a failed cwd restore in the
+    guard's `Drop` now panics loudly at the actual cause (unless already unwinding), instead of
+    surfacing later as a confusing `unwrap()` panic inside an unrelated subsequent test.
+  - Note: `zeph-session --lib`'s plain `cargo test` run time increased (~10-20s for 83 tests,
+    since ~2/3 are now serialized) as a direct consequence of this fix — `cargo nextest` (CI) is
+    unaffected; only `cargo insta test`, the harness this issue is about, pays it.
+
 - `.claude/rules/continuous-improvement.md`: fixed the "Local Trace Analysis" jq recipes, which
   matched zero events against every real local trace file (issue #6676). `tracing-chrome` 0.7.2
   writes a bare top-level JSON array (not `{"traceEvents": [...]}`) and never emits `ph:"X"`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11938,6 +11938,7 @@ dependencies = [
  "rustix 1.1.4",
  "serde",
  "serde_json",
+ "serial_test",
  "sqlx",
  "tempfile",
  "testcontainers",

--- a/crates/zeph-memory/src/db_vector_store.rs
+++ b/crates/zeph-memory/src/db_vector_store.rs
@@ -8,6 +8,7 @@
 //! running Qdrant instance.  Not optimised for large collections.
 
 use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
 #[allow(unused_imports)]
 use zeph_db::sql;
 
@@ -159,6 +160,11 @@ impl VectorStore for DbVectorStore {
         return Box::pin(tracing::Instrument::instrument(fut, span));
         #[cfg(not(feature = "profiling"))]
         fut
+    }
+
+    fn search_clamp_diagnostics(&self) -> (&'static str, &'static AtomicBool) {
+        static CLAMP_WARNED: AtomicBool = AtomicBool::new(false);
+        ("DbVectorStore::search", &CLAMP_WARNED)
     }
 
     fn search_clamped(

--- a/crates/zeph-memory/src/in_memory_store.rs
+++ b/crates/zeph-memory/src/in_memory_store.rs
@@ -8,6 +8,7 @@
 //! Not suitable for production — use [`crate::qdrant_ops::QdrantOps`] instead.
 
 use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
 
 use parking_lot::RwLock;
 
@@ -147,6 +148,11 @@ impl VectorStore for InMemoryVectorStore {
             }
             Ok(())
         })
+    }
+
+    fn search_clamp_diagnostics(&self) -> (&'static str, &'static AtomicBool) {
+        static CLAMP_WARNED: AtomicBool = AtomicBool::new(false);
+        ("InMemoryVectorStore::search", &CLAMP_WARNED)
     }
 
     fn search_clamped(

--- a/crates/zeph-memory/src/qdrant_ops.rs
+++ b/crates/zeph-memory/src/qdrant_ops.rs
@@ -10,6 +10,7 @@
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::atomic::AtomicBool;
 use std::time::Duration;
 
 use crate::vector_store::BoxFuture;
@@ -492,6 +493,11 @@ impl QdrantOps {
 }
 
 impl crate::vector_store::VectorStore for QdrantOps {
+    fn search_clamp_diagnostics(&self) -> (&'static str, &'static AtomicBool) {
+        static CLAMP_WARNED: AtomicBool = AtomicBool::new(false);
+        ("QdrantOps::search", &CLAMP_WARNED)
+    }
+
     fn ensure_collection(
         &self,
         collection: &str,

--- a/crates/zeph-memory/src/semantic/tests/summarization.rs
+++ b/crates/zeph-memory/src/semantic/tests/summarization.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicBool, AtomicU64};
 
 use zeph_llm::any::AnyProvider;
 use zeph_llm::mock::MockProvider;
@@ -25,6 +25,11 @@ use super::test_semantic_memory;
 struct FailingSearchStore(DbVectorStore);
 
 impl VectorStore for FailingSearchStore {
+    fn search_clamp_diagnostics(&self) -> (&'static str, &'static AtomicBool) {
+        static CLAMP_WARNED: AtomicBool = AtomicBool::new(false);
+        ("FailingSearchStore::search", &CLAMP_WARNED)
+    }
+
     fn ensure_collection(
         &self,
         collection: &str,

--- a/crates/zeph-memory/src/vector_store.rs
+++ b/crates/zeph-memory/src/vector_store.rs
@@ -178,10 +178,36 @@ pub trait VectorStore: Send + Sync {
         limit: u64,
         filter: Option<VectorFilter>,
     ) -> BoxFuture<'_, Result<Vec<ScoredVectorPoint>, VectorStoreError>> {
-        static CLAMP_WARNED: AtomicBool = AtomicBool::new(false);
-        let limit = clamp_search_limit("VectorStore::search", limit, &CLAMP_WARNED);
+        let (site, warned) = self.search_clamp_diagnostics();
+        let limit = clamp_search_limit(site, limit, warned);
         self.search_clamped(collection, vector, limit, filter)
     }
+
+    /// Per-implementor diagnostic label and "already warned" flag backing [`Self::search`]'s
+    /// one-shot clamp warning.
+    ///
+    /// [`Self::search`] is one shared default-method body invoked identically for every
+    /// implementor, so a `static` declared directly inside it would be a single item shared
+    /// by *all* implementors — Rust does not duplicate function-local statics per
+    /// monomorphization, and a default method reached through `dyn VectorStore` compiles to
+    /// one shared body regardless of the concrete backend behind it. For the same reason, a
+    /// generic helper like `std::any::type_name::<Self>()` called from within that one shared
+    /// body cannot distinguish implementors either. Each implementor must therefore supply its
+    /// own label and flag here — a distinct `&'static str` identifying the concrete type (so an
+    /// operator can tell which backend logged the warning) and a reference to a local
+    /// `static AtomicBool` initialized to `false` — mirroring the per-call-site static already
+    /// used by `EmbeddingStore::search`, `EmbeddingRegistry::search_raw`, and
+    /// `ReasoningMemory::search` (see module docs).
+    ///
+    /// The flag this returns is per-*implementor-type*, not per-instance: every `Self` value
+    /// shares the one `static` declared in this method's body. This crate's own test suite
+    /// currently has exactly one `logs_contain(...)`-asserting clamp test per implementor type,
+    /// which is why that is safe today — a *second* such test against the same concrete type
+    /// would silently race on this same flag (the identical #6686 hazard this method exists to
+    /// prevent, just reintroduced one level up). If you add another oversized-limit clamp test
+    /// for a type that already has one, give the existing test's assertion double duty instead
+    /// of adding a second one.
+    fn search_clamp_diagnostics(&self) -> (&'static str, &'static AtomicBool);
 
     /// Backend-specific search implementation invoked by [`Self::search`].
     ///
@@ -307,6 +333,11 @@ mod tests {
             _points: Vec<VectorPoint>,
         ) -> BoxFuture<'_, Result<(), VectorStoreError>> {
             Box::pin(async { Ok(()) })
+        }
+
+        fn search_clamp_diagnostics(&self) -> (&'static str, &'static AtomicBool) {
+            static CLAMP_WARNED: AtomicBool = AtomicBool::new(false);
+            ("RecordingStore::search", &CLAMP_WARNED)
         }
 
         fn search_clamped(

--- a/crates/zeph-plugins/src/marketplace/skills_sh.rs
+++ b/crates/zeph-plugins/src/marketplace/skills_sh.rs
@@ -101,6 +101,11 @@ pub struct SkillsShClient {
     base_url: String,
     token: Option<Secret>,
     client: reqwest::Client,
+    /// Parent directory for [`Self::fetch`]'s extraction tempdir. `None` (the production
+    /// default) uses the process temp dir via `tempfile::tempdir()`. Overridable only in
+    /// tests via [`Self::with_tmp_root_for_test`], so a test can force tempdir creation to
+    /// fail without mutating the process-wide `TMPDIR` env var (issue #6686).
+    tmp_root: Option<std::path::PathBuf>,
 }
 
 impl SkillsShClient {
@@ -154,7 +159,19 @@ impl SkillsShClient {
             base_url,
             token,
             client,
+            tmp_root: None,
         }
+    }
+
+    /// Force [`Self::fetch`] to create its extraction tempdir under `dir` instead of the
+    /// process temp dir. Test-only seam (issue #6686) so a test can point at a non-directory
+    /// path to make `tempdir_in` fail deterministically, without mutating the process-wide
+    /// `TMPDIR` env var and racing every other test that calls `tempfile::tempdir()`.
+    #[cfg(test)]
+    #[must_use]
+    fn with_tmp_root_for_test(mut self, dir: std::path::PathBuf) -> Self {
+        self.tmp_root = Some(dir);
+        self
     }
 
     /// Reject `base_url` schemes other than `http`/`https` (SSRF hardening — review fix #6).
@@ -330,7 +347,10 @@ impl RegistryClient for SkillsShClient {
                     ));
                 }
 
-                let tmp = tempfile::tempdir()?;
+                let tmp = match &self.tmp_root {
+                    Some(root) => tempfile::Builder::new().tempdir_in(root)?,
+                    None => tempfile::tempdir()?,
+                };
                 let (has_plugin_manifest, install_dir) = materialize_package(tmp.path(), &files)?;
 
                 Ok(PackageArchive {
@@ -675,22 +695,14 @@ mod tests {
             .mount(&server)
             .await;
 
-        // Force tempdir() itself to fail by pointing TMPDIR at a path that doesn't exist and
-        // cannot be created (a file, not a directory, as the parent).
+        // Force tempdir_in() itself to fail by pointing the client's tempdir parent at a
+        // regular file rather than a directory — injected directly into this client instance
+        // (issue #6686), not via the process-wide TMPDIR env var, so no other concurrently
+        // running test racing on `tempfile::tempdir()` is affected.
         let bogus_parent = tempfile::NamedTempFile::new().unwrap();
-        // SAFETY-equivalent: std::env::set_var is unsafe in edition 2024; safe here because
-        // nextest runs each test in its own process (full env isolation from other tests), and
-        // the mutation is restored before this test function returns.
-        #[allow(unsafe_code)]
-        unsafe {
-            std::env::set_var("TMPDIR", bogus_parent.path());
-        }
-        let client = client_for(&server, None);
+        let client =
+            client_for(&server, None).with_tmp_root_for_test(bogus_parent.path().to_path_buf());
         let result = client.fetch("acme/x").await;
-        #[allow(unsafe_code)]
-        unsafe {
-            std::env::remove_var("TMPDIR");
-        }
 
         let err = result.unwrap_err();
         assert!(matches!(err, RegistryError::Io(_)));

--- a/crates/zeph-session/Cargo.toml
+++ b/crates/zeph-session/Cargo.toml
@@ -43,6 +43,7 @@ testcontainers = { workspace = true, features = ["watchdog"], optional = true }
 testcontainers = { workspace = true, optional = true }
 
 [dev-dependencies]
+serial_test.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 zeph-llm = { workspace = true, features = ["testing"] }

--- a/crates/zeph-session/src/fork.rs
+++ b/crates/zeph-session/src/fork.rs
@@ -348,6 +348,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_fork_copies_events() {
         let store = SessionStore::new(make_pool().await);
         let data_dir = tempfile::tempdir().unwrap();
@@ -372,7 +373,9 @@ mod tests {
     /// (also chain-verified) — either one must reject a tampered parent before any event is
     /// copied into the child log.
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_fork_rejects_a_tampered_parent_chain() {
+        let _guard = crate::log::IntegrityConfigGuard::new();
         let ring = Arc::new(zeph_common::hash_chain::ChainKeyRing::new(
             0,
             zeph_common::hash_chain::ChainKey::new([77u8; 32]),
@@ -410,11 +413,10 @@ mod tests {
             !child_dir.join("events.jsonl").exists(),
             "a rejected fork must not leave behind a partially-written child log"
         );
-
-        crate::log::configure_history_integrity(None);
     }
 
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_fork_provenance_metadata() {
         let store = SessionStore::new(make_pool().await);
         let data_dir = tempfile::tempdir().unwrap();
@@ -433,6 +435,7 @@ mod tests {
     /// row's `owner_key` column end-to-end (through `record_fork`), not just at the
     /// `SessionStore::record_fork` unit level.
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn fork_propagates_owner_to_child_row() {
         let pool = make_pool().await;
         let store = SessionStore::new(pool.clone());
@@ -461,6 +464,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_fork_appends_forkpoint_to_parent() {
         let store = SessionStore::new(make_pool().await);
         let data_dir = tempfile::tempdir().unwrap();
@@ -480,6 +484,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_fork_rejects_seq_beyond_source() {
         let store = SessionStore::new(make_pool().await);
         let data_dir = tempfile::tempdir().unwrap();
@@ -492,6 +497,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_fork_rejects_unknown_source() {
         let store = SessionStore::new(make_pool().await);
         let data_dir = tempfile::tempdir().unwrap();
@@ -503,6 +509,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_fork_none_copies_everything() {
         let store = SessionStore::new(make_pool().await);
         let data_dir = tempfile::tempdir().unwrap();
@@ -518,6 +525,7 @@ mod tests {
     /// Regression test for #5982 (spec §7.2 step 6): a blob referenced by a copied
     /// `UserMessage.image_refs` must be hard-linked into the child's `blobs/` directory.
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_fork_copies_referenced_blobs() {
         let store = SessionStore::new(make_pool().await);
         let data_dir = tempfile::tempdir().unwrap();
@@ -559,6 +567,7 @@ mod tests {
     /// the fork — it is logged and skipped, since the event-log copy (the fork's primary
     /// content) already succeeded.
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_fork_skips_missing_blob_without_failing() {
         let store = SessionStore::new(make_pool().await);
         let data_dir = tempfile::tempdir().unwrap();
@@ -592,6 +601,7 @@ mod tests {
     /// create an empty `blobs/` directory in the child (keeps the eager-copy path a no-op for
     /// the common, image-free case).
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_fork_without_image_refs_creates_no_blobs_dir() {
         let store = SessionStore::new(make_pool().await);
         let data_dir = tempfile::tempdir().unwrap();
@@ -610,6 +620,7 @@ mod tests {
     /// joined (which would let the parent-side `hard_link` read an arbitrary file, or the
     /// child-side path escape `blobs/`).
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_fork_rejects_path_traversal_in_image_refs() {
         let store = SessionStore::new(make_pool().await);
         let data_dir = tempfile::tempdir().unwrap();
@@ -644,6 +655,7 @@ mod tests {
     /// also be rejected — `PathBuf::join` with an absolute path silently discards the base
     /// directory entirely, which is the most severe form of this traversal.
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_fork_rejects_absolute_path_in_image_refs() {
         let store = SessionStore::new(make_pool().await);
         let data_dir = tempfile::tempdir().unwrap();
@@ -674,6 +686,7 @@ mod tests {
     /// copied range must not trigger the cross-device copy fallback on the second occurrence —
     /// the hash list is deduped before any `hard_link` is attempted.
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_fork_dedups_duplicate_blob_hash() {
         let store = SessionStore::new(make_pool().await);
         let data_dir = tempfile::tempdir().unwrap();
@@ -728,6 +741,7 @@ mod tests {
     /// destination that is already a hard link to the source truncates the shared inode to 0
     /// bytes, corrupting every link to it — including the parent's original blob.
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_copy_referenced_blobs_retry_does_not_truncate_shared_blob() {
         let data_dir = tempfile::tempdir().unwrap();
         let src_dir = data_dir.path().join("parent");
@@ -785,6 +799,7 @@ mod tests {
     /// same `0o700` permission the crate already enforces on the sibling session directory.
     #[cfg(unix)]
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_fork_sets_0700_on_child_blobs_dir() {
         use std::os::unix::fs::PermissionsExt;
 

--- a/crates/zeph-session/src/log.rs
+++ b/crates/zeph-session/src/log.rs
@@ -1175,6 +1175,35 @@ pub(crate) async fn set_permissions(_path: &Path, _mode: u32) -> Result<(), Sess
     Ok(())
 }
 
+/// RAII guard that resets [`HISTORY_INTEGRITY`] and [`ANCHOR_STORE`] to `None` on drop
+/// (issue #6686).
+///
+/// Both are process-wide statics reconfigured per-test; a manual reset call at the end of a
+/// test body is skipped by a panic or early return, leaking a foreign key ring / anchor store
+/// into whichever test runs next in the same process — including tests in `fork.rs` and
+/// `replay.rs` that never call [`configure_history_integrity`]/[`configure_anchor_store`]
+/// themselves but still open a [`SessionEventLog`]. Every test across this crate that
+/// configures either static, or that opens a [`SessionEventLog`] while one could be configured,
+/// must both construct this guard and carry `#[serial_test::serial(session_history_integrity)]`
+/// so no two such tests run concurrently.
+#[cfg(test)]
+pub(crate) struct IntegrityConfigGuard(());
+
+#[cfg(test)]
+impl IntegrityConfigGuard {
+    pub(crate) fn new() -> Self {
+        Self(())
+    }
+}
+
+#[cfg(test)]
+impl Drop for IntegrityConfigGuard {
+    fn drop(&mut self) {
+        configure_history_integrity(None);
+        configure_anchor_store(None);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::future::Future;
@@ -1183,6 +1212,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_append_and_read_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
         let log = SessionEventLog::open(dir.path()).await.unwrap();
@@ -1209,6 +1239,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_reopen_resumes_seq() {
         let dir = tempfile::tempdir().unwrap();
         {
@@ -1235,6 +1266,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_torn_write_truncation() {
         let dir = tempfile::tempdir().unwrap();
         let path;
@@ -1276,6 +1308,7 @@ mod tests {
     /// writer's data out from under it. Only `open_exclusive()` may repair.
     #[cfg(unix)]
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_open_does_not_physically_truncate_torn_tail() {
         let dir = tempfile::tempdir().unwrap();
         let path;
@@ -1325,6 +1358,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_torn_write_truncation_various_offsets() {
         for cut_from_end in [1usize, 3, 10, 20] {
             let dir = tempfile::tempdir().unwrap();
@@ -1357,6 +1391,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_empty_log_read_all() {
         let dir = tempfile::tempdir().unwrap();
         let log = SessionEventLog::open(dir.path()).await.unwrap();
@@ -1366,6 +1401,7 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_file_permissions_are_0600() {
         use std::os::unix::fs::PermissionsExt;
         let dir = tempfile::tempdir().unwrap();
@@ -1379,6 +1415,7 @@ mod tests {
     /// shape a pre-fix concurrent-append race could produce: seq 7 written physically before
     /// seq 6.
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_max_seq_survives_out_of_order_physical_lines() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(EVENTS_FILE_NAME);
@@ -1426,6 +1463,7 @@ mod tests {
     /// Before the fix the lock file was permanently empty.
     #[cfg(unix)]
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_open_exclusive_writes_own_pid_into_lock_file() {
         let dir = tempfile::tempdir().unwrap();
         let _log = SessionEventLog::open_exclusive(dir.path()).await.unwrap();
@@ -1444,6 +1482,7 @@ mod tests {
     /// process — a genuinely alive PID is exactly what `pid_alive` must report.
     #[cfg(unix)]
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_open_exclusive_rejects_second_writer() {
         let dir = tempfile::tempdir().unwrap();
         let _first = SessionEventLog::open_exclusive(dir.path()).await.unwrap();
@@ -1459,6 +1498,7 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_open_exclusive_allows_reacquire_after_drop() {
         let dir = tempfile::tempdir().unwrap();
         {
@@ -1470,6 +1510,7 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_open_is_not_blocked_by_open_exclusive() {
         let dir = tempfile::tempdir().unwrap();
         let _writer = SessionEventLog::open_exclusive(dir.path()).await.unwrap();
@@ -1483,6 +1524,7 @@ mod tests {
     /// was assigned via `fetch_add` before acquiring the writer lock, so a task could win a
     /// low seq but lose the race for the lock, landing its line after a higher-seq task's line.
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_concurrent_append_preserves_seq_order() {
         const N: u64 = 100;
 
@@ -1531,6 +1573,7 @@ mod tests {
     /// [`REPLAY_CHUNK_SIZE`] raw envelopes at once, and the concatenation of all chunks must
     /// exactly reproduce what `read_events` (the whole-file `Vec` path) returns, in order.
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_read_chunked_bounds_memory_and_matches_whole_file_read() {
         const N: u64 = 733; // comfortably > REPLAY_CHUNK_SIZE, not an exact multiple of it
 
@@ -1598,7 +1641,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn chained_log_roundtrip() {
+        let _guard = IntegrityConfigGuard::new();
         configure_history_integrity(Some(test_ring(0, 20)));
         let dir = tempfile::tempdir().unwrap();
         let log = SessionEventLog::open(dir.path()).await.unwrap();
@@ -1632,12 +1677,12 @@ mod tests {
         let log = SessionEventLog::open(dir.path()).await.unwrap();
         let events = log.read_all().await.unwrap();
         assert_eq!(events.len(), 2);
-
-        configure_history_integrity(None);
     }
 
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn tamper_in_place_edit_is_detected() {
+        let _guard = IntegrityConfigGuard::new();
         configure_history_integrity(Some(test_ring(0, 21)));
         let dir = tempfile::tempdir().unwrap();
         let log = SessionEventLog::open(dir.path()).await.unwrap();
@@ -1674,12 +1719,12 @@ mod tests {
 
         let result = SessionEventLog::open(dir.path()).await;
         assert!(matches!(result, Err(SessionError::Integrity(ref m)) if m.contains("TAMPER")));
-
-        configure_history_integrity(None);
     }
 
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn legacy_log_is_auto_trusted_once_when_integrity_configured_later() {
+        let _guard = IntegrityConfigGuard::new();
         configure_history_integrity(None);
         let dir = tempfile::tempdir().unwrap();
         let log = SessionEventLog::open(dir.path()).await.unwrap();
@@ -1726,12 +1771,12 @@ mod tests {
             warned_count_before,
             "a second read of the same path must not add a second warned-set entry"
         );
-
-        configure_history_integrity(None);
     }
 
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn partial_strip_of_chain_field_is_detected_as_tamper() {
+        let _guard = IntegrityConfigGuard::new();
         configure_history_integrity(Some(test_ring(0, 23)));
         let dir = tempfile::tempdir().unwrap();
         let log = SessionEventLog::open(dir.path()).await.unwrap();
@@ -1770,12 +1815,12 @@ mod tests {
         assert!(
             matches!(result, Err(SessionError::Integrity(ref m)) if m.contains("partial strip"))
         );
-
-        configure_history_integrity(None);
     }
 
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn key_unavailable_on_chained_log_fails_closed_not_legacy() {
+        let _guard = IntegrityConfigGuard::new();
         configure_history_integrity(Some(test_ring(0, 24)));
         let dir = tempfile::tempdir().unwrap();
         let log = SessionEventLog::open(dir.path()).await.unwrap();
@@ -1797,7 +1842,9 @@ mod tests {
     /// `open_exclusive_allow_unverified`, and the bypass must persist across `read_all` calls
     /// on the same handle, not just the initial open.
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn allow_unverified_bypasses_tamper_detection_for_the_whole_handle() {
+        let _guard = IntegrityConfigGuard::new();
         configure_history_integrity(Some(test_ring(0, 40)));
         let dir = tempfile::tempdir().unwrap();
         let log = SessionEventLog::open(dir.path()).await.unwrap();
@@ -1838,12 +1885,12 @@ mod tests {
             .unwrap();
         let events = log.read_all().await.unwrap();
         assert_eq!(events.len(), 2);
-
-        configure_history_integrity(None);
     }
 
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn rotated_key_epoch_verifies_as_rekeyed_not_tampered() {
+        let _guard = IntegrityConfigGuard::new();
         let old_key_byte = 25u8;
         configure_history_integrity(Some(test_ring(0, old_key_byte)));
         let dir = tempfile::tempdir().unwrap();
@@ -1868,8 +1915,6 @@ mod tests {
         let log = SessionEventLog::open(dir.path()).await.unwrap();
         let events = log.read_all().await.unwrap();
         assert_eq!(events.len(), 1);
-
-        configure_history_integrity(None);
     }
 
     /// S1 regression: a mid-file (non-trailing) malformed line must never be silently
@@ -1877,6 +1922,7 @@ mod tests {
     /// error instead. This is a correctness bug independent of chaining (it corrupts crash
     /// recovery itself), reproduced here without configuring any key ring.
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn internal_malformed_line_is_never_treated_as_torn_tail() {
         configure_history_integrity(None);
         let dir = tempfile::tempdir().unwrap();
@@ -1927,8 +1973,10 @@ mod tests {
     /// S2 regression: concurrent `append` calls must never desynchronize on-disk physical order
     /// from chain-link order.
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    #[serial_test::serial(session_history_integrity)]
     async fn concurrent_append_preserves_chain_order() {
         const N: u64 = 60;
+        let _guard = IntegrityConfigGuard::new();
         configure_history_integrity(Some(test_ring(0, 26)));
         let dir = tempfile::tempdir().unwrap();
         let log = std::sync::Arc::new(SessionEventLog::open(dir.path()).await.unwrap());
@@ -1957,14 +2005,14 @@ mod tests {
         let log = SessionEventLog::open(dir.path()).await.unwrap();
         let events = log.read_all().await.unwrap();
         assert_eq!(events.len(), usize::try_from(N).unwrap());
-
-        configure_history_integrity(None);
     }
 
     /// Chunked reads (used by replay) must verify the chain identically to the whole-file read.
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn chunked_read_verifies_chain_and_matches_whole_file_read() {
         const N: u64 = 250; // > REPLAY_CHUNK_SIZE, exercises the chunk-boundary epoch resolution
+        let _guard = IntegrityConfigGuard::new();
         configure_history_integrity(Some(test_ring(0, 27)));
         let dir = tempfile::tempdir().unwrap();
         let log = SessionEventLog::open(dir.path()).await.unwrap();
@@ -1992,15 +2040,15 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(chunked.len(), whole.len());
-
-        configure_history_integrity(None);
     }
 
     /// Chunked reads must also detect tamper, not just the whole-file read — a tampered event
     /// deep enough to land in a later chunk must abort before ever reaching `on_chunk`.
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn chunked_read_detects_tamper_in_a_later_chunk() {
         const N: u64 = 150;
+        let _guard = IntegrityConfigGuard::new();
         configure_history_integrity(Some(test_ring(0, 28)));
         let dir = tempfile::tempdir().unwrap();
         let log = SessionEventLog::open(dir.path()).await.unwrap();
@@ -2044,8 +2092,6 @@ mod tests {
             }
             Err(other) => panic!("expected Integrity error, got {other:?}"),
         }
-
-        configure_history_integrity(None);
     }
 
     // --- Vault-anchor downgrade-resistance tests (issue #6449) ---
@@ -2109,7 +2155,9 @@ mod tests {
     /// FINDING B regression: a session log chained before any anchor store existed must still
     /// open normally once one comes online — an absent anchor is never a tamper signature.
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn pre_anchor_chained_log_still_opens_with_anchor_store_online() {
+        let _guard = IntegrityConfigGuard::new();
         configure_history_integrity(Some(test_ring(0, 40)));
         let dir = tempfile::tempdir().unwrap();
         let log = SessionEventLog::open(dir.path()).await.unwrap();
@@ -2133,13 +2181,12 @@ mod tests {
             1,
             "absent anchor must never brick a legacy-chained log"
         );
-
-        configure_anchor_store(None);
-        configure_history_integrity(None);
     }
 
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn whole_strip_of_anchored_session_is_tamper() {
+        let _guard = IntegrityConfigGuard::new();
         configure_history_integrity(Some(test_ring(0, 41)));
         let store: Arc<dyn AnchorStore> = Arc::new(MockAnchorStore::default());
         configure_anchor_store(Some(Arc::clone(&store)));
@@ -2189,13 +2236,12 @@ mod tests {
             }
             other => panic!("expected Integrity TAMPER error, got {}", other.is_ok()),
         }
-
-        configure_anchor_store(None);
-        configure_history_integrity(None);
     }
 
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn truncation_below_anchored_session_count_is_tamper() {
+        let _guard = IntegrityConfigGuard::new();
         configure_history_integrity(Some(test_ring(0, 42)));
         let store: Arc<dyn AnchorStore> = Arc::new(MockAnchorStore::default());
         configure_anchor_store(Some(Arc::clone(&store)));
@@ -2235,15 +2281,14 @@ mod tests {
             }
             other => panic!("expected Integrity TAMPER error, got {}", other.is_ok()),
         }
-
-        configure_anchor_store(None);
-        configure_history_integrity(None);
     }
 
     /// Legitimate post-close growth (on-disk count > anchor.count, prefix matches) must open OK
     /// — the anchor is a prefix commitment, not an exact-count requirement, for sessions.
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn growth_after_anchor_with_matching_prefix_is_ok() {
+        let _guard = IntegrityConfigGuard::new();
         configure_history_integrity(Some(test_ring(0, 43)));
         let store: Arc<dyn AnchorStore> = Arc::new(MockAnchorStore::default());
         configure_anchor_store(Some(Arc::clone(&store)));
@@ -2280,13 +2325,12 @@ mod tests {
             2,
             "post-anchor growth with a matching prefix must open OK"
         );
-
-        configure_anchor_store(None);
-        configure_history_integrity(None);
     }
 
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn finalize_is_noop_without_anchor_store_or_without_chaining() {
+        let _guard = IntegrityConfigGuard::new();
         configure_history_integrity(Some(test_ring(0, 44)));
         let dir = tempfile::tempdir().unwrap();
         let log = SessionEventLog::open(dir.path()).await.unwrap();
@@ -2322,7 +2366,5 @@ mod tests {
                 .is_none(),
             "no anchor should be written for an unchained handle"
         );
-
-        configure_anchor_store(None);
     }
 }

--- a/crates/zeph-session/src/replay.rs
+++ b/crates/zeph-session/src/replay.rs
@@ -310,6 +310,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_replay_empty_session() {
         let dir = tempfile::tempdir().unwrap();
         let state = ReplayEngine::replay(dir.path(), None).await.unwrap();
@@ -318,6 +319,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_replay_basic_turn() {
         let dir = tempfile::tempdir().unwrap();
         let log = SessionEventLog::open(dir.path()).await.unwrap();
@@ -366,6 +368,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(session_history_integrity)]
     fn test_replay_tool_roundtrip() {
         let events = vec![
             envelope(
@@ -417,6 +420,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(session_history_integrity)]
     fn test_replay_tool_result_batch_merges_into_one_user_message() {
         // Multiple ToolResult events from the same tool-call batch (tier_loop.rs's
         // process_tool_result_batch persists one Role::User message per batch, holding one
@@ -468,6 +472,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(session_history_integrity)]
     fn test_replay_tool_result_never_merges_into_plain_user_message() {
         // A genuine SessionEvent::UserMessage (folds to empty `parts`) must never be treated as
         // an open tool-result batch, even if a ToolResult event immediately follows it.
@@ -497,6 +502,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(session_history_integrity)]
     fn test_replay_condensation_folds() {
         let summary = AnchoredSummary {
             session_intent: "test".to_owned(),
@@ -550,6 +556,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(session_history_integrity)]
     fn test_replay_stop_at_seq() {
         let events = vec![
             envelope(
@@ -750,6 +757,7 @@ mod tests {
     /// produce output equivalent to the old whole-file-`Vec` + `fold` path on a large synthetic
     /// log spanning several hundred events and every `SessionEvent` variant `fold_step` handles.
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_replay_streaming_matches_vec_based_fold_on_large_log() {
         const N_TURNS: u64 = 250; // produces well over 100 events (> one REPLAY_CHUNK_SIZE)
 
@@ -786,6 +794,7 @@ mod tests {
     /// `read_events_chunked` only fires once, at EOF, so it must still catch a torn line that
     /// falls beyond the last full chunk boundary.
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_replay_torn_tail_across_chunk_boundary() {
         const N_TURNS: u64 = 250; // produces well over one REPLAY_CHUNK_SIZE (100) of events
 
@@ -836,6 +845,7 @@ mod tests {
     /// chunk still being accumulated, right at a chunk-flush point, or just past one, and the
     /// chunked path must still stop the fold at the exact same seq the whole-file path does.
     #[tokio::test]
+    #[serial_test::serial(session_history_integrity)]
     async fn test_replay_up_to_matches_fold_at_chunk_boundaries() {
         const N_TURNS: u64 = 250; // produces well over 200 events
 

--- a/crates/zeph-subagent/src/cwd_guard.rs
+++ b/crates/zeph-subagent/src/cwd_guard.rs
@@ -99,6 +99,53 @@ impl Drop for CwdRestoreGuard {
 /// Convenience type alias for the shared mutex used as the process-level cwd lock.
 pub type CwdLock = Arc<Mutex<()>>;
 
+/// Test-only RAII cwd save/restore guard (issue #6686).
+///
+/// `std::env::current_dir`/`set_current_dir` are process-wide, not per-thread, so every test
+/// across the crate that changes the cwd (here, `memory.rs`, `manager/tests.rs`) must both
+/// restore it even on panic *and* run mutually exclusively with every other such test — pair
+/// this guard with `#[serial_test::serial]` (this crate's default, unnamed group, shared with
+/// this module's own tests above) on every test that constructs one.
+#[cfg(test)]
+pub(crate) struct TestCwdGuard {
+    prev: PathBuf,
+}
+
+#[cfg(test)]
+impl TestCwdGuard {
+    /// Saves the current cwd and switches to `dir`.
+    pub(crate) fn enter(dir: &std::path::Path) -> Self {
+        let prev = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir).unwrap();
+        Self { prev }
+    }
+}
+
+#[cfg(test)]
+impl Drop for TestCwdGuard {
+    fn drop(&mut self) {
+        if let Err(e) = std::env::set_current_dir(&self.prev) {
+            // A failed restore here corrupts the cwd for every subsequent test until the next
+            // `TestCwdGuard::enter` overwrites it — surfacing as a confusing `unwrap()` panic
+            // inside *that* unrelated test's `enter` rather than here, at the actual cause
+            // (issue #6686 review). Panic loudly, unless already unwinding (e.g. this test's
+            // own assertion just failed) — a second panic during unwind would abort the whole
+            // process instead of just failing this one test.
+            if std::thread::panicking() {
+                eprintln!(
+                    "TestCwdGuard: failed to restore cwd to {} during unwind: {e}",
+                    self.prev.display()
+                );
+            } else {
+                panic!(
+                    "TestCwdGuard: failed to restore cwd to {}: {e}",
+                    self.prev.display()
+                );
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;

--- a/crates/zeph-subagent/src/manager/tests.rs
+++ b/crates/zeph-subagent/src/manager/tests.rs
@@ -210,7 +210,16 @@ async fn collect_unknown_task_id_returns_not_found() {
 /// read against that path must succeed after `collect()` has removed the handle — proving
 /// grounding reads (`build_tool_trace_for_task` in `zeph-core`) do not silently degrade to
 /// `None` merely because the orchestration dispatch path has already reaped the handle.
+///
+/// Joins `subagent_transcript_integrity` (issue #6686): `mgr.spawn` creates a real
+/// `TranscriptWriter`, which captures the process-global `HISTORY_INTEGRITY` ring at
+/// construction, and `load_strict` below re-reads the (possibly since-reset) global at call
+/// time — the one other test in this group that installs a real ring
+/// (`run_agent_loop_finalizes_transcript_anchor_on_llm_error_exit_path`) could otherwise chain
+/// this test's transcript with a foreign ring that is gone by the time `load_strict` runs,
+/// hard-failing `verify_and_extract_messages`.
 #[tokio::test]
+#[serial_test::serial(subagent_transcript_integrity)]
 async fn transcript_path_for_stable_across_collect_and_readable_after() {
     let tmp = tempfile::tempdir().unwrap();
     let config = SubAgentConfig {
@@ -2121,8 +2130,7 @@ fn def_name_for_resume_not_found_returns_error() {
 #[serial]
 async fn spawn_with_memory_scope_project_creates_directory() {
     let tmp = tempfile::tempdir().unwrap();
-    let orig_dir = std::env::current_dir().unwrap();
-    std::env::set_current_dir(tmp.path()).unwrap();
+    let _cwd = crate::cwd_guard::TestCwdGuard::enter(tmp.path());
 
     let def = SubAgentDef::parse(indoc! {"
         ---
@@ -2163,16 +2171,13 @@ async fn spawn_with_memory_scope_project_creates_directory() {
         mem_dir.exists(),
         "memory directory should be created at spawn"
     );
-
-    std::env::set_current_dir(orig_dir).unwrap();
 }
 
 #[tokio::test]
 #[serial]
 async fn spawn_with_config_default_memory_scope_applies_when_def_has_none() {
     let tmp = tempfile::tempdir().unwrap();
-    let orig_dir = std::env::current_dir().unwrap();
-    std::env::set_current_dir(tmp.path()).unwrap();
+    let _cwd = crate::cwd_guard::TestCwdGuard::enter(tmp.path());
 
     let def = SubAgentDef::parse(indoc! {"
         ---
@@ -2217,16 +2222,13 @@ async fn spawn_with_config_default_memory_scope_applies_when_def_has_none() {
         mem_dir.exists(),
         "config default memory scope should create directory"
     );
-
-    std::env::set_current_dir(orig_dir).unwrap();
 }
 
 #[tokio::test]
 #[serial]
 async fn spawn_with_memory_blocked_by_disallowed_tools_skips_memory() {
     let tmp = tempfile::tempdir().unwrap();
-    let orig_dir = std::env::current_dir().unwrap();
-    std::env::set_current_dir(tmp.path()).unwrap();
+    let _cwd = crate::cwd_guard::TestCwdGuard::enter(tmp.path());
 
     let def = SubAgentDef::parse(indoc! {"
         ---
@@ -2272,16 +2274,13 @@ async fn spawn_with_memory_blocked_by_disallowed_tools_skips_memory() {
         !mem_dir.exists(),
         "memory directory should not be created when tools are blocked"
     );
-
-    std::env::set_current_dir(orig_dir).unwrap();
 }
 
 #[tokio::test]
 #[serial]
 async fn spawn_without_memory_scope_no_directory_created() {
     let tmp = tempfile::tempdir().unwrap();
-    let orig_dir = std::env::current_dir().unwrap();
-    std::env::set_current_dir(tmp.path()).unwrap();
+    let _cwd = crate::cwd_guard::TestCwdGuard::enter(tmp.path());
 
     let def = SubAgentDef::parse(indoc! {"
         ---
@@ -2317,16 +2316,13 @@ async fn spawn_without_memory_scope_no_directory_created() {
         !mem_dir.exists(),
         "no agent-memory directory should be created without memory scope"
     );
-
-    std::env::set_current_dir(orig_dir).unwrap();
 }
 
 #[tokio::test]
 #[serial]
 async fn build_prompt_injects_memory_block_after_behavioral_prompt() {
     let tmp = tempfile::tempdir().unwrap();
-    let orig_dir = std::env::current_dir().unwrap();
-    std::env::set_current_dir(tmp.path()).unwrap();
+    let _cwd = crate::cwd_guard::TestCwdGuard::enter(tmp.path());
 
     // Create memory directory and MEMORY.md.
     let mem_dir = tmp
@@ -2366,16 +2362,13 @@ async fn build_prompt_injects_memory_block_after_behavioral_prompt() {
         prompt.contains("key: value"),
         "MEMORY.md content must be injected"
     );
-
-    std::env::set_current_dir(orig_dir).unwrap();
 }
 
 #[tokio::test]
 #[serial]
 async fn build_prompt_auto_enables_read_write_edit_for_allowlist() {
     let tmp = tempfile::tempdir().unwrap();
-    let orig_dir = std::env::current_dir().unwrap();
-    std::env::set_current_dir(tmp.path()).unwrap();
+    let _cwd = crate::cwd_guard::TestCwdGuard::enter(tmp.path());
 
     let mut def = SubAgentDef::parse(indoc! {"
         ---
@@ -2411,16 +2404,13 @@ async fn build_prompt_auto_enables_read_write_edit_for_allowlist() {
                 && list.contains(&"edit".to_owned())),
         "read/write/edit must be auto-enabled in AllowList when memory is set"
     );
-
-    std::env::set_current_dir(orig_dir).unwrap();
 }
 
 #[tokio::test]
 #[serial]
 async fn spawn_with_explicit_def_memory_overrides_config_default() {
     let tmp = tempfile::tempdir().unwrap();
-    let orig_dir = std::env::current_dir().unwrap();
-    std::env::set_current_dir(tmp.path()).unwrap();
+    let _cwd = crate::cwd_guard::TestCwdGuard::enter(tmp.path());
 
     // Agent explicitly sets memory: local, config sets default: project.
     // The explicit local should win.
@@ -2475,16 +2465,13 @@ async fn spawn_with_explicit_def_memory_overrides_config_default() {
         !project_dir.exists(),
         "project memory dir must NOT be created"
     );
-
-    std::env::set_current_dir(orig_dir).unwrap();
 }
 
 #[tokio::test]
 #[serial]
 async fn spawn_memory_blocked_by_deny_list_policy() {
     let tmp = tempfile::tempdir().unwrap();
-    let orig_dir = std::env::current_dir().unwrap();
-    std::env::set_current_dir(tmp.path()).unwrap();
+    let _cwd = crate::cwd_guard::TestCwdGuard::enter(tmp.path());
 
     // tools.deny: [Read, Write, Edit] — DenyList policy blocking all file tools.
     let def = SubAgentDef::parse(indoc! {"
@@ -2531,8 +2518,6 @@ async fn spawn_memory_blocked_by_deny_list_policy() {
         !mem_dir.exists(),
         "memory dir must not be created when DenyList blocks all file tools"
     );
-
-    std::env::set_current_dir(orig_dir).unwrap();
 }
 
 // ── regression tests for #1467: sub-agent tools passed to LLM ────────────
@@ -2838,13 +2823,15 @@ impl zeph_common::anchor::AnchorStore for MockAnchorStoreForLoopTest {
 }
 
 #[tokio::test]
+#[serial_test::serial(subagent_transcript_integrity)]
 async fn run_agent_loop_finalizes_transcript_anchor_on_llm_error_exit_path() {
     // Regression test for #6494: an LLM-call error/timeout must still finalize (anchor) the
     // transcript before `run_agent_loop` returns `Err` — otherwise the transcript is left
     // chained-but-unanchored, reopening the whole-strip downgrade #6449/#6461 closed for any
     // turn that ends on an LLM error. `configure_history_integrity`/`configure_anchor_store`
-    // mutate process-global state; safe here because `cargo nextest` runs each test in its own
-    // process (see `transcript.rs`'s own anchor tests for the same convention).
+    // mutate process-global state shared with every other test in `transcript.rs`'s own
+    // `subagent_transcript_integrity` serial group (issue #6686).
+    let _guard = crate::transcript::IntegrityConfigGuard::new();
     crate::transcript::configure_history_integrity(Some(std::sync::Arc::new(
         zeph_common::hash_chain::ChainKeyRing::new(
             0,
@@ -2911,16 +2898,24 @@ async fn run_agent_loop_finalizes_transcript_anchor_on_llm_error_exit_path() {
         "expected the LLM-call timeout to still propagate as an error"
     );
 
-    assert_eq!(
-        store.map.lock().unwrap().len(),
-        1,
+    // Check for this test's own anchor key rather than the map's total size: `ANCHOR_STORE`
+    // is a process-global shared with every other test's `run_agent_loop` invocation in this
+    // binary (including ordinary spawn tests that never configure anchoring themselves — they
+    // just see `anchor_store() == None` and no-op), so under plain `cargo test`'s thread-per-test
+    // model a concurrently running spawn test can legitimately finalize its own (differently
+    // keyed) transcript into this same store while it's installed here. That is expected
+    // ambient noise, not a defect — only the presence of *this* test's own key proves finalize()
+    // ran (issue #6686).
+    let expected_key = zeph_common::anchor::anchor_key(
+        zeph_common::anchor::AnchorSubsystem::SubagentTranscript,
+        b"abc",
+    );
+    assert!(
+        store.map.lock().unwrap().contains_key(&expected_key),
         "finalize() must have persisted a vault anchor even though the loop exited via the \
          LLM-error path — a missing entry means finalize was skipped, reopening the \
          whole-strip downgrade #6449/#6461 closed"
     );
-
-    crate::transcript::configure_anchor_store(None);
-    crate::transcript::configure_history_integrity(None);
 }
 
 // ── idle-timeout progress heartbeat (#6245) ──────────────────────────────
@@ -3209,12 +3204,12 @@ async fn run_agent_loop_executes_native_tool_call() {
 // --- Fix #2582 tests ---
 
 #[tokio::test]
+#[serial]
 async fn build_system_prompt_injects_working_directory() {
     use tempfile::TempDir;
 
     let tmp = TempDir::new().unwrap();
-    let orig = std::env::current_dir().unwrap();
-    std::env::set_current_dir(tmp.path()).unwrap();
+    let _cwd = crate::cwd_guard::TestCwdGuard::enter(tmp.path());
 
     let mut def = SubAgentDef::parse(indoc! {"
         ---
@@ -3226,7 +3221,6 @@ async fn build_system_prompt_injects_working_directory() {
     .unwrap();
 
     let prompt = build_system_prompt_with_memory(&mut def, None, &SpawnContext::default()).await;
-    std::env::set_current_dir(orig).unwrap();
 
     assert!(
         prompt.contains("Working directory:"),

--- a/crates/zeph-subagent/src/memory.rs
+++ b/crates/zeph-subagent/src/memory.rs
@@ -283,17 +283,27 @@ mod tests {
     #![allow(clippy::format_collect)]
     use std::assert_matches;
 
+    use serial_test::serial;
+
     use super::*;
 
     // ── resolve_memory_dir ────────────────────────────────────────────────────
+    //
+    // `Project`/`Local` scope reads the real process CWD (`std::env::current_dir`), which is
+    // process-wide, not per-thread — every test below that reaches that code path, whether or
+    // not it mutates the CWD itself, must share the crate's single (default, unnamed) `#[serial]`
+    // group with `ensure_*` below and `cwd_guard.rs`'s tests, or it can observe a directory a
+    // concurrent test has just deleted (issue #6686).
 
     #[test]
+    #[serial]
     fn resolve_project_scope_returns_correct_path() {
         let dir = resolve_memory_dir(MemoryScope::Project, "my-agent").unwrap();
         assert!(dir.ends_with(".zeph/agent-memory/my-agent"));
     }
 
     #[test]
+    #[serial]
     fn resolve_local_scope_returns_correct_path() {
         let dir = resolve_memory_dir(MemoryScope::Local, "my-agent").unwrap();
         assert!(dir.ends_with(".zeph/agent-memory-local/my-agent"));
@@ -334,11 +344,13 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn resolve_accepts_single_char_name() {
         resolve_memory_dir(MemoryScope::Project, "a").unwrap();
     }
 
     #[test]
+    #[serial]
     fn resolve_accepts_64_char_name() {
         let name = "a".repeat(64);
         resolve_memory_dir(MemoryScope::Project, &name).unwrap();
@@ -368,25 +380,23 @@ mod tests {
     // ── ensure_memory_dir ────────────────────────────────────────────────────
 
     #[tokio::test]
+    #[serial]
     async fn ensure_creates_directory_for_project_scope() {
         let tmp = tempfile::tempdir().unwrap();
-        let orig_dir = std::env::current_dir().unwrap();
-        std::env::set_current_dir(tmp.path()).unwrap();
+        let _cwd = crate::cwd_guard::TestCwdGuard::enter(tmp.path());
 
         let result = ensure_memory_dir(MemoryScope::Project, "test-agent")
             .await
             .unwrap();
         assert!(result.exists());
         assert!(result.ends_with(".zeph/agent-memory/test-agent"));
-
-        std::env::set_current_dir(orig_dir).unwrap();
     }
 
     #[tokio::test]
+    #[serial]
     async fn ensure_idempotent_when_directory_exists() {
         let tmp = tempfile::tempdir().unwrap();
-        let orig_dir = std::env::current_dir().unwrap();
-        std::env::set_current_dir(tmp.path()).unwrap();
+        let _cwd = crate::cwd_guard::TestCwdGuard::enter(tmp.path());
 
         let dir1 = ensure_memory_dir(MemoryScope::Project, "idempotent-agent")
             .await
@@ -395,8 +405,6 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(dir1, dir2);
-
-        std::env::set_current_dir(orig_dir).unwrap();
     }
 
     // ── load_memory_content ───────────────────────────────────────────────────

--- a/crates/zeph-subagent/src/transcript.rs
+++ b/crates/zeph-subagent/src/transcript.rs
@@ -968,6 +968,31 @@ fn epoch_to_parts(epoch: u64) -> (u32, u32, u32, u32, u32, u32) {
     )
 }
 
+/// RAII guard that resets [`HISTORY_INTEGRITY`] and [`ANCHOR_STORE`] to `None` on drop
+/// (issue #6686). See `zeph_session::log::IntegrityConfigGuard`'s identical doc for the full
+/// rationale — this mirrors it exactly. Every test in this crate that configures either
+/// static, or that constructs a [`TranscriptWriter`]/[`TranscriptReader`] while one could be
+/// configured (e.g. `manager::tests::run_agent_loop_finalizes_transcript_anchor_on_llm_error_exit_path`),
+/// must both construct this guard and carry
+/// `#[serial_test::serial(subagent_transcript_integrity)]`.
+#[cfg(test)]
+pub(crate) struct IntegrityConfigGuard(());
+
+#[cfg(test)]
+impl IntegrityConfigGuard {
+    pub(crate) fn new() -> Self {
+        Self(())
+    }
+}
+
+#[cfg(test)]
+impl Drop for IntegrityConfigGuard {
+    fn drop(&mut self) {
+        configure_history_integrity(None);
+        configure_anchor_store(None);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::assert_matches;
@@ -999,6 +1024,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     async fn writer_reader_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.jsonl");
@@ -1021,6 +1047,7 @@ mod tests {
     /// current-turn-only vision input (spec-072 §4, C1), mirroring the strip already enforced
     /// for `Agent::persist_message`'s `SQLite`/Qdrant/durable-JSONL writers.
     #[tokio::test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     async fn append_strips_image_parts() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.jsonl");
@@ -1063,6 +1090,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     async fn append_preserves_non_image_parts() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.jsonl");
@@ -1090,6 +1118,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     async fn append_empty_parts_unchanged() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.jsonl");
@@ -1109,6 +1138,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     fn load_missing_file_no_meta_returns_empty() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("ghost.jsonl");
@@ -1117,6 +1147,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     fn load_missing_file_with_meta_returns_error() {
         let dir = tempfile::tempdir().unwrap();
         let meta_path = dir.path().join("ghost.meta.json");
@@ -1127,6 +1158,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     fn load_skips_malformed_lines() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("mixed.jsonl");
@@ -1147,6 +1179,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     fn load_strict_fails_on_first_malformed_line() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("mixed.jsonl");
@@ -1174,6 +1207,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     fn load_strict_succeeds_on_intact_file() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("clean.jsonl");
@@ -1193,6 +1227,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     fn load_strict_missing_file_no_meta_returns_empty() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("ghost.jsonl");
@@ -1201,6 +1236,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     fn meta_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
         let meta = test_meta("abc-123");
@@ -1211,6 +1247,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     fn meta_not_found_returns_not_found_error() {
         let dir = tempfile::tempdir().unwrap();
         let err = TranscriptReader::load_meta(dir.path(), "ghost").unwrap_err();
@@ -1218,6 +1255,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     fn find_by_prefix_exact() {
         let dir = tempfile::tempdir().unwrap();
         let meta = test_meta("abcdef01-0000-0000-0000-000000000000");
@@ -1230,6 +1268,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     fn find_by_prefix_short_prefix() {
         let dir = tempfile::tempdir().unwrap();
         let meta = test_meta("deadbeef-0000-0000-0000-000000000000");
@@ -1240,6 +1279,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     fn find_by_prefix_not_found() {
         let dir = tempfile::tempdir().unwrap();
         let err = TranscriptReader::find_by_prefix(dir.path(), "xxxxxxxx").unwrap_err();
@@ -1247,6 +1287,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     fn find_by_prefix_ambiguous() {
         let dir = tempfile::tempdir().unwrap();
         TranscriptWriter::write_meta(dir.path(), "aabb0001-x", &test_meta("aabb0001-x")).unwrap();
@@ -1256,6 +1297,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     fn sweep_old_transcripts_removes_oldest() {
         let dir = tempfile::tempdir().unwrap();
 
@@ -1280,6 +1322,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     fn sweep_with_zero_max_does_nothing() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("a.jsonl"), b"").unwrap();
@@ -1288,6 +1331,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     fn sweep_below_max_does_nothing() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("a.jsonl"), b"").unwrap();
@@ -1296,6 +1340,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     fn utc_now_format() {
         let ts = utc_now();
         // Basic format check: 2026-03-05T00:18:16Z
@@ -1305,6 +1350,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     fn load_empty_file_returns_empty() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("empty.jsonl");
@@ -1314,6 +1360,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     fn load_meta_invalid_json_returns_transcript_error() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("bad.meta.json"), b"not json at all {{{{").unwrap();
@@ -1322,6 +1369,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     fn sweep_removes_companion_meta() {
         let dir = tempfile::tempdir().unwrap();
         // Create 4 JSONL files each with a companion meta sidecar.
@@ -1345,6 +1393,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     fn data_loss_guard_uses_stem_based_meta_path() {
         // path.with_extension("meta.json") on "abc.jsonl" should yield "abc.meta.json"
         // which matches write_meta's format!("{agent_id}.meta.json") when agent_id == stem.
@@ -1358,6 +1407,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     fn meta_roundtrip_preserves_mcp_tool_names() {
         let dir = tempfile::tempdir().unwrap();
         let agent_id = "abc-123";
@@ -1382,7 +1432,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     async fn chained_writer_reader_roundtrip() {
+        let _guard = IntegrityConfigGuard::new();
         configure_history_integrity(Some(test_ring(0, 1)));
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("abc.jsonl");
@@ -1408,12 +1460,12 @@ mod tests {
         assert_eq!(messages.len(), 2);
         assert_eq!(messages[0].content, "hello");
         assert_eq!(messages[1].content, "world");
-
-        configure_history_integrity(None);
     }
 
     #[tokio::test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     async fn tamper_in_place_edit_is_detected() {
+        let _guard = IntegrityConfigGuard::new();
         configure_history_integrity(Some(test_ring(0, 2)));
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("abc.jsonl");
@@ -1443,12 +1495,12 @@ mod tests {
         // that otherwise differ only on JSON-syntax leniency.
         let err = TranscriptReader::load_strict(&path).unwrap_err();
         assert_matches!(err, SubAgentError::Integrity(_));
-
-        configure_history_integrity(None);
     }
 
     #[tokio::test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     async fn legacy_file_is_auto_trusted_once_when_integrity_configured_later() {
+        let _guard = IntegrityConfigGuard::new();
         // Written with integrity disabled (the pre-feature/legacy shape).
         configure_history_integrity(None);
         let dir = tempfile::tempdir().unwrap();
@@ -1488,12 +1540,12 @@ mod tests {
             warned_count_before,
             "a second read of the same path must not add a second warned-set entry"
         );
-
-        configure_history_integrity(None);
     }
 
     #[tokio::test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     async fn partial_strip_of_chain_field_is_detected_as_tamper() {
+        let _guard = IntegrityConfigGuard::new();
         configure_history_integrity(Some(test_ring(0, 4)));
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("abc.jsonl");
@@ -1521,12 +1573,12 @@ mod tests {
 
         let err = TranscriptReader::load(&path).unwrap_err();
         assert_matches!(err, SubAgentError::Integrity(ref m) if m.contains("partial strip"));
-
-        configure_history_integrity(None);
     }
 
     #[tokio::test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     async fn key_unavailable_on_chained_file_fails_closed_not_legacy() {
+        let _guard = IntegrityConfigGuard::new();
         configure_history_integrity(Some(test_ring(0, 5)));
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("abc.jsonl");
@@ -1544,7 +1596,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     async fn rotated_key_epoch_verifies_as_rekeyed_not_tampered() {
+        let _guard = IntegrityConfigGuard::new();
         let old_key_byte = 6u8;
         configure_history_integrity(Some(test_ring(0, old_key_byte)));
         let dir = tempfile::tempdir().unwrap();
@@ -1571,12 +1625,12 @@ mod tests {
             1,
             "a legitimately re-keyed file must still verify"
         );
-
-        configure_history_integrity(None);
     }
 
     #[tokio::test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     async fn writer_reopen_seeds_chain_from_existing_tail() {
+        let _guard = IntegrityConfigGuard::new();
         configure_history_integrity(Some(test_ring(0, 7)));
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("abc.jsonl");
@@ -1600,16 +1654,16 @@ mod tests {
         // The full file, spanning both writer instances, must verify as one continuous chain.
         let messages = TranscriptReader::load(&path).unwrap();
         assert_eq!(messages.len(), 2);
-
-        configure_history_integrity(None);
     }
 
     /// S2 regression: concurrent `append` calls via a cloned writer must never desynchronize
     /// on-disk physical order from chain-link order. Mirrors
     /// `zeph_session::log::tests::test_concurrent_append_preserves_seq_order`.
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    #[serial_test::serial(subagent_transcript_integrity)]
     async fn concurrent_append_preserves_chain_order() {
         const N: u32 = 50;
+        let _guard = IntegrityConfigGuard::new();
         configure_history_integrity(Some(test_ring(0, 8)));
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("abc.jsonl");
@@ -1632,8 +1686,6 @@ mod tests {
         // definite Mismatch tamper verdict even though nothing was actually tampered with.
         let messages = TranscriptReader::load(&path).unwrap();
         assert_eq!(messages.len(), usize::try_from(N).unwrap());
-
-        configure_history_integrity(None);
     }
 
     // --- Vault-anchor downgrade-resistance tests (issue #6449) ---
@@ -1710,7 +1762,9 @@ mod tests {
     /// anchor store configured when it was written) must still open normally when an anchor
     /// store comes online later — an absent anchor is never a tamper signature.
     #[tokio::test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     async fn pre_anchor_chained_file_still_opens_with_anchor_store_online() {
+        let _guard = IntegrityConfigGuard::new();
         configure_history_integrity(Some(test_ring(0, 20)));
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("abc.jsonl");
@@ -1731,15 +1785,14 @@ mod tests {
             1,
             "absent anchor must never brick a legacy-chained file"
         );
-
-        configure_anchor_store(None);
-        configure_history_integrity(None);
     }
 
     /// Acceptance criterion 1/3: whole-strip of an anchored transcript is TAMPER, and so is
     /// truncation below the anchored count.
     #[tokio::test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     async fn whole_strip_of_anchored_transcript_is_tamper() {
+        let _guard = IntegrityConfigGuard::new();
         configure_history_integrity(Some(test_ring(0, 21)));
         let store: Arc<dyn AnchorStore> = Arc::new(MockAnchorStore::default());
         configure_anchor_store(Some(Arc::clone(&store)));
@@ -1778,13 +1831,12 @@ mod tests {
 
         let err = TranscriptReader::load(&path).unwrap_err();
         assert_matches!(err, SubAgentError::Integrity(ref m) if m.contains("TAMPER") && m.contains("vault anchor"));
-
-        configure_anchor_store(None);
-        configure_history_integrity(None);
     }
 
     #[tokio::test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     async fn truncation_below_anchored_count_is_tamper() {
+        let _guard = IntegrityConfigGuard::new();
         configure_history_integrity(Some(test_ring(0, 22)));
         let store: Arc<dyn AnchorStore> = Arc::new(MockAnchorStore::default());
         configure_anchor_store(Some(Arc::clone(&store)));
@@ -1810,13 +1862,12 @@ mod tests {
 
         let err = TranscriptReader::load(&path).unwrap_err();
         assert_matches!(err, SubAgentError::Integrity(ref m) if m.contains("TAMPER") && m.contains("truncated"));
-
-        configure_anchor_store(None);
-        configure_history_integrity(None);
     }
 
     #[tokio::test]
+    #[serial_test::serial(subagent_transcript_integrity)]
     async fn finalize_is_noop_without_anchor_store_or_without_chaining() {
+        let _guard = IntegrityConfigGuard::new();
         // No anchor store configured: finalize must succeed as a no-op.
         configure_history_integrity(Some(test_ring(0, 23)));
         let dir = tempfile::tempdir().unwrap();
@@ -1847,7 +1898,5 @@ mod tests {
                 .is_none(),
             "no anchor should be written for an unchained writer"
         );
-
-        configure_anchor_store(None);
     }
 }

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -5390,8 +5390,13 @@ mod tests {
     /// a documented no-op on non-Unix targets (`AdvisoryLock`, zeph-session's `log.rs`), so a
     /// second `open_exclusive` on non-Unix never contends — matching zeph-session's own
     /// `#[cfg(unix)]`-gated contention tests for the same primitive.
+    ///
+    /// Joins `zeph_bin_history_integrity` (issue #6686): opens a real `SessionEventLog`, which
+    /// reads the process-global `HISTORY_INTEGRITY` this binary's `src/runner.rs` tests share —
+    /// `main.rs` compiles every test module reachable from it into one test process.
     #[cfg(unix)]
     #[tokio::test]
+    #[serial_test::serial(zeph_bin_history_integrity)]
     async fn already_locked_session_log_notifies_client_proactively_without_prompt() {
         let tmp = TempDir::new().unwrap();
         let session_path = tmp.path().join("already-locked-session");

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -4677,6 +4677,33 @@ mod deep_link_tests {
     }
 }
 
+/// RAII guard that resets `zeph_subagent::transcript::HISTORY_INTEGRITY` and
+/// `zeph_session::log::HISTORY_INTEGRITY` to `None` on drop (issue #6686).
+///
+/// This binary crate compiles every `#[cfg(test)]` module reachable from `main.rs` (including
+/// `src/acp.rs`) into one test binary/process, so the one test here that installs a real key
+/// ring via [`configure_history_integrity`] shares that process-wide state with every other
+/// test that opens a `SessionEventLog` — not just the tests in this file. Pair this guard with
+/// `#[serial_test::serial(zeph_bin_history_integrity)]` on every such test, mirroring
+/// `zeph_session::log::IntegrityConfigGuard` / `zeph_subagent::transcript::IntegrityConfigGuard`.
+#[cfg(test)]
+pub(crate) struct HistoryIntegrityTestGuard(());
+
+#[cfg(test)]
+impl HistoryIntegrityTestGuard {
+    pub(crate) fn new() -> Self {
+        Self(())
+    }
+}
+
+#[cfg(test)]
+impl Drop for HistoryIntegrityTestGuard {
+    fn drop(&mut self) {
+        zeph_subagent::transcript::configure_history_integrity(None);
+        zeph_session::log::configure_history_integrity(None);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -4686,11 +4713,15 @@ mod tests {
     //
     // `configure_history_integrity` mutates process-global state (via
     // `zeph_subagent::transcript::configure_history_integrity`/
-    // `zeph_session::log::configure_history_integrity`), so this relies on cargo nextest's
-    // one-process-per-test model for isolation, the same precondition
-    // `crates/zeph-subagent/src/transcript.rs`'s own hash-chain tests document and depend on.
+    // `zeph_session::log::configure_history_integrity`) shared by every test in this binary's
+    // single test process, including `src/acp.rs`'s `SessionEventLog` tests — not just this
+    // file's own (issue #6686). `#[serial_test::serial(zeph_bin_history_integrity)]` plus
+    // `HistoryIntegrityTestGuard` keep this test mutually exclusive with, and always cleaned up
+    // before, every other test in the group.
     #[tokio::test]
+    #[serial_test::serial(zeph_bin_history_integrity)]
     async fn configure_history_integrity_resolves_key_from_explicit_path_not_default_vault_dir() {
+        let _guard = HistoryIntegrityTestGuard::new();
         let vault_dir = tempfile::tempdir().unwrap();
         zeph_core::vault::AgeVaultProvider::init_vault(vault_dir.path()).unwrap();
         let key_path = vault_dir.path().join("vault-key.txt");
@@ -4728,8 +4759,6 @@ mod tests {
         drop(writer);
 
         let raw = std::fs::read_to_string(&transcript_path).unwrap();
-        zeph_subagent::transcript::configure_history_integrity(None);
-        zeph_session::log::configure_history_integrity(None);
 
         assert!(
             raw.contains("\"chain\":"),
@@ -5798,7 +5827,12 @@ mod tests {
 
     /// New conversation with no linked session: `init_session_sink` must create and link a
     /// fresh session and fall back to a bare log open — there is nothing to hydrate yet.
+    ///
+    /// Joins `zeph_bin_history_integrity` (issue #6686): opens a `SessionEventLog`, which reads
+    /// the process-global `HISTORY_INTEGRITY` this binary's one integrity-configuring test
+    /// installs.
     #[tokio::test]
+    #[serial_test::serial(zeph_bin_history_integrity)]
     async fn init_session_sink_creates_and_links_new_session() {
         let memory = make_runner_test_memory().await;
         let cid = memory.sqlite().create_conversation().await.unwrap();
@@ -5831,6 +5865,7 @@ mod tests {
     /// the same hydration pipeline as explicit resume, ACP, and `zeph serve` — not silently fall
     /// back to the `SQLite`-only `messages` projection just because a session already existed.
     #[tokio::test]
+    #[serial_test::serial(zeph_bin_history_integrity)]
     async fn init_session_sink_hydrates_existing_linked_session() {
         let memory = make_runner_test_memory().await;
         let cid = memory.sqlite().create_conversation().await.unwrap();
@@ -5873,6 +5908,7 @@ mod tests {
     /// would still succeed at minting a row, making the failure observable via the row count
     /// below rather than merely via the returned sink.
     #[tokio::test]
+    #[serial_test::serial(zeph_bin_history_integrity)]
     async fn init_session_sink_returns_none_on_store_query_error() {
         let memory = make_runner_test_memory().await;
         let cid = memory.sqlite().create_conversation().await.unwrap();
@@ -5926,6 +5962,7 @@ mod tests {
     /// — the same guarantee the pre-#5451 inline resume path always gave, now reachable directly
     /// without driving `run()` end-to-end.
     #[tokio::test]
+    #[serial_test::serial(zeph_bin_history_integrity)]
     async fn resume_session_sink_fallback_returns_some_when_open_succeeds() {
         let dir = tempfile::tempdir().unwrap();
         let session_path = dir.path().join("session-abc");
@@ -5942,6 +5979,7 @@ mod tests {
     /// #5456 regression: when the bare open also fails (e.g. the session directory cannot be
     /// created), the helper must return `None` rather than panicking or fabricating a sink.
     #[tokio::test]
+    #[serial_test::serial(zeph_bin_history_integrity)]
     async fn resume_session_sink_fallback_returns_none_when_open_fails() {
         let dir = tempfile::tempdir().unwrap();
         // A regular file where a directory component is expected: `create_dir_all` inside
@@ -5966,6 +6004,7 @@ mod tests {
     /// same directory (not a mocked error), exercising the actual `hydrate_and_condense` ->
     /// `hydrate_from_event_log` -> `open_exclusive` call chain.
     #[tokio::test]
+    #[serial_test::serial(zeph_bin_history_integrity)]
     async fn init_session_sink_bails_when_hydration_hits_already_locked() {
         let memory = make_runner_test_memory().await;
         let cid = memory.sqlite().create_conversation().await.unwrap();
@@ -6004,6 +6043,7 @@ mod tests {
     /// `SessionEventLog::open_exclusive` on the same directory must make
     /// `resume_session_sink_fallback` fail fast with `Err`, not silently return `None`.
     #[tokio::test]
+    #[serial_test::serial(zeph_bin_history_integrity)]
     async fn resume_session_sink_fallback_bails_when_already_locked() {
         let dir = tempfile::tempdir().unwrap();
         let session_path = dir.path().join("session-abc");


### PR DESCRIPTION
## Summary

- Fixes 4 independent shared-process-state test-isolation hazards that made `cargo insta test`'s underlying plain `cargo test` (thread-parallel, one process per crate) intermittently fail 41 tests across `zeph-memory`, `zeph-plugins`, `zeph-session`, and `zeph-subagent`, while the same tests always passed under `cargo nextest run`'s process-per-test isolation.
- All four hazards are test-only defects (no production races): a `static` inside a shared `VectorStore` default trait-method body, a process-wide `TMPDIR` env mutation, process-global session-integrity statics reconfigured without synchronization or panic-safe cleanup, and unsynchronized `std::env::set_current_dir` usage.
- Fix-round (post adversarial-critique and independent test-validation passes) additionally closed a same-class hazard in the `zeph` bin crate's own test suite (in scope via the issue's `--bins` acceptance criterion) and a second, independently-flagged untagged test in `zeph-subagent`.
- Filed #6699 separately for an unrelated pre-existing stack overflow discovered while verifying the fix under `--features full` (confirmed unrelated: zero files touched under `src/serve/`, reproduces in total isolation with no concurrency, does not reproduce under the CI feature subset).

Closes #6686

## Test plan

- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 15186 passed, 0 failed
- [x] Each of the 4 touched crates individually repeated 3-15x under plain `cargo test` (the actual harness `cargo insta test` uses) and under `cargo nextest` — 0 failures
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`) — clean
- [x] `cargo insta test --workspace --features full --check --lib --bins` (the issue's literal acceptance command) — run; surfaced only the unrelated, pre-existing #6699 stack overflow, not a regression from this fix
- [x] CHANGELOG.md updated