### PR TITLE
refactor(vault): add SecretFuture alias to de-duplicate get_secret return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   cross containers — the native runner ships the real MSVC ARM64 toolchain and SDK, so the
   problem no longer applies.
 - Added `SecretFuture` type alias to `zeph-vault` to de-duplicate the `VaultProvider::get_secret`
-  return type (PR link pending).
+  return type (#6760).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   because crypto crates (`ring`, `aws-lc-sys`) require Windows ARM64 SDK headers unavailable in
   cross containers — the native runner ships the real MSVC ARM64 toolchain and SDK, so the
   problem no longer applies.
+- Added `SecretFuture` type alias to `zeph-vault` to de-duplicate the `VaultProvider::get_secret`
+  return type (PR link pending).
 
 ### Changed
 

--- a/crates/zeph-vault/src/age.rs
+++ b/crates/zeph-vault/src/age.rs
@@ -9,15 +9,12 @@
 
 use std::collections::BTreeMap;
 use std::fmt;
-use std::future::Future;
 use std::io::{Read as _, Write as _};
 use std::path::{Path, PathBuf};
-use std::pin::Pin;
 
 use zeroize::Zeroizing;
 
-use crate::VaultProvider;
-use zeph_common::secret::VaultError;
+use crate::{SecretFuture, VaultProvider};
 
 // ---------------------------------------------------------------------------
 // Error type
@@ -564,10 +561,7 @@ impl AgeVaultProvider {
 }
 
 impl VaultProvider for AgeVaultProvider {
-    fn get_secret(
-        &self,
-        key: &str,
-    ) -> Pin<Box<dyn Future<Output = Result<Option<String>, VaultError>> + Send + '_>> {
+    fn get_secret(&self, key: &str) -> SecretFuture<'_> {
         let result = self.secrets.get(key).map(|v| (**v).clone());
         Box::pin(async move { Ok(result) })
     }

--- a/crates/zeph-vault/src/arc.rs
+++ b/crates/zeph-vault/src/arc.rs
@@ -7,13 +7,9 @@
 //! while the inner `Arc` is separately accessible for mutable operations such as OAuth
 //! credential persistence.
 
-use std::future::Future;
-use std::pin::Pin;
 use std::sync::{Arc, RwLock};
 
-use zeph_common::secret::VaultError;
-
-use crate::{AgeVaultProvider, VaultProvider};
+use crate::{AgeVaultProvider, SecretFuture, VaultProvider};
 
 /// [`VaultProvider`] wrapper around `Arc<RwLock<AgeVaultProvider>>`.
 ///
@@ -48,10 +44,7 @@ use crate::{AgeVaultProvider, VaultProvider};
 pub struct ArcAgeVaultProvider(pub Arc<RwLock<AgeVaultProvider>>);
 
 impl VaultProvider for ArcAgeVaultProvider {
-    fn get_secret(
-        &self,
-        key: &str,
-    ) -> Pin<Box<dyn Future<Output = Result<Option<String>, VaultError>> + Send + '_>> {
+    fn get_secret(&self, key: &str) -> SecretFuture<'_> {
         let value = self
             .0
             .read()

--- a/crates/zeph-vault/src/env.rs
+++ b/crates/zeph-vault/src/env.rs
@@ -6,12 +6,7 @@
 //! [`EnvVaultProvider`] reads secrets directly from process environment variables.
 //! Designed for quick local development and CI environments.
 
-use std::future::Future;
-use std::pin::Pin;
-
-use zeph_common::secret::VaultError;
-
-use crate::VaultProvider;
+use crate::{SecretFuture, VaultProvider};
 
 /// Vault backend that reads secrets from environment variables.
 ///
@@ -37,10 +32,7 @@ use crate::VaultProvider;
 pub struct EnvVaultProvider;
 
 impl VaultProvider for EnvVaultProvider {
-    fn get_secret(
-        &self,
-        key: &str,
-    ) -> Pin<Box<dyn Future<Output = Result<Option<String>, VaultError>> + Send + '_>> {
+    fn get_secret(&self, key: &str) -> SecretFuture<'_> {
         let key = key.to_owned();
         Box::pin(async move { Ok(std::env::var(&key).ok()) })
     }

--- a/crates/zeph-vault/src/lib.rs
+++ b/crates/zeph-vault/src/lib.rs
@@ -77,6 +77,11 @@ pub use env::EnvVaultProvider;
 #[cfg(any(test, feature = "mock"))]
 pub use mock::MockVaultProvider;
 
+/// A boxed, `Send` future resolving to a secret lookup result, borrowed for the
+/// lifetime of the `&self` receiver that produced it.
+pub type SecretFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<Option<String>, VaultError>> + Send + 'a>>;
+
 /// Pluggable secret retrieval backend.
 ///
 /// Implement this trait to integrate a custom secret store (e.g. `HashiCorp` Vault, `AWS` Secrets
@@ -86,17 +91,12 @@ pub use mock::MockVaultProvider;
 /// # Implementing
 ///
 /// ```
-/// use std::pin::Pin;
-/// use std::future::Future;
-/// use zeph_vault::{VaultProvider, VaultError};
+/// use zeph_vault::{SecretFuture, VaultProvider, VaultError};
 ///
 /// struct ConstantVault(&'static str);
 ///
 /// impl VaultProvider for ConstantVault {
-///     fn get_secret(
-///         &self,
-///         key: &str,
-///     ) -> Pin<Box<dyn Future<Output = Result<Option<String>, VaultError>> + Send + '_>> {
+///     fn get_secret(&self, key: &str) -> SecretFuture<'_> {
 ///         let value = if key == "MY_KEY" { Some(self.0.to_owned()) } else { None };
 ///         Box::pin(async move { Ok(value) })
 ///     }
@@ -107,10 +107,7 @@ pub trait VaultProvider: Send + Sync {
     ///
     /// Returns `Ok(None)` when the key does not exist. Returns `Err(VaultError)` on
     /// backend failures (I/O, decryption, network, etc.).
-    fn get_secret(
-        &self,
-        key: &str,
-    ) -> Pin<Box<dyn Future<Output = Result<Option<String>, VaultError>> + Send + '_>>;
+    fn get_secret(&self, key: &str) -> SecretFuture<'_>;
 
     /// Return all known secret keys.
     ///

--- a/crates/zeph-vault/src/mock.rs
+++ b/crates/zeph-vault/src/mock.rs
@@ -5,12 +5,7 @@
 //!
 //! Available when the `mock` feature is enabled or in `#[cfg(test)]` contexts.
 
-use std::future::Future;
-use std::pin::Pin;
-
-use zeph_common::secret::VaultError;
-
-use crate::VaultProvider;
+use crate::{SecretFuture, VaultProvider};
 
 /// In-memory vault backend for tests and mocking.
 ///
@@ -108,10 +103,7 @@ impl MockVaultProvider {
 }
 
 impl VaultProvider for MockVaultProvider {
-    fn get_secret(
-        &self,
-        key: &str,
-    ) -> Pin<Box<dyn Future<Output = Result<Option<String>, VaultError>> + Send + '_>> {
+    fn get_secret(&self, key: &str) -> SecretFuture<'_> {
         let result = self.secrets.get(key).cloned();
         Box::pin(async move { Ok(result) })
     }


### PR DESCRIPTION
## Summary

- Adds a `pub type SecretFuture<'a> = Pin<Box<dyn Future<Output = Result<Option<String>, VaultError>> + Send + 'a>>` alias in `crates/zeph-vault/src/lib.rs` next to the `VaultProvider` trait.
- Replaces the repeated, letter-for-letter `Pin<Box<dyn Future<...>>>` return type on `VaultProvider::get_secret` (trait definition and its rustdoc example) with `SecretFuture<'_>`.
- Updates all four backend implementations (`age.rs`, `arc.rs`, `env.rs`, `mock.rs`) to use `SecretFuture<'_>` and removes the now-unused `Future`/`Pin`/`VaultError` imports in each.
- Adds a `CHANGELOG.md` `[Unreleased]` entry.

Pure textual/readability change scoped to `zeph-vault` only, as specified in the issue — no behavior, call-site, or downstream-consumer change. The same unaliased pattern exists in 11 other files workspace-wide (e.g. `zeph-llm/src/provider.rs`), explicitly out of scope for this issue.

Note: a fifth, test-only implementation matching this exact return-type shape exists at `src/acp.rs` (`impl zeph_core::vault::VaultProvider for TestVault`, gated `#[cfg(all(test, feature = "acp"))]`) and was intentionally left untouched, consistent with the zeph-vault-only scope. It cannot use the new alias today because `crates/zeph-core/src/lib.rs`'s vault re-export does not expose `SecretFuture` — a possible small follow-up, not addressed here.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings` — clean
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 15406 passed
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"` — clean
- [x] `cargo test --doc -p zeph-vault` — 18 passed, including the updated trait rustdoc example
- [x] `gitleaks protect --staged` — clean

Closes #6484

https://claude.ai/code/session_01AuS1BgDsmbgaK9YMBzyCQA