### PR TITLE
fix(skills): persist quarantined trust row for AutoSkill drafts at generation time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-skills`, `zeph-core`: `SkillGenerator::write_quarantined` wrote an AutoSkill draft's
+  `SKILL.md` to `_quarantine/<name>/` but never persisted a `skill_trust` DB row (issue #6702).
+  The doc comment claimed the `_quarantine` directory prefix kept the registry from ever loading
+  these drafts, but the loader applies no directory-name filtering at all — quarantine was never
+  actually enforced. Because no DB row existed yet, the first hot-reload's
+  `update_trust_for_reloaded_skills` had no existing row to preserve and fell through to
+  `[skills.trust] default_level`, silently trusting an unreviewed draft whenever an operator set
+  `default_level = "trusted"`. `TraceExtractionResult` now reports `saved_skill_paths` for every
+  skill written during extraction (`Add` and `Merge` branches), keyed on the name actually
+  written to disk — the `Merge` branch previously keyed the row on the *pre-merge* skill's name
+  (`nearest_name`), which could clobber an unrelated Bundled/Trusted skill's trust row when the
+  merge LLM renamed the result, and left the actually-written skill without any row at all.
+  `trace_extraction::log_and_persist` eagerly writes a `Quarantined` `skill_trust` row right
+  after generation, before the skill can ever be hot-reloaded, retrying the write once on
+  failure and escalating to `error!` if the retry also fails. Because `MERGE_SYSTEM_PROMPT`
+  instructs the merge LLM to *preserve* the existing skill's name, `merged.name == nearest_name`
+  is the dominant merge outcome, not the exception — so the eager write additionally checks the
+  target skill's existing `skill_trust.source_path` (if any) against the quarantine directory
+  about to be recorded, and skips the upsert with a `tracing::warn!` instead of overwriting when
+  they differ. Without this guard, merging against a Bundled or Trusted skill living outside the
+  quarantine dir would silently clobber its trust row, causing the following hot-reload to demote
+  it to `[skills.trust] hash_mismatch_level` as a tampered skill. Also extracted the native-tool-ID
+  collision `tracing::warn!` (fired when a skill name collides with a tool ID after
+  hyphen/underscore normalization) into its own helper called from `skill_catalog_items` — the
+  call site shared by both the startup catalog emit and every hot-reload — so the warning no
+  longer depends on `SemanticMemory` being configured and fires at startup, not only after the
+  first post-startup file change.
+
 - `zeph-channels`: `MAX_RETRY_SECS` (the upper bound `send_with_retry` clamps a `Retry-After`
   delay to) had no compile-time invariant guard (issue #6517). #6516 (closing #6496) filtered
   the *parsed* `Retry-After` values so a negative/non-finite header or body field could no

--- a/crates/zeph-core/src/agent/skill_reload.rs
+++ b/crates/zeph-core/src/agent/skill_reload.rs
@@ -7,6 +7,8 @@
 //! per-skill trust scores, and reloads `instructions`/`AGENTS.md` overlays when the
 //! filesystem watcher signals a change.
 
+use std::collections::HashSet;
+
 use super::Agent;
 use crate::channel::Channel;
 use crate::context::build_system_prompt;
@@ -14,6 +16,7 @@ use zeph_llm::provider::LlmProvider;
 use zeph_skills::loader::Skill;
 use zeph_skills::matcher::{SkillMatcher, SkillMatcherBackend};
 use zeph_skills::registry::SkillRegistry;
+use zeph_tools::registry::ToolDef;
 
 impl<C: Channel> Agent<C> {
     /// Builds the current skill catalog (name + description) for
@@ -23,7 +26,9 @@ impl<C: Channel> Agent<C> {
     /// apply the same [`zeph_common::SkillTrustLevel::Blocked`] filter — reading
     /// `registry.read().all_meta()` raw at only one of the two sites would let blocked
     /// skills appear in the mention picker until the first hot-reload, then silently
-    /// vanish (M2).
+    /// vanish (M2). Also runs [`Self::warn_on_tool_id_collisions`] here for the same reason:
+    /// it is the one call site that fires on both startup and every hot-reload, independent
+    /// of trust-DB/`memory` availability (#6702 S4).
     pub(super) async fn skill_catalog_items(&mut self) -> Vec<crate::channel::SkillCatalogItem> {
         let all_meta: Vec<zeph_skills::loader::SkillMeta> = self
             .services
@@ -34,6 +39,7 @@ impl<C: Channel> Agent<C> {
             .into_iter()
             .cloned()
             .collect();
+        self.warn_on_tool_id_collisions(&all_meta);
         let trust_map = match self.build_skill_trust_map().await {
             crate::agent::trust_commands::SkillTrustMapLoad::Fresh(map) => map,
             crate::agent::trust_commands::SkillTrustMapLoad::LoadFailed => {
@@ -53,6 +59,36 @@ impl<C: Channel> Agent<C> {
                 description: m.description,
             })
             .collect()
+    }
+
+    /// WARN when a skill name collides with a native (non-MCP) tool ID after hyphen/underscore
+    /// normalization (#6702). `AutoSkill` names can never contain `_` (rejected by both
+    /// `validate_generated_name` and `validate_skill_name`), so only `-` -> `_` normalization
+    /// is needed.
+    ///
+    /// Deliberately independent of `memory`/trust-DB availability, and called from
+    /// [`Self::skill_catalog_items`] rather than [`Self::update_trust_for_reloaded_skills`] —
+    /// the latter early-returns when `memory` is `None` and is only invoked from the
+    /// hot-reload path, so a collision present at startup (before any file changes) never
+    /// warned (#6702 S4).
+    fn warn_on_tool_id_collisions(&self, all_meta: &[zeph_skills::loader::SkillMeta]) {
+        let native_tool_ids: HashSet<String> = self
+            .tool_executor
+            .tool_definitions_erased()
+            .into_iter()
+            .filter(|t| !ToolDef::is_mcp_tool(t))
+            .map(|t| t.id.to_string())
+            .collect();
+        for meta in all_meta {
+            let normalized = meta.name.replace('-', "_");
+            if native_tool_ids.contains(&normalized) {
+                tracing::warn!(
+                    skill = %meta.name,
+                    tool_id = %normalized,
+                    "skill name collides with a native tool ID after hyphen/underscore normalization"
+                );
+            }
+        }
     }
 
     /// Update trust DB records for all reloaded skills.
@@ -380,5 +416,244 @@ impl<C: Channel> Agent<C> {
             "reloaded instruction files"
         );
         self.runtime.instructions.blocks = new_blocks;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use tracing_subscriber::layer::SubscriberExt as _;
+    use zeph_common::SkillTrustLevel;
+    use zeph_memory::semantic::SemanticMemory;
+    use zeph_memory::store::SourceKind;
+
+    use super::super::agent_tests::{
+        MockChannel, MockToolExecutor, create_test_registry, mock_provider,
+    };
+    use super::*;
+
+    async fn test_memory() -> Arc<SemanticMemory> {
+        let provider = zeph_llm::any::AnyProvider::Mock(zeph_llm::mock::MockProvider::default());
+        Arc::new(
+            SemanticMemory::new(
+                ":memory:",
+                "http://127.0.0.1:1",
+                None,
+                provider,
+                "test-model",
+            )
+            .await
+            .unwrap(),
+        )
+    }
+
+    fn agent_with_memory_and_executor(
+        memory: Arc<SemanticMemory>,
+        executor: MockToolExecutor,
+    ) -> Agent<MockChannel> {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        Agent::new(provider, channel, registry, None, 5, executor).with_memory(
+            memory,
+            zeph_memory::ConversationId(1),
+            50,
+            5,
+            50,
+        )
+    }
+
+    /// Regression test for #6702: once a `skill_trust` row has been written at
+    /// `Quarantined` (simulating the eager write `log_and_persist` now performs right
+    /// after an `AutoSkill` draft is generated), a hot-reload pass with
+    /// `trust_cfg.default_level = Trusted` must NOT silently promote it. Only the
+    /// `_quarantine/` directory naming used to be relied on for this — which the loader
+    /// never actually enforced.
+    #[tokio::test]
+    async fn update_trust_preserves_quarantine_despite_trusted_default() {
+        let managed = tempfile::tempdir().unwrap();
+        let skill_dir = managed.path().join("_quarantine").join("my-skill");
+        tokio::fs::create_dir_all(&skill_dir).await.unwrap();
+        tokio::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: my-skill\ndescription: A test skill.\nversion: 0\nsource: trace_extraction\n---\n\n## How to use\nDo the thing.\n",
+        )
+        .await
+        .unwrap();
+        let hash = zeph_skills::compute_skill_hash(&skill_dir).unwrap();
+
+        let memory = test_memory().await;
+        memory
+            .sqlite()
+            .upsert_skill_trust(
+                "my-skill",
+                SkillTrustLevel::Quarantined,
+                SourceKind::Hub,
+                None,
+                skill_dir.to_str(),
+                &hash,
+            )
+            .await
+            .unwrap();
+
+        let mut agent =
+            agent_with_memory_and_executor(memory.clone(), MockToolExecutor::no_tools());
+        agent.services.skill.trust_config.default_level = SkillTrustLevel::Trusted;
+        agent.services.skill.managed_dir = Some(managed.path().to_path_buf());
+
+        let meta = zeph_skills::loader::SkillMeta {
+            name: "my-skill".into(),
+            description: "A test skill.".into(),
+            version: 0,
+            source: "trace_extraction".into(),
+            skill_dir: skill_dir.clone(),
+            ..Default::default()
+        };
+        agent.update_trust_for_reloaded_skills(&[meta]).await;
+
+        let row = memory
+            .sqlite()
+            .load_skill_trust("my-skill")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            row.trust_level,
+            SkillTrustLevel::Quarantined,
+            "an existing Quarantined row must survive a reload even when default_level=Trusted"
+        );
+    }
+
+    struct MessageCaptureLayer {
+        messages: Arc<Mutex<Vec<String>>>,
+    }
+    struct MessageVisitor(String);
+    impl tracing::field::Visit for MessageVisitor {
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            if field.name() == "message" {
+                self.0 = format!("{value:?}");
+            }
+        }
+    }
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for MessageCaptureLayer {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            let mut visitor = MessageVisitor(String::new());
+            event.record(&mut visitor);
+            self.messages.lock().unwrap().push(visitor.0);
+        }
+    }
+
+    fn colliding_tool_executor() -> MockToolExecutor {
+        let tool_def = ToolDef {
+            id: "list_directory".into(),
+            description: "list directory tool".into(),
+            schema: schemars::Schema::default(),
+            invocation: zeph_tools::registry::InvocationHint::ToolCall,
+            output_schema: None,
+            server_id: None,
+        };
+        MockToolExecutor::no_tools().with_definitions(vec![tool_def])
+    }
+
+    fn colliding_skill_meta() -> zeph_skills::loader::SkillMeta {
+        zeph_skills::loader::SkillMeta {
+            name: "list-directory".into(),
+            description: "A colliding skill.".into(),
+            version: 0,
+            source: "trace_extraction".into(),
+            skill_dir: std::path::PathBuf::from("/nonexistent/list-directory"),
+            ..Default::default()
+        }
+    }
+
+    fn capture_warn_messages() -> (Arc<Mutex<Vec<String>>>, tracing::subscriber::DefaultGuard) {
+        let messages: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let layer = MessageCaptureLayer {
+            messages: messages.clone(),
+        };
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let guard = tracing::subscriber::set_default(subscriber);
+        (messages, guard)
+    }
+
+    fn assert_collision_warn_fired(captured: &[String]) {
+        assert!(
+            captured.iter().any(|m| m.contains(
+                "skill name collides with a native tool ID after hyphen/underscore normalization"
+            )),
+            "expected a collision WARN, got: {captured:?}"
+        );
+    }
+
+    /// Regression test for #6702 direction 1: a skill whose name collides with a native
+    /// tool ID after hyphen/underscore normalization must WARN, with `memory` present.
+    #[tokio::test]
+    async fn update_trust_warns_on_native_tool_id_collision() {
+        let memory = test_memory().await;
+        let agent = agent_with_memory_and_executor(memory, colliding_tool_executor());
+
+        let (messages, _guard) = capture_warn_messages();
+        agent.warn_on_tool_id_collisions(&[colliding_skill_meta()]);
+        assert_collision_warn_fired(&messages.lock().unwrap());
+    }
+
+    /// Regression test for #6702 S4(a): the collision WARN must fire even when `memory` is
+    /// `None` (no `SemanticMemory` configured) — the check must not be gated behind trust-DB
+    /// availability, since `update_trust_for_reloaded_skills` early-returns without memory but
+    /// the collision itself has nothing to do with the trust DB.
+    #[tokio::test]
+    async fn warn_on_tool_id_collisions_fires_without_memory() {
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let registry = create_test_registry();
+        let agent = Agent::new(
+            provider,
+            channel,
+            registry,
+            None,
+            5,
+            colliding_tool_executor(),
+        );
+
+        let (messages, _guard) = capture_warn_messages();
+        agent.warn_on_tool_id_collisions(&[colliding_skill_meta()]);
+        assert_collision_warn_fired(&messages.lock().unwrap());
+    }
+
+    /// Regression test for #6702 S4(b): the collision check must run from
+    /// `skill_catalog_items()` — the call site shared by the startup emit (`Agent::run`) and
+    /// every hot-reload — so a colliding skill present at startup (steady state, before any
+    /// file changes) is caught too, not only after the first hot-reload's fingerprint change.
+    #[tokio::test]
+    async fn skill_catalog_items_warns_on_native_tool_id_collision() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let skill_dir = temp_dir.path().join("list-directory");
+        std::fs::create_dir(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: list-directory\ndescription: A colliding skill.\n---\nBody",
+        )
+        .unwrap();
+        let registry = SkillRegistry::load(&[temp_dir.path().to_path_buf()]);
+
+        let provider = mock_provider(vec![]);
+        let channel = MockChannel::new(vec![]);
+        let mut agent = Agent::new(
+            provider,
+            channel,
+            registry,
+            None,
+            5,
+            colliding_tool_executor(),
+        );
+
+        let (messages, _guard) = capture_warn_messages();
+        let _ = agent.skill_catalog_items().await;
+        assert_collision_warn_fired(&messages.lock().unwrap());
     }
 }

--- a/crates/zeph-core/src/agent/trace_extraction.rs
+++ b/crates/zeph-core/src/agent/trace_extraction.rs
@@ -8,9 +8,11 @@
 //! Idempotency is enforced via the `skill_trace_sessions` `SQLite` table.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use zeph_llm::any::AnyProvider;
 use zeph_llm::provider::Role;
+use zeph_memory::semantic::SemanticMemory;
 use zeph_skills::loader::SkillMeta;
 use zeph_skills::trace_extractor::{
     TraceExtractionResult, TraceExtractor, UserMessage, session_record,
@@ -90,6 +92,7 @@ impl<C: Channel> super::Agent<C> {
 
         let status_tx = self.services.session.status_tx.clone();
         let db_pool = self.get_db_pool_for_trace_extraction();
+        let memory = self.services.memory.persistence.memory.clone();
 
         let _ = self
             .services
@@ -114,6 +117,7 @@ impl<C: Channel> super::Agent<C> {
                     user_messages,
                     conversation_id,
                     db_pool,
+                    memory,
                     status_tx,
                 )
             },
@@ -161,6 +165,7 @@ async fn run_extraction(
     user_messages: Vec<UserMessage>,
     session_id: String,
     db_pool: Option<zeph_db::DbPool>,
+    memory: Option<Arc<SemanticMemory>>,
     status_tx: Option<tokio::sync::mpsc::UnboundedSender<String>>,
 ) {
     let extractor = TraceExtractor::new(
@@ -180,7 +185,7 @@ async fn run_extraction(
         .await
     {
         Ok(result) => {
-            log_and_persist(&session_id, &result, db_pool).await;
+            log_and_persist(&session_id, &result, db_pool, memory).await;
         }
         Err(e) => {
             tracing::warn!(session_id = %session_id, error = %e, "trace_extraction: failed (session NOT marked as processed)");
@@ -188,10 +193,19 @@ async fn run_extraction(
     }
 }
 
+/// Log the extraction summary, persist the idempotency row, and record each freshly
+/// quarantined skill's `skill_trust` row at [`zeph_common::SkillTrustLevel::Quarantined`].
+///
+/// The trust write happens here — not in `zeph-skills` — because writing the draft `SKILL.md`
+/// to `_quarantine/` is not itself a security boundary (see `SkillGenerator::write_quarantined`
+/// doc comment): without this DB row, the next hot-reload's `update_trust_for_reloaded_skills`
+/// finds no existing row for the new skill and falls back to `trust_cfg.default_level`, which
+/// can silently trust an unreviewed draft (#6702).
 async fn log_and_persist(
     session_id: &str,
     result: &TraceExtractionResult,
     db_pool: Option<zeph_db::DbPool>,
+    memory: Option<Arc<SemanticMemory>>,
 ) {
     tracing::info!(
         session_id = %session_id,
@@ -200,21 +214,342 @@ async fn log_and_persist(
         merged = result.candidates_merged,
         "trace_extraction: session complete"
     );
-    let Some(pool) = db_pool else { return };
-    let (sid, ts, proposed, saved, merged) = session_record(session_id, result);
-    let _ = zeph_db::query(
-        "INSERT OR IGNORE INTO skill_trace_sessions \
-         (session_id, processed_at, candidates_proposed, candidates_saved, candidates_merged) \
-         VALUES (?, ?, ?, ?, ?)",
-    )
-    .bind(sid)
-    .bind(ts)
-    .bind(proposed)
-    .bind(saved)
-    .bind(merged)
-    .execute(&pool)
+    if let Some(pool) = db_pool {
+        let (sid, ts, proposed, saved, merged) = session_record(session_id, result);
+        let _ = zeph_db::query(
+            "INSERT OR IGNORE INTO skill_trace_sessions \
+             (session_id, processed_at, candidates_proposed, candidates_saved, candidates_merged) \
+             VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(sid)
+        .bind(ts)
+        .bind(proposed)
+        .bind(saved)
+        .bind(merged)
+        .execute(&pool)
+        .await
+        .map_err(|e| {
+            tracing::warn!(error = %e, "trace_extraction: failed to write idempotency row");
+        });
+    }
+
+    let Some(memory) = memory else { return };
+    for (skill_name, skill_md_path) in &result.saved_skill_paths {
+        persist_quarantined_trust_row(session_id, &memory, skill_name, skill_md_path).await;
+    }
+}
+
+/// Hash a single quarantined skill and (re)write its `skill_trust` row, unless doing so would
+/// clobber the row of an unrelated skill that happens to share the name.
+async fn persist_quarantined_trust_row(
+    session_id: &str,
+    memory: &SemanticMemory,
+    skill_name: &str,
+    skill_md_path: &std::path::Path,
+) {
+    let md_path = skill_md_path.to_path_buf();
+    let Ok(Some((skill_dir, hash))) = tokio::task::spawn_blocking(move || {
+        let skill_dir = md_path.parent().map(std::path::Path::to_path_buf)?;
+        let hash = zeph_skills::compute_skill_hash(&skill_dir).ok()?;
+        Some((skill_dir, hash))
+    })
     .await
-    .map_err(|e| {
-        tracing::warn!(error = %e, "trace_extraction: failed to write idempotency row");
-    });
+    else {
+        tracing::warn!(
+            session_id = %session_id,
+            skill = %skill_name,
+            "trace_extraction: failed to hash quarantined skill, trust row not written"
+        );
+        return;
+    };
+    // `source_path` stores the skill *directory*, matching the convention used by
+    // `update_trust_for_reloaded_skills` (skill_reload.rs) — the two write sites must agree so
+    // the column doesn't flip-flop between the eager write here and the next hot-reload
+    // (#6702 M3).
+    let source_path = skill_dir.to_str();
+    if has_conflicting_trust_row(memory, skill_name, source_path).await {
+        tracing::warn!(
+            session_id = %session_id,
+            skill = %skill_name,
+            quarantine_source_path = ?source_path,
+            "trace_extraction: name collision with an existing skill outside the quarantine \
+             dir, skipping trust upsert to avoid clobbering it"
+        );
+        return;
+    }
+    // A failed write here means the exact #6702 bug recurs on the next reload with nothing
+    // left to retry it (the draft is already on disk, quarantine-only). Retry once
+    // synchronously before giving up — this is a local SQLite write, so a bounded retry is
+    // cheap and covers transient lock contention (#6702 M1).
+    let mut attempt = memory
+        .sqlite()
+        .upsert_skill_trust(
+            skill_name,
+            zeph_common::SkillTrustLevel::Quarantined,
+            zeph_memory::store::SourceKind::Hub,
+            None,
+            source_path,
+            &hash,
+        )
+        .await;
+    if attempt.is_err() {
+        attempt = memory
+            .sqlite()
+            .upsert_skill_trust(
+                skill_name,
+                zeph_common::SkillTrustLevel::Quarantined,
+                zeph_memory::store::SourceKind::Hub,
+                None,
+                source_path,
+                &hash,
+            )
+            .await;
+    }
+    if let Err(e) = attempt {
+        tracing::error!(
+            session_id = %session_id,
+            skill = %skill_name,
+            error = %e,
+            "trace_extraction: failed to persist quarantined trust row after retry"
+        );
+    }
+}
+
+/// Whether `skill_name` already has a trust row owned by a *different* on-disk skill.
+///
+/// The merge prompt instructs the LLM to preserve the existing skill's name
+/// (`merge_prompts.rs`), so `skill_name` here routinely collides with a Bundled or Trusted
+/// skill living outside the quarantine dir. Blindly upserting would clobber that unrelated
+/// skill's trust row, and the next hot-reload would demote it via `hash_mismatch_level`
+/// (#6702 S1'). A row with no recorded `source_path` (legacy/manual rows) or one that already
+/// points at `quarantine_source_path` (re-extracting the same evolving draft in place) is safe
+/// to overwrite; only a row whose `source_path` names a different directory is a genuine
+/// collision.
+async fn has_conflicting_trust_row(
+    memory: &SemanticMemory,
+    skill_name: &str,
+    quarantine_source_path: Option<&str>,
+) -> bool {
+    let Some(row) = memory
+        .sqlite()
+        .load_skill_trust(skill_name)
+        .await
+        .ok()
+        .flatten()
+    else {
+        return false;
+    };
+    match row.source_path.as_deref() {
+        None => false,
+        existing => existing != quarantine_source_path,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use zeph_memory::semantic::SemanticMemory;
+
+    use super::*;
+
+    async fn test_memory() -> Arc<SemanticMemory> {
+        let provider = zeph_llm::any::AnyProvider::Mock(zeph_llm::mock::MockProvider::default());
+        Arc::new(
+            SemanticMemory::new(
+                ":memory:",
+                "http://127.0.0.1:1",
+                None,
+                provider,
+                "test-model",
+            )
+            .await
+            .unwrap(),
+        )
+    }
+
+    /// Regression test for #6702: `log_and_persist` must eagerly write a `Quarantined`
+    /// `skill_trust` row for every skill saved during extraction, so the very first
+    /// hot-reload never has to fall back to `trust_cfg.default_level`.
+    #[tokio::test]
+    async fn log_and_persist_writes_quarantined_trust_row_for_saved_skills() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skill_dir = tmp.path().join("my-new-skill");
+        tokio::fs::create_dir_all(&skill_dir).await.unwrap();
+        let skill_md_path = skill_dir.join("SKILL.md");
+        tokio::fs::write(
+            &skill_md_path,
+            "---\nname: my-new-skill\ndescription: A test skill.\nversion: 0\nsource: trace_extraction\n---\n\n## How to use\nDo the thing.\n",
+        )
+        .await
+        .unwrap();
+
+        let memory = test_memory().await;
+        let result = TraceExtractionResult {
+            saved_skill_paths: vec![("my-new-skill".to_string(), skill_md_path)],
+            ..Default::default()
+        };
+
+        log_and_persist("test-session", &result, None, Some(memory.clone())).await;
+
+        let row = memory
+            .sqlite()
+            .load_skill_trust("my-new-skill")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.trust_level, zeph_common::SkillTrustLevel::Quarantined);
+        assert_eq!(row.source_kind, zeph_memory::store::SourceKind::Hub);
+    }
+
+    /// Spec 057 NEVER clause: a merge result written under a name that already carries a
+    /// `Trusted` row (a human-reviewed skill, or a coincidental name reuse) must still be
+    /// reset to `Quarantined` — trust must never be inherited from an existing row. Locks in
+    /// the S1/S2 fix (`saved_skill_paths` keyed on the written name) end-to-end through
+    /// `log_and_persist`. The existing row has no recorded `source_path`, which also exercises
+    /// the "unknown provenance" branch of the S1' guard
+    /// (`log_and_persist_skips_upsert_on_source_path_collision` below covers the "known,
+    /// different directory" branch).
+    #[tokio::test]
+    async fn log_and_persist_resets_already_trusted_skill_to_quarantined() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skill_dir = tmp.path().join("existing-skill-v2");
+        tokio::fs::create_dir_all(&skill_dir).await.unwrap();
+        let skill_md_path = skill_dir.join("SKILL.md");
+        tokio::fs::write(
+            &skill_md_path,
+            "---\nname: existing-skill-v2\ndescription: A merged skill.\nversion: 1\nsource: trace_extraction\n---\n\n## How to use\nDo the merged thing.\n",
+        )
+        .await
+        .unwrap();
+
+        let memory = test_memory().await;
+        memory
+            .sqlite()
+            .upsert_skill_trust(
+                "existing-skill-v2",
+                zeph_common::SkillTrustLevel::Trusted,
+                zeph_memory::store::SourceKind::Local,
+                None,
+                None,
+                "stale-hash",
+            )
+            .await
+            .unwrap();
+
+        let result = TraceExtractionResult {
+            saved_skill_paths: vec![("existing-skill-v2".to_string(), skill_md_path)],
+            ..Default::default()
+        };
+
+        log_and_persist("test-session", &result, None, Some(memory.clone())).await;
+
+        let row = memory
+            .sqlite()
+            .load_skill_trust("existing-skill-v2")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            row.trust_level,
+            zeph_common::SkillTrustLevel::Quarantined,
+            "trust must never be inherited from an existing row (spec 057)"
+        );
+    }
+
+    /// #6702 S1': the merge prompt instructs the LLM to preserve the existing skill's name, so
+    /// `saved_skill_paths` routinely carries a name that already belongs to an unrelated skill
+    /// living outside the quarantine dir (e.g. a Bundled skill). `log_and_persist` must detect
+    /// the `source_path` mismatch and skip the upsert entirely, leaving that skill's real trust
+    /// row untouched instead of clobbering it with quarantine metadata for an unrelated draft.
+    #[tokio::test]
+    async fn log_and_persist_skips_upsert_on_source_path_collision() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bundled_dir = tmp.path().join("bundled").join("existing-skill");
+        let quarantine_dir = tmp.path().join("_quarantine").join("existing-skill");
+        tokio::fs::create_dir_all(&quarantine_dir).await.unwrap();
+        let skill_md_path = quarantine_dir.join("SKILL.md");
+        tokio::fs::write(
+            &skill_md_path,
+            "---\nname: existing-skill\ndescription: A merged draft.\nversion: 1\nsource: trace_extraction\n---\n\n## How to use\nDo the merged thing.\n",
+        )
+        .await
+        .unwrap();
+
+        let memory = test_memory().await;
+        memory
+            .sqlite()
+            .upsert_skill_trust(
+                "existing-skill",
+                zeph_common::SkillTrustLevel::Trusted,
+                zeph_memory::store::SourceKind::Bundled,
+                None,
+                bundled_dir.to_str(),
+                "bundled-hash",
+            )
+            .await
+            .unwrap();
+
+        let result = TraceExtractionResult {
+            saved_skill_paths: vec![("existing-skill".to_string(), skill_md_path)],
+            ..Default::default()
+        };
+
+        log_and_persist("test-session", &result, None, Some(memory.clone())).await;
+
+        let row = memory
+            .sqlite()
+            .load_skill_trust("existing-skill")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            row.trust_level,
+            zeph_common::SkillTrustLevel::Trusted,
+            "a name collision with a skill outside the quarantine dir must not clobber its trust row"
+        );
+        assert_eq!(row.source_kind, zeph_memory::store::SourceKind::Bundled);
+        assert_eq!(row.source_path.as_deref(), bundled_dir.to_str());
+        assert_eq!(row.blake3_hash, "bundled-hash");
+    }
+
+    // Opens a migrated in-memory SQLite pool with the `skill_trace_sessions` table, mirroring
+    // `shadow_sentinel.rs`'s `test_pool` helper.
+    async fn test_pool() -> zeph_db::DbPool {
+        zeph_db::DbConfig {
+            url: ":memory:".to_owned(),
+            ..Default::default()
+        }
+        .connect()
+        .await
+        .expect("connect + migrate in-memory sqlite pool")
+    }
+
+    /// When `memory` is `None` (no `SemanticMemory` configured), `log_and_persist` must still
+    /// persist the `skill_trace_sessions` idempotency row — the trust-write loop and the
+    /// session-row insert are structurally independent, so the absence of one must not silently
+    /// drop the other.
+    #[tokio::test]
+    async fn log_and_persist_without_memory_still_persists_session_row() {
+        let pool = test_pool().await;
+        let result = TraceExtractionResult {
+            candidates_proposed: 1,
+            candidates_saved: 1,
+            saved_skill_paths: vec![("orphan-skill".to_string(), PathBuf::from("/nonexistent"))],
+            ..Default::default()
+        };
+
+        log_and_persist("test-session", &result, Some(pool.clone()), None).await;
+
+        let count: i64 =
+            zeph_db::query_scalar("SELECT COUNT(*) FROM skill_trace_sessions WHERE session_id = ?")
+                .bind("test-session")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            count, 1,
+            "session row must be persisted even without memory"
+        );
+    }
 }

--- a/crates/zeph-skills/src/generator.rs
+++ b/crates/zeph-skills/src/generator.rs
@@ -314,8 +314,12 @@ impl SkillGenerator {
     /// does not check for directory existence (re-extraction overwrites previous candidates).
     /// The output path is `<output_dir>/_quarantine/<name>/SKILL.md`.
     ///
-    /// The `_quarantine` prefix ensures the registry's directory scanner never loads these
-    /// files as active skills, because `validate_skill_name` rejects `_`-prefixed names.
+    /// The `_quarantine` prefix is a human-readable convention only — the registry's directory
+    /// scanner applies no directory-name filtering and will happily load a `SKILL.md` found
+    /// under this path as an active skill. Quarantine is enforced solely by the `skill_trust`
+    /// database row that the caller MUST write immediately after this call returns, at
+    /// [`zeph_common::SkillTrustLevel::Quarantined`]. Never treat the directory name as a
+    /// security boundary.
     ///
     /// # Errors
     ///

--- a/crates/zeph-skills/src/trace_extractor.rs
+++ b/crates/zeph-skills/src/trace_extractor.rs
@@ -100,6 +100,13 @@ pub struct TraceExtractionResult {
     pub candidates_merged: u32,
     /// Candidates discarded as near-duplicates.
     pub candidates_discarded: u32,
+    /// Skills written to the quarantine directory this run, as `(skill_name, skill_md_path)`.
+    ///
+    /// Covers both the `Add` path (new draft) and the `Merge` path (new version of an
+    /// existing skill). The caller uses this to persist a `skill_trust` row at
+    /// [`zeph_common::SkillTrustLevel::Quarantined`] for each entry — quarantine is enforced
+    /// at the DB layer, not by the `_quarantine/` directory name.
+    pub saved_skill_paths: Vec<(String, PathBuf)>,
 }
 
 /// Orchestrates the conversation trace → skill extraction pipeline.
@@ -309,7 +316,9 @@ impl TraceExtractor {
         result: &mut TraceExtractionResult,
     ) {
         if existing_embeddings.is_empty() {
-            self.save_quarantined(skill, session_id).await;
+            if let Some(path) = self.save_quarantined(skill, session_id).await {
+                result.saved_skill_paths.push((skill.name.clone(), path));
+            }
             result.candidates_saved += 1;
             self.notify_proposed(&skill.name);
             return;
@@ -317,7 +326,9 @@ impl TraceExtractor {
 
         let Some((nearest_meta, nearest_sim)) = find_nearest(candidate_emb, existing_embeddings)
         else {
-            self.save_quarantined(skill, session_id).await;
+            if let Some(path) = self.save_quarantined(skill, session_id).await {
+                result.saved_skill_paths.push((skill.name.clone(), path));
+            }
             result.candidates_saved += 1;
             self.notify_proposed(&skill.name);
             return;
@@ -331,7 +342,9 @@ impl TraceExtractor {
             nearest_meta,
         ) {
             MergeDecision::Add => {
-                self.save_quarantined(skill, session_id).await;
+                if let Some(path) = self.save_quarantined(skill, session_id).await {
+                    result.saved_skill_paths.push((skill.name.clone(), path));
+                }
                 result.candidates_saved += 1;
                 self.notify_proposed(&skill.name);
             }
@@ -358,7 +371,12 @@ impl TraceExtractor {
                     )
                     .await
                 {
-                    Ok(()) => {
+                    Ok((merged_name, path)) => {
+                        // Key the trust row on the name actually written to disk, never on
+                        // `nearest_name` — the merge LLM is free to rename the skill, and
+                        // `nearest_meta` carries no trust/source gating, so it can point at an
+                        // unrelated Bundled/Trusted skill (#6702 S1/S2).
+                        result.saved_skill_paths.push((merged_name, path));
                         result.candidates_merged += 1;
                         self.notify_proposed(&format!("{nearest_name} v{}", nearest_version + 1));
                     }
@@ -426,24 +444,34 @@ impl TraceExtractor {
 
     /// Write a candidate skill to the quarantine directory. Logs on failure.
     #[tracing::instrument(name = "skills.trace_extraction.save_quarantined", skip_all, fields(skill = %skill.name, session_id))]
-    async fn save_quarantined(&self, skill: &GeneratedSkill, session_id: &str) {
+    async fn save_quarantined(&self, skill: &GeneratedSkill, session_id: &str) -> Option<PathBuf> {
         match self.generator.write_quarantined(skill).await {
-            Ok(path) => tracing::info!(
-                session_id,
-                skill = %skill.name,
-                path = %path.display(),
-                "trace_extractor: skill quarantined"
-            ),
-            Err(e) => tracing::warn!(
-                session_id,
-                skill = %skill.name,
-                error = %e,
-                "trace_extractor: failed to write quarantined skill"
-            ),
+            Ok(path) => {
+                tracing::info!(
+                    session_id,
+                    skill = %skill.name,
+                    path = %path.display(),
+                    "trace_extractor: skill quarantined"
+                );
+                Some(path)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    session_id,
+                    skill = %skill.name,
+                    error = %e,
+                    "trace_extractor: failed to write quarantined skill"
+                );
+                None
+            }
         }
     }
 
     /// Call the LLM merge prompt and write the merged skill to quarantine.
+    ///
+    /// Returns the *written* skill's name paired with its path — the merge LLM is free to
+    /// rename the skill, so callers must never assume the returned name equals
+    /// `existing_name` (spec 057; see #6702 S2).
     ///
     /// # Errors
     ///
@@ -456,7 +484,7 @@ impl TraceExtractor {
         existing_version: u32,
         existing_skill_dir: &Path,
         session_id: &str,
-    ) -> Result<(), SkillError> {
+    ) -> Result<(String, PathBuf), SkillError> {
         async move {
             // Read the existing skill body from disk so the merge LLM sees full content.
             // Fall back to a minimal stub when the file cannot be read (e.g. quarantined draft).
@@ -495,16 +523,17 @@ impl TraceExtractor {
             }
 
             let merged = parse_and_validate_pub(&content)?;
-            self.generator.write_quarantined(&merged).await?;
+            let path = self.generator.write_quarantined(&merged).await?;
 
             tracing::info!(
                 session_id,
                 existing = existing_name,
+                merged = %merged.name,
                 next_version = existing_version + 1,
                 "trace_extractor: merged skill quarantined"
             );
 
-            Ok(())
+            Ok((merged.name, path))
         }
         .instrument(tracing::info_span!(
             "skills.trace_extraction.merge",
@@ -638,6 +667,7 @@ mod tests {
             candidates_merged: 1,
             candidates_discarded: 0,
             candidates_rejected_injection: 0,
+            saved_skill_paths: vec![],
         };
         let (sid, _ts, proposed, saved, merged) = session_record("test-session-123", &result);
         assert_eq!(sid, "test-session-123");
@@ -867,5 +897,167 @@ mod tests {
             has_line_delimiter,
             "closing delimiter must be appended even when '---' appears inside a field value"
         );
+    }
+
+    #[tokio::test]
+    async fn apply_decision_add_path_populates_saved_skill_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        let extract_provider = zeph_llm::any::AnyProvider::Mock(
+            zeph_llm::mock::MockProvider::with_responses(vec![
+                "---\nname: my-new-skill\ndescription: A new skill for testing.\nversion: 0\nsource: trace_extraction\n---\n\n## How to use\nDo the thing.".to_string(),
+            ]),
+        );
+        let embed_provider = zeph_llm::any::AnyProvider::Mock(
+            zeph_llm::mock::MockProvider::default().with_embedding(vec![1.0, 0.0]),
+        );
+        let extractor = TraceExtractor::new(
+            extract_provider,
+            embed_provider,
+            tmp.path().to_path_buf(),
+            200,
+            131_072,
+            0.75,
+            0.90,
+            true,
+            None,
+        );
+        let messages = [UserMessage {
+            text: "help me write a script".into(),
+        }];
+        let result = extractor
+            .extract_from_trace(&messages, &[], "add-session")
+            .await
+            .unwrap();
+        assert_eq!(result.candidates_saved, 1);
+        assert_eq!(result.saved_skill_paths.len(), 1);
+        assert_eq!(result.saved_skill_paths[0].0, "my-new-skill");
+        assert!(result.saved_skill_paths[0].1.ends_with("SKILL.md"));
+    }
+
+    #[tokio::test]
+    async fn apply_decision_merge_path_populates_saved_skill_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        // The merge LLM response deliberately renames the skill (`existing-skill-v2` !=
+        // `existing-skill`) so this test locks in #6702 S1/S2: `saved_skill_paths` must be
+        // keyed on the name actually written to disk, never on `nearest_name`.
+        let extract_provider = zeph_llm::any::AnyProvider::Mock(
+            zeph_llm::mock::MockProvider::with_responses(vec![
+                "---\nname: improved-script-helper\ndescription: A refined script helper.\nversion: 0\nsource: trace_extraction\n---\n\n## How to use\nDo the thing better.".to_string(),
+                "---\nname: existing-skill-v2\ndescription: An improved version.\nversion: 1\nsource: trace_extraction\n---\n\n## How to use\nDo the merged thing.".to_string(),
+            ]),
+        );
+        // Fixed candidate embedding [1.0, 0.0]; existing skill embedding [0.8, 0.6] yields
+        // cosine similarity 0.8, landing inside the (0.75, 0.90) merge zone.
+        let embed_provider = zeph_llm::any::AnyProvider::Mock(
+            zeph_llm::mock::MockProvider::default().with_embedding(vec![1.0, 0.0]),
+        );
+        let extractor = TraceExtractor::new(
+            extract_provider,
+            embed_provider,
+            tmp.path().to_path_buf(),
+            200,
+            131_072,
+            0.75,
+            0.90,
+            true,
+            None,
+        );
+        let existing_meta = SkillMeta {
+            name: "existing-skill".into(),
+            description: "An existing skill.".into(),
+            version: 1,
+            source: "trace_extraction".into(),
+            session_id: None,
+            compatibility: None,
+            license: None,
+            metadata: vec![],
+            allowed_tools: vec![],
+            requires_secrets: vec![],
+            skill_dir: tmp.path().join("existing-skill"),
+            source_url: None,
+            git_hash: None,
+            category: None,
+            triggers: vec![],
+            parent_skill: None,
+            proactive_domain: None,
+            extensions: None,
+        };
+        let existing_embeddings = vec![(existing_meta, SkillEmbedding::from_raw(vec![0.8, 0.6]))];
+        let messages = [UserMessage {
+            text: "help me improve my script".into(),
+        }];
+        let result = extractor
+            .extract_from_trace(&messages, &existing_embeddings, "merge-session")
+            .await
+            .unwrap();
+        assert_eq!(result.candidates_merged, 1);
+        assert_eq!(result.saved_skill_paths.len(), 1);
+        assert_eq!(
+            result.saved_skill_paths[0].0, "existing-skill-v2",
+            "must key the trust row on the name actually written, not on nearest_name"
+        );
+        assert_ne!(result.saved_skill_paths[0].0, "existing-skill");
+        assert!(result.saved_skill_paths[0].1.ends_with("SKILL.md"));
+    }
+
+    #[tokio::test]
+    async fn apply_decision_merge_same_name_path_populates_saved_skill_paths() {
+        // `MERGE_SYSTEM_PROMPT` instructs the merge LLM to preserve the existing skill's name,
+        // so `merged.name == nearest_name` is the dominant production outcome, not the
+        // exception covered by the rename test above (#6702 S1'/N2 — the round-2 fix rewrote
+        // the only merge test to mock a rename, dropping coverage of this path entirely).
+        let tmp = tempfile::tempdir().unwrap();
+        let extract_provider = zeph_llm::any::AnyProvider::Mock(
+            zeph_llm::mock::MockProvider::with_responses(vec![
+                "---\nname: improved-script-helper\ndescription: A refined script helper.\nversion: 0\nsource: trace_extraction\n---\n\n## How to use\nDo the thing better.".to_string(),
+                "---\nname: existing-skill\ndescription: An improved version.\nversion: 1\nsource: trace_extraction\n---\n\n## How to use\nDo the merged thing.".to_string(),
+            ]),
+        );
+        let embed_provider = zeph_llm::any::AnyProvider::Mock(
+            zeph_llm::mock::MockProvider::default().with_embedding(vec![1.0, 0.0]),
+        );
+        let extractor = TraceExtractor::new(
+            extract_provider,
+            embed_provider,
+            tmp.path().to_path_buf(),
+            200,
+            131_072,
+            0.75,
+            0.90,
+            true,
+            None,
+        );
+        let existing_meta = SkillMeta {
+            name: "existing-skill".into(),
+            description: "An existing skill.".into(),
+            version: 1,
+            source: "trace_extraction".into(),
+            session_id: None,
+            compatibility: None,
+            license: None,
+            metadata: vec![],
+            allowed_tools: vec![],
+            requires_secrets: vec![],
+            skill_dir: tmp.path().join("existing-skill"),
+            source_url: None,
+            git_hash: None,
+            category: None,
+            triggers: vec![],
+            parent_skill: None,
+            proactive_domain: None,
+            extensions: None,
+        };
+        let existing_embeddings = vec![(existing_meta, SkillEmbedding::from_raw(vec![0.8, 0.6]))];
+        let messages = [UserMessage {
+            text: "help me improve my script".into(),
+        }];
+        let result = extractor
+            .extract_from_trace(&messages, &existing_embeddings, "merge-same-name-session")
+            .await
+            .unwrap();
+        assert_eq!(result.candidates_merged, 1);
+        assert_eq!(result.saved_skill_paths.len(), 1);
+        assert_eq!(result.saved_skill_paths[0].0, "existing-skill");
+        assert!(result.saved_skill_paths[0].1.ends_with("SKILL.md"));
     }
 }


### PR DESCRIPTION
## Summary

`SkillGenerator::write_quarantined` wrote an AutoSkill trace-extraction draft's `SKILL.md` to `_quarantine/<name>/` but never persisted a `skill_trust` DB row. The doc comment claimed the `_quarantine` directory prefix kept the registry from ever loading these drafts, but the loader applies no directory-name filtering at all — quarantine was never actually enforced at the trust layer. Because no DB row existed yet, the draft's first hot-reload had no existing row to preserve and fell through to `[skills.trust] default_level`, silently trusting an unreviewed draft whenever an operator set `default_level = "trusted"`. Separately, AutoSkill-generated names had no collision check against native tool IDs.

- `trace_extraction::log_and_persist` now eagerly writes a `Quarantined` `skill_trust` row right after generation, keyed on the name actually written to disk (both `Add` and `Merge` branches), before the skill can ever reach a hot-reload.
- A guard skips the write (and warns) instead of overwriting when the target name already has a trust row pointing at a *different* on-disk path — the merge LLM is prompted to preserve the existing skill's name, so a merge landing on an already-Bundled or -Trusted skill is the dominant case, not an edge case, and must not clobber that skill's trust row.
- The native-tool-ID name-collision warning is extracted into a shared helper called from both the startup catalog emit and every hot-reload, so it no longer depends on `SemanticMemory` being configured and fires at startup rather than only after the first post-startup file change.
- Corrected the false `_quarantine` "security boundary" doc comment on `write_quarantined`.

Closes #6702

## Test plan

- `cargo nextest -p zeph-skills`: 590/590 passed
- `cargo nextest -p zeph-core`: 2232/2232 passed (2 skipped)
- `cargo nextest --workspace --lib --bins` (CI feature set): 15269/15269 passed
- `cargo +nightly fmt --check`, `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`, rustdoc gate, `gitleaks protect --staged` all clean
- New regression-lock tests: eager quarantine survives a hot-reload despite `default_level = trusted`; merge into an already-Trusted skill resets to `Quarantined`; merge/add against a differently-pathed Bundled/Trusted skill leaves its trust row untouched and warns instead; native-tool-ID collision warning fires with and without `SemanticMemory` configured, from both the startup and hot-reload call sites
- `.local/testing/playbooks/autoskill-a1-a2.md` updated with 3 new live-session scenarios (not yet run live this cycle) and a corrected "Known Edge Cases" note; `.local/testing/coverage-status.md` row updated in place