### PR TITLE
fix(cli): flush tracing guards on all remaining application-level exit sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph` (binary): closed every remaining `std::process::exit` call site reachable from `run()`
+  after `init_tracing` (issue #6709, follow-up to #6708/#6698) — the last of the guard-flush-
+  bypass bug class where a direct `exit()` skips `TracingGuards::drop`'s flush and can truncate
+  the log file or local trace. `load_config_or_default` (`src/bootstrap/config.rs`) no longer
+  exits internally on a config parse failure; it returns `Result<Config, ConfigLoadError>` and
+  every one of its 18 callers propagates the failure via `?`, which unwinds normally and flushes
+  `tracing_guards` before `main()` ever sees the error — no explicit flush call needed, since the
+  bug was always the bare `exit()`, not the absence of a signal-passing mechanism. Applied the
+  same treatment to `commands/bench.rs`'s 7 `std::process::exit` sites (`handle_download`,
+  `handle_show`, `handle_run`, `resolve_data_path`, `dispatch_run`), converting them to
+  `anyhow::bail!`/`?`. `handle_url_open`'s own config-load call (a latent instance of the same
+  bug left behind by #6708) is fixed too. Zero application-level `std::process::exit` calls
+  remain in `src/` outside `tracing_init.rs`'s own sanctioned flush-then-exit primitives.
 - `zeph-skills`, `zeph-core`: `SkillGenerator::write_quarantined` wrote an AutoSkill draft's
   `SKILL.md` to `_quarantine/<name>/` but never persisted a `skill_trust` DB row (issue #6702).
   The doc comment claimed the `_quarantine` directory prefix kept the registry from ever loading

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -7,26 +7,59 @@ use crate::bootstrap::VaultArgs;
 use zeph_config::VaultBackend;
 use zeph_core::config::Config;
 
+/// Error returned by [`load_config_or_default`] when the config file exists but fails to parse.
+///
+/// Deliberately does *not* print anything itself (unlike the old inline `eprintln!` +
+/// `std::process::exit`) — every caller already returns `anyhow::Result<...>`, so the standard
+/// `?` operator propagates this up to `main()`, which prints it once via its default `Error:
+/// {e:?}` handler and exits non-zero. This is flush-safe by construction: propagating an `Err`
+/// unwinds the stack normally, so any `TracingGuards` local (e.g. in `run()`) still drops and
+/// flushes before `main()` ever sees the error — no `std::process::exit` call sits between the
+/// failure and `?`'s propagation up through `run()`, unlike the pre-#6709 code (#6709).
+#[derive(Debug)]
+pub struct ConfigLoadError {
+    path: PathBuf,
+    source: zeph_config::ConfigError,
+}
+
+impl std::fmt::Display for ConfigLoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The source (`self.source`) is intentionally omitted here — it is exposed via
+        // `Error::source()` below, which anyhow's chain rendering already walks and prints once;
+        // including it in both places produced a doubled "failed to parse ...: TOML parse
+        // error..." followed by a "Caused by:" section repeating the same detail.
+        write!(f, "failed to parse config at {}", self.path.display())
+    }
+}
+
+impl std::error::Error for ConfigLoadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
 /// Load config from `path`, falling back to defaults with a notice when the file is absent.
 ///
-/// When the file does **not exist**, prints a notice to stderr and returns [`Config::default()`].
-/// When the file exists but fails to parse, prints the error to stderr and exits non-zero.
-pub fn load_config_or_default(path: &Path) -> Config {
+/// When the file does **not exist**, prints a notice to stderr and returns
+/// `Ok(Config::default())`. When the file exists but fails to parse, returns
+/// [`ConfigLoadError`] — propagate it with `?` from any `anyhow::Result`-returning caller.
+///
+/// # Errors
+///
+/// Returns [`ConfigLoadError`] when the file exists but its contents fail to parse.
+pub fn load_config_or_default(path: &Path) -> Result<Config, ConfigLoadError> {
     if !path.exists() {
         eprintln!(
             "Config file not found at {} — running with defaults. \
              Run 'zeph init' to create one.",
             path.display()
         );
-        return Config::default();
+        return Ok(Config::default());
     }
-    match zeph_config::Config::load(path) {
-        Ok(cfg) => cfg,
-        Err(e) => {
-            eprintln!("Failed to parse config at {}: {e}", path.display());
-            std::process::exit(1);
-        }
-    }
+    zeph_config::Config::load(path).map_err(|source| ConfigLoadError {
+        path: path.to_owned(),
+        source,
+    })
 }
 
 pub fn resolve_config_path(cli_override: Option<&Path>) -> PathBuf {
@@ -249,9 +282,21 @@ mod tests {
         // Drop the file so the path no longer exists.
         drop(tmp);
         assert!(!path.exists(), "temp file must be gone before the test");
-        let cfg = load_config_or_default(&path);
+        let cfg = load_config_or_default(&path).expect("missing file falls back to defaults");
         // A default config has the expected default agent name.
         let default_cfg = zeph_core::config::Config::default();
         assert_eq!(cfg.agent.name, default_cfg.agent.name);
+    }
+
+    #[test]
+    fn load_config_or_default_parse_failure_returns_err() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), "this is not valid = = toml").unwrap();
+        let err = load_config_or_default(tmp.path())
+            .expect_err("malformed TOML must be reported, not silently defaulted");
+        assert!(
+            err.to_string().contains("failed to parse config at"),
+            "unexpected error message: {err}"
+        );
     }
 }

--- a/src/commands/acp.rs
+++ b/src/commands/acp.rs
@@ -69,7 +69,7 @@ pub(crate) async fn handle_acp_command(
             command: AcpModelConfigCommand::Show,
         } => {
             let config_file = resolve_config_path(config_path);
-            let config = load_config_or_default(&config_file);
+            let config = load_config_or_default(&config_file)?;
             print!("{}", render_model_config_table(&config, &config_file));
             Ok(())
         }

--- a/src/commands/agents.rs
+++ b/src/commands/agents.rs
@@ -35,7 +35,7 @@ pub(crate) async fn handle_agents_command(
 
 fn load_all_defs(config_path: Option<&Path>) -> anyhow::Result<Vec<SubAgentDef>> {
     let config_file = resolve_config_path(config_path);
-    let config = load_config_or_default(&config_file);
+    let config = load_config_or_default(&config_file)?;
     let paths = resolve_agent_paths(
         &[],
         config.agents.user_agents_dir.as_ref(),
@@ -234,7 +234,7 @@ async fn handle_fleet(
     config_path: Option<&Path>,
 ) -> anyhow::Result<()> {
     let config_file = resolve_config_path(config_path);
-    let config = load_config_or_default(&config_file);
+    let config = load_config_or_default(&config_file)?;
     let db_path = &config.memory.sqlite_path;
     let store = zeph_memory::store::SqliteStore::new(db_path)
         .await

--- a/src/commands/bench.rs
+++ b/src/commands/bench.rs
@@ -109,9 +109,9 @@ async fn handle_run_baseline(
         }
     }
 
-    let data_path = resolve_data_path(dataset, data_file);
+    let data_path = resolve_data_path(dataset, data_file)?;
     let path = resolve_config_path(config_path);
-    let mut config = load_config_or_default(&path);
+    let mut config = load_config_or_default(&path)?;
 
     let vault_args = parse_vault_args(
         &config,
@@ -284,14 +284,14 @@ fn handle_download(dataset: &str) -> anyhow::Result<()> {
     }
     let reg = DatasetRegistry::new();
     if reg.get(dataset).is_none() {
-        eprintln!(
-            "error: unknown dataset '{dataset}'. Run `zeph bench list` to see available datasets."
+        anyhow::bail!(
+            "unknown dataset '{dataset}'. Run `zeph bench list` to see available datasets."
         );
-        std::process::exit(1);
     }
-    eprintln!("Dataset download is not yet implemented for '{dataset}'.");
-    eprintln!("See the dataset URL in `zeph bench list` output for manual download instructions.");
-    std::process::exit(1);
+    anyhow::bail!(
+        "Dataset download is not yet implemented for '{dataset}'. \
+         See the dataset URL in `zeph bench list` output for manual download instructions."
+    );
 }
 
 /// Clone `sierra-research/tau2-bench` and copy the JSON data files for retail and airline.
@@ -363,11 +363,7 @@ fn download_tau2_bench() -> anyhow::Result<()> {
 
 fn handle_show(results: &std::path::Path) -> anyhow::Result<()> {
     if !results.exists() {
-        eprintln!(
-            "error: results file '{}' does not exist.",
-            results.display()
-        );
-        std::process::exit(1);
+        anyhow::bail!("results file '{}' does not exist.", results.display());
     }
     let data = std::fs::read_to_string(results)?;
     println!("{data}");
@@ -390,16 +386,15 @@ async fn handle_run(
 ) -> anyhow::Result<()> {
     let reg = DatasetRegistry::new();
     if reg.get(dataset).is_none() {
-        eprintln!(
-            "error: unknown dataset '{dataset}'. Run `zeph bench list` to see available datasets."
+        anyhow::bail!(
+            "unknown dataset '{dataset}'. Run `zeph bench list` to see available datasets."
         );
-        std::process::exit(1);
     }
 
-    let data_path = resolve_data_path(dataset, data_file);
+    let data_path = resolve_data_path(dataset, data_file)?;
 
     let path = resolve_config_path(config_path);
-    let mut config = load_config_or_default(&path);
+    let mut config = load_config_or_default(&path)?;
 
     // Resolve vault secrets before building the provider.
     // The bench command is dispatched before AppBuilder runs, so we must
@@ -460,19 +455,20 @@ async fn handle_run(
 }
 
 /// Resolve the dataset file path from `--data-file` or exit with a clear error.
-fn resolve_data_path(dataset: &str, data_file: Option<&std::path::Path>) -> std::path::PathBuf {
+fn resolve_data_path(
+    dataset: &str,
+    data_file: Option<&std::path::Path>,
+) -> anyhow::Result<std::path::PathBuf> {
     if let Some(p) = data_file {
         if !p.exists() {
-            eprintln!("error: data file '{}' does not exist.", p.display());
-            std::process::exit(1);
+            anyhow::bail!("data file '{}' does not exist.", p.display());
         }
-        return p.to_path_buf();
+        return Ok(p.to_path_buf());
     }
-    eprintln!("error: --data-file <path> is required until automatic download is implemented.");
-    eprintln!(
-        "Obtain the dataset file from the URL shown by `zeph bench list --dataset {dataset}`."
+    anyhow::bail!(
+        "--data-file <path> is required until automatic download is implemented. \
+         Obtain the dataset file from the URL shown by `zeph bench list --dataset {dataset}`."
     );
-    std::process::exit(1);
 }
 
 /// Dispatch to the correct loader/evaluator pair based on dataset name.
@@ -519,13 +515,10 @@ async fn dispatch_run(
                 )
                 .await?)
         }
-        other => {
-            eprintln!(
-                "error: no built-in runner for dataset '{other}'. \
-                 Supported: locomo, gaia, frames, longmemeval, tau2-bench-retail, tau2-bench-airline."
-            );
-            std::process::exit(1);
-        }
+        other => anyhow::bail!(
+            "no built-in runner for dataset '{other}'. \
+             Supported: locomo, gaia, frames, longmemeval, tau2-bench-retail, tau2-bench-airline."
+        ),
     }
 }
 
@@ -629,6 +622,89 @@ mod tests {
 
         assert!(
             err.to_string().contains("unknown vault backend"),
+            "unexpected error: {err}"
+        );
+    }
+
+    // Regression tests for #6709: these sites used to call `std::process::exit(1)` directly,
+    // bypassing `TracingGuards::drop`'s flush logic. They now report failure via
+    // `anyhow::bail!`/`?`, which is unit-testable for the first time (the old behavior killed
+    // the test process).
+
+    #[test]
+    fn handle_download_rejects_unknown_dataset() {
+        let err = handle_download("not-a-real-dataset").expect_err("unknown dataset must error");
+        assert!(
+            err.to_string().contains("unknown dataset"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn handle_download_reports_not_yet_implemented_for_known_dataset() {
+        // "gaia" is a real, registered dataset with no download support yet.
+        let err = handle_download("gaia").expect_err("unimplemented download must error");
+        assert!(
+            err.to_string().contains("not yet implemented"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn handle_show_rejects_missing_results_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("does-not-exist.json");
+        let err = handle_show(&missing).expect_err("missing results file must error");
+        assert!(
+            err.to_string().contains("does not exist"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_data_path_rejects_nonexistent_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("does-not-exist.jsonl");
+        let err = resolve_data_path("longmemeval", Some(&missing))
+            .expect_err("nonexistent data file must error");
+        assert!(
+            err.to_string().contains("does not exist"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_data_path_rejects_missing_data_file_flag() {
+        let err =
+            resolve_data_path("longmemeval", None).expect_err("missing --data-file must error");
+        assert!(
+            err.to_string().contains("--data-file"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_run_rejects_unsupported_dataset() {
+        use zeph_llm::any::AnyProvider;
+        use zeph_llm::mock::MockProvider;
+
+        let provider = AnyProvider::Mock(MockProvider::with_responses(vec![]));
+        let runner = BenchRunner::new(provider);
+        let opts = RunOptions {
+            scenario_filter: None,
+            completed_ids: std::collections::HashSet::new(),
+            memory_mode: MemoryMode::Off,
+        };
+        let err = dispatch_run(
+            &runner,
+            "not-a-supported-dataset",
+            std::path::Path::new("x"),
+            opts,
+        )
+        .await
+        .expect_err("unsupported dataset must error");
+        assert!(
+            err.to_string().contains("no built-in runner"),
             "unexpected error: {err}"
         );
     }

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -15,7 +15,7 @@ use zeph_db::{DbConfig, redact_url};
 /// the database connection / migration fails.
 pub(crate) async fn handle_db_migrate(config_path: Option<&std::path::Path>) -> anyhow::Result<()> {
     let config_path = resolve_config_path(config_path);
-    let config = load_config_or_default(&config_path);
+    let config = load_config_or_default(&config_path)?;
 
     let db_url = crate::db_url::resolve_db_url(&config);
 

--- a/src/commands/durable.rs
+++ b/src/commands/durable.rs
@@ -514,7 +514,7 @@ async fn handle_durable_command_inner(
     vault_path_override: Option<&Path>,
 ) -> anyhow::Result<()> {
     let config_file = crate::bootstrap::resolve_config_path(config_path);
-    let config = load_config_or_default(&config_file);
+    let config = load_config_or_default(&config_file)?;
     // CLI-resolved vault key/secrets-file paths (--vault-key/--vault-path overrides, falling
     // back to default_vault_dir()) — see `crate::bootstrap::resolve_vault_paths` (#6548). Shared
     // by every key-material loader this command dispatches to below.
@@ -1937,7 +1937,7 @@ mod tests {
     async fn handle_durable_command_cancel_marks_a_running_execution_canceled() {
         let dir = tempfile::tempdir().unwrap();
         let config_path = write_config_toml(dir.path());
-        let config = load_config_or_default(&config_path);
+        let config = load_config_or_default(&config_path).unwrap();
 
         let exec = ExecutionId::new();
         {
@@ -2015,7 +2015,7 @@ mod tests {
     async fn handle_durable_command_resume_on_canceled_execution_refuses_distinctly() {
         let dir = tempfile::tempdir().unwrap();
         let config_path = write_config_toml(dir.path());
-        let config = load_config_or_default(&config_path);
+        let config = load_config_or_default(&config_path).unwrap();
 
         let exec = ExecutionId::new();
         {
@@ -2369,7 +2369,10 @@ mod tests {
             "rotate-key must resolve the vault from the explicit --vault-key/--vault-path \
              override, not default_vault_dir() (which is empty in this test): {result:?}"
         );
-        assert_eq!(load_config_or_default(&config_path).durable.key_id, 1);
+        assert_eq!(
+            load_config_or_default(&config_path).unwrap().durable.key_id,
+            1
+        );
 
         // The rotated ZEPH_DURABLE_KEY_PREVIOUS must land in the OVERRIDE vault, not the
         // (empty) default_vault_dir().
@@ -2467,7 +2470,7 @@ mod tests {
         .await;
         assert!(result.is_ok(), "rotate-key must succeed: {result:?}");
 
-        let config = load_config_or_default(&config_path);
+        let config = load_config_or_default(&config_path).unwrap();
         assert_eq!(config.durable.key_id, 1);
         assert_eq!(config.durable.previous_key_id, Some(0));
 
@@ -2506,7 +2509,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let after_first = load_config_or_default(&config_path);
+        let after_first = load_config_or_default(&config_path).unwrap();
         assert_eq!(after_first.durable.previous_key_id, Some(0));
 
         let result = handle_durable_command(
@@ -2526,7 +2529,7 @@ mod tests {
             "a second rotation while a window is open must be refused"
         );
 
-        let after_second = load_config_or_default(&config_path);
+        let after_second = load_config_or_default(&config_path).unwrap();
         assert_eq!(
             after_second.durable, after_first.durable,
             "the refused second rotation must not mutate config"
@@ -2635,7 +2638,7 @@ mod tests {
         // Seal a payload directly under key-id 0 (the now-previous key) by writing through a
         // no-cipher backend with a byte-0-prefixed plaintext payload — this exercises the scan
         // predicate itself without depending on the real AEAD cipher's on-disk framing.
-        let config = load_config_or_default(&config_path);
+        let config = load_config_or_default(&config_path).unwrap();
         let url = resolve_durable_db_url(&config);
         let backend = LocalBackend::open(&url, config.durable.max_payload_bytes)
             .await
@@ -2681,7 +2684,10 @@ mod tests {
             "drop-previous must refuse while a matching sealed payload remains"
         );
         assert_eq!(
-            load_config_or_default(&config_path).durable.previous_key_id,
+            load_config_or_default(&config_path)
+                .unwrap()
+                .durable
+                .previous_key_id,
             Some(0),
             "the refused drop must not clear previous_key_id"
         );
@@ -2700,7 +2706,10 @@ mod tests {
         .await;
         assert!(forced.is_ok(), "--force must skip the scan: {forced:?}");
         assert_eq!(
-            load_config_or_default(&config_path).durable.previous_key_id,
+            load_config_or_default(&config_path)
+                .unwrap()
+                .durable
+                .previous_key_id,
             None,
             "--force must still clear previous_key_id once it proceeds"
         );
@@ -2775,9 +2784,15 @@ mod tests {
             "a shared database must rotate without any acknowledgement flag now that the \
              control-entry HMAC key has its own rotation window: {result:?}"
         );
-        assert_eq!(load_config_or_default(&config_path).durable.key_id, 1);
         assert_eq!(
-            load_config_or_default(&config_path).durable.previous_key_id,
+            load_config_or_default(&config_path).unwrap().durable.key_id,
+            1
+        );
+        assert_eq!(
+            load_config_or_default(&config_path)
+                .unwrap()
+                .durable
+                .previous_key_id,
             Some(0)
         );
     }
@@ -2967,7 +2982,7 @@ mod tests {
         .await
         .unwrap();
 
-        let final_config = load_config_or_default(&config_path);
+        let final_config = load_config_or_default(&config_path).unwrap();
         assert_eq!(final_config.durable.previous_key_id, None);
         let backend = open_backend(
             &final_config,
@@ -3017,7 +3032,7 @@ mod tests {
         .await
         .unwrap();
 
-        let config = load_config_or_default(&config_path);
+        let config = load_config_or_default(&config_path).unwrap();
         let url = resolve_durable_db_url(&config);
         let backend = LocalBackend::open(&url, config.durable.max_payload_bytes)
             .await
@@ -3073,7 +3088,10 @@ mod tests {
             "--drop-previous --dry-run must still refuse when a matching sealed payload remains"
         );
         assert_eq!(
-            load_config_or_default(&config_path).durable.previous_key_id,
+            load_config_or_default(&config_path)
+                .unwrap()
+                .durable
+                .previous_key_id,
             Some(0),
             "the refused dry-run drop must not clear previous_key_id"
         );
@@ -3168,7 +3186,7 @@ mod tests {
         .await
         .unwrap();
 
-        let rotated_config = load_config_or_default(&config_path);
+        let rotated_config = load_config_or_default(&config_path).unwrap();
         assert_eq!(rotated_config.durable.key_id, 1);
         assert_eq!(rotated_config.durable.previous_key_id, Some(0));
 
@@ -3267,7 +3285,7 @@ mod tests {
         .await
         .unwrap();
 
-        let rotated = load_config_or_default(&config_path);
+        let rotated = load_config_or_default(&config_path).unwrap();
         let url = resolve_durable_db_url(&rotated);
         let vault_root = zeph_core::vault::default_vault_dir();
         let previous_hmac = load_control_hmac_key(
@@ -3364,7 +3382,7 @@ mod tests {
         .await
         .unwrap();
 
-        let rotated = load_config_or_default(&config_path);
+        let rotated = load_config_or_default(&config_path).unwrap();
         let url = resolve_durable_db_url(&rotated);
         let vault_root = zeph_core::vault::default_vault_dir();
         let previous_hmac = load_control_hmac_key(
@@ -3425,7 +3443,10 @@ mod tests {
              the previous control-entry HMAC key"
         );
         assert_eq!(
-            load_config_or_default(&config_path).durable.previous_key_id,
+            load_config_or_default(&config_path)
+                .unwrap()
+                .durable
+                .previous_key_id,
             Some(0),
             "the refused drop must not clear previous_key_id"
         );
@@ -3479,7 +3500,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let rotated = load_config_or_default(&config_path);
+        let rotated = load_config_or_default(&config_path).unwrap();
         assert_eq!(rotated.durable.previous_key_id, Some(0));
 
         let url = resolve_durable_db_url(&rotated);
@@ -3528,7 +3549,10 @@ mod tests {
              even with no payload or control-entry evidence"
         );
         assert_eq!(
-            load_config_or_default(&config_path).durable.previous_key_id,
+            load_config_or_default(&config_path)
+                .unwrap()
+                .durable
+                .previous_key_id,
             Some(0),
             "the refused drop must not clear previous_key_id"
         );
@@ -3568,7 +3592,7 @@ mod tests {
 
         let exec = ExecutionId::new();
         {
-            let config = load_config_or_default(&config_path);
+            let config = load_config_or_default(&config_path).unwrap();
             let vault_root = zeph_core::vault::default_vault_dir();
             let hwm_keys = load_write_hwm_key(
                 &config,
@@ -3627,7 +3651,7 @@ mod tests {
         .await
         .unwrap();
 
-        let rotated = load_config_or_default(&config_path);
+        let rotated = load_config_or_default(&config_path).unwrap();
         assert_eq!(rotated.durable.key_id, 1);
         assert_eq!(rotated.durable.previous_key_id, Some(0));
         let vault_root = zeph_core::vault::default_vault_dir();

--- a/src/commands/memory.rs
+++ b/src/commands/memory.rs
@@ -11,7 +11,7 @@ pub(crate) async fn handle_memory_command(
     use zeph_memory::store::SqliteStore;
 
     let config_file = resolve_config_path(config_path);
-    let config = load_config_or_default(&config_file);
+    let config = load_config_or_default(&config_file)?;
     let sqlite = SqliteStore::new(crate::db_url::resolve_db_url(&config))
         .await
         .map_err(|e| anyhow::anyhow!("failed to open SQLite: {e}"))?;

--- a/src/commands/plugin.rs
+++ b/src/commands/plugin.rs
@@ -65,7 +65,7 @@ pub(crate) async fn handle_plugin_command(
     use crate::bootstrap::{load_config_or_default, resolve_config_path};
 
     let config_file = resolve_config_path(config_path);
-    let config = load_config_or_default(&config_file);
+    let config = load_config_or_default(&config_file)?;
 
     let plugins_dir = crate::bootstrap::plugins_dir();
     std::fs::create_dir_all(&plugins_dir)

--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -33,7 +33,7 @@ pub(crate) async fn handle_project_command(
 
             let effective_path = purge_config.as_deref().or(global_config_path);
             let config_file = resolve_config_path(effective_path);
-            let config = load_config_or_default(&config_file);
+            let config = load_config_or_default(&config_file)?;
 
             run_purge(&config, dry_run, yes).await
         }

--- a/src/commands/schedule.rs
+++ b/src/commands/schedule.rs
@@ -109,7 +109,7 @@ pub(crate) async fn handle_schedule_command(
     use zeph_scheduler::JobStore;
 
     let config_file = resolve_config_path(config_path);
-    let config = load_config_or_default(&config_file);
+    let config = load_config_or_default(&config_file)?;
     let db_url = crate::db_url::resolve_db_url(&config);
     let store = JobStore::open(db_url)
         .await

--- a/src/commands/scheduler_daemon.rs
+++ b/src/commands/scheduler_daemon.rs
@@ -32,7 +32,7 @@ pub(crate) async fn handle_serve(
     vault_path_override: Option<&std::path::Path>,
 ) -> anyhow::Result<()> {
     let config_file = resolve_config_path(config_path);
-    let config = load_config_or_default(&config_file);
+    let config = load_config_or_default(&config_file)?;
     let daemon_cfg = build_daemon_config(&config);
 
     if foreground {
@@ -106,7 +106,7 @@ pub(crate) fn handle_stop(
     timeout_secs: u64,
 ) -> anyhow::Result<()> {
     let config_file = resolve_config_path(config_path);
-    let config = load_config_or_default(&config_file);
+    let config = load_config_or_default(&config_file)?;
     let daemon_cfg = build_daemon_config(&config);
 
     zeph_scheduler::stop_daemon(&daemon_cfg, timeout_secs)
@@ -120,7 +120,7 @@ pub(crate) async fn handle_status(
     n: usize,
 ) -> anyhow::Result<()> {
     let config_file = resolve_config_path(config_path);
-    let config = load_config_or_default(&config_file);
+    let config = load_config_or_default(&config_file)?;
     let daemon_cfg = build_daemon_config(&config);
     let db_url = crate::db_url::resolve_db_url(&config);
 

--- a/src/commands/sessions.rs
+++ b/src/commands/sessions.rs
@@ -13,7 +13,7 @@ pub(crate) async fn handle_sessions_command(
     use zeph_memory::store::SqliteStore;
 
     let config_file = resolve_config_path(config_path);
-    let config = load_config_or_default(&config_file);
+    let config = load_config_or_default(&config_file)?;
     let store = SqliteStore::new(crate::db_url::resolve_db_url(&config))
         .await
         .map_err(|e| anyhow::anyhow!("failed to open SQLite: {e}"))?;

--- a/src/commands/skill.rs
+++ b/src/commands/skill.rs
@@ -16,7 +16,7 @@ pub(crate) async fn handle_skill_command(
     use zeph_skills::manager::SkillManager;
 
     let config_file = resolve_config_path(config_path);
-    let config = load_config_or_default(&config_file);
+    let config = load_config_or_default(&config_file)?;
 
     let managed_dir = managed_skills_dir();
     std::fs::create_dir_all(&managed_dir)

--- a/src/commands/store.rs
+++ b/src/commands/store.rs
@@ -14,7 +14,7 @@ pub(crate) async fn handle_store_command(
     use zeph_memory::store::SqliteStore;
 
     let config_file = resolve_config_path(config_path);
-    let config = load_config_or_default(&config_file);
+    let config = load_config_or_default(&config_file)?;
     if !config.memory.store.enabled {
         anyhow::bail!(
             "cross-thread store is disabled ([memory.store].enabled = false in {}); \

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -814,7 +814,7 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
 
     // Load logging config early (sync, cheap) so every code path gets file logging.
     let config_path = resolve_config_path(cli.config.as_deref());
-    let base_config = load_config_or_default(&config_path);
+    let base_config = load_config_or_default(&config_path)?;
     let logging_config =
         resolve_logging_config(base_config.logging.clone(), cli.log_file.as_deref());
     let telemetry_config = &base_config.telemetry;
@@ -1059,7 +1059,11 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         }
         Some(Command::Classifiers { command: clf_cmd }) => {
             let config_path = resolve_config_path(cli.config.as_deref());
-            let config = load_config_or_default(&config_path);
+            // A parse failure here returns `Err` and propagates via `?`, which drops (and
+            // flushes) `tracing_guards` through ordinary stack unwind — no explicit
+            // `exit_with_flush` call needed, since only a bare `std::process::exit` (which
+            // this deliberately avoids) would skip that drop (#6709).
+            let config = load_config_or_default(&config_path)?;
             return handle_classifiers_command(&clf_cmd, &config);
         }
         Some(Command::Db { command: db_cmd }) => {
@@ -1083,6 +1087,10 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         }
         #[cfg(feature = "bench")]
         Some(Command::Bench { command: bench_cmd }) => {
+            // `handle_bench_command`'s early-exit paths (unknown dataset, missing data file,
+            // unparseable config, ...) all report failure via `anyhow::bail!`/`?` rather than
+            // calling `std::process::exit` directly, so an ordinary `Err` return here already
+            // drops (and flushes) `tracing_guards` through normal stack unwind (#6709).
             return crate::commands::bench::handle_bench_command(
                 &bench_cmd,
                 cli.config.as_deref(),
@@ -4508,7 +4516,13 @@ fn handle_url_open(
 
     // Load config once; all subsequent validations reference the same instance.
     let config_path = resolve_config_path(config_override);
-    let config = load_config_or_default(&config_path);
+    let config = match load_config_or_default(&config_path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("zeph url-open: {e}");
+            return Some(1);
+        }
+    };
 
     // Validate CWD and change working directory.
     if let Some(ref cwd) = params.cwd {
@@ -4726,6 +4740,27 @@ mod deep_link_tests {
         assert!(
             matches!(result, Some(1)),
             "expected Some(1) for an invalid URI, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn handle_url_open_returns_exit_code_for_unparseable_config() {
+        // Regression test for #6709: `load_config_or_default`'s parse-failure branch used to
+        // call `std::process::exit(1)` directly inside `handle_url_open`, bypassing
+        // `TracingGuards::drop`. It now returns `Err`, which this call site converts to
+        // `Some(1)` like every other validation failure in this function.
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let config_path = tmp.path().join("malformed-config.toml");
+        std::fs::write(&config_path, "this is not valid = = toml").expect("write fixture");
+        let mut cli = crate::cli::Cli::default();
+        let result = super::handle_url_open(
+            "zeph://new-session".to_owned(),
+            Some(&config_path),
+            &mut cli,
+        );
+        assert!(
+            matches!(result, Some(1)),
+            "expected Some(1) for an unparseable config file, got {result:?}"
         );
     }
 

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -116,7 +116,7 @@ pub(crate) async fn handle_serve_sessions_command(
     use crate::bootstrap::{load_config_or_default, resolve_config_path};
 
     let config_file = resolve_config_path(config_path);
-    let config = load_config_or_default(&config_file);
+    let config = load_config_or_default(&config_file)?;
     let serve_config = &config.serve;
 
     let http_addr: SocketAddr = args


### PR DESCRIPTION
## Summary

Follow-up to #6698/#6708 — closes the last application-level `std::process::exit` sites that bypassed `TracingGuards::drop`'s flush-on-drop logic. The issue named two sites (`src/bootstrap/config.rs:27`, seven in `src/commands/bench.rs`), but review turned up 16 more instances of the same pattern reachable from `run()` after `init_tracing`.

Rather than threading a bespoke exit-signal type through each site, this unifies on plain `anyhow::Result` + `?` propagation everywhere: `load_config_or_default` now returns `Result<Config, ConfigLoadError>` instead of exiting internally, and all 18 callers (including bench.rs's 7 sites) use `?`/`anyhow::bail!` so an ordinary `Err` return unwinds and flushes `tracing_guards` via normal `drop`. No new machinery, less code than the original approach.

Verified: zero application-level `std::process::exit` calls remain in `src/` outside `tracing_init.rs`'s own sanctioned flush primitives.

Closes #6709

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo clippy --profile ci --workspace --all-targets --features bench -- -D warnings` (separate bench matrix entry)
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 15312/15312 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] 8 new tests covering the previously-untestable error branches (config parse failure, handle_url_open error path, 6 in bench.rs)
- [x] `gitleaks protect --staged --no-banner --redact`