### PR TITLE
refactor(config): use explicit re-exports in memory and migrate modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `index` (AST-based code indexing) joins the `desktop` bundle, and therefore `full` — the first
   time `full` compiles `zeph-index` in (#6747).
 - `zeph-config`: replaced glob re-exports with explicit named lists in `memory/mod.rs` and
-  `migrate/mod.rs` (#6486).
+  `migrate/mod.rs` (#6486, #6759).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   LLM providers must now add `testing` explicitly (`--features full,testing`) (#6747).
 - `index` (AST-based code indexing) joins the `desktop` bundle, and therefore `full` — the first
   time `full` compiles `zeph-index` in (#6747).
+- `zeph-config`: replaced glob re-exports with explicit named lists in `memory/mod.rs` and
+  `migrate/mod.rs` (#6486).
 
 ### Removed
 

--- a/crates/zeph-config/src/memory/mod.rs
+++ b/crates/zeph-config/src/memory/mod.rs
@@ -33,17 +33,42 @@ mod store;
 #[cfg(test)]
 mod tests;
 
-pub use consent_gate::*;
-pub use consolidation::*;
-pub use fidelity::*;
-pub use graph::*;
-pub use hebbian::*;
-pub use persona::*;
-pub use reasoning::*;
-pub use retrieval::*;
-pub use root::*;
-pub use session::*;
-pub use store::*;
+pub use consent_gate::ConsentGateConfig;
+pub use consolidation::{
+    EpisodicConsolidationConfig, FiveSignalConfig, FiveSignalConsolidationConfig,
+};
+pub use fidelity::{
+    AconConfig, ArcCompactionConfig, CompressionConfig, CompressionGuidelinesConfig,
+    CompressionStrategy, DigestConfig, EvictionConfig, EvictionPolicy, ForgettingConfig,
+    MicrocompactConfig, OpticalForgettingConfig, PruningStrategy, TypedPagesConfig,
+    TypedPagesEnforcement,
+};
+pub use graph::{
+    ApexMemConfig, BeamSearchConfig, ConflictResolutionStrategy, ConsolidationDaemonConfig,
+    EmGraphConfig, ExperienceConfig, GraphConfig, GraphRetrievalStrategy, ImplicitConflictConfig,
+    NoteLinkingConfig, SimilarityMethod, SpreadingActivationConfig, WaterCirclesConfig,
+    WriteQualityGateConfig,
+};
+pub use hebbian::{
+    BeliefRevisionConfig, ConflictRecencyConfig, HebbianConfig, RpeConfig, WriteGateConfig,
+};
+pub use persona::{
+    CategoryConfig, PersonaConfig, SidequestConfig, TrajectoryConfig,
+    TrajectoryRiskAccumulatorConfig, TrajectorySeverityMultipliers, TrajectorySignalWeights,
+    TreeConfig,
+};
+pub use reasoning::{
+    AutoDreamConfig, CompactionProbeConfig, MagicDocsConfig, MemCotConfig, ProbeCategory,
+    ReasoningConfig, RecallViewConfig,
+};
+pub use retrieval::{
+    AdmissionConfig, AdmissionStrategy, AdmissionWeights, ConsolidationConfig, ContextFormat,
+    RetrievalConfig, RetrievalFailuresConfig, StoreRoutingConfig, StoreRoutingStrategy, TierConfig,
+    TieredRetrievalConfig, TypeAwareComposeConfig,
+};
+pub use root::{MemoryConfig, VectorBackend};
+pub use session::{ContextStrategy, DocumentConfig, SemanticConfig, SessionsConfig};
+pub use store::CrossThreadStoreConfig;
 
 pub(crate) fn default_embed_timeout_secs() -> u64 {
     5

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -34,18 +34,59 @@ pub use features::{
     migrate_telegram_expandable_blockquote_config, migrate_tui_delights, migrate_tui_mouse,
     migrate_tui_panel_sizing, migrate_tui_theme_config, migrate_tui_theme_defaults,
 };
-pub use infra::*;
+/// Crate-internal: re-exported only so `migrate/tests.rs` can reach it via `super::*`.
+#[cfg(test)]
+pub(crate) use infra::is_unsafe_shared_topology;
+pub use infra::{
+    migrate_a2a_card_trust_config, migrate_a2a_server_remove_inert_fields, migrate_database_url,
+    migrate_durable_config, migrate_durable_hwm_advisory, migrate_durable_key_rotation,
+    migrate_durable_shared_db, migrate_durable_stale_running_after_secs, migrate_egress_config,
+    migrate_nli_config, migrate_otel_filter, migrate_pii_filter_names, migrate_sandbox_config,
+    migrate_sandbox_egress_filter, migrate_scheduler_daemon_config, migrate_secret_masking_config,
+    migrate_shadow_sentinel_config, migrate_shell_transactional, migrate_supervisor_config,
+    migrate_telemetry_config, migrate_trace_metadata, migrate_vigil_config,
+    migrate_worktree_config, migrate_worktree_git_timeout, migrate_worktree_quota_fields,
+};
 pub use integrity::migrate_integrity_config;
 /// Advisory `GonkaGate` migration is crate-internal (registered via the [`MIGRATIONS`] registry).
 pub(crate) use llm::migrate_gonkagate_to_gonka;
-pub use llm::*;
-pub use mcp::*;
-pub use memory::*;
+pub use llm::{
+    migrate_cocoon_provider_notice, migrate_cocoon_show_balance, migrate_embed_provider_rename,
+    migrate_eval_model_to_provider, migrate_llm_stream_limits, migrate_llm_to_providers,
+    migrate_orchestration_orchestrator_provider, migrate_planner_model_to_provider,
+    migrate_provider_max_concurrent, migrate_stt_to_provider,
+};
+pub use mcp::{
+    migrate_mcp_elicitation_config, migrate_mcp_max_connect_attempts, migrate_mcp_media_config,
+    migrate_mcp_retry_and_tool_timeout, migrate_mcp_trust_levels,
+};
+pub use memory::{
+    migrate_fidelity_timeout_defaults, migrate_focus_auto_consolidate_min_window,
+    migrate_forgetting_config, migrate_memory_consent_gate_config, migrate_memory_graph_config,
+    migrate_memory_graph_recall_include_imported, migrate_memory_hebbian_config,
+    migrate_memory_hebbian_consolidation_config, migrate_memory_hebbian_spread_config,
+    migrate_memory_persona_config, migrate_memory_reasoning_config,
+    migrate_memory_reasoning_judge_config, migrate_memory_retrieval_config,
+    migrate_memory_retrieval_query_bias, migrate_memory_store_config,
+    migrate_memory_type_aware_compose_config, migrate_qdrant_api_key, migrate_qdrant_timeout_secs,
+};
 pub use plugins::migrate_plugins_reputation_config;
 pub use serve::migrate_serve_config;
-pub use session::*;
+pub use session::{
+    migrate_acp_auth_clients_config, migrate_acp_subagents_config,
+    migrate_hooks_permission_denied_config, migrate_hooks_turn_complete_config,
+    migrate_session_persist_provider_overrides, migrate_session_persistence_config,
+    migrate_session_provider_persistence, migrate_session_recap_config,
+    migrate_session_resume_config,
+};
 pub use subagent::{migrate_agents_delegation_mode, migrate_agents_max_spawns_per_session};
-pub use tools::*;
+pub use tools::{
+    migrate_agent_budget_hint, migrate_agent_retry_to_tools_retry, migrate_agent_time_reminder,
+    migrate_overflow_max_per_call_override, migrate_policy_provider_and_utility_window,
+    migrate_quality_config, migrate_search_config, migrate_shell_checkpoints_config,
+    migrate_shell_risk_chain_window_turns, migrate_tools_compression_config,
+    migrate_utility_high_gain_tools,
+};
 
 /// Returns `true` when `name` is an active (non-commented) TOML section header in `src`.
 ///


### PR DESCRIPTION
## Summary

`zeph-config` used `pub use <submodule>::*;` glob re-exports in `crates/zeph-config/src/memory/mod.rs` (10 globs) and `crates/zeph-config/src/migrate/mod.rs` (6 globs, mixed with explicit named re-exports in the same file), obscuring which submodule a given public type comes from. This PR replaces every glob re-export in both files with an explicit named list, matching the style already used elsewhere in `migrate/mod.rs` (`features`, `integrity`, `plugins`, `serve`).

- `memory/mod.rs`: 11 glob re-exports (including `consent_gate`, added after the issue was filed) converted to explicit lists — 71 items total.
- `migrate/mod.rs`: 6 glob re-exports converted to explicit lists — 78 `migrate_*` functions total. A `#[cfg(test)] pub(crate) use infra::is_unsafe_shared_topology;` re-export was added since that item was previously reachable inside `migrate/tests.rs` only via the removed `infra::*` glob.
- No behavior change and no change to the effective public API surface — every previously-glob-reachable item remains reachable at the identical path.

## Why

Wildcard re-exports hide item provenance, make "go to definition" navigation opaque, and — as verified during review — allow an explicit `pub use b::X` to silently shadow a same-named item from a sibling `pub use a::*` with no `unused_imports` warning, turning what used to be a compile-time ambiguity error into a silent public-API drop. `zeph-config` is a large crate (131+ config structs across 30+ files), so explicit provenance matters more here, not less.

## Test plan

- [x] `cargo build -p zeph-config` / `cargo build --workspace`
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-config` — 992/992
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 15406/15406
- [x] `cargo test --doc --workspace --features "desktop,ide,server,chat,pdf,scheduler"`
- [x] Every explicit re-export list independently verified against actual submodule `pub` declarations (no dropped or extra items) by three separate reviewers
- [x] `gitleaks protect --staged`

Closes #6486