### PR TITLE
ci(rustdoc): build zeph-skills docs with default (non-qdrant) features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -887,6 +887,15 @@ jobs:
         run: cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"
       - name: Doc-tests
         run: cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"
+      # The workspace-wide build above always force-enables zeph-skills' `qdrant` feature,
+      # because crates/zeph-core/Cargo.toml depends on `zeph-skills = { features = ["qdrant"] }`
+      # unconditionally and Cargo unifies features per-package across the whole build. A doc
+      # defect that only reproduces under zeph-skills' own default (non-qdrant) feature set is
+      # therefore invisible to the step above (#6754). Building only `-p zeph-skills`, without
+      # `--workspace`, excludes zeph-core from this invocation's unit graph so its forced
+      # `qdrant` feature request never applies here.
+      - name: Build zeph-skills docs (default features, no qdrant)
+        run: cargo doc --no-deps -p zeph-skills
 
   validate-specs:
     name: Validate Specs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `ci.yml`: added a `zeph-skills` default-features doc-build step to the `rustdoc` job, closing
   a gap where CI only ever built `zeph-skills` docs with `qdrant` force-enabled via workspace
-  feature unification, hiding doc defects specific to its default (non-qdrant) feature set.
+  feature unification, hiding doc defects specific to its default (non-qdrant) feature set (#6758).
 - `ci.yml`: added `default-build-check` (plain `cargo check --workspace --all-targets`, no
   `--features` flag) and `feature-matrix` (`cargo-hack`-based, 4-way partitioned isolation
   check of every leaf feature flag) jobs, closing a gap where CI never built the bare-default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `ci.yml`: added a `zeph-skills` default-features doc-build step to the `rustdoc` job, closing
+  a gap where CI only ever built `zeph-skills` docs with `qdrant` force-enabled via workspace
+  feature unification, hiding doc defects specific to its default (non-qdrant) feature set.
 - `ci.yml`: added `default-build-check` (plain `cargo check --workspace --all-targets`, no
   `--features` flag) and `feature-matrix` (`cargo-hack`-based, 4-way partitioned isolation
   check of every leaf feature flag) jobs, closing a gap where CI never built the bare-default


### PR DESCRIPTION
## Summary

- The workspace-wide `rustdoc` CI job builds docs with `cargo doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`. Because `crates/zeph-core/Cargo.toml` declares `zeph-skills = { features = ["qdrant"] }` unconditionally, Cargo's feature unification force-enables `qdrant` on `zeph-skills` in every such invocation, so a doc defect specific to `zeph-skills`' own default (non-qdrant) feature set is invisible to CI — the intra-doc-link bug fixed in #6533/PR #6753 passed CI both before and after the fix.
- Adds a new step to the `rustdoc` job: `cargo doc --no-deps -p zeph-skills` (no `--features`, no `--workspace`), which excludes `zeph-core` from the unit graph and therefore genuinely exercises `zeph-skills`' own default (`sqlite`, non-qdrant) features. Reuses the job's existing `RUSTDOCFLAGS`/`CARGO_BUILD_WARNINGS` env — no new job or env vars.
- `crates/zeph-core/Cargo.toml`'s `qdrant` feature declaration is untouched — this closes the CI coverage gap only, not the underlying feature-unification behavior.

## Test plan

- [x] `cargo doc --no-deps -p zeph-skills` builds clean with the job's `RUSTDOCFLAGS` (`--deny rustdoc::broken_intra_doc_links --deny rustdoc::private_intra_doc_links --deny rustdoc::redundant_explicit_links`)
- [x] `cargo tree -p zeph-skills -e normal,features` confirms `qdrant`/`qdrant-client`/`zeph-memory` are absent from the default-feature dependency graph for this invocation
- [x] Verified the new step's command reproduces the pre-fix failure described in PR #6753 (i.e. would have caught #6533) and passes post-fix
- [x] `gitleaks protect --staged --redact` — no leaks
- [x] Local warm run of the new step: ~1s (shares cached deps with the preceding workspace doc-build step); negligible impact on the job's 10-minute timeout

Closes #6754

https://claude.ai/code/session_01UEBKc6XfYiehHFhTTRn1d1