### PR TITLE
fix(channels): add compile-time invariant guard for MAX_RETRY_SECS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-channels`: `MAX_RETRY_SECS` (the upper bound `send_with_retry` clamps a `Retry-After`
+  delay to) had no compile-time invariant guard (issue #6517). #6516 (closing #6496) filtered
+  the *parsed* `Retry-After` values so a negative/non-finite header or body field could no
+  longer reach `Duration::from_secs_f64`, but nothing stopped `MAX_RETRY_SECS` itself from
+  being edited into a negative, non-finite, or overflow-inducing constant, which
+  `delay_secs.min(MAX_RETRY_SECS)` would silently let through the same panic path — and the
+  existing `max_retry_secs_clamps` test only asserts clamp *behavior*, not the constant's
+  validity. Added a `const _: () = assert!(...)` in `crates/zeph-channels/src/common/http_retry.rs`
+  bounding `MAX_RETRY_SECS` to `[0.0, 3600.0]` and finite, with an explanatory message, so any
+  future edit violating the invariant fails the build instead of silently reintroducing the
+  panic — including the idiomatic-but-unsafe "disable the cap" edit of setting it to `f64::MAX`,
+  which passes a finite/non-negative-only check but still overflows `Duration::from_secs_f64`.
+
 - `src/tracing_init.rs`: `log_guard` (the `WorkerGuard` for the rolling file appender) had the
   same SIGTERM-flush gap as `chrome_guard` before #6683/#6692 fixed it (issue #6693) — a `SIGTERM`
   killed the process before Rust's normal `Drop` glue ran, discarding whatever log lines were

--- a/crates/zeph-channels/src/common/http_retry.rs
+++ b/crates/zeph-channels/src/common/http_retry.rs
@@ -17,6 +17,23 @@ const MAX_RETRY_SECS: f64 = 60.0;
 /// Maximum number of retry attempts before giving up and surfacing the error.
 const MAX_RETRIES: u32 = 3;
 
+/// Guards against `MAX_RETRY_SECS` ever being edited into a negative,
+/// non-finite, or overflow-inducing value: `delay_secs.min(MAX_RETRY_SECS)`
+/// would silently let such a value flow into [`Duration::from_secs_f64`],
+/// which panics on all three cases (negative/NaN, ±infinity, and magnitudes
+/// beyond `Duration::MAX`) — the same panic fixed for parsed `Retry-After`
+/// values by [`valid_retry_secs`]. The 3600.0 (one hour) ceiling bounds how
+/// large a single backoff step can grow if `MAX_RETRY_SECS` is ever edited;
+/// the cumulative worst case across all retries (`MAX_RETRIES *
+/// MAX_RETRY_SECS`) is documented in the `# Timing` section of
+/// [`send_with_retry`] for whatever value is configured.
+const _: () = assert!(
+    MAX_RETRY_SECS.is_finite() && MAX_RETRY_SECS >= 0.0 && MAX_RETRY_SECS <= 3600.0,
+    "MAX_RETRY_SECS must be finite, non-negative, and at most 3600.0 (1 hour): \
+     out-of-range values reach Duration::from_secs_f64, which panics on negative, \
+     non-finite, or overflowing input"
+);
+
 /// Body shape used by rate-limit responses that carry `retry_after` as JSON.
 #[derive(Deserialize, Default)]
 struct RateLimitBody {


### PR DESCRIPTION
## Summary
- `MAX_RETRY_SECS` is the upper bound `send_with_retry` clamps a `Retry-After` delay to via `delay_secs.min(MAX_RETRY_SECS)`. PR #6516 filtered the *parsed* `Retry-After` values so a negative/non-finite header could no longer reach `Duration::from_secs_f64`, but `MAX_RETRY_SECS` itself had no compile-time guarantee of staying finite, non-negative, and `Duration`-safe.
- Adds `const _: () = assert!(MAX_RETRY_SECS.is_finite() && MAX_RETRY_SECS >= 0.0 && MAX_RETRY_SECS <= 3600.0, "...")` in `crates/zeph-channels/src/common/http_retry.rs`, so any future edit that violates the invariant fails the build instead of reintroducing the panic fixed by #6516/#6496 at runtime.
- The upper bound (beyond what the issue originally asked for) closes a real gap found during review: `MAX_RETRY_SECS = f64::MAX` — the idiomatic "disable the cap" edit — passes a finite/non-negative-only check but still overflows `Duration::from_secs_f64`.

Closes #6517

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (15258 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `gitleaks protect --staged`