### PR TITLE
fix(skills): resolve broken intra-doc links to Qdrant variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ running for the first time, each masked previously by combined feature strings.
   `cargo-fuzz` defaults to `x86_64-unknown-linux-musl` even on a glibc host, and its AddressSanitizer
   build is incompatible with the statically-linked musl libc, so every scheduled fuzz job failed
   during the build step before any fuzzing ran.
+- `zeph-skills`: replaced two unconditional intra-doc links to the `qdrant`-feature-gated
+  `Qdrant` variant with plain code spans, fixing `cargo doc` under default features (#6533).
 
 ## [0.22.4] - 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ running for the first time, each masked previously by combined feature strings.
   build is incompatible with the statically-linked musl libc, so every scheduled fuzz job failed
   during the build step before any fuzzing ran.
 - `zeph-skills`: replaced two unconditional intra-doc links to the `qdrant`-feature-gated
-  `Qdrant` variant with plain code spans, fixing `cargo doc` under default features (#6533).
+  `Qdrant` variant with plain code spans, fixing `cargo doc` under default features (#6533, #6753).
 
 ## [0.22.4] - 2026-08-16
 

--- a/crates/zeph-skills/src/matcher.rs
+++ b/crates/zeph-skills/src/matcher.rs
@@ -575,7 +575,7 @@ impl SkillMatcherBackend {
     /// Return the embedding vector for a skill at the given index, if available.
     ///
     /// For [`Self::InMemory`], this is the pre-computed description embedding. For
-    /// [`Self::Qdrant`], this is served from a per-turn cache populated by
+    /// the `Qdrant` backend, this is served from a per-turn cache populated by
     /// [`Self::refresh_skill_embeddings`] — `None` if that hasn't been called yet,
     /// `skill_index` wasn't among its candidates, or the fetch failed or returned a partial
     /// result (see issue #5786).
@@ -606,7 +606,7 @@ impl SkillMatcherBackend {
     /// top-K that [`Self::match_skills`] alone would have cached.
     ///
     /// No-op for [`Self::InMemory`], whose embeddings are already resident in memory. For
-    /// [`Self::Qdrant`], this issues a bounded `get_points` round-trip scoped to `scored` — only
+    /// the `Qdrant` backend, this issues a bounded `get_points` round-trip scoped to `scored` — only
     /// call it when a consumer of [`Self::skill_embedding`] is actually enabled (RL rerank
     /// and/or `GoSkills` grouping), so turns using neither feature don't pay for the extra
     /// Qdrant round-trip (see issue #5786).


### PR DESCRIPTION
## Summary

`crates/zeph-skills/src/matcher.rs` had two doc comments on `SkillMatcherBackend` methods (`skill_embedding`, `refresh_skill_embeddings`) that referenced the `qdrant`-feature-gated `Qdrant` variant via an unconditional `[Self::Qdrant]` intra-doc link. When documenting without the `qdrant` feature, rustdoc's `--deny rustdoc::broken_intra_doc_links` fails because the link target does not exist in that configuration.

Fix: replace both links with a plain backticked `` `Qdrant` `` code span, matching the convention already used elsewhere in the same file (`matcher.rs:562-563`, `:661`, `:695`) for the same reason.

## Verification

- `cargo doc -p zeph-skills` (default features) — pass (previously failed)
- `cargo doc -p zeph-skills --features qdrant` — pass
- `cargo doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"` with `RUSTFLAGS="-D warnings"` — pass
- `cargo test --doc -p zeph-skills` — 50 passed, 3 ignored, 0 failed
- `cargo nextest run -p zeph-skills` — 578 passed, 0 skipped
- `cargo +nightly fmt --check`, `cargo clippy` (crate-appropriate feature sets) — clean

Doc-comment-only change, no behavior change.

## Follow-up

This fix restores `cargo doc -p zeph-skills` (default features), but does not add regression
protection: the workspace `rustdoc` CI job always builds `zeph-skills` with `qdrant` enabled,
because `zeph-core` depends on it unconditionally (`crates/zeph-core/Cargo.toml:84`). The
default-feature build that originally exposed this defect is not exercised by any CI job.
Will file a follow-up issue proposing a per-crate default-feature doc pass in the `rustdoc` job.

The same defect class (an unconditional intra-doc link to a feature-gated item) exists
independently in `zeph-a2a` (3 occurrences referencing `sign_card`, gated behind
`card-signing`). Out of scope for this PR; will file a separate follow-up issue against
`zeph-a2a`.

Closes #6533