### PR TITLE
fix(a2a): reword broken intra-doc links to feature-gated sign_card

### DIFF
--- a/crates/zeph-a2a/src/card_signing.rs
+++ b/crates/zeph-a2a/src/card_signing.rs
@@ -29,7 +29,7 @@
 //!
 //! The [`SignatureVerification`], [`SigAlg`], and [`TrustedKey`] types are always
 //! compiled (needed for config plumbing and the crypto-free URL-origin check in
-//! [`crate::discovery`]). [`verify_card_signatures`] and [`sign_card`] require the
+//! [`crate::discovery`]). [`verify_card_signatures`] and `sign_card` require the
 //! `card-signing` feature; without it, [`verify_card_signatures`] returns
 //! [`SignatureVerification::FeatureDisabled`] and `sign_card` does not exist at all
 //! (it has no meaningful behavior to fall back to — signing requires the crypto crates).
@@ -40,7 +40,7 @@
 //! the A2A 1.0.0 spec text (§8.4.1–§8.4.3) retrieved verbatim during design review, not
 //! from a real signed-card test vector produced by a reference implementation (e.g. the
 //! Python/JS `a2a-sdk`). `canonical_payload` (private, used by both [`verify_card_signatures`]
-//! and [`sign_card`]) strips proto3-default-valued fields (empty
+//! and `sign_card`) strips proto3-default-valued fields (empty
 //! string, `false`, `0`, empty array/object, recursively through nested objects) before
 //! JCS, matching the spec text's canonicalization rules — this closes the specific
 //! divergence a compliant signer that strips defaults before signing would otherwise

--- a/crates/zeph-a2a/src/lib.rs
+++ b/crates/zeph-a2a/src/lib.rs
@@ -33,7 +33,7 @@
 //! |---------|-------------|
 //! | `server` | Enables `A2aServer`, `TaskManager`, and `TaskProcessor` |
 //! | `ibct`   | Enables [`Ibct`] token issuance and verification (HMAC-SHA256) |
-//! | `card-signing` | Enables [`card_signing::verify_card_signatures`] and [`card_signing::sign_card`] (JWS/ES256 over RFC 8785 JCS). Without it, `AgentCardSignature`/`signatures` still (de)serialize, but verification always returns `SignatureVerification::FeatureDisabled`. |
+//! | `card-signing` | Enables [`card_signing::verify_card_signatures`] and `sign_card` (JWS/ES256 over RFC 8785 JCS). Without it, `AgentCardSignature`/`signatures` still (de)serialize, but verification always returns `SignatureVerification::FeatureDisabled`. |
 //!
 //! # Examples
 //!


### PR DESCRIPTION
## Summary

`crates/zeph-a2a` had the same defect class fixed in `zeph-skills` by PR #6753 (issue #6533): unconditional intra-doc links to an item gated behind a non-default feature. Three occurrences reference `sign_card`, which is gated behind the `card-signing` feature:

- `crates/zeph-a2a/src/lib.rs:36`
- `crates/zeph-a2a/src/card_signing.rs:32`
- `crates/zeph-a2a/src/card_signing.rs:43`

With `card-signing` disabled (default features), `cargo doc -p zeph-a2a` failed under `rustdoc::broken_intra_doc_links` because `sign_card` does not exist in that configuration.

Fix: replace the three `` [`sign_card`] ``-style links with plain backticked `` `sign_card` `` code spans, matching the convention used for the analogous fix in #6753.

A fourth `[`sign_card`]` link exists at `card_signing.rs:147`, on the doc comment for `CardSigningError`, but that item is itself `#[cfg(feature = "card-signing")]`-gated, so the link only compiles when `sign_card` actually exists — correctly left unchanged.

## Verification

- `cargo doc -p zeph-a2a` (default features) — pass (previously failed)
- `cargo doc -p zeph-a2a --features card-signing` — pass
- `cargo +nightly fmt --check` — clean
- `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 15402 passed, 42 skipped
- `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- `gitleaks protect --staged` — no leaks

Doc-comment-only change, no behavior change.

Closes #6755