### PR TITLE
ci: raise release build-binaries timeout to 60 minutes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
   build-binaries:
     name: Build (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   (LRU + 7-day unused-entry eviction) by the time the next release runs, making the cache a
   cold miss anyway — while still costing multi-GB writes against the shared cache quota that
   `ci.yml` depends on for its frequent, cache-effective runs.
+- `release.yml`: `build-binaries` job timeout raised from 30 to 60 minutes. The `aarch64-apple-darwin`
+  build hit the 30-minute limit and was cancelled — a direct consequence of the sccache removal
+  above, since a cold `--features full` build (including the heavier candle/ML dependencies) now
+  compiles from scratch on every release instead of reusing a warm cache.
 
 ## [0.22.4] - 2026-08-16
 


### PR DESCRIPTION
## Summary

- Raise `build-binaries` job timeout from 30 to 60 minutes in `release.yml`

`aarch64-apple-darwin` hit the previous 30-minute limit and was cancelled on the v0.22.4 release run (#31959609206). Direct consequence of removing sccache in #6742: a cold `--features full` build (including the heavier candle/ML dependencies) now compiles from scratch on every release instead of reusing a warm cache.

## Test plan

- [x] `gitleaks protect --staged`
- [ ] Next release tag push will exercise the new timeout