### PR TITLE
fix(deps): bump qdrant-client to 1.19, drop rustls-pemfile

### DIFF
--- a/.github/deny.toml
+++ b/.github/deny.toml
@@ -17,8 +17,6 @@ features = ["full"]
 [advisories]
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-# rustls-pemfile unmaintained (RUSTSEC-2025-0134, via qdrant-client -> tonic 0.12)
-# Verified in qdrant-client 1.18 (tonic 0.12.3); remove once qdrant/rust-client#255 merges
 # number_prefix unmaintained (via indicatif -> hf-hub, candle transitive dep)
 # proc-macro-error2 unmaintained (RUSTSEC-2026-0173, via aquamarine -> teloxide and i18n-embed-fl -> age)
 # Both are transitive; remove once teloxide/age update their proc-macro dependencies
@@ -26,7 +24,7 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 # No patched version exists; advisory suggests migrating to `skrifa`. Transitive via
 # pdf-extract/lopdf, which do not offer a ttf-parser-free path yet; track migrating off
 # ttf-parser (or pdf-extract/lopdf entirely) once an upstream alternative lands
-ignore = ["RUSTSEC-2025-0134", "RUSTSEC-2024-0436", "RUSTSEC-2026-0173", "RUSTSEC-2026-0192"]
+ignore = ["RUSTSEC-2024-0436", "RUSTSEC-2026-0173", "RUSTSEC-2026-0192"]
 
 [licenses]
 confidence-threshold = 0.93

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `zeph-memory`, `zeph-mcp`, `zeph-skills`: bumped `qdrant-client` from `1.18` to `1.19`
+  (issue #3772), pulling in `tonic` `0.14.6` in place of `0.12.3` and removing the unmaintained
+  `rustls-pemfile` `2.2.0` from the dependency tree (RUSTSEC-2025-0134). This also unifies the
+  workspace onto a single `tonic` version — `opentelemetry-otlp`'s `grpc-tonic` feature already
+  pulled in `tonic` `0.14.x` separately, so the two coexisting copies noted in the removed
+  `Cargo.toml` comment (tracked in #2347) no longer apply. No source changes were required: the
+  `qdrant-client` 1.18 → 1.19 API surface is additive-only for the subset used here, and the
+  codebase has no direct `tonic::` imports. `.github/deny.toml`'s stale `RUSTSEC-2025-0134`
+  ignore entry was removed now that the advisory no longer matches any package in the tree.
+  This also fixes a latent panic: on `tonic` `0.12.3`, TLS setup resolved the rustls
+  `CryptoProvider` via the ambiguous `ClientConfig::builder()`, which `.expect()`-panics
+  whenever more than one crypto backend feature is enabled workspace-wide (both `ring`, via
+  `sqlx`, and `aws-lc-rs`, via `reqwest`, already were) and nothing calls
+  `CryptoProvider::install_default()`. In practice this meant pointing `memory.qdrant_url` at
+  an `https://` endpoint (e.g. Qdrant Cloud) panicked at client construction — a configuration
+  the project actively documents as supported. `tonic` `0.14.6` selects
+  `crypto::ring::default_provider()` explicitly, resolving the panic.
 - `zeph` (binary): closed every remaining `std::process::exit` call site reachable from `run()`
   after `init_tracing` (issue #6709, follow-up to #6708/#6698) — the last of the guard-flush-
   bypass bug class where a direct `exit()` skips `TracingGuards::drop`'s flush and can truncate

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,38 +597,11 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper",
- "tower 0.5.3",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "axum-core 0.5.6",
+ "axum-core",
  "axum-macros",
  "base64 0.22.1",
  "bytes",
@@ -640,7 +613,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -653,30 +626,10 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite 0.29.0",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -934,7 +887,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic 0.14.6",
+ "tonic",
  "tower-service",
  "url",
  "winapi",
@@ -948,7 +901,7 @@ checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
 dependencies = [
  "prost 0.14.4",
  "prost-types 0.14.4",
- "tonic 0.14.6",
+ "tonic",
  "tonic-prost",
  "ureq",
 ]
@@ -3891,7 +3844,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4760,12 +4713,6 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -5493,7 +5440,7 @@ dependencies = [
  "prost 0.14.4",
  "thiserror 2.0.19",
  "tokio",
- "tonic 0.14.6",
+ "tonic",
  "tonic-types",
 ]
 
@@ -5506,7 +5453,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "prost 0.14.4",
- "tonic 0.14.6",
+ "tonic",
  "tonic-prost",
 ]
 
@@ -6305,16 +6252,6 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
-dependencies = [
- "bytes",
- "prost-derive 0.13.5",
-]
-
-[[package]]
-name = "prost"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
@@ -6359,19 +6296,6 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "prost-derive"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
@@ -6390,15 +6314,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
  "prost 0.12.6",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
-dependencies = [
- "prost 0.13.5",
 ]
 
 [[package]]
@@ -6493,22 +6408,23 @@ checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "qdrant-client"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cef4e669bcf9c07471463adab5ee080dd9bc9381f3652ea4981f6030b2c309"
+checksum = "dddc19df129bad7346ebd027288621ab1ac7e52678371f906b9a8622d7aaf87e"
 dependencies = [
  "anyhow",
  "derive_builder",
  "futures",
  "parking_lot",
- "prost 0.13.5",
- "prost-types 0.13.5",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
  "semver",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
  "tokio",
- "tonic 0.12.3",
+ "tonic",
+ "tonic-prost",
 ]
 
 [[package]]
@@ -6551,7 +6467,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -6590,7 +6506,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -7046,7 +6962,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-http 0.6.11",
  "tower-service",
  "url",
@@ -7092,7 +7008,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-http 0.6.11",
  "tower-service",
  "url",
@@ -7325,15 +7241,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -8058,16 +7965,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9164,7 +9061,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -9344,13 +9241,12 @@ checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
- "async-stream",
  "async-trait",
- "axum 0.7.9",
+ "axum",
  "base64 0.22.1",
  "bytes",
  "flate2",
@@ -9363,43 +9259,13 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost 0.13.5",
  "rustls-native-certs",
- "rustls-pemfile",
- "socket2 0.5.10",
+ "socket2",
+ "sync_wrapper",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
-dependencies = [
- "async-trait",
- "axum 0.8.9",
- "base64 0.22.1",
- "bytes",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "socket2 0.6.5",
- "sync_wrapper",
- "tokio",
- "tokio-stream",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -9413,7 +9279,7 @@ checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost 0.14.4",
- "tonic 0.14.6",
+ "tonic",
 ]
 
 [[package]]
@@ -9424,27 +9290,7 @@ checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
 dependencies = [
  "prost 0.14.4",
  "prost-types 0.14.4",
- "tonic 0.14.6",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.7",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
+ "tonic",
 ]
 
 [[package]]
@@ -9478,7 +9324,7 @@ dependencies = [
  "http",
  "http-body",
  "pin-project-lite",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "url",
@@ -11177,7 +11023,7 @@ dependencies = [
  "agent-client-protocol",
  "anyhow",
  "async-trait",
- "axum 0.8.9",
+ "axum",
  "blake3",
  "bytes",
  "chrono",
@@ -11214,7 +11060,7 @@ dependencies = [
  "tokio-util",
  "toml 1.1.4+spec-1.1.0",
  "toml_edit",
- "tower 0.5.3",
+ "tower",
  "tracing",
  "tracing-appender",
  "tracing-chrome",
@@ -11260,7 +11106,7 @@ dependencies = [
 name = "zeph-a2a"
 version = "0.22.3"
 dependencies = [
- "axum 0.8.9",
+ "axum",
  "base64 0.23.0",
  "chrono",
  "eventsource-stream",
@@ -11278,7 +11124,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
- "tower 0.5.3",
+ "tower",
  "tower-http 0.7.0",
  "tracing",
  "url",
@@ -11294,7 +11140,7 @@ dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
  "async-stream",
- "axum 0.8.9",
+ "axum",
  "base64 0.23.0",
  "blake3",
  "chrono",
@@ -11316,7 +11162,7 @@ dependencies = [
  "tokio-tungstenite 0.30.0",
  "tokio-util",
  "toml 1.1.4+spec-1.1.0",
- "tower 0.5.3",
+ "tower",
  "tower-http 0.7.0",
  "tracing",
  "uuid",
@@ -11420,7 +11266,7 @@ dependencies = [
 name = "zeph-channels"
 version = "0.22.3"
 dependencies = [
- "axum 0.8.9",
+ "axum",
  "criterion",
  "crossterm",
  "futures",
@@ -11460,7 +11306,7 @@ dependencies = [
 name = "zeph-common"
 version = "0.22.3"
 dependencies = [
- "axum 0.8.9",
+ "axum",
  "blake3",
  "cpu-time",
  "metrics",
@@ -11477,7 +11323,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tracing",
  "tracing-test",
  "tree-sitter",
@@ -11680,14 +11526,14 @@ dependencies = [
 name = "zeph-gateway"
 version = "0.22.3"
 dependencies = [
- "axum 0.8.9",
+ "axum",
  "http-body-util",
  "prometheus-client",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
  "tokio",
- "tower 0.5.3",
+ "tower",
  "tower-http 0.7.0",
  "tracing",
  "zeph-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ pprof = { version = "0.15.0", default-features = false }
 prometheus-client = "0.25.0"
 proptest = "1.11"
 pulldown-cmark = "0.13.4"
-qdrant-client = { version = "1.18", default-features = false }
+qdrant-client = { version = "1.19", default-features = false }
 rand = "0.10.2"
 rand_distr = "0.6"
 ratatui = "0.30.2"
@@ -364,8 +364,6 @@ futures.workspace = true
 glob.workspace = true
 metrics.workspace = true
 opentelemetry = { workspace = true, optional = true }
-# NOTE: grpc-tonic pulls tonic ^0.14 which coexists with qdrant-client's tonic 0.12.
-# Binary bloat is acceptable until qdrant-client upgrades (tracked in #2347).
 opentelemetry-otlp = { workspace = true, optional = true, features = ["grpc-tonic", "trace"] }
 opentelemetry_sdk = { workspace = true, optional = true, features = ["trace"] }
 parking_lot.workspace = true


### PR DESCRIPTION
## Summary

Bumps `qdrant-client` from 1.18 to 1.19, which pulls in `tonic` 0.14.6 in place of 0.12.3 and removes the unmaintained `rustls-pemfile` from the dependency tree (RUSTSEC-2025-0134), while also unifying the workspace onto the single `tonic` version already pulled in by `opentelemetry-otlp`. Zero source changes were required — the client API surface used here is unaffected — and the bump incidentally fixes a latent panic where `tonic` 0.12.3's ambiguous rustls `ClientConfig::builder()` would `.expect()`-panic when connecting to an `https://` Qdrant endpoint with multiple crypto providers enabled workspace-wide (a documented-supported configuration).

Full CI-matching check suite (fmt, clippy `--profile ci`, nextest, rustdoc gate, doc-tests, `cargo deny check advisories`) passes clean with zero new advisories.

**Note:** the Qdrant TLS wire path itself remains untested by any suite in this repo (pre-existing gap, not introduced or narrowed by this change) — only the plaintext path is exercised by CI's `integration` job.

Closes #3772

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (15320 passed, 0 failed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] `cargo deny check advisories` — RUSTSEC-2025-0134 no longer fires, no new advisories
- [x] `cargo tree -i rustls-pemfile` — confirms the crate is fully gone from the tree
- [x] `cargo audit` — 0 vulnerabilities