### PR TITLE
ci: pin fuzz jobs to gnu target to fix musl/sanitizer conflict

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Fuzz ${{ matrix.target }}
         id: fuzz
         working-directory: fuzz
-        run: cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=${{ matrix.budget }}
+        run: cargo +nightly fuzz run --target x86_64-unknown-linux-gnu ${{ matrix.target }} -- -max_total_time=${{ matrix.budget }}
 
       - name: Minimize crash and file issue
         if: failure() && steps.fuzz.outcome == 'failure'
@@ -63,7 +63,7 @@ jobs:
             echo "no crash artifact found under artifacts/${FUZZ_TARGET}/, skipping issue filing"
             exit 0
           fi
-          cargo +nightly fuzz tmin "$FUZZ_TARGET" "$crash" || true
+          cargo +nightly fuzz tmin --target x86_64-unknown-linux-gnu "$FUZZ_TARGET" "$crash" || true
 
           title="fuzz: crash in ${FUZZ_TARGET}"
           existing="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
@@ -148,7 +148,7 @@ jobs:
         id: coverage
         continue-on-error: true
         working-directory: fuzz
-        run: cargo +nightly fuzz coverage ${{ matrix.target }}
+        run: cargo +nightly fuzz coverage --target x86_64-unknown-linux-gnu ${{ matrix.target }}
 
       # Uses `rust-cov` (the cargo-binutils-installed llvm-cov wrapper) directly rather than
       # the `cargo cov --` subcommand: cargo-binutils 0.4.0's `cargo cov`/`cargo profdata`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 All four found and fixed via the new `feature-matrix` `cargo-hack` CI job (#6744) actually
 running for the first time, each masked previously by combined feature strings.
+- `fuzz.yml`: pinned `cargo fuzz run`/`tmin`/`coverage` to `--target x86_64-unknown-linux-gnu`.
+  `cargo-fuzz` defaults to `x86_64-unknown-linux-musl` even on a glibc host, and its AddressSanitizer
+  build is incompatible with the statically-linked musl libc, so every scheduled fuzz job failed
+  during the build step before any fuzzing ran.
 
 ## [0.22.4] - 2026-08-16
 


### PR DESCRIPTION
## Summary
- The scheduled `Fuzz` workflow (all matrix targets, e.g. `chunk_file`) has been failing at the build step, before any fuzzing runs: https://github.com/bug-ops/zeph/actions/runs/32676206762/job/97284679711
- Root cause: `cargo-fuzz` defaults to the `x86_64-unknown-linux-musl` target even when running on a glibc (`x86_64-unknown-linux-gnu`) host. AddressSanitizer, which `cargo fuzz` enables by default, is incompatible with musl's statically linked libc, so the build fails with `sanitizer is incompatible with statically linked libc` before `core` even compiles. This is a known `cargo-fuzz` behavior (`rust-fuzz/cargo-fuzz#398`).
- Fix: explicitly pass `--target x86_64-unknown-linux-gnu` to `cargo fuzz run`, `cargo fuzz tmin`, and `cargo fuzz coverage` in `.github/workflows/fuzz.yml`.
- As a side effect, this also fixes the `coverage` job: it was silently failing at the same build step every run (masked by `continue-on-error: true`), so no coverage report was ever produced.

## Test plan
- [ ] CI run of `fuzz.yml` (`workflow_dispatch` or next scheduled run) completes the build step and starts fuzzing for all matrix targets
- [ ] `Coverage` job produces a non-empty coverage report artifact