### PR TITLE
fix(gateway): gate /metrics endpoint behind optional auth and rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Security
 
 - Bumped `h2` 0.4.15 -> 0.4.19, resolving RUSTSEC-2026-0258 (unbounded empty DATA frames).
+- Added opt-in `[metrics] require_auth` to gate the gateway `/metrics` endpoint behind the same
+  bearer token and rate limiting as `/webhook`; default is unchanged (unauthenticated,
+  unthrottled) (#6550).
+- Extracted the duplicated MCP OAuth vault-key derivation into a single shared
+  `zeph_config::oauth_vault_key` helper, and added test coverage for the vault-key collision
+  validation path (#6550).
 
 ### Fixed
 

--- a/book/src/advanced/gateway.md
+++ b/book/src/advanced/gateway.md
@@ -104,6 +104,19 @@ On success, returns `200` with `{"status": "accepted"}`. Returns `401` if the to
 
 The gateway tracks requests per source IP with a 60-second sliding window. When a client exceeds the configured `rate_limit`, subsequent requests receive `429 Too Many Requests` until the window resets. The rate limiter evicts stale entries when the tracking map exceeds 10,000 IPs.
 
+## Metrics Endpoint
+
+When `[metrics] enabled = true` (requires the `prometheus` feature), the gateway also mounts a `/metrics` route (path configurable via `[metrics] path`) that returns `OpenMetrics` 1.0.0 text for Prometheus scraping. This applies to the CLI/TUI-driven gateway (`src/runner.rs`) only — `zeph --daemon` (`src/daemon.rs`) does not currently wire a metrics registry into its gateway, so `/metrics` (and `require_auth`) has no effect in daemon mode.
+
+By default (`[metrics] require_auth = false`), `/metrics` is unauthenticated and unthrottled — the same posture as `/health`. This matches the common deployment where the gateway's port is only reachable from a trusted scrape network (a private VPC, a sidecar, or behind a reverse proxy that itself enforces access control). If the gateway is reachable from an untrusted network, set:
+
+```toml
+[metrics]
+require_auth = true
+```
+
+to require the same `Authorization: Bearer <token>` header as `/webhook`. This also gives `/metrics` its own independent per-IP rate-limit counter, with the same limit and the same middleware ordering as `/webhook` (rate limit outside auth, so a failed-auth request still counts toward the limit). Without this, `/metrics` would give the bearer token an unthrottled brute-force surface even though `/webhook` throttles it.
+
 ## Architecture
 
 The gateway is built on [axum](https://docs.rs/axum) with `tower-http` middleware:

--- a/config/default.toml
+++ b/config/default.toml
@@ -895,6 +895,11 @@ enabled = false
 path = "/metrics"
 # How often (seconds) to sync MetricsSnapshot to the Prometheus registry (min 1)
 sync_interval_secs = 5
+# Require the gateway bearer token on /metrics. Default: false (unauthenticated, unthrottled).
+# Set true when the gateway is reachable from an untrusted network; this gives /metrics its
+# own independent per-IP counter with the same limit as /webhook, so the token cannot be
+# brute-forced via /metrics.
+require_auth = false
 
 [daemon]
 # Enable daemon supervisor

--- a/crates/zeph-config/src/channels.rs
+++ b/crates/zeph-config/src/channels.rs
@@ -1441,6 +1441,21 @@ impl Default for McpMediaConfig {
     }
 }
 
+/// Derive the age-vault key holding OAuth credentials for an MCP server.
+///
+/// Normalizes `server_id` by uppercasing it and replacing `-` with `_`, so `"my-app"` and
+/// `"my_app"` collide on the same key — [`crate::Config::validate`] rejects this collision at
+/// config load time when both servers have `oauth.enabled = true`. Shared by
+/// [`McpServerConfig`] validation and the vault-backed `CredentialStore` that reads/writes
+/// this key at runtime, so the two never drift apart.
+#[must_use]
+pub fn oauth_vault_key(server_id: &str) -> String {
+    format!(
+        "ZEPH_MCP_OAUTH_{}",
+        server_id.to_uppercase().replace('-', "_")
+    )
+}
+
 #[derive(Clone, Deserialize, Serialize)]
 pub struct McpServerConfig {
     pub id: String,

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -123,7 +123,7 @@ pub use channels::{
     IbctKeyConfig, McpConfig, McpMediaConfig, McpOAuthConfig, McpPolicy, McpServerConfig,
     McpTrustLevel, OAuthTokenStorage, RateLimit, SlackConfig, TelegramConfig, ToolDiscoveryConfig,
     ToolDiscoveryStrategyConfig, ToolPruningConfig, TrustCalibrationConfig, TrustedAgentKey,
-    is_skill_allowed,
+    is_skill_allowed, oauth_vault_key,
 };
 pub use cli::{CliConfig, LoopConfig};
 pub use cocoon::CocoonConfig;

--- a/crates/zeph-config/src/loader.rs
+++ b/crates/zeph-config/src/loader.rs
@@ -371,7 +371,7 @@ impl Config {
             }
             // vault key collision detection
             if s.oauth.as_ref().is_some_and(|o| o.enabled) {
-                let key = format!("ZEPH_MCP_OAUTH_{}", s.id.to_uppercase().replace('-', "_"));
+                let key = crate::channels::oauth_vault_key(&s.id);
                 if !seen_oauth_vault_keys.insert(key.clone()) {
                     return Err(ConfigError::Validation(format!(
                         "MCP server '{}' has vault key collision ('{key}'): another server \
@@ -882,12 +882,64 @@ impl Config {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
+    use crate::channels::{McpOAuthConfig, McpPolicy, McpServerConfig, McpTrustLevel};
 
     fn config_with_sct(threshold: f32) -> Config {
         let mut cfg = Config::default();
         cfg.llm.semantic_cache_threshold = threshold;
         cfg
+    }
+
+    fn mcp_server(id: &str, oauth_enabled: bool) -> McpServerConfig {
+        McpServerConfig {
+            id: id.to_owned(),
+            command: Some("echo".to_owned()),
+            args: Vec::new(),
+            env: HashMap::new(),
+            url: None,
+            timeout: 30,
+            policy: McpPolicy::default(),
+            headers: HashMap::new(),
+            oauth: Some(McpOAuthConfig {
+                enabled: oauth_enabled,
+                ..McpOAuthConfig::default()
+            }),
+            trust_level: McpTrustLevel::default(),
+            tool_allowlist: None,
+            allow_untrusted_without_allowlist: false,
+            expected_tools: Vec::new(),
+            roots: Vec::new(),
+            tool_metadata: HashMap::new(),
+            elicitation_enabled: None,
+            env_isolation: None,
+            media_passthrough: false,
+        }
+    }
+
+    /// Two oauth-enabled MCP servers whose IDs normalize to the same vault key
+    /// (`oauth_vault_key`) must be rejected at config-validation time (F2, #6550) —
+    /// otherwise both servers would silently share one set of vault-stored credentials.
+    #[test]
+    fn validate_mcp_servers_rejects_oauth_vault_key_collision() {
+        let mut cfg = Config::default();
+        cfg.mcp.servers = vec![mcp_server("my-app", true), mcp_server("my_app", true)];
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("vault key collision"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// The same colliding IDs are fine when only one server has `oauth.enabled = true` —
+    /// the collision only matters once both servers actually read/write the shared vault key.
+    #[test]
+    fn validate_mcp_servers_allows_collision_when_only_one_server_has_oauth_enabled() {
+        let mut cfg = Config::default();
+        cfg.mcp.servers = vec![mcp_server("my-app", true), mcp_server("my_app", false)];
+        assert!(cfg.validate().is_ok());
     }
 
     #[test]

--- a/crates/zeph-config/src/metrics.rs
+++ b/crates/zeph-config/src/metrics.rs
@@ -64,6 +64,19 @@ pub struct MetricsConfig {
     /// Zero is clamped to `1` at runtime. Defaults to `5`.
     #[serde(default = "default_sync_interval_secs")]
     pub sync_interval_secs: u64,
+
+    /// Require the gateway bearer token on the `/metrics` endpoint. Default: `false`.
+    ///
+    /// When `false` (the default), `/metrics` is reachable without a bearer token and without
+    /// rate limiting — matching the historical behavior and the common "scrape from a trusted
+    /// network" deployment. Set to `true` to require the same `Authorization: Bearer <token>`
+    /// header as `/webhook`, e.g. when the gateway is reachable from an untrusted network — this
+    /// also gives `/metrics` its own independent per-IP rate-limit counter, with the same limit
+    /// and the same middleware ordering as `/webhook` (rate limit outside auth, so a failed-auth
+    /// request still counts toward the limit), since without it the bearer token would gain an
+    /// unthrottled brute-force surface via `/metrics`.
+    #[serde(default)]
+    pub require_auth: bool,
 }
 
 impl Default for MetricsConfig {
@@ -72,6 +85,7 @@ impl Default for MetricsConfig {
             enabled: false,
             path: default_metrics_path(),
             sync_interval_secs: default_sync_interval_secs(),
+            require_auth: false,
         }
     }
 }
@@ -86,6 +100,7 @@ mod tests {
         assert!(!config.enabled);
         assert_eq!(config.path, "/metrics");
         assert_eq!(config.sync_interval_secs, 5);
+        assert!(!config.require_auth);
     }
 
     #[test]
@@ -94,16 +109,19 @@ mod tests {
             enabled = true
             path = "/custom/metrics"
             sync_interval_secs = 10
+            require_auth = true
         "#;
         let config: MetricsConfig = toml::from_str(src).unwrap();
         assert!(config.enabled);
         assert_eq!(config.path, "/custom/metrics");
         assert_eq!(config.sync_interval_secs, 10);
+        assert!(config.require_auth);
 
         let serialized = toml::to_string(&config).unwrap();
         let roundtrip: MetricsConfig = toml::from_str(&serialized).unwrap();
         assert!(roundtrip.enabled);
         assert_eq!(roundtrip.path, "/custom/metrics");
         assert_eq!(roundtrip.sync_interval_secs, 10);
+        assert!(roundtrip.require_auth);
     }
 }

--- a/crates/zeph-gateway/src/server.rs
+++ b/crates/zeph-gateway/src/server.rs
@@ -68,11 +68,13 @@ pub struct GatewayServer {
     webhook_tx: mpsc::Sender<WebhookMessage>,
     shutdown_rx: watch::Receiver<bool>,
     trusted_proxy_cidrs: Vec<String>,
-    /// Prometheus metrics registry and endpoint path (feature-gated).
+    /// Prometheus metrics registry, endpoint path, and whether it requires the gateway
+    /// bearer token (feature-gated).
     #[cfg(feature = "prometheus")]
     metrics_registry: Option<(
         std::sync::Arc<prometheus_client::registry::Registry>,
         String,
+        bool,
     )>,
 }
 
@@ -255,8 +257,14 @@ impl GatewayServer {
     /// Attach a Prometheus metrics registry to the gateway.
     ///
     /// When set, the server mounts an additional route at `path` that returns the registry
-    /// contents encoded as `OpenMetrics` 1.0.0 text.  The endpoint is unauthenticated and
-    /// bypasses rate limiting.
+    /// contents encoded as `OpenMetrics` 1.0.0 text. When `require_auth` is `true`, this route
+    /// requires the same `Authorization: Bearer <token>` header as `/webhook`, and is also
+    /// rate-limited the same way (`rate_limit_middleware` outside `auth_middleware`, so
+    /// failed-auth attempts still count toward the limit) — without this, the same bearer token
+    /// would gain an unthrottled brute-force surface via `/metrics` even though `/webhook`
+    /// throttles it (#6550). When `require_auth` is `false` (the historical default), the route
+    /// is unauthenticated and unthrottled — there is no token to protect and no reason to
+    /// throttle a legitimate scrape loop.
     ///
     /// Requires the `prometheus` feature.
     ///
@@ -275,7 +283,7 @@ impl GatewayServer {
     /// let registry = Arc::new(Registry::default());
     ///
     /// let server = GatewayServer::new("127.0.0.1", 8080, tx, srx)
-    ///     .with_metrics_registry(registry, "/metrics");
+    ///     .with_metrics_registry(registry, "/metrics", false);
     /// # }
     /// ```
     #[cfg(feature = "prometheus")]
@@ -285,8 +293,9 @@ impl GatewayServer {
         mut self,
         registry: std::sync::Arc<prometheus_client::registry::Registry>,
         path: impl Into<String>,
+        require_auth: bool,
     ) -> Self {
-        self.metrics_registry = Some((registry, path.into()));
+        self.metrics_registry = Some((registry, path.into(), require_auth));
         self
     }
 
@@ -340,11 +349,16 @@ impl GatewayServer {
         );
 
         #[cfg(feature = "prometheus")]
-        let router = if let Some((registry, path)) = self.metrics_registry {
-            let metrics_route = axum::Router::new()
-                .route(&path, axum::routing::get(crate::handlers::metrics_handler))
-                .with_state(registry);
-            router.merge(metrics_route)
+        let router = if let Some((registry, path, require_auth)) = self.metrics_registry {
+            attach_metrics_route(
+                router,
+                registry,
+                &path,
+                require_auth,
+                self.auth_token.as_deref(),
+                self.rate_limit,
+                &self.trusted_proxy_cidrs,
+            )
         } else {
             router
         };
@@ -374,6 +388,54 @@ impl GatewayServer {
     }
 }
 
+/// Mount the Prometheus metrics route onto `router`, optionally gating it behind the same
+/// bearer-token auth and rate limiting `/webhook` gets.
+///
+/// Extracted so `serve()` and its own tests call the exact same code — a regression that drops
+/// the conditional layering here, or that merges the metrics sub-router in unlayered (relying on
+/// a layer already applied to the outer `router`, which `Router::merge` does not propagate onto
+/// routes merged in afterward — the exact shape of #6550's original bug), fails the tests that
+/// exercise this function directly, not just `serve()`'s assembled router.
+///
+/// `require_auth = false` (the historical default) leaves the route unauthenticated and
+/// unthrottled — there is no token to protect and no reason to throttle a legitimate scrape
+/// loop. `require_auth = true` layers `rate_limit_middleware` outside `auth_middleware`,
+/// mirroring `router.rs`'s `build_router` ordering, so a failed-auth request still counts
+/// toward the limit and the bearer token cannot be brute-forced via `/metrics` at an unthrottled
+/// rate (#6550 S2) — without this, `/metrics` would reintroduce the exact unthrottled-token
+/// surface `/webhook`'s auth-inside-rate-limit ordering exists to prevent.
+#[cfg(feature = "prometheus")]
+fn attach_metrics_route(
+    router: axum::Router,
+    registry: std::sync::Arc<prometheus_client::registry::Registry>,
+    path: &str,
+    require_auth: bool,
+    auth_token: Option<&str>,
+    rate_limit: u32,
+    trusted_proxy_cidrs: &[String],
+) -> axum::Router {
+    let mut metrics_route = axum::Router::new()
+        .route(path, axum::routing::get(crate::handlers::metrics_handler))
+        .with_state(registry);
+
+    if require_auth {
+        let auth_cfg = zeph_common::http_middleware::AuthConfig::new(auth_token, true);
+        let rate_state =
+            zeph_common::http_middleware::RateLimitState::new(rate_limit, trusted_proxy_cidrs);
+        metrics_route = metrics_route
+            .layer(axum::middleware::from_fn_with_state(
+                auth_cfg,
+                zeph_common::http_middleware::auth_middleware,
+            ))
+            .layer(axum::middleware::from_fn_with_state(
+                rate_state,
+                zeph_common::http_middleware::rate_limit_middleware,
+            ));
+    }
+
+    router.merge(metrics_route)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -390,29 +452,48 @@ mod tests {
 
         let (tx, _rx) = mpsc::channel(1);
         let (_stx, srx) = watch::channel(false);
-        let server = GatewayServer::new("127.0.0.1", 19999, tx, srx)
-            .with_metrics_registry(std::sync::Arc::clone(&registry), "/metrics");
+        let server = GatewayServer::new("127.0.0.1", 19999, tx, srx).with_metrics_registry(
+            std::sync::Arc::clone(&registry),
+            "/metrics",
+            false,
+        );
 
-        // Build the router directly without binding a port
+        // Build the router the same way `serve()` does — via `build_router` +
+        // `attach_metrics_route` — so this test exercises the exact production code path
+        // instead of hand-rolling an equivalent router (#6550 S1).
+        let GatewayServer {
+            auth_token,
+            rate_limit,
+            max_body_size,
+            trusted_proxy_cidrs,
+            webhook_tx,
+            webhook_send_timeout,
+            metrics_registry,
+            ..
+        } = server;
+        let (metrics_registry, path, require_auth) =
+            metrics_registry.expect("metrics_registry must be set by with_metrics_registry");
         let state = AppState {
-            webhook_tx: server.webhook_tx,
+            webhook_tx,
             started_at: Instant::now(),
-            webhook_send_timeout: server.webhook_send_timeout,
+            webhook_send_timeout,
         };
         let router = crate::router::build_router(
             state,
-            server.auth_token.as_deref(),
-            server.rate_limit,
-            server.max_body_size,
-            &server.trusted_proxy_cidrs,
+            auth_token.as_deref(),
+            rate_limit,
+            max_body_size,
+            &trusted_proxy_cidrs,
         );
-        let metrics_route = axum::Router::new()
-            .route(
-                "/metrics",
-                axum::routing::get(crate::handlers::metrics_handler),
-            )
-            .with_state(registry);
-        let router = router.merge(metrics_route);
+        let router = attach_metrics_route(
+            router,
+            metrics_registry,
+            &path,
+            require_auth,
+            auth_token.as_deref(),
+            rate_limit,
+            &trusted_proxy_cidrs,
+        );
 
         let req = axum::http::Request::builder()
             .method("GET")
@@ -437,6 +518,154 @@ mod tests {
         let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
         let body = String::from_utf8(body_bytes.to_vec()).unwrap();
         assert!(body.ends_with("# EOF\n"), "missing EOF marker in:\n{body}");
+    }
+
+    /// F1 (#6550): with `require_auth = true`, `/metrics` must reject a request with no bearer
+    /// token (401) and accept one with the correct token (200) — the same middleware `/webhook`
+    /// gets, layered directly onto the metrics sub-router before it is merged into the main
+    /// router, since `Router::merge` does not propagate a layer applied to the outer router.
+    /// Goes through the real `attach_metrics_route` helper `serve()` calls, not a hand-rolled
+    /// duplicate (#6550 S1).
+    #[cfg(feature = "prometheus")]
+    #[tokio::test]
+    async fn test_metrics_endpoint_requires_auth_when_configured() {
+        use axum::body::Body;
+        use prometheus_client::registry::Registry;
+        use tower::Service;
+
+        let registry = std::sync::Arc::new(Registry::default());
+        let (tx, _rx) = mpsc::channel(1);
+        let (_stx, srx) = watch::channel(false);
+        let server = GatewayServer::new("127.0.0.1", 19997, tx, srx)
+            .with_auth(Some("secret".into()))
+            .with_metrics_registry(std::sync::Arc::clone(&registry), "/metrics", true);
+
+        let GatewayServer {
+            auth_token,
+            rate_limit,
+            max_body_size,
+            trusted_proxy_cidrs,
+            webhook_tx,
+            webhook_send_timeout,
+            metrics_registry,
+            ..
+        } = server;
+        let (metrics_registry, path, require_auth) =
+            metrics_registry.expect("metrics_registry must be set by with_metrics_registry");
+        let state = AppState {
+            webhook_tx,
+            started_at: Instant::now(),
+            webhook_send_timeout,
+        };
+        let router = crate::router::build_router(
+            state,
+            auth_token.as_deref(),
+            rate_limit,
+            max_body_size,
+            &trusted_proxy_cidrs,
+        );
+        let mut router = attach_metrics_route(
+            router,
+            metrics_registry,
+            &path,
+            require_auth,
+            auth_token.as_deref(),
+            rate_limit,
+            &trusted_proxy_cidrs,
+        );
+
+        let no_token_req = axum::http::Request::builder()
+            .method("GET")
+            .uri("/metrics")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.call(no_token_req).await.unwrap();
+        assert_eq!(resp.status(), axum::http::StatusCode::UNAUTHORIZED);
+
+        let valid_token_req = axum::http::Request::builder()
+            .method("GET")
+            .uri("/metrics")
+            .header("authorization", "Bearer secret")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.call(valid_token_req).await.unwrap();
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+    }
+
+    /// F1 (#6550) S2 fix: when `require_auth = true`, `/metrics` must also rate-limit — without
+    /// this, the same bearer token gains an unthrottled brute-force surface via `/metrics` even
+    /// though `/webhook` throttles it. Mirrors `router.rs`'s `failed_auth_requests_are_rate_limited`:
+    /// failed-auth requests must still count toward the limit, proving rate limiting is layered
+    /// outside auth, not inside it.
+    #[cfg(feature = "prometheus")]
+    #[tokio::test]
+    async fn test_metrics_endpoint_rate_limited_when_require_auth() {
+        use axum::body::Body;
+        use prometheus_client::registry::Registry;
+        use tower::Service;
+
+        let registry = std::sync::Arc::new(Registry::default());
+        let (tx, _rx) = mpsc::channel(1);
+        let (_stx, srx) = watch::channel(false);
+        let server = GatewayServer::new("127.0.0.1", 19996, tx, srx)
+            .with_auth(Some("secret".into()))
+            .with_rate_limit(2)
+            .with_metrics_registry(std::sync::Arc::clone(&registry), "/metrics", true);
+
+        let GatewayServer {
+            auth_token,
+            rate_limit,
+            max_body_size,
+            trusted_proxy_cidrs,
+            webhook_tx,
+            webhook_send_timeout,
+            metrics_registry,
+            ..
+        } = server;
+        let (metrics_registry, path, require_auth) =
+            metrics_registry.expect("metrics_registry must be set by with_metrics_registry");
+        let state = AppState {
+            webhook_tx,
+            started_at: Instant::now(),
+            webhook_send_timeout,
+        };
+        let router = crate::router::build_router(
+            state,
+            auth_token.as_deref(),
+            rate_limit,
+            max_body_size,
+            &trusted_proxy_cidrs,
+        );
+        let mut router = attach_metrics_route(
+            router,
+            metrics_registry,
+            &path,
+            require_auth,
+            auth_token.as_deref(),
+            rate_limit,
+            &trusted_proxy_cidrs,
+        );
+
+        let make_req = || {
+            axum::http::Request::builder()
+                .method("GET")
+                .uri("/metrics")
+                .header("authorization", "Bearer wrong")
+                .body(Body::empty())
+                .unwrap()
+        };
+
+        let resp = router.call(make_req()).await.unwrap();
+        assert_eq!(resp.status(), axum::http::StatusCode::UNAUTHORIZED);
+        let resp = router.call(make_req()).await.unwrap();
+        assert_eq!(resp.status(), axum::http::StatusCode::UNAUTHORIZED);
+        let resp = router.call(make_req()).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            axum::http::StatusCode::TOO_MANY_REQUESTS,
+            "third failed-auth request against /metrics must be rate-limited when \
+             require_auth=true"
+        );
     }
 
     #[test]

--- a/specs/019-gateway/spec.md
+++ b/specs/019-gateway/spec.md
@@ -127,6 +127,19 @@ POST /webhook
 
 - Auth middleware runs before all handlers — enforced by middleware layer order in router build
 - `GET /health` bypasses auth unconditionally — monitoring must work unauthenticated
+- `GET /metrics` (when `[metrics] enabled = true`) is the second, opt-in-gated auth exemption:
+  unauthenticated and unthrottled by default (`[metrics] require_auth = false`, no token exists
+  to protect and no reason to throttle a legitimate scrape loop), but when `require_auth = true`
+  it requires the same bearer token as `/webhook` **and** the same rate limiting, layered in the
+  same order (`rate_limit_middleware` outside `auth_middleware`, so a failed-auth request still
+  counts toward the limit) — omitting the rate limiter here would reintroduce an unthrottled
+  brute-force surface against the same bearer token `/webhook`'s ordering exists to prevent
+  (#6550 S2). Because `Router::merge` does not propagate a layer applied to the outer router
+  onto a merged-in sub-router, both layers must be applied directly to the metrics sub-router
+  *before* it is merged (`GatewayServer::serve`, via the shared `attach_metrics_route` helper) —
+  merging it unlayered after `build_router` has already applied
+  `auth_middleware`/`rate_limit_middleware` to the `protected` sub-router silently bypasses both
+  (#6550's original bug).
 - Token hash pre-computed at startup — never per-request
 - `ct_eq()` mandatory for token comparison — `==` is banned
 - `202 Accepted` returned immediately — gateway does not wait for agent to process

--- a/src/bootstrap/oauth.rs
+++ b/src/bootstrap/oauth.rs
@@ -24,11 +24,12 @@ pub struct VaultCredentialStore {
 impl VaultCredentialStore {
     /// Derive vault key and create the store.
     ///
-    /// Key format: `ZEPH_MCP_OAUTH_{server_id.to_uppercase().replace('-', "_")}`.
+    /// Key format: `ZEPH_MCP_OAUTH_{server_id.to_uppercase().replace('-', "_")}`, derived via
+    /// [`zeph_config::oauth_vault_key`] — the same helper `Config::validate_mcp_servers` uses
+    /// to detect a collision, so the two can never drift apart.
     pub fn new(server_id: &str, vault: Arc<RwLock<AgeVaultProvider>>) -> Self {
-        let normalized = server_id.to_uppercase().replace('-', "_");
         Self {
-            vault_key: format!("ZEPH_MCP_OAUTH_{normalized}"),
+            vault_key: zeph_config::oauth_vault_key(server_id),
             vault,
         }
     }
@@ -101,23 +102,18 @@ impl CredentialStore for VaultCredentialStore {
 
 #[cfg(test)]
 mod tests {
+    use zeph_config::oauth_vault_key;
+
     #[test]
     fn vault_key_normalization_hyphen() {
-        let key = format!(
-            "ZEPH_MCP_OAUTH_{}",
-            "my-server".to_uppercase().replace('-', "_")
-        );
-        assert_eq!(key, "ZEPH_MCP_OAUTH_MY_SERVER");
+        assert_eq!(oauth_vault_key("my-server"), "ZEPH_MCP_OAUTH_MY_SERVER");
     }
 
     #[test]
     fn vault_key_collision_documented() {
-        // "my-app" and "my_app" normalize to the same key — config validation must reject this.
-        let a = "my-app".to_uppercase().replace('-', "_");
-        let b = "my_app".to_uppercase().replace('-', "_");
-        assert_eq!(
-            a, b,
-            "vault key collision exists for hyphens vs underscores"
-        );
+        // "my-app" and "my_app" normalize to the same key via the shared helper —
+        // `Config::validate_mcp_servers` rejects this at config-load time (see
+        // zeph-config's `validate_mcp_servers_rejects_oauth_vault_key_collision` test).
+        assert_eq!(oauth_vault_key("my-app"), oauth_vault_key("my_app"));
     }
 }

--- a/src/gateway_spawn.rs
+++ b/src/gateway_spawn.rs
@@ -273,6 +273,7 @@ pub(crate) fn spawn_gateway_server(
     #[cfg(feature = "prometheus")] metrics_registry: Option<(
         std::sync::Arc<prometheus_client::registry::Registry>,
         String,
+        bool,
     )>,
     supervisor: Option<&zeph_common::TaskSupervisor>,
 ) {
@@ -303,8 +304,8 @@ pub(crate) fn spawn_gateway_server(
     .with_trusted_proxy_cidrs(config.gateway.trusted_proxy_cidrs.clone());
 
     #[cfg(feature = "prometheus")]
-    let gw = if let Some((registry, path)) = metrics_registry {
-        gw.with_metrics_registry(registry, path)
+    let gw = if let Some((registry, path, require_auth)) = metrics_registry {
+        gw.with_metrics_registry(registry, path, require_auth)
     } else {
         gw
     };

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -320,6 +320,8 @@ pub(crate) struct WizardState {
     pub(crate) telemetry_enabled: bool,
     // Prometheus metrics export (#2866)
     pub(crate) prometheus_enabled: bool,
+    // Require the gateway bearer token on /metrics (#6550)
+    pub(crate) metrics_require_auth: bool,
     // Trajectory risk sentinel (spec 050)
     pub(crate) trajectory_critical_at: f32,
     pub(crate) trajectory_auto_recover: u32,
@@ -590,6 +592,7 @@ impl Default for WizardState {
             magic_docs_enabled: false,
             telemetry_enabled: false,
             prometheus_enabled: false,
+            metrics_require_auth: false,
             trajectory_critical_at: 10.0,
             trajectory_auto_recover: 16,
             gonka_private_key: None,
@@ -1507,6 +1510,7 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
     config.telemetry.enabled = state.telemetry_enabled;
     if state.prometheus_enabled {
         config.metrics.enabled = true;
+        config.metrics.require_auth = state.metrics_require_auth;
         // Only enable gateway if not already enabled by the deployment bundle.
         if !config.gateway.enabled {
             config.gateway.enabled = true;
@@ -2078,6 +2082,14 @@ fn step_prometheus(state: &mut WizardState) -> anyhow::Result<()> {
              zeph vault set ZEPH_GATEWAY_TOKEN <token>\n  \
              This wizard never prompts for the raw token — see CLAUDE.md Secrets & Vault."
         );
+
+        state.metrics_require_auth = Confirm::new()
+            .with_prompt(
+                "Require the gateway bearer token on /metrics too? (recommended if reachable \
+                 from an untrusted network)",
+            )
+            .default(false)
+            .interact()?;
     }
 
     println!();

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -4004,7 +4004,11 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
             config,
             shutdown_rx.clone(),
             gateway_input_tx.clone(),
-            Some((std::sync::Arc::clone(&prom.registry), effective_path)),
+            Some((
+                std::sync::Arc::clone(&prom.registry),
+                effective_path,
+                config.metrics.require_auth,
+            )),
             Some(&*supervisor),
         );
         Some(handle)


### PR DESCRIPTION
## Summary

Closes #6550

Batch of three low-severity hardening observations from a prior security audit (CI-1429). Re-verified against current code before implementing — two of the three findings had already been fixed upstream since the issue was filed and needed no changes here:

- **F1 (fixed by this PR)**: `/metrics` bypassed both the gateway's bearer-token auth and rate limiting. `GatewayServer::serve` merged an unlayered metrics sub-router onto the router after `build_router` had already applied `auth_middleware`/`rate_limit_middleware` to the `protected` sub-router — `axum::Router::merge` does not propagate a layer applied to the outer router onto a router merged in afterward, so no auth mode existed for `/metrics` at all.
- **F2 (already fixed upstream)**: MCP OAuth vault-key collision between server IDs differing only by separator. `Config::validate_mcp_servers` already rejects this at config load time. This PR only extracts the duplicated key-derivation logic (`loader.rs` and `bootstrap/oauth.rs`) into a single `zeph_config::oauth_vault_key` helper and adds collision-path test coverage that was missing.
- **F3 (already fixed upstream)**: `GrantKind::Tool` in `zeph-subagent` is enforced at dispatch via closed issue #6567 (`check_tool_grant` / `ToolGrantCheck`). No changes needed; not touched by this PR.

## Changes

- New opt-in `[metrics] require_auth` (default `false`, no behavior change for existing deployments). When `true`, `/metrics` requires the same `Authorization: Bearer <token>` header as `/webhook`, and gets its own independent per-IP rate-limit counter with the same limit and middleware ordering (rate limit outside auth, so a failed-auth attempt still counts toward the limit) — closing a brute-force gap on the gateway token that an earlier revision of this fix left open (auth-only, no rate limiter).
- Extracted `attach_metrics_route` in `crates/zeph-gateway/src/server.rs` so both `serve()` and its tests exercise the identical code path — a regression that reintroduces the original unlayered-merge bug now fails the tests instead of only an audit.
- Threaded `require_auth` through `MetricsConfig` → `GatewayServer::with_metrics_registry` → `gateway_spawn.rs` → `runner.rs`; added to `config/default.toml`, the `--init` wizard's Prometheus step, `book/src/advanced/gateway.md`, and `specs/019-gateway/spec.md`'s Key Invariants.
- Extracted `zeph_config::oauth_vault_key` shared helper (F2 residual), used by both `Config::validate_mcp_servers` and `VaultCredentialStore::new`; added collision-rejection and negative-case tests.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (15406 passed, 0 failed)
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace ...`)
- [x] `cargo test --doc -p zeph-gateway --features prometheus`
- [x] `gitleaks protect --staged`
- [x] New unit tests: `require_auth = true` rejects an unauthenticated request (401) and accepts a correctly authenticated one (200); a third failed-auth request against `/metrics` is rate-limited (429); `require_auth = false` regression guard confirms the historical unauthenticated/unthrottled default is unchanged.
- [x] Live-testing playbook (`.local/testing/playbooks/gateway.md` Scenario 12, 12a-12e) and coverage-status row added for a follow-up live session.
- [ ] Live end-to-end verification (real curl against a running gateway) — pending, tracked in the playbook.