### PR TITLE
feat(subagent): add live peer-to-peer messaging between subagents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   problem no longer applies.
 - Added `SecretFuture` type alias to `zeph-vault` to de-duplicate the `VaultProvider::get_secret`
   return type (#6760).
+- Live inter-sub-agent messaging (`send_peer_message`/`check_messages`/`list_peers` tools,
+  `/agent msg`/`/agent inbox` slash commands, TUI unread-message badge) — spawner, coordinator,
+  and sibling sub-agents can now exchange messages while running, gated by spawn-tree
+  authorization and a new `[agents.peer_messaging]` config section (#5871).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Live inter-sub-agent messaging (`send_peer_message`/`check_messages`/`list_peers` tools,
   `/agent msg`/`/agent inbox` slash commands, TUI unread-message badge) — spawner, coordinator,
   and sibling sub-agents can now exchange messages while running, gated by spawn-tree
-  authorization and a new `[agents.peer_messaging]` config section (#5871).
+  authorization and a new `[agents.peer_messaging]` config section (#6776).
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11957,8 +11957,10 @@ dependencies = [
 name = "zeph-subagent"
 version = "0.22.4"
 dependencies = [
+ "chrono",
  "dirs",
  "indoc",
+ "parking_lot",
  "proptest",
  "regex",
  "schemars 1.2.2",

--- a/book/src/advanced/sub-agents.md
+++ b/book/src/advanced/sub-agents.md
@@ -45,6 +45,8 @@ That's it. The sub-agent works in the background and reports results when done.
 | `/agent resume <id> <prompt>` | Resume a completed sub-agent with its conversation history |
 | `/agent approve <id>` | Approve a pending secret request |
 | `/agent deny <id>` | Deny a pending secret request |
+| `/agent msg <id> <body>` | Send a message to a running sub-agent (accepts ID prefix) |
+| `/agent inbox` | List messages received from sub-agents this session |
 | `@name <prompt>` | Shorthand for `/agent spawn` |
 
 ### Checking Status
@@ -76,6 +78,42 @@ Resuming sub-agent a1b2c3d4-... (code-reviewer) with 12 messages
 The `<id>` argument accepts a UUID prefix, just like `cancel`. The `<prompt>` is appended as a new user message after the restored history.
 
 Resume requires transcript storage to be enabled (it is by default). If the transcript file for the given ID does not exist, the command returns an error.
+
+### Peer Messaging
+
+Sub-agents can exchange messages with each other and with you while they're still running — no need to cancel and respawn a sub-agent to redirect it, or wait for it to finish to ask it something.
+
+Every sub-agent gets three tools automatically:
+
+- `send_peer_message` — send a message to another sub-agent (or you, the spawner) by task ID or name
+- `check_messages` — drain its own inbox, optionally waiting up to `wait_ms` milliseconds for a reply
+- `list_peers` — discover which sub-agents (and you) it's allowed to message
+
+A sub-agent can only message its own spawner, its siblings (other sub-agents spawned by the same parent), and its own descendants — never a sub-agent from an unrelated spawn tree (e.g. one dispatched by a separate `/plan` execution).
+
+From your side, reply to a sub-agent's question with `/agent msg`:
+
+```
+> /agent msg a1b2 Use the new auth module in src/auth2.rs instead
+Message delivered to sub-agent a1b2c3d4-....
+```
+
+Messages a sub-agent sends you appear as notices in your channel and are listed with `/agent inbox`:
+
+```
+> /agent inbox
+[2026-09-06T10:15:32Z] from code-reviewer: Should I also check the test files, or just src/?
+```
+
+Peer messaging is on by default. Configure it under `[agents.peer_messaging]`:
+
+```toml
+[agents.peer_messaging]
+enabled = true          # kill switch — disables the three tools and all routing
+mailbox_capacity = 32   # bounded queue per agent; a full mailbox fails the send fast
+max_body_bytes = 8192   # per-message size cap
+max_wait_ms = 30000     # ceiling for check_messages' optional wait
+```
 
 ### Transcript Storage
 

--- a/book/src/reference/configuration.md
+++ b/book/src/reference/configuration.md
@@ -782,6 +782,12 @@ extra_dirs = []            # Additional directories to scan for agent definition
 # type = "command"
 # command = "./scripts/cleanup.sh"
 
+[agents.peer_messaging]
+enabled = true          # Enable live inter-sub-agent messaging (default: true)
+mailbox_capacity = 32   # Bounded inbound message queue per agent (default: 32)
+max_body_bytes = 8192   # Max size of a single message body in bytes (default: 8192)
+max_wait_ms = 30000     # Ceiling for check_messages' optional wait_ms argument (default: 30000)
+
 [orchestration]
 enabled = false                          # Enable task orchestration (default: false, requires `orchestration` feature)
 max_tasks = 20                           # Max tasks per graph (default: 20)

--- a/config/default.toml
+++ b/config/default.toml
@@ -1219,6 +1219,18 @@ llm_timeout_secs = 120
 # ZEPH_AGENTS_FORWARD_TRANSCRIPT. CLI override: --forward-subagent-text.
 forward_transcript = false
 
+[agents.peer_messaging]
+# Live inter-sub-agent messaging (spec 046-subagent-peer-messaging-parity, issue #5871).
+# Lets a spawner, coordinator, or sibling sub-agent send an addressed message to a
+# currently-running sub-agent's own mailbox, without it terminating or being respawned.
+enabled = true
+# Bounded inbound message queue capacity per addressable agent.
+mailbox_capacity = 32
+# Maximum size, in bytes, of a single message body.
+max_body_bytes = 8192
+# Ceiling, in milliseconds, for the check_messages tool's optional wait_ms argument.
+max_wait_ms = 30000
+
 [orchestration]
 # Enable the orchestration subsystem (/plan commands and task graph execution)
 enabled = false

--- a/crates/zeph-config/src/agent.rs
+++ b/crates/zeph-config/src/agent.rs
@@ -727,6 +727,9 @@ pub struct SubAgentConfig {
     /// because the bootstrap overwrites this value before passing it to `SubAgentManager`.
     #[serde(default)]
     pub worktree: crate::worktree::WorktreeConfig,
+    /// Live inter-sub-agent messaging settings (spec `046-subagent-peer-messaging-parity`).
+    #[serde(default)]
+    pub peer_messaging: PeerMessagingConfig,
 }
 
 impl Default for SubAgentConfig {
@@ -755,6 +758,7 @@ impl Default for SubAgentConfig {
             summary_max_chars: default_summary_max_chars(),
             llm_timeout_secs: default_llm_timeout_secs(),
             worktree: crate::worktree::WorktreeConfig::default(),
+            peer_messaging: PeerMessagingConfig::default(),
         }
     }
 }
@@ -792,6 +796,67 @@ impl SubAgentConfig {
     }
 }
 
+fn default_peer_messaging_enabled() -> bool {
+    true
+}
+
+fn default_peer_mailbox_capacity() -> usize {
+    32
+}
+
+fn default_peer_max_body_bytes() -> usize {
+    8192
+}
+
+fn default_peer_max_wait_ms() -> u64 {
+    30_000
+}
+
+/// Live inter-sub-agent messaging settings (spec `046-subagent-peer-messaging-parity`,
+/// issue #5871).
+///
+/// Governs the bounded mailbox every addressable agent (parent and sub-agents) is
+/// registered with, and the three peer-messaging tools (`send_peer_message`,
+/// `check_messages`, `list_peers`) a spawned sub-agent's tool executor exposes.
+///
+/// # Examples
+///
+/// ```toml
+/// [agents.peer_messaging]
+/// enabled = true          # kill switch
+/// mailbox_capacity = 32   # bounded queue per agent
+/// max_body_bytes = 8192   # per-message cap
+/// max_wait_ms = 30000     # ceiling for check_messages(wait_ms)
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct PeerMessagingConfig {
+    /// Kill switch. When `false`, no route is registered for any spawn and the three
+    /// peer-messaging tools are absent from every sub-agent's tool catalog.
+    #[serde(default = "default_peer_messaging_enabled")]
+    pub enabled: bool,
+    /// Bounded inbound message queue capacity per addressable agent.
+    #[serde(default = "default_peer_mailbox_capacity")]
+    pub mailbox_capacity: usize,
+    /// Maximum size, in bytes, of a single message body.
+    #[serde(default = "default_peer_max_body_bytes")]
+    pub max_body_bytes: usize,
+    /// Ceiling, in milliseconds, for the `check_messages` tool's optional `wait_ms` argument.
+    #[serde(default = "default_peer_max_wait_ms")]
+    pub max_wait_ms: u64,
+}
+
+impl Default for PeerMessagingConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_peer_messaging_enabled(),
+            mailbox_capacity: default_peer_mailbox_capacity(),
+            max_body_bytes: default_peer_max_body_bytes(),
+            max_wait_ms: default_peer_max_wait_ms(),
+        }
+    }
+}
+
 /// Config-level lifecycle hooks fired when any sub-agent starts or stops.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(default)]
@@ -824,6 +889,23 @@ mod tests {
             !cfg.forward_transcript,
             "forward_transcript must default to false (NFR-003)"
         );
+    }
+
+    #[test]
+    fn peer_messaging_config_defaults() {
+        let cfg = PeerMessagingConfig::default();
+        assert!(cfg.enabled);
+        assert_eq!(cfg.mailbox_capacity, 32);
+        assert_eq!(cfg.max_body_bytes, 8192);
+        assert_eq!(cfg.max_wait_ms, 30_000);
+    }
+
+    #[test]
+    fn peer_messaging_config_omitted_key_defaults_to_enabled() {
+        let toml_str = "enabled = true\n";
+        let cfg: SubAgentConfig = toml::from_str(toml_str).unwrap();
+        assert!(cfg.peer_messaging.enabled);
+        assert_eq!(cfg.peer_messaging.mailbox_capacity, 32);
     }
 
     #[test]

--- a/crates/zeph-config/src/lib.rs
+++ b/crates/zeph-config/src/lib.rs
@@ -115,8 +115,8 @@ pub mod worktree;
 
 pub use agent::{
     AgentConfig, ContextInjectionMode, DelegationMode, FocusConfig, GoalConfig, ModelSpec,
-    ParentContextPolicy, SubAgentConfig, SubAgentLifecycleHooks, TaskSupervisorConfig,
-    ToolFilterConfig,
+    ParentContextPolicy, PeerMessagingConfig, SubAgentConfig, SubAgentLifecycleHooks,
+    TaskSupervisorConfig, ToolFilterConfig,
 };
 pub use channels::{
     A2aClientConfig, A2aServerConfig, CardTrustPolicy, ChannelSkillsConfig, DiscordConfig,

--- a/crates/zeph-config/src/migrate/mod.rs
+++ b/crates/zeph-config/src/migrate/mod.rs
@@ -79,7 +79,10 @@ pub use session::{
     migrate_session_provider_persistence, migrate_session_recap_config,
     migrate_session_resume_config,
 };
-pub use subagent::{migrate_agents_delegation_mode, migrate_agents_max_spawns_per_session};
+pub use subagent::{
+    migrate_agents_delegation_mode, migrate_agents_max_spawns_per_session,
+    migrate_agents_peer_messaging_config,
+};
 pub use tools::{
     migrate_agent_budget_hint, migrate_agent_retry_to_tools_retry, migrate_agent_time_reminder,
     migrate_overflow_max_per_call_override, migrate_policy_provider_and_utility_window,
@@ -650,9 +653,9 @@ use steps::{
     MigrateA2aCardTrustConfig, MigrateA2aServerRemoveInertFields, MigrateAcpAuthClientsConfig,
     MigrateAcpSubagentsConfig, MigrateAgentBudgetHint, MigrateAgentRetryToToolsRetry,
     MigrateAgentTimeReminder, MigrateAgentsDelegationMode, MigrateAgentsMaxSpawnsPerSession,
-    MigrateAutodreamConfig, MigrateCavemanConfig, MigrateCocoonProviderNotice,
-    MigrateCocoonShowBalance, MigrateCompressionPredictorConfig, MigrateDatabaseUrl,
-    MigrateDeepLinkConfig, MigrateDurableConfig, MigrateDurableHwmAdvisory,
+    MigrateAgentsPeerMessagingConfig, MigrateAutodreamConfig, MigrateCavemanConfig,
+    MigrateCocoonProviderNotice, MigrateCocoonShowBalance, MigrateCompressionPredictorConfig,
+    MigrateDatabaseUrl, MigrateDeepLinkConfig, MigrateDurableConfig, MigrateDurableHwmAdvisory,
     MigrateDurableKeyRotation, MigrateDurableSharedDb, MigrateDurableStaleRunningAfterSecs,
     MigrateEgressConfig, MigrateEmbedProviderRename, MigrateEvalModelToProvider,
     MigrateFidelityTimeoutDefaults, MigrateFiveSignalConfig, MigrateFocusAutoConsolidateMinWindow,
@@ -910,6 +913,9 @@ pub static MIGRATIONS: std::sync::LazyLock<Vec<Box<dyn Migration + Send + Sync>>
             Box::new(MigrateShellRiskChainWindowTurns),
             // Step 107 — add panel_sizing = "auto" advisory comment under [tui] (#6675)
             Box::new(MigrateTuiPanelSizing),
+            // Step 108 — add [agents.peer_messaging] advisory block for live inter-sub-agent
+            // messaging (spec 046-subagent-peer-messaging-parity, #5871)
+            Box::new(MigrateAgentsPeerMessagingConfig),
         ]
     });
 

--- a/crates/zeph-config/src/migrate/steps.rs
+++ b/crates/zeph-config/src/migrate/steps.rs
@@ -92,13 +92,13 @@ use super::{
     migrate_a2a_server_remove_inert_fields, migrate_acp_auth_clients_config,
     migrate_acp_subagents_config, migrate_agent_budget_hint, migrate_agent_retry_to_tools_retry,
     migrate_agent_time_reminder, migrate_agents_delegation_mode,
-    migrate_agents_max_spawns_per_session, migrate_autodream_config, migrate_caveman_config,
-    migrate_cocoon_provider_notice, migrate_cocoon_show_balance,
-    migrate_compression_predictor_config, migrate_database_url, migrate_deep_link_config,
-    migrate_durable_config, migrate_durable_hwm_advisory, migrate_durable_key_rotation,
-    migrate_durable_shared_db, migrate_durable_stale_running_after_secs, migrate_egress_config,
-    migrate_embed_provider_rename, migrate_eval_model_to_provider,
-    migrate_fidelity_timeout_defaults, migrate_five_signal_config,
+    migrate_agents_max_spawns_per_session, migrate_agents_peer_messaging_config,
+    migrate_autodream_config, migrate_caveman_config, migrate_cocoon_provider_notice,
+    migrate_cocoon_show_balance, migrate_compression_predictor_config, migrate_database_url,
+    migrate_deep_link_config, migrate_durable_config, migrate_durable_hwm_advisory,
+    migrate_durable_key_rotation, migrate_durable_shared_db,
+    migrate_durable_stale_running_after_secs, migrate_egress_config, migrate_embed_provider_rename,
+    migrate_eval_model_to_provider, migrate_fidelity_timeout_defaults, migrate_five_signal_config,
     migrate_focus_auto_consolidate_min_window, migrate_forgetting_config, migrate_goals_config,
     migrate_hooks_permission_denied_config, migrate_hooks_turn_complete_config,
     migrate_integrity_config, migrate_knowledge_config, migrate_llm_stream_limits,
@@ -1381,5 +1381,18 @@ impl Migration for MigrateTuiPanelSizing {
 
     fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
         migrate_tui_panel_sizing(toml_src)
+    }
+}
+
+/// Step 108 — add an `[agents.peer_messaging]` advisory block for live inter-sub-agent
+/// messaging (spec `046-subagent-peer-messaging-parity`, issue #5871).
+pub(super) struct MigrateAgentsPeerMessagingConfig;
+impl Migration for MigrateAgentsPeerMessagingConfig {
+    fn name(&self) -> &'static str {
+        "migrate_agents_peer_messaging_config"
+    }
+
+    fn apply(&self, toml_src: &str) -> Result<MigrationResult, MigrateError> {
+        migrate_agents_peer_messaging_config(toml_src)
     }
 }

--- a/crates/zeph-config/src/migrate/subagent.rs
+++ b/crates/zeph-config/src/migrate/subagent.rs
@@ -131,6 +131,63 @@ pub fn migrate_agents_max_spawns_per_session(
     })
 }
 
+/// Add a `[agents.peer_messaging]` advisory block to an existing active `[agents]` table
+/// (spec `046-subagent-peer-messaging-parity`, issue #5871).
+///
+/// `#[serde(default)]` on every field of `PeerMessagingConfig` already makes the section's
+/// absence safe on load, so this insertion is purely for discoverability — an operator who
+/// already has `[agents]` active sees the new inter-sub-agent messaging knobs in their config
+/// file rather than having them resolved silently.
+///
+/// No-op when `[agents]` is absent or not active (only commented-out), or
+/// `[agents.peer_messaging]` is already present (active or as a prior advisory comment).
+///
+/// # Errors
+///
+/// Returns `MigrateError::Parse` if the TOML cannot be parsed.
+pub fn migrate_agents_peer_messaging_config(
+    toml_src: &str,
+) -> Result<MigrationResult, MigrateError> {
+    if section_header_present(toml_src, "agents.peer_messaging")
+        || toml_src.contains("# [agents.peer_messaging]")
+        || !section_header_present(toml_src, "agents")
+    {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let doc = toml_src.parse::<toml_edit::DocumentMut>()?;
+    if !doc.contains_key("agents") {
+        return Ok(MigrationResult {
+            output: toml_src.to_owned(),
+            changed_count: 0,
+            sections_changed: Vec::new(),
+        });
+    }
+
+    let comment = "\n# Live inter-sub-agent messaging (spec 046-subagent-peer-messaging-parity, #5871).\n\
+         # Lets a spawner, coordinator, or sibling sub-agent send an addressed message to a\n\
+         # currently-running sub-agent's own mailbox, without it terminating or being respawned.\n\
+         # Enabled by default; each addressable agent's mailbox is bounded and denies delivery\n\
+         # across spawn-tree roots.\n\
+         # [agents.peer_messaging]\n\
+         # enabled = true\n\
+         # mailbox_capacity = 32   # bounded queue per agent\n\
+         # max_body_bytes = 8192  # per-message cap\n\
+         # max_wait_ms = 30000    # ceiling for check_messages(wait_ms)\n";
+    let raw = doc.to_string();
+    let output = format!("{raw}{comment}");
+
+    Ok(MigrationResult {
+        output,
+        changed_count: 1,
+        sections_changed: vec!["agents.peer_messaging".to_owned()],
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -229,6 +286,48 @@ mod tests {
         let src = "[agents]\nenabled = true\n";
         let once = migrate_agents_max_spawns_per_session(src).expect("migrate");
         let twice = migrate_agents_max_spawns_per_session(&once.output).expect("migrate");
+        assert_eq!(twice.changed_count, 0);
+        assert_eq!(twice.output, once.output);
+    }
+
+    #[test]
+    fn peer_messaging_inserts_advisory_block_when_agents_active() {
+        let src = "[agents]\nenabled = true\n";
+        let result = migrate_agents_peer_messaging_config(src).expect("migrate");
+        assert_eq!(result.changed_count, 1);
+        assert!(result.output.contains("# [agents.peer_messaging]"));
+        assert!(result.output.contains("# max_wait_ms = 30000"));
+    }
+
+    #[test]
+    fn peer_messaging_noop_when_section_absent() {
+        let src = "[llm]\nprovider = \"claude\"\n";
+        let result = migrate_agents_peer_messaging_config(src).expect("migrate");
+        assert_eq!(result.changed_count, 0);
+        assert_eq!(result.output, src);
+    }
+
+    #[test]
+    fn peer_messaging_noop_when_section_only_commented_out() {
+        let src = "# [agents]\n# enabled = true\n";
+        let result = migrate_agents_peer_messaging_config(src).expect("migrate");
+        assert_eq!(result.changed_count, 0);
+        assert_eq!(result.output, src);
+    }
+
+    #[test]
+    fn peer_messaging_noop_when_already_present() {
+        let src = "[agents]\nenabled = true\n\n[agents.peer_messaging]\nenabled = false\n";
+        let result = migrate_agents_peer_messaging_config(src).expect("migrate");
+        assert_eq!(result.changed_count, 0);
+        assert_eq!(result.output, src);
+    }
+
+    #[test]
+    fn peer_messaging_idempotent() {
+        let src = "[agents]\nenabled = true\n";
+        let once = migrate_agents_peer_messaging_config(src).expect("migrate");
+        let twice = migrate_agents_peer_messaging_config(&once.output).expect("migrate");
         assert_eq!(twice.changed_count, 0);
         assert_eq!(twice.output, once.output);
     }

--- a/crates/zeph-config/src/migrate/tests.rs
+++ b/crates/zeph-config/src/migrate/tests.rs
@@ -9,8 +9,8 @@ use super::*;
 fn migrations_registry_has_all_steps() {
     assert_eq!(
         MIGRATIONS.len(),
-        107,
-        "MIGRATIONS registry must contain all 107 sequential steps"
+        108,
+        "MIGRATIONS registry must contain all 108 sequential steps"
     );
     for m in MIGRATIONS.iter() {
         assert!(
@@ -2124,7 +2124,7 @@ fn migrate_focus_auto_consolidate_noop_when_only_commented_section() {
 
 #[test]
 fn registry_has_fifty_entries() {
-    assert_eq!(MIGRATIONS.len(), 107);
+    assert_eq!(MIGRATIONS.len(), 108);
 }
 
 /// Mirrors the SC-003 wire-X-into-registry check below for `MigrateTuiPanelSizing` (#6675):
@@ -2327,6 +2327,7 @@ fn registry_preserves_order_matches_dispatch() {
         "migrate_agents_max_spawns_per_session",
         "migrate_shell_risk_chain_window_turns",
         "migrate_tui_panel_sizing",
+        "migrate_agents_peer_messaging_config",
     ];
     let actual: Vec<&str> = MIGRATIONS.iter().map(|m| m.name()).collect();
     assert_eq!(actual, expected);

--- a/crates/zeph-core/src/agent/mod.rs
+++ b/crates/zeph-core/src/agent/mod.rs
@@ -466,6 +466,7 @@ impl<C: Channel> Agent<C> {
             self.process_pending_elicitations().await;
             self.refresh_subagent_metrics();
             self.notify_completed_subagents().await?;
+            self.notify_peer_messages().await;
             self.drain_channel();
 
             let (text, image_parts) = if let Some(queued) = self.msg.message_queue.pop_front() {

--- a/crates/zeph-core/src/agent/scheduler_loop.rs
+++ b/crates/zeph-core/src/agent/scheduler_loop.rs
@@ -628,6 +628,13 @@ impl<C: crate::channel::Channel> Agent<C> {
         // its base value (correct for its other, user-command-driven callers) — this is the
         // one caller that isn't user-driven, so override it back to `Autonomous` here.
         spawn_ctx.origin = zeph_subagent::SpawnOrigin::Autonomous;
+        // Spec 046 (peer messaging) FR-013/FR-014: this DAG execution's own `GraphId` (already
+        // computed above as `graph_id`, a stable per-execution UUID) is a distinct
+        // `PeerGroupId::Plan` root from the interactive session's own `PeerGroupId::Session` —
+        // makes US-003's cross-group authorization denial reachable in production, since a
+        // `background: true` interactively-spawned sub-agent can stay alive concurrently with
+        // a running plan's sub-agents in the same `SubAgentManager`, with no shared ancestor.
+        spawn_ctx.peer_group = Some(zeph_subagent::peer::PeerGroupId::Plan(graph_id.to_string()));
 
         // Idle-timeout progress heartbeat (issue #6245, Alt-A): the driver owns creation of
         // the Arc. One clone flows into the sub-agent loop via `spawn_ctx.progress_at`
@@ -1438,6 +1445,7 @@ impl<C: crate::channel::Channel> Agent<C> {
 
             self.process_pending_secret_requests(&mut denied_secrets)
                 .await;
+            self.notify_peer_messages().await;
 
             let snapshot = crate::metrics::TaskGraphSnapshot::from(scheduler.graph());
             self.update_metrics(|m| {
@@ -1531,6 +1539,15 @@ impl<C: crate::channel::Channel> Agent<C> {
 
         self.process_pending_secret_requests(&mut std::collections::HashSet::new())
             .await;
+        self.notify_peer_messages().await;
+
+        // Critic round-4 S2: release this plan execution's peer-messaging root now that the
+        // plan has reached a terminal state, mirroring how a `SubAgentHandle`'s own
+        // `PeerRegistration` is dropped on collection — drained one last time just above so
+        // no in-flight message to the parent is lost by tearing the mailbox down under it.
+        if let Some(mgr) = self.services.orchestration.subagent_manager.as_mut() {
+            mgr.release_plan_peer_group(&scheduler.graph().id.to_string());
+        }
 
         // Clear lookahead cache so stale hints are never seen after plan completion.
         self.services.orchestration.cached_lookahead = Vec::new();
@@ -3219,6 +3236,7 @@ mod tests {
             started_at_str: String::new(),
             transcript_dir: None,
             mcp_tool_names: Vec::new(),
+            peer: None,
         };
 
         let mut mgr = SubAgentManager::new(4);
@@ -3336,6 +3354,7 @@ mod tests {
             started_at_str: String::new(),
             transcript_dir: None,
             mcp_tool_names: Vec::new(),
+            peer: None,
         };
 
         let mut mgr = SubAgentManager::new(4);

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -844,7 +844,17 @@ pub(crate) struct OrchestrationState {
     pub(crate) durable_integrity_sealed: bool,
     /// Execution IDs explicitly grandfathered past the seal (issue #6449).
     pub(crate) durable_integrity_grandfather: std::collections::HashSet<zeph_durable::ExecutionId>,
+    /// Peer messages addressed to the parent agent itself, drained non-blocking from
+    /// `SubAgentManager::try_recv_peer_message` (spec `046-subagent-peer-messaging-parity`).
+    ///
+    /// Bounded to [`PEER_INBOX_CAPACITY`] entries (oldest evicted first) so a chatty sub-agent
+    /// cannot grow this unboundedly; backs the `/agent inbox` slash command.
+    pub(crate) peer_inbox: std::collections::VecDeque<zeph_subagent::peer::PeerMessage>,
 }
+
+/// Maximum number of parent-addressed peer messages retained in
+/// [`OrchestrationState::peer_inbox`] for `/agent inbox` (spec `046`).
+pub(crate) const PEER_INBOX_CAPACITY: usize = 50;
 
 /// Groups instruction hot-reload state.
 #[derive(Default)]

--- a/crates/zeph-core/src/agent/subagent_commands.rs
+++ b/crates/zeph-core/src/agent/subagent_commands.rs
@@ -114,6 +114,7 @@ impl<C: Channel> Agent<C> {
                         .agent_transcript_dir(&id)
                         .map(|p| p.to_string_lossy().into_owned()),
                     live_transcript: mgr.forwarded_tail(&id, LIVE_TRANSCRIPT_TAIL_LINES),
+                    unread_messages: u32::try_from(mgr.mailbox_depth(&id)).unwrap_or(u32::MAX),
                 }
             })
             .collect();
@@ -149,6 +150,39 @@ impl<C: Channel> Agent<C> {
             }
         }
         Ok(())
+    }
+    /// Non-blocking poll: drain and surface peer messages addressed to the parent agent
+    /// itself (spec `046-subagent-peer-messaging-parity`), mirroring
+    /// [`notify_completed_subagents`](Self::notify_completed_subagents)'s shape.
+    ///
+    /// # Known latency limitation
+    ///
+    /// Same as [`try_recv_peer_message`](zeph_subagent::SubAgentManager::try_recv_peer_message):
+    /// a message is not observed until the parent reaches this drain point, at most one turn
+    /// away.
+    pub(super) async fn notify_peer_messages(&mut self) {
+        let Some(mgr) = self.services.orchestration.subagent_manager.as_mut() else {
+            return;
+        };
+        while let Some(mut msg) = mgr.try_recv_peer_message() {
+            let source = zeph_sanitizer::ContentSource::new(
+                zeph_sanitizer::ContentSourceKind::SubagentPeerMessage,
+            )
+            .with_identifier(msg.sender_name.as_str());
+            let sanitized = self.services.security.sanitizer.sanitize(&msg.body, source);
+            let notice = format!("[peer message from {}] {}", msg.sender_name, sanitized.body);
+            if let Err(e) = self.channel.send(&notice).await {
+                tracing::warn!(error = %e, "failed to send peer-message notice");
+            }
+            // Store the sanitized body, not the raw one — `/agent inbox` is an operator
+            // display surface, not an LLM context injection, but re-showing unsanitized
+            // attacker-influenceable content there defeats the point of sanitizing it above.
+            msg.body = sanitized.body;
+            self.services.orchestration.peer_inbox.push_back(msg);
+            while self.services.orchestration.peer_inbox.len() > super::state::PEER_INBOX_CAPACITY {
+                self.services.orchestration.peer_inbox.pop_front();
+            }
+        }
     }
     /// Poll a sub-agent until it reaches a terminal state, bridging secret requests to the
     /// channel. Returns a human-readable status string and success flag suitable for
@@ -393,8 +427,47 @@ impl<C: Channel> Agent<C> {
             AgentCommand::Approve { id } => self.handle_agent_approve(&id),
             AgentCommand::Deny { id } => self.handle_agent_deny(&id),
             AgentCommand::Resume { id, prompt } => self.handle_agent_resume(&id, &prompt).await,
+            AgentCommand::Msg { id, body } => self.handle_agent_msg(&id, &body).await,
+            AgentCommand::Inbox => Some(self.handle_agent_inbox()),
             _ => None,
         }
+    }
+    /// `/agent msg <id> <body>` — parent-to-sub-agent send (spec
+    /// `046-subagent-peer-messaging-parity`, US-002).
+    async fn handle_agent_msg(&mut self, id: &str, body: &str) -> Option<String> {
+        let full_id = match self.resolve_agent_id_prefix(id)? {
+            Ok(fid) => fid,
+            Err(msg) => return Some(msg),
+        };
+        // TUI Rules: every background/implicit operation gets a visible status indicator.
+        self.channel
+            .send_status_best_effort("Delivering message…")
+            .await;
+        let mgr = self.services.orchestration.subagent_manager.as_ref()?;
+        match mgr.send_to_subagent(&full_id, body.to_owned()) {
+            Ok(()) => Some(format!("Message delivered to sub-agent {full_id}.")),
+            Err(e) => Some(format!("Delivery failed: {e}")),
+        }
+    }
+    /// `/agent inbox` — list peer messages addressed to the parent, drained this session
+    /// (spec `046-subagent-peer-messaging-parity`).
+    fn handle_agent_inbox(&self) -> String {
+        use std::fmt::Write as _;
+
+        if self.services.orchestration.peer_inbox.is_empty() {
+            return "No peer messages received this session.".to_owned();
+        }
+        let mut out = String::new();
+        for msg in &self.services.orchestration.peer_inbox {
+            let _ = writeln!(
+                out,
+                "[{}] from {}: {}",
+                msg.sent_at.to_rfc3339(),
+                msg.sender_name,
+                msg.body
+            );
+        }
+        out
     }
     /// Return the sub-agent definitions section formatted for the `/agents` fleet view.
     ///
@@ -933,6 +1006,10 @@ impl<C: Channel> Agent<C> {
                 if score > 0.0 { Some(score) } else { None }
             },
             content_isolation: self.runtime.config.security.content_isolation.clone(),
+            // Spec 046 FR-012/NFR-007: the sub-agent's PeerToolExecutor constructs its own
+            // ExfiltrationGuard from this, mirroring the parent's own exfiltration_guard so
+            // peer message bodies are scanned to the same policy as parent-turn LLM output.
+            exfiltration_guard: self.runtime.config.security.exfiltration_guard.clone(),
             orchestrator_name: Some("zeph".to_owned()),
             orchestrator_role: Some("orchestrator".to_owned()),
             session_mcp_servers: Vec::new(),

--- a/crates/zeph-core/src/agent/tests/compaction_e2e.rs
+++ b/crates/zeph-core/src/agent/tests/compaction_e2e.rs
@@ -736,6 +736,7 @@ async fn test_secret_drain_after_instant_completion() {
             started_at_str: "2026-01-01T00:00:00Z".to_owned(),
             transcript_dir: None,
             mcp_tool_names: Vec::new(),
+            peer: None,
         },
     );
     agent.services.orchestration.subagent_manager = Some(mgr);

--- a/crates/zeph-core/src/metrics.rs
+++ b/crates/zeph-core/src/metrics.rs
@@ -342,6 +342,9 @@ pub struct SubAgentMetrics {
     /// Empty unless `agents.forward_transcript = true` and a consumer surface (TUI/`--bare`)
     /// is active — see `SubAgentManager::forwarded_tail`.
     pub live_transcript: Vec<String>,
+    /// Queued (undelivered) peer-message count for this sub-agent's mailbox (spec
+    /// `046-subagent-peer-messaging-parity`, FR-010) — see `SubAgentManager::mailbox_depth`.
+    pub unread_messages: u32,
 }
 
 /// Per-turn latency breakdown for the four agent hot-path phases.

--- a/crates/zeph-sanitizer/src/types.rs
+++ b/crates/zeph-sanitizer/src/types.rs
@@ -166,6 +166,13 @@ pub enum ContentSourceKind {
     /// that the message content is safe — treated as `ExternalUntrusted` like any other
     /// network-supplied text.
     ChannelMessage,
+    /// Message received from another sub-agent via the in-process peer-messaging
+    /// mailbox (spec `046-subagent-peer-messaging-parity`).
+    ///
+    /// A sibling or parent sub-agent can only ever influence the receiver through this
+    /// message body, so it is classified the same as [`A2aMessage`](Self::A2aMessage) —
+    /// `ExternalUntrusted` — even though the sender runs in the same process.
+    SubagentPeerMessage,
 }
 
 impl ContentSourceKind {
@@ -190,7 +197,8 @@ impl ContentSourceKind {
             | Self::McpResponse
             | Self::A2aMessage
             | Self::MemoryRetrieval
-            | Self::ChannelMessage => ContentTrustLevel::ExternalUntrusted,
+            | Self::ChannelMessage
+            | Self::SubagentPeerMessage => ContentTrustLevel::ExternalUntrusted,
         }
     }
 
@@ -215,6 +223,7 @@ impl ContentSourceKind {
             Self::MemoryRetrieval => "memory_retrieval",
             Self::InstructionFile => "instruction_file",
             Self::ChannelMessage => "channel_message",
+            Self::SubagentPeerMessage => "subagent_peer_message",
         }
     }
 
@@ -245,6 +254,7 @@ impl ContentSourceKind {
             "memory_retrieval" => Some(Self::MemoryRetrieval),
             "instruction_file" => Some(Self::InstructionFile),
             "channel_message" => Some(Self::ChannelMessage),
+            "subagent_peer_message" => Some(Self::SubagentPeerMessage),
             _ => None,
         }
     }
@@ -533,6 +543,10 @@ mod tests {
             (ContentSourceKind::MemoryRetrieval, "memory_retrieval"),
             (ContentSourceKind::InstructionFile, "instruction_file"),
             (ContentSourceKind::ChannelMessage, "channel_message"),
+            (
+                ContentSourceKind::SubagentPeerMessage,
+                "subagent_peer_message",
+            ),
         ];
         for (kind, s) in &variants {
             assert_eq!(ContentSourceKind::from_str_opt(s), Some(*kind));
@@ -653,6 +667,7 @@ mod tests {
             ContentSourceKind::A2aMessage,
             ContentSourceKind::MemoryRetrieval,
             ContentSourceKind::ChannelMessage,
+            ContentSourceKind::SubagentPeerMessage,
         ] {
             assert_eq!(
                 kind.default_trust_level(),

--- a/crates/zeph-subagent/Cargo.toml
+++ b/crates/zeph-subagent/Cargo.toml
@@ -19,8 +19,11 @@ postgres = ["zeph-durable/postgres", "zeph-sanitizer/postgres", "zeph-skills/pos
 default = ["sqlite"]
 
 [dependencies]
+chrono = { workspace = true, features = ["clock"] }
 dirs.workspace = true
+parking_lot.workspace = true
 regex.workspace = true
+schemars.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_norway.workspace = true
@@ -45,7 +48,6 @@ zeroize.workspace = true
 [dev-dependencies]
 indoc.workspace = true
 proptest.workspace = true
-schemars.workspace = true
 serial_test.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }

--- a/crates/zeph-subagent/src/agent_loop.rs
+++ b/crates/zeph-subagent/src/agent_loop.rs
@@ -115,7 +115,11 @@ pub(super) struct AgentLoopArgs {
 
 /// Record a progress heartbeat, if this loop has a live handle. No-op for `None` (untracked
 /// or `RunInline`-style spawns — see [`AgentLoopArgs::progress_at`]).
-fn record_progress(progress_at: Option<&Arc<AtomicU64>>) {
+///
+/// `pub(crate)` so [`crate::peer::PeerToolExecutor`]'s `check_messages(wait_ms)` progress
+/// ticker can also call it (critic round-2 S2) — a legitimately-waiting sub-agent must not
+/// read as orchestration idle-time and get reaped mid-wait.
+pub(crate) fn record_progress(progress_at: Option<&Arc<AtomicU64>>) {
     if let Some(p) = progress_at {
         p.store(zeph_common::monotonic_millis(), Ordering::Relaxed);
     }

--- a/crates/zeph-subagent/src/command.rs
+++ b/crates/zeph-subagent/src/command.rs
@@ -154,6 +154,11 @@ pub enum AgentCommand {
     Mention { agent: String, prompt: String },
     /// Resume a previously completed sub-agent session by ID prefix.
     Resume { id: String, prompt: String },
+    /// Send a message to a running sub-agent by task ID prefix (spec
+    /// `046-subagent-peer-messaging-parity`).
+    Msg { id: String, body: String },
+    /// List messages addressed to the parent agent, drained this session (spec `046`).
+    Inbox,
 }
 
 impl AgentCommand {
@@ -187,7 +192,8 @@ impl AgentCommand {
 
         if rest.is_empty() {
             return Err(SubAgentError::InvalidCommand(
-                "usage: /agent <list|spawn|bg|resume|status|cancel|approve|deny> [args]".into(),
+                "usage: /agent <list|spawn|bg|resume|status|cancel|approve|deny|msg|inbox> [args]"
+                    .into(),
             ));
         }
 
@@ -250,35 +256,61 @@ impl AgentCommand {
                     id: args.to_owned(),
                 })
             }
-            "resume" => {
-                let (id, prompt) = args.split_once(' ').ok_or_else(|| {
-                    SubAgentError::InvalidCommand("usage: /agent resume <id> <prompt>".into())
-                })?;
-                let id = id.trim().to_owned();
-                let prompt = prompt.trim().to_owned();
-                if id.is_empty() {
-                    return Err(SubAgentError::InvalidCommand(
-                        "agent id must not be empty".into(),
-                    ));
-                }
-                // Require at least 4 characters to prevent accidental mass-match or session
-                // enumeration via very short prefixes.
-                if id.len() < 4 {
-                    return Err(SubAgentError::InvalidCommand(
-                        "agent id prefix must be at least 4 characters".into(),
-                    ));
-                }
-                if prompt.is_empty() {
-                    return Err(SubAgentError::InvalidCommand(
-                        "prompt must not be empty".into(),
-                    ));
-                }
-                Ok(Self::Resume { id, prompt })
-            }
+            "resume" => Self::parse_resume(args),
+            "msg" => Self::parse_msg(args),
+            "inbox" => Ok(Self::Inbox),
             other => Err(SubAgentError::InvalidCommand(format!(
-                "unknown subcommand '{other}'; try: list, spawn, bg, resume, status, cancel, approve, deny"
+                "unknown subcommand '{other}'; try: list, spawn, bg, resume, status, cancel, approve, deny, msg, inbox"
             ))),
         }
+    }
+
+    /// Parse the `resume <id> <prompt>` subcommand's arguments.
+    fn parse_resume(args: &str) -> Result<Self, SubAgentError> {
+        let (id, prompt) = args.split_once(' ').ok_or_else(|| {
+            SubAgentError::InvalidCommand("usage: /agent resume <id> <prompt>".into())
+        })?;
+        let id = id.trim().to_owned();
+        let prompt = prompt.trim().to_owned();
+        if id.is_empty() {
+            return Err(SubAgentError::InvalidCommand(
+                "agent id must not be empty".into(),
+            ));
+        }
+        // Require at least 4 characters to prevent accidental mass-match or session
+        // enumeration via very short prefixes.
+        if id.len() < 4 {
+            return Err(SubAgentError::InvalidCommand(
+                "agent id prefix must be at least 4 characters".into(),
+            ));
+        }
+        if prompt.is_empty() {
+            return Err(SubAgentError::InvalidCommand(
+                "prompt must not be empty".into(),
+            ));
+        }
+        Ok(Self::Resume { id, prompt })
+    }
+
+    /// Parse the `msg <id> <body>` subcommand's arguments (spec
+    /// `046-subagent-peer-messaging-parity`).
+    fn parse_msg(args: &str) -> Result<Self, SubAgentError> {
+        let (id, body) = args
+            .split_once(' ')
+            .ok_or_else(|| SubAgentError::InvalidCommand("usage: /agent msg <id> <body>".into()))?;
+        let id = id.trim().to_owned();
+        let body = body.trim().to_owned();
+        if id.is_empty() {
+            return Err(SubAgentError::InvalidCommand(
+                "agent id must not be empty".into(),
+            ));
+        }
+        if body.is_empty() {
+            return Err(SubAgentError::InvalidCommand(
+                "message body must not be empty".into(),
+            ));
+        }
+        Ok(Self::Msg { id, body })
     }
 
     /// Parse an `@agent_name <prompt>` mention from raw input.
@@ -663,6 +695,40 @@ mod tests {
         let err = AgentCommand::parse("/agent resume deadbeef    ", &[]).unwrap_err();
         // Either split_once returns None (no space after id) or prompt trims to empty.
         assert_matches!(err, SubAgentError::InvalidCommand(_));
+    }
+
+    // ── parse msg/inbox (spec 046) ──────────────────────────────────────────
+
+    #[test]
+    fn parse_msg() {
+        let cmd = AgentCommand::parse("/agent msg abc123 what should I do next?", &[]).unwrap();
+        assert_eq!(
+            cmd,
+            AgentCommand::Msg {
+                id: "abc123".into(),
+                body: "what should I do next?".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_msg_missing_body_returns_error() {
+        let err = AgentCommand::parse("/agent msg abc123", &[]).unwrap_err();
+        assert_matches!(err, SubAgentError::InvalidCommand(ref m) if m.contains("usage"));
+    }
+
+    #[test]
+    fn parse_msg_missing_id_and_body_returns_error() {
+        let err = AgentCommand::parse("/agent msg", &[]).unwrap_err();
+        assert_matches!(err, SubAgentError::InvalidCommand(_));
+    }
+
+    #[test]
+    fn parse_inbox() {
+        assert_eq!(
+            AgentCommand::parse("/agent inbox", &[]).unwrap(),
+            AgentCommand::Inbox
+        );
     }
 
     // ── AgentsCommand (definition CRUD) ────────────────────────────────────

--- a/crates/zeph-subagent/src/lib.rs
+++ b/crates/zeph-subagent/src/lib.rs
@@ -52,6 +52,7 @@ pub mod grants;
 pub mod hooks;
 pub mod manager;
 pub mod memory;
+pub mod peer;
 pub mod resolve;
 pub mod state;
 pub mod transcript;

--- a/crates/zeph-subagent/src/manager/mod.rs
+++ b/crates/zeph-subagent/src/manager/mod.rs
@@ -4,6 +4,7 @@
 //! Sub-agent lifecycle management: spawn, cancel, collect, and resume.
 
 mod collect;
+mod peer_api;
 mod secrets;
 mod spawn;
 mod worktree;
@@ -27,6 +28,7 @@ use crate::error::SubAgentError;
 use crate::fleet::SharedFleetRegistry;
 use crate::forward::ForwardSurfaces;
 use crate::grants::{GrantedSecret, PermissionGrants, SecretRequest};
+use crate::peer::{AgentId, PeerGroupId, PeerRegistration, PeerRouter};
 use crate::state::SubAgentState;
 
 /// Classifies what triggered a given spawn attempt, for [`DelegationMode`] enforcement
@@ -251,6 +253,32 @@ pub struct SpawnContext {
     /// the existing post-construction override pattern used for
     /// [`network_denied`][Self::network_denied] and [`progress_at`][Self::progress_at].
     pub origin: SpawnOrigin,
+
+    /// Peer-messaging spawn-tree root this sub-agent joins (spec
+    /// `046-subagent-peer-messaging-parity`, FR-013/FR-014).
+    ///
+    /// `None` resolves to [`PeerGroupId::Session`] — the interactive session's own root,
+    /// used by `/agent spawn`/`/agent resume`. The orchestration scheduler sets
+    /// `Some(PeerGroupId::Plan(plan_run_id))` so a `DagScheduler`-dispatched sub-agent joins
+    /// a distinct root per plan execution, making US-003's cross-group authorization denial
+    /// reachable in production: a `background: true` interactively-spawned sub-agent can
+    /// stay alive concurrently with a running plan's sub-agents, in the same
+    /// [`SubAgentManager`], with no shared ancestor.
+    ///
+    /// # Caller responsibility for nested spawns
+    ///
+    /// Like [`max_trust_level`][Self::max_trust_level], this field does **not** propagate
+    /// automatically — a sub-agent that spawns its own children must copy this field from
+    /// its received `SpawnContext` into the child's, or the grandchild silently joins the
+    /// wrong spawn-tree root.
+    pub peer_group: Option<PeerGroupId>,
+
+    /// Exfiltration-guard configuration this sub-agent's [`PeerToolExecutor`][crate::peer::PeerToolExecutor]
+    /// constructs its own [`ExfiltrationGuard`][zeph_sanitizer::exfiltration::ExfiltrationGuard]
+    /// from (FR-012, NFR-007) — peer message bodies are attacker-influenceable across an
+    /// agent boundary, so `check_messages` scans them the same way parent-turn LLM output is
+    /// scanned. Defaults to [`zeph_config::ExfiltrationGuardConfig::default`].
+    pub exfiltration_guard: zeph_config::ExfiltrationGuardConfig,
 }
 
 /// Intersect two optional tool allowlists, preserving the "narrow only" invariant shared by
@@ -353,6 +381,15 @@ pub struct SubAgentHandle {
     pub transcript_dir: Option<PathBuf>,
     /// MCP tool names available at spawn time, persisted for transcript meta on collect.
     pub mcp_tool_names: Vec<String>,
+    /// Peer-messaging route registration for this sub-agent (spec
+    /// `046-subagent-peer-messaging-parity`).
+    ///
+    /// `None` for `for_test` handles and any spawn made while
+    /// `peer_messaging.enabled = false`. Dropping this (explicitly, or via
+    /// `SubAgentHandle`'s own `Drop`) deregisters the route, so a send addressed to this
+    /// agent after that point returns `DeliveryError::TargetNotFound` rather than a silent
+    /// drop into a dangling mailbox.
+    pub peer: Option<PeerRegistration>,
 }
 
 impl SubAgentHandle {
@@ -389,6 +426,7 @@ impl SubAgentHandle {
             started_at_str: String::new(),
             transcript_dir: None,
             mcp_tool_names: Vec::new(),
+            peer: None,
         }
     }
 
@@ -551,6 +589,24 @@ pub struct SubAgentManager {
     /// enforce the same session-wide cap. See [`SessionSpawnBudget`]'s own doc comment for why
     /// it is a plain, uncloned `AtomicUsize` newtype rather than a shared `Arc` handle.
     session_spawn_budget: crate::budget::SessionSpawnBudget,
+    /// `Arc`-shared peer-messaging routing table (spec `046-subagent-peer-messaging-parity`),
+    /// cloned into every spawned sub-agent's own `PeerToolExecutor` decorator. Never owned by
+    /// value by a running sub-agent task — see the crate's `peer` module docs for why.
+    peer_router: Arc<PeerRouter>,
+    /// This manager's own `PeerGroupId::Session` root registration, kept alive for the
+    /// manager's lifetime so `AgentId::Root(PeerGroupId::Session)` stays addressable.
+    #[allow(dead_code)] // held only to keep the route registered; never read directly
+    peer_root_registration: PeerRegistration,
+    /// Receiver half of the session root's own mailbox, drained by
+    /// [`try_recv_peer_message`][Self::try_recv_peer_message] (T005).
+    peer_root_rx: mpsc::Receiver<crate::peer::PeerMessage>,
+    /// One `Root(PeerGroupId::Plan(graph_id))` registration + mailbox receiver per
+    /// orchestration plan execution currently live in this manager, keyed by `graph_id`
+    /// (critic round-4 S2). Registered lazily on first spawn into a given plan
+    /// ([`ensure_plan_peer_group`][Self::ensure_plan_peer_group]); released when the plan
+    /// completes ([`release_plan_peer_group`][Self::release_plan_peer_group]), mirroring how
+    /// dropping a `SubAgentHandle`'s own `PeerRegistration` deregisters its route.
+    plan_peer_roots: HashMap<String, (PeerRegistration, mpsc::Receiver<crate::peer::PeerMessage>)>,
 }
 
 impl std::fmt::Debug for SubAgentManager {
@@ -575,6 +631,10 @@ impl std::fmt::Debug for SubAgentManager {
             .field("pii_filter", &self.pii_filter.is_some())
             .field("delegation_mode", &self.delegation_mode)
             .field("session_spawn_budget", &self.session_spawn_budget)
+            .field("peer_router", &self.peer_router)
+            .field("peer_root_registration", &"<PeerRegistration>")
+            .field("peer_root_rx", &"<mpsc::Receiver>")
+            .field("plan_peer_roots_count", &self.plan_peer_roots.len())
             .finish()
     }
 }
@@ -583,6 +643,13 @@ impl SubAgentManager {
     /// Create a new manager with the given concurrency limit.
     #[must_use]
     pub fn new(max_concurrent: usize) -> Self {
+        let peer_router = PeerRouter::new(zeph_config::PeerMessagingConfig::default(), None);
+        let (peer_root_registration, peer_root_rx) = peer_router.register(
+            AgentId::Root(PeerGroupId::Session),
+            "spawner".to_owned(),
+            None,
+            PeerGroupId::Session,
+        );
         Self {
             definitions: Vec::new(),
             agents: HashMap::new(),
@@ -603,7 +670,71 @@ impl SubAgentManager {
             pii_filter: None,
             delegation_mode: zeph_config::DelegationMode::default(),
             session_spawn_budget: crate::budget::SessionSpawnBudget::default(),
+            peer_router,
+            peer_root_registration,
+            peer_root_rx,
+            plan_peer_roots: HashMap::new(),
         }
+    }
+
+    /// Reconfigure the peer-messaging router's mailbox capacity/body-size/wait limits and
+    /// enabled kill switch (spec `046-subagent-peer-messaging-parity`).
+    ///
+    /// Call during bootstrap, before the first [`spawn`][Self::spawn] — replaces the router
+    /// (and re-registers the session root) wholesale, so any route already registered before
+    /// this call would be silently orphaned. Carries over whatever secret-mask registry is
+    /// already wired via [`set_secret_registry`][Self::set_secret_registry], regardless of
+    /// call order relative to this method.
+    pub fn set_peer_messaging_config(&mut self, config: zeph_config::PeerMessagingConfig) {
+        let peer_router = PeerRouter::new(config, self.secret_registry.clone());
+        let (peer_root_registration, peer_root_rx) = peer_router.register(
+            AgentId::Root(PeerGroupId::Session),
+            "spawner".to_owned(),
+            None,
+            PeerGroupId::Session,
+        );
+        self.peer_router = peer_router;
+        self.peer_root_registration = peer_root_registration;
+        self.peer_root_rx = peer_root_rx;
+        // Any existing plan-root registrations are bound to the router just replaced; drop
+        // them (deregistering from the now-discarded router is harmless) rather than leaving
+        // stale entries that reference an `Arc<PeerRouter>` nothing else uses anymore.
+        self.plan_peer_roots.clear();
+    }
+
+    /// Ensure a `Root(PeerGroupId::Plan(graph_id))` node is registered, registering one lazily
+    /// on first use (critic round-4 S2). A no-op if a root for `graph_id` is already live.
+    ///
+    /// Without this, no node ever exists for a `Plan` group's root, so `send_to_subagent`
+    /// (backing `/agent msg`) and the parent's `try_recv_peer_message` drain can never reach
+    /// or observe a `DagScheduler`-dispatched sub-agent — US-002 would be structurally
+    /// unreachable on that path.
+    pub(crate) fn ensure_plan_peer_group(&mut self, graph_id: &str) {
+        if self.plan_peer_roots.contains_key(graph_id) {
+            return;
+        }
+        let group = PeerGroupId::Plan(graph_id.to_owned());
+        let (registration, rx) =
+            self.peer_router
+                .register(AgentId::Root(group.clone()), "plan".to_owned(), None, group);
+        self.plan_peer_roots
+            .insert(graph_id.to_owned(), (registration, rx));
+    }
+
+    /// Release the `Root(PeerGroupId::Plan(graph_id))` node for a completed or torn-down plan
+    /// execution, deregistering its route (critic round-4 S2).
+    ///
+    /// A no-op if no root was ever registered for `graph_id` (e.g. the plan never actually
+    /// dispatched a sub-agent).
+    pub fn release_plan_peer_group(&mut self, graph_id: &str) {
+        self.plan_peer_roots.remove(graph_id);
+    }
+
+    /// The `Arc`-shared peer-messaging router, cloned into every spawned sub-agent's own
+    /// `PeerToolExecutor` decorator.
+    #[must_use]
+    pub fn peer_router(&self) -> &Arc<PeerRouter> {
+        &self.peer_router
     }
 
     /// The session-wide cumulative subagent-spawn budget this manager originates (issue
@@ -673,7 +804,10 @@ impl SubAgentManager {
         &mut self,
         registry: Arc<zeph_sanitizer::secret_mask::SecretMaskRegistry>,
     ) {
-        self.secret_registry = Some(registry);
+        self.secret_registry = Some(Arc::clone(&registry));
+        // Propagate into the peer router regardless of call order relative to
+        // `set_peer_messaging_config` — see that method's doc comment.
+        self.peer_router.set_secret_registry(Some(registry));
     }
 
     /// Wire a PII filter into the forwarding pipeline (issue #6359, security Finding 1 /

--- a/crates/zeph-subagent/src/manager/peer_api.rs
+++ b/crates/zeph-subagent/src/manager/peer_api.rs
@@ -1,0 +1,273 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Parent-side surface for live inter-sub-agent messaging (spec
+//! `046-subagent-peer-messaging-parity`), mirroring the shape of
+//! [`secrets`](super::secrets)'s approve/deny/`try_recv` API.
+
+use crate::peer::{AgentId, DeliveryError, PeerGroupId, PeerMessage};
+
+use super::SubAgentManager;
+
+impl SubAgentManager {
+    /// Send a message from the parent agent to the sub-agent addressable as `task_id`,
+    /// backing the `/agent msg` slash command.
+    ///
+    /// The parent session holds a root registration for every spawn-tree group it has
+    /// spawned into — its own [`PeerGroupId::Session`] root (always live) plus one
+    /// [`PeerGroupId::Plan`] root per orchestration plan execution that has dispatched at
+    /// least one sub-agent (registered lazily by `ensure_plan_peer_group`, crate-private).
+    /// This method looks up
+    /// `task_id`'s actual group and sends *as that group's own root*, since only a node's own
+    /// root satisfies the authorization model's ancestor-walk clause for it — sending
+    /// unconditionally as `Root(Session)` would make `/agent msg` unable to reach a
+    /// `DagScheduler`-dispatched sub-agent at all (critic round-4 S2).
+    ///
+    /// # Errors
+    ///
+    /// See [`DeliveryError`]. An unresolvable `task_id` falls back to the `Session` group,
+    /// which then fails as [`DeliveryError::TargetNotFound`] — the same outcome as an unknown
+    /// id in any other group.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_subagent::SubAgentManager;
+    /// use zeph_subagent::peer::DeliveryError;
+    ///
+    /// let manager = SubAgentManager::new(4);
+    /// let err = manager
+    ///     .send_to_subagent("nonexistent-task-id", "hello".to_owned())
+    ///     .unwrap_err();
+    /// assert!(matches!(err, DeliveryError::TargetNotFound(_)));
+    /// ```
+    pub fn send_to_subagent(&self, task_id: &str, body: String) -> Result<(), DeliveryError> {
+        let target_id = AgentId::Task(task_id.to_owned());
+        let group = self
+            .peer_router
+            .group_of(&target_id)
+            .unwrap_or(PeerGroupId::Session);
+        let from = AgentId::Root(group);
+        self.peer_router.send(&from, task_id, body)
+    }
+
+    /// Non-blocking drain of one message addressed to the parent agent itself — either its
+    /// `AgentId::Root(PeerGroupId::Session)` identity, or any live
+    /// `AgentId::Root(PeerGroupId::Plan(graph_id))` identity registered via
+    /// `ensure_plan_peer_group` (crate-private, critic round-4 S2).
+    ///
+    /// `try_recv`-only — no `.await` anywhere on this path, exactly the shape of
+    /// [`try_recv_secret_request`](Self::try_recv_secret_request). Call from the main loop
+    /// (next to `notify_completed_subagents`) and the scheduler loop (next to
+    /// `process_pending_secret_requests`) to surface incoming peer messages to the operator.
+    ///
+    /// # Known latency limitation
+    ///
+    /// A message addressed to the parent is not observed until the parent reaches its next
+    /// drain point — at most one turn (or one scheduler tick) away. This is the same
+    /// structural property as `plan_cancel_token` (issue #1603): the parent holds `&mut self`
+    /// through a turn, so nothing can interrupt it mid-turn. It does **not** affect
+    /// subagent-to-subagent traffic, which never routes through the parent.
+    pub fn try_recv_peer_message(&mut self) -> Option<PeerMessage> {
+        if let Ok(msg) = self.peer_root_rx.try_recv() {
+            return Some(msg);
+        }
+        for (_registration, rx) in self.plan_peer_roots.values_mut() {
+            if let Ok(msg) = rx.try_recv() {
+                return Some(msg);
+            }
+        }
+        None
+    }
+
+    /// Current queued (undelivered) peer-message count for `task_id`'s mailbox, backing the
+    /// TUI unread badge (FR-010).
+    ///
+    /// Returns `0` for an unknown or already-terminated `task_id`, mirroring
+    /// [`forwarded_tail`](Self::forwarded_tail)'s empty-on-unknown convention.
+    #[must_use]
+    pub fn mailbox_depth(&self, task_id: &str) -> usize {
+        self.peer_router
+            .mailbox_depth(&AgentId::Task(task_id.to_owned()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::def::SubAgentDef;
+    use crate::manager::SubAgentHandle;
+
+    #[test]
+    fn send_to_unknown_subagent_fails() {
+        let mgr = SubAgentManager::new(4);
+        let err = mgr
+            .send_to_subagent("nonexistent", "hi".to_owned())
+            .unwrap_err();
+        assert!(matches!(err, DeliveryError::TargetNotFound(_)));
+    }
+
+    #[test]
+    fn try_recv_peer_message_drains_once_then_none() {
+        let mut mgr = SubAgentManager::new(4);
+        let (_reg, _rx) = mgr.peer_router.register(
+            AgentId::Task("child".to_owned()),
+            "child".to_owned(),
+            Some(AgentId::Root(PeerGroupId::Session)),
+            PeerGroupId::Session,
+        );
+        mgr.send_to_subagent("child", "clarify?".to_owned())
+            .expect("send to registered child");
+
+        let received = mgr.try_recv_peer_message();
+        assert!(
+            received.is_none(),
+            "message was sent to the child, not the parent"
+        );
+
+        // Send a message addressed back to the parent root and confirm the drain sees it.
+        mgr.peer_router
+            .send(
+                &AgentId::Task("child".to_owned()),
+                "spawner",
+                "clarifying question".to_owned(),
+            )
+            .expect("child to parent send");
+        let received = mgr
+            .try_recv_peer_message()
+            .expect("parent-addressed message must be observable");
+        assert_eq!(received.body, "clarifying question");
+        assert!(
+            mgr.try_recv_peer_message().is_none(),
+            "second drain must be empty"
+        );
+    }
+
+    #[test]
+    fn mailbox_depth_reflects_router_state() {
+        let mgr = SubAgentManager::new(4);
+        let (_reg, _rx) = mgr.peer_router.register(
+            AgentId::Task("child".to_owned()),
+            "child".to_owned(),
+            Some(AgentId::Root(PeerGroupId::Session)),
+            PeerGroupId::Session,
+        );
+        assert_eq!(mgr.mailbox_depth("child"), 0);
+        mgr.send_to_subagent("child", "hi".to_owned())
+            .expect("send");
+        assert_eq!(mgr.mailbox_depth("child"), 1);
+        assert_eq!(mgr.mailbox_depth("unknown"), 0);
+    }
+
+    #[test]
+    fn set_peer_messaging_config_preserves_secret_registry_set_before() {
+        let mut mgr = SubAgentManager::new(4);
+        let registry = std::sync::Arc::new(zeph_sanitizer::secret_mask::SecretMaskRegistry::new());
+        registry.register(
+            "K",
+            "super-secret-value",
+            zeph_sanitizer::secret_mask::SecretCategory::Generic,
+        );
+        mgr.set_secret_registry(std::sync::Arc::clone(&registry));
+        mgr.set_peer_messaging_config(zeph_config::PeerMessagingConfig::default());
+
+        let (_reg, mut rx) = mgr.peer_router.register(
+            AgentId::Task("child".to_owned()),
+            "child".to_owned(),
+            Some(AgentId::Root(PeerGroupId::Session)),
+            PeerGroupId::Session,
+        );
+        mgr.send_to_subagent("child", "value is super-secret-value".to_owned())
+            .expect("send");
+        let msg = rx.try_recv().expect("delivered");
+        assert!(!msg.body.contains("super-secret-value"));
+    }
+
+    #[test]
+    fn set_peer_messaging_config_then_set_secret_registry_still_masks() {
+        let mut mgr = SubAgentManager::new(4);
+        mgr.set_peer_messaging_config(zeph_config::PeerMessagingConfig::default());
+        let registry = std::sync::Arc::new(zeph_sanitizer::secret_mask::SecretMaskRegistry::new());
+        registry.register(
+            "K",
+            "super-secret-value",
+            zeph_sanitizer::secret_mask::SecretCategory::Generic,
+        );
+        mgr.set_secret_registry(std::sync::Arc::clone(&registry));
+
+        let (_reg, mut rx) = mgr.peer_router.register(
+            AgentId::Task("child".to_owned()),
+            "child".to_owned(),
+            Some(AgentId::Root(PeerGroupId::Session)),
+            PeerGroupId::Session,
+        );
+        mgr.send_to_subagent("child", "value is super-secret-value".to_owned())
+            .expect("send");
+        let msg = rx.try_recv().expect("delivered");
+        assert!(!msg.body.contains("super-secret-value"));
+    }
+
+    #[test]
+    fn send_to_subagent_reaches_a_plan_group_task_via_its_own_root() {
+        // Critic round-4 S2: /agent msg must be able to reach a DagScheduler-dispatched
+        // sub-agent, not just Session-group ones.
+        let mut mgr = SubAgentManager::new(4);
+        mgr.ensure_plan_peer_group("plan-1");
+        let plan_root_id = AgentId::Root(PeerGroupId::Plan("plan-1".to_owned()));
+        let (_reg, _rx) = mgr.peer_router.register(
+            AgentId::Task("plan-task".to_owned()),
+            "plan-task".to_owned(),
+            Some(plan_root_id),
+            PeerGroupId::Plan("plan-1".to_owned()),
+        );
+
+        mgr.send_to_subagent("plan-task", "go".to_owned())
+            .expect("send must reach the plan-group task via its own Plan root");
+    }
+
+    #[test]
+    fn try_recv_peer_message_observes_a_plan_group_root_mailbox() {
+        let mut mgr = SubAgentManager::new(4);
+        mgr.ensure_plan_peer_group("plan-1");
+        let plan_root_id = AgentId::Root(PeerGroupId::Plan("plan-1".to_owned()));
+        let (task_reg, _rx) = mgr.peer_router.register(
+            AgentId::Task("plan-task".to_owned()),
+            "plan-task".to_owned(),
+            Some(plan_root_id.clone()),
+            PeerGroupId::Plan("plan-1".to_owned()),
+        );
+
+        mgr.peer_router
+            .send(task_reg.id(), "plan", "clarifying question".to_owned())
+            .expect("plan task to its own plan root must succeed");
+
+        let received = mgr
+            .try_recv_peer_message()
+            .expect("a Plan-root mailbox message must be observable, not just Session's");
+        assert_eq!(received.body, "clarifying question");
+    }
+
+    #[test]
+    fn release_plan_peer_group_drops_the_route() {
+        let mut mgr = SubAgentManager::new(4);
+        mgr.ensure_plan_peer_group("plan-1");
+        mgr.release_plan_peer_group("plan-1");
+
+        let err = mgr
+            .send_to_subagent("nonexistent-in-released-plan", "hi".to_owned())
+            .unwrap_err();
+        assert!(matches!(err, DeliveryError::TargetNotFound(_)));
+        assert!(
+            mgr.try_recv_peer_message().is_none(),
+            "no dangling Plan-root mailbox after release"
+        );
+    }
+
+    #[test]
+    fn insert_handle_for_test_default_peer_is_none() {
+        let mut mgr = SubAgentManager::new(4);
+        let handle = SubAgentHandle::for_test("t1", SubAgentDef::for_test("helper"));
+        assert!(handle.peer.is_none());
+        mgr.insert_handle_for_test("t1".to_owned(), handle);
+    }
+}

--- a/crates/zeph-subagent/src/manager/secrets.rs
+++ b/crates/zeph-subagent/src/manager/secrets.rs
@@ -226,6 +226,7 @@ mod tests {
             started_at_str: String::new(),
             transcript_dir: None,
             mcp_tool_names: Vec::new(),
+            peer: None,
         };
         (handle, secret_rx)
     }

--- a/crates/zeph-subagent/src/manager/spawn.rs
+++ b/crates/zeph-subagent/src/manager/spawn.rs
@@ -138,12 +138,27 @@ impl ErasedToolExecutor for MemoryAwareExecutor {
     zeph_tools::erased_tool_executor_forward!(inner);
 }
 
+/// Bundles the construction arguments for [`crate::peer::PeerToolExecutor`], installed by
+/// [`build_filtered_executor`] when peer messaging is enabled (spec
+/// `046-subagent-peer-messaging-parity`, FR-012).
+pub(crate) struct PeerInstallArgs {
+    pub(crate) id: crate::peer::AgentId,
+    pub(crate) router: Arc<crate::peer::PeerRouter>,
+    pub(crate) mailbox_rx: mpsc::Receiver<crate::peer::PeerMessage>,
+    pub(crate) cancel: CancellationToken,
+    pub(crate) progress_at: Option<Arc<std::sync::atomic::AtomicU64>>,
+    pub(crate) sanitizer: zeph_sanitizer::ContentSanitizer,
+    pub(crate) exfil_guard: zeph_sanitizer::exfiltration::ExfiltrationGuard,
+    pub(crate) max_wait_ms: u64,
+}
+
 pub(crate) fn build_filtered_executor(
     tool_executor: Arc<dyn ErasedToolExecutor>,
     permission_mode: PermissionMode,
     def: &SubAgentDef,
     memory_dir: Option<PathBuf>,
     network_denied: bool,
+    peer: Option<PeerInstallArgs>,
 ) -> FilteredToolExecutor {
     let base: Arc<dyn ErasedToolExecutor> = match memory_dir {
         Some(dir) => Arc::new(MemoryAwareExecutor::new(tool_executor, dir)),
@@ -154,6 +169,24 @@ pub(crate) fn build_filtered_executor(
     // tool-level allow/deny policy.
     let base: Arc<dyn ErasedToolExecutor> = if network_denied {
         Arc::new(NetworkDenyToolExecutor::new(base))
+    } else {
+        base
+    };
+    // Peer messaging (spec 046) is not network egress, so it wraps outside the network-deny
+    // gate; it is still wrapped *inside* FilteredToolExecutor below so `tools.except`/
+    // `ToolPolicy` can still deny the three peer tools for a given definition.
+    let base: Arc<dyn ErasedToolExecutor> = if let Some(peer) = peer {
+        Arc::new(crate::peer::PeerToolExecutor::new(
+            base,
+            peer.id,
+            peer.router,
+            peer.mailbox_rx,
+            peer.cancel,
+            peer.progress_at,
+            peer.sanitizer,
+            peer.exfil_guard,
+            peer.max_wait_ms,
+        ))
     } else {
         base
     };
@@ -434,6 +467,24 @@ fn build_orchestrator_header(ctx: &SpawnContext) -> String {
 
 pub(crate) fn sanitize_identity_field(s: &str) -> String {
     s.lines().next().unwrap_or("").chars().take(128).collect()
+}
+
+/// Resolve the `ExfiltrationGuardConfig` for `resume()`'s peer-install site (critic round-4
+/// S4): from `spawn_context` when present, `::default()` otherwise. Mirrors the
+/// `max_trust_level` resolution pattern used two statements below this call site — unlike
+/// `content_isolation`, which `resume()` deliberately always defaults (see this function's
+/// own doc comment), the exfiltration-guard policy has no such documented "never propagate on
+/// resume" rationale, so silently defaulting it was a real regression versus `spawn()`'s
+/// equivalent site.
+///
+/// Factored out as a free function so the resolution itself is directly unit-testable without
+/// needing to drive a full `resume()` call and inspect a background task's internal executor.
+pub(crate) fn resolve_resume_exfiltration_guard_config(
+    spawn_context: Option<&SpawnContext>,
+) -> zeph_config::ExfiltrationGuardConfig {
+    spawn_context
+        .map(|ctx| ctx.exfiltration_guard.clone())
+        .unwrap_or_default()
 }
 
 pub(crate) fn apply_context_injection(
@@ -760,12 +811,52 @@ impl SubAgentManager {
                 .push("set_working_directory".to_string());
         }
 
+        // Peer-messaging route registration (spec 046-subagent-peer-messaging-parity): every
+        // top-level spawn's parent is its own group's root — no subagent-side spawn tool
+        // exists yet, so nesting deeper than one level never occurs in production today.
+        let peer_group = ctx
+            .peer_group
+            .clone()
+            .unwrap_or(crate::peer::PeerGroupId::Session);
+        let (peer_registration, peer_install) = if config.peer_messaging.enabled {
+            // Critic round-4 S2: a `Plan` group's own root is never registered anywhere else
+            // — without this, `send_to_subagent`/the parent's drain can never reach or
+            // observe a `DagScheduler`-dispatched sub-agent at all. No-op if already live for
+            // this `graph_id` (e.g. a second task spawned into the same plan).
+            if let crate::peer::PeerGroupId::Plan(ref graph_id) = peer_group {
+                self.ensure_plan_peer_group(graph_id);
+            }
+            let peer_id = crate::peer::AgentId::Task(task_id.clone());
+            let (registration, mailbox_rx) = self.peer_router.register(
+                peer_id.clone(),
+                def.name.clone(),
+                Some(crate::peer::AgentId::Root(peer_group.clone())),
+                peer_group,
+            );
+            let install = PeerInstallArgs {
+                id: peer_id,
+                router: Arc::clone(&self.peer_router),
+                mailbox_rx,
+                cancel: cancel.clone(),
+                progress_at: ctx.progress_at.clone(),
+                sanitizer: zeph_sanitizer::ContentSanitizer::new(&ctx.content_isolation),
+                exfil_guard: zeph_sanitizer::exfiltration::ExfiltrationGuard::new(
+                    ctx.exfiltration_guard.clone(),
+                ),
+                max_wait_ms: config.peer_messaging.max_wait_ms,
+            };
+            (Some(registration), Some(install))
+        } else {
+            (None, None)
+        };
+
         let executor = build_filtered_executor(
             tool_executor,
             permission_mode,
             &def,
             memory_dir,
             network_denied,
+            peer_install,
         );
 
         if let Some(cap) = ctx.max_trust_level {
@@ -929,6 +1020,7 @@ impl SubAgentManager {
             started_at_str: crate::transcript::utc_now(),
             transcript_dir: handle_transcript_dir,
             mcp_tool_names: handle_mcp_tool_names,
+            peer: peer_registration,
         };
 
         self.agents.insert(task_id.clone(), handle);
@@ -1249,8 +1341,44 @@ impl SubAgentManager {
         let agent_name_clone = def.name.clone();
 
         let network_denied = spawn_context.is_some_and(|ctx| ctx.network_denied);
-        let executor =
-            build_filtered_executor(tool_executor, permission_mode, &def, None, network_denied);
+        // Peer-messaging route registration (spec 046-subagent-peer-messaging-parity): a
+        // resumed sub-agent is always session-scoped in v1 (critic round-2 S1) — without
+        // this, `resume()` would silently produce a handle with no route and no peer tools,
+        // since it is a spawn path distinct from `spawn()`/`spawn_for_task()`.
+        let (peer_registration, peer_install) = if config.peer_messaging.enabled {
+            let peer_id = crate::peer::AgentId::Task(new_task_id.clone());
+            let (registration, mailbox_rx) = self.peer_router.register(
+                peer_id.clone(),
+                def.name.clone(),
+                Some(crate::peer::AgentId::Root(
+                    crate::peer::PeerGroupId::Session,
+                )),
+                crate::peer::PeerGroupId::Session,
+            );
+            let install = PeerInstallArgs {
+                id: peer_id,
+                router: Arc::clone(&self.peer_router),
+                mailbox_rx,
+                cancel: cancel.clone(),
+                progress_at: None,
+                sanitizer: zeph_sanitizer::ContentSanitizer::new(&ContentIsolationConfig::default()),
+                exfil_guard: zeph_sanitizer::exfiltration::ExfiltrationGuard::new(
+                    resolve_resume_exfiltration_guard_config(spawn_context),
+                ),
+                max_wait_ms: config.peer_messaging.max_wait_ms,
+            };
+            (Some(registration), Some(install))
+        } else {
+            (None, None)
+        };
+        let executor = build_filtered_executor(
+            tool_executor,
+            permission_mode,
+            &def,
+            None,
+            network_denied,
+            peer_install,
+        );
 
         if let Some(ctx) = spawn_context
             && let Some(cap) = ctx.max_trust_level
@@ -1365,6 +1493,7 @@ impl SubAgentManager {
             started_at_str: crate::transcript::utc_now(),
             transcript_dir: resume_handle_transcript_dir,
             mcp_tool_names: resumed_mcp_tool_names_for_handle,
+            peer: peer_registration,
         };
 
         self.agents.insert(new_task_id.clone(), handle);
@@ -1588,6 +1717,7 @@ mod build_filtered_executor_tests {
             &def,
             None,
             true,
+            None,
         );
         let res = exec
             .execute_tool_call_erased(&bash_call("curl https://evil.example"))
@@ -1604,6 +1734,7 @@ mod build_filtered_executor_tests {
             &def,
             None,
             false,
+            None,
         );
         let res = exec
             .execute_tool_call_erased(&bash_call("curl https://example.com"))
@@ -1623,6 +1754,7 @@ mod build_filtered_executor_tests {
             &def,
             None,
             true,
+            None,
         );
         let res = exec.execute_tool_call_erased(&bash_call("ls -la")).await;
         assert!(

--- a/crates/zeph-subagent/src/manager/tests.rs
+++ b/crates/zeph-subagent/src/manager/tests.rs
@@ -30,7 +30,8 @@ use zeph_llm::provider::{ChatResponse, Role};
 use super::*;
 use crate::manager::spawn::{
     MemoryAwareExecutor, apply_constraint_propagation, apply_context_injection,
-    build_context_summary, build_system_prompt_with_memory, sanitize_identity_field,
+    build_context_summary, build_system_prompt_with_memory,
+    resolve_resume_exfiltration_guard_config, sanitize_identity_field,
 };
 
 fn make_manager() -> SubAgentManager {
@@ -455,6 +456,7 @@ fn insert_handle_with_pending_secret_channel(
             started_at_str: String::new(),
             transcript_dir: None,
             mcp_tool_names: Vec::new(),
+            peer: None,
         },
     );
     req_tx
@@ -1711,6 +1713,7 @@ fn resume_still_running_via_active_agents_returns_error() {
             started_at_str: "2026-01-01T00:00:00Z".to_owned(),
             transcript_dir: None,
             mcp_tool_names: Vec::new(),
+            peer: None,
         },
     );
     drop(status_tx);
@@ -1909,6 +1912,37 @@ fn resume_with_spawn_context_applies_constraint_propagation() {
 
     let _guard = rt.enter();
     mgr.cancel(&new_id).unwrap();
+}
+
+// --- Critic round-4 S4: resume()'s peer-install exfiltration-guard regression ---
+//
+// No test previously asserted that a non-default `exfiltration_guard` on `SpawnContext`
+// actually reaches the constructed guard through `resume()` — exactly why the regression
+// (a hardcoded `ExfiltrationGuardConfig::default()`) shipped uncaught. The resolution logic
+// is factored into `resolve_resume_exfiltration_guard_config` specifically so it is directly
+// testable without needing to drive a full `resume()` call and inspect a background task's
+// internal executor.
+
+#[test]
+fn resolve_resume_exfiltration_guard_config_uses_spawn_context_when_present() {
+    let ctx = SpawnContext {
+        exfiltration_guard: zeph_config::ExfiltrationGuardConfig {
+            block_markdown_images: false,
+            ..zeph_config::ExfiltrationGuardConfig::default()
+        },
+        ..SpawnContext::default()
+    };
+    let resolved = resolve_resume_exfiltration_guard_config(Some(&ctx));
+    assert!(
+        !resolved.block_markdown_images,
+        "resume() must read the real policy from spawn_context, not silently default it"
+    );
+}
+
+#[test]
+fn resolve_resume_exfiltration_guard_config_defaults_when_spawn_context_absent() {
+    let resolved = resolve_resume_exfiltration_guard_config(None);
+    assert_eq!(resolved, zeph_config::ExfiltrationGuardConfig::default());
 }
 
 /// Executor that records the trust level passed to `set_effective_trust`.
@@ -5802,4 +5836,201 @@ fn intersect_allowlists_disjoint_sets_returns_empty_not_none() {
         intersect_allowlists(Some(a), Some(b)),
         Some(std::collections::HashSet::new())
     );
+}
+
+/// End-to-end integration tests through the real `SubAgentManager::spawn()` path (spec
+/// `046-subagent-peer-messaging-parity`, tasks.md T008), one per user story. Route
+/// registration happens synchronously inside `spawn()` before the background agent loop
+/// task is even launched, so these assertions need no timing coordination with that task.
+mod peer_messaging_integration_tests {
+    use crate::peer::{AgentId, DeliveryError, PeerGroupId};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn us001_siblings_spawned_under_one_manager_can_message_each_other_while_running() {
+        let mut mgr = make_manager();
+        mgr.definitions.push(sample_def());
+
+        let task_a = do_spawn(&mut mgr, "bot", "research").await.unwrap();
+        let task_b = do_spawn(&mut mgr, "bot", "implement").await.unwrap();
+
+        mgr.peer_router
+            .send(
+                &AgentId::Task(task_a.clone()),
+                &task_b,
+                "redirect".to_owned(),
+            )
+            .expect("sibling send must succeed");
+        assert_eq!(
+            mgr.peer_router
+                .mailbox_depth(&AgentId::Task(task_b.clone())),
+            1
+        );
+
+        // Neither handle was cancelled or collected by this test — both remain tracked.
+        let ids: Vec<String> = mgr.statuses().into_iter().map(|(id, _)| id).collect();
+        assert!(ids.contains(&task_a));
+        assert!(ids.contains(&task_b));
+    }
+
+    #[tokio::test]
+    async fn us002_running_subagent_messages_its_parent_root() {
+        let mut mgr = make_manager();
+        mgr.definitions.push(sample_def());
+
+        let task_a = do_spawn(&mut mgr, "bot", "work").await.unwrap();
+
+        mgr.peer_router
+            .send(
+                &AgentId::Task(task_a.clone()),
+                "spawner",
+                "clarifying question".to_owned(),
+            )
+            .expect("child to parent send must succeed");
+
+        let received = mgr
+            .try_recv_peer_message()
+            .expect("parent-addressed message must be observable");
+        assert_eq!(received.body, "clarifying question");
+        assert_eq!(received.sender_id, AgentId::Task(task_a.clone()));
+
+        // The sub-agent was never collected — still tracked by the manager.
+        assert!(
+            mgr.statuses().iter().any(|(id, _)| id == &task_a),
+            "sub-agent must remain non-collect()-able after sending"
+        );
+    }
+
+    #[tokio::test]
+    async fn us003_session_and_plan_group_agents_in_one_manager_deny_cross_group_send() {
+        let mut mgr = make_manager();
+        mgr.definitions.push(sample_def());
+
+        let session_task = do_spawn(&mut mgr, "bot", "session work").await.unwrap();
+
+        let plan_ctx = SpawnContext {
+            peer_group: Some(PeerGroupId::Plan("plan-1".to_owned())),
+            ..SpawnContext::default()
+        };
+        let plan_task = mgr
+            .spawn(
+                "bot",
+                "plan work",
+                mock_provider(vec!["done"]),
+                noop_executor(),
+                None,
+                &SubAgentConfig::default(),
+                plan_ctx,
+            )
+            .await
+            .unwrap();
+
+        let err = mgr
+            .peer_router
+            .send(&AgentId::Task(session_task), &plan_task, "leak?".to_owned())
+            .unwrap_err();
+        // Critic round-4 S3: a cross-group target must be indistinguishable from a
+        // nonexistent one (NFR-003) — `TargetNotFound`, not `Unauthorized`.
+        assert!(
+            matches!(err, DeliveryError::TargetNotFound(_)),
+            "expected TargetNotFound (no existence oracle across groups), got: {err:?}"
+        );
+        assert_eq!(
+            mgr.peer_router.mailbox_depth(&AgentId::Task(plan_task)),
+            0,
+            "a denied send must never silently queue into the target's mailbox"
+        );
+    }
+
+    #[tokio::test]
+    async fn us002_plan_group_task_reaches_its_own_root_via_send_to_subagent() {
+        // Critic round-4 S2: /agent msg (send_to_subagent) must be able to reach a
+        // DagScheduler-dispatched sub-agent through its own Plan-group root, not just
+        // Session-group sub-agents.
+        let mut mgr = make_manager();
+        mgr.definitions.push(sample_def());
+
+        let plan_ctx = SpawnContext {
+            peer_group: Some(PeerGroupId::Plan("plan-2".to_owned())),
+            ..SpawnContext::default()
+        };
+        let plan_task = mgr
+            .spawn(
+                "bot",
+                "plan work",
+                mock_provider(vec!["done"]),
+                noop_executor(),
+                None,
+                &SubAgentConfig::default(),
+                plan_ctx,
+            )
+            .await
+            .unwrap();
+
+        mgr.send_to_subagent(&plan_task, "go".to_owned())
+            .expect("send_to_subagent must route through the Plan-group's own root");
+
+        mgr.peer_router
+            .send(
+                &AgentId::Task(plan_task),
+                "plan",
+                "clarifying question".to_owned(),
+            )
+            .expect("plan task to its own plan root must succeed");
+        let received = mgr
+            .try_recv_peer_message()
+            .expect("try_recv_peer_message must observe a Plan-root mailbox, not just Session's");
+        assert_eq!(received.body, "clarifying question");
+    }
+
+    #[tokio::test]
+    async fn us004_full_mailbox_fails_fast_without_awaiting() {
+        let mut mgr = make_manager();
+        mgr.definitions.push(sample_def());
+        let cfg = SubAgentConfig {
+            peer_messaging: zeph_config::PeerMessagingConfig {
+                mailbox_capacity: 1,
+                ..zeph_config::PeerMessagingConfig::default()
+            },
+            ..SubAgentConfig::default()
+        };
+        // Mailbox capacity is a router-wide setting applied at bootstrap, not read per-spawn
+        // from `SubAgentConfig` — mirrors `runner.rs`'s real bootstrap call order.
+        mgr.set_peer_messaging_config(cfg.peer_messaging.clone());
+
+        let task_a = mgr
+            .spawn(
+                "bot",
+                "work",
+                mock_provider(vec!["done"]),
+                noop_executor(),
+                None,
+                &cfg,
+                SpawnContext::default(),
+            )
+            .await
+            .unwrap();
+
+        mgr.peer_router
+            .send(
+                &AgentId::Root(PeerGroupId::Session),
+                &task_a,
+                "first".to_owned(),
+            )
+            .expect("first message fits the capacity-1 mailbox");
+
+        // `PeerRouter::send` has no `.await` on its path at all — a tight timeout proves the
+        // full-mailbox case returns immediately rather than by wall-clock feel.
+        let result = tokio::time::timeout(std::time::Duration::from_millis(50), async {
+            mgr.peer_router.send(
+                &AgentId::Root(PeerGroupId::Session),
+                &task_a,
+                "second".to_owned(),
+            )
+        })
+        .await
+        .expect("send must return well within the timeout, not hang");
+        assert!(matches!(result, Err(DeliveryError::MailboxFull(_))));
+    }
 }

--- a/crates/zeph-subagent/src/peer/mod.rs
+++ b/crates/zeph-subagent/src/peer/mod.rs
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Live, addressable peer-to-peer messaging between sub-agents and their spawner
+//! (spec `046-subagent-peer-messaging-parity`, issue #5871).
+//!
+//! # Architecture
+//!
+//! Routing state lives in an [`Arc<PeerRouter>`][router::PeerRouter] shared between
+//! [`SubAgentManager`](crate::manager::SubAgentManager) and every spawned sub-agent's own
+//! tool executor decorator ([`PeerToolExecutor`]) — never on
+//! [`SubAgentHandle`](crate::manager::SubAgentHandle) itself, since a running sub-agent task
+//! cannot reach back into the manager that owns its handle. A send is a direct,
+//! non-blocking `try_send` from the sender's tool call into the target's mailbox; it never
+//! touches the parent agent and adds no new `tokio::spawn` call site.
+//!
+//! Only messages addressed to the parent agent itself are drained by the parent, via
+//! [`SubAgentManager::try_recv_peer_message`](crate::manager::SubAgentManager::try_recv_peer_message).
+
+mod router;
+mod tools;
+
+pub use router::{PeerRegistration, PeerRouter};
+pub use tools::PeerToolExecutor;
+
+/// Addressable identity of a node in the peer graph.
+///
+/// [`Root`](Self::Root) is the parent [`Agent`](crate) for a given spawn scope;
+/// [`Task`](Self::Task) is a spawned sub-agent, keyed by its `task_id`.
+///
+/// # Examples
+///
+/// ```rust
+/// use zeph_subagent::peer::{AgentId, PeerGroupId};
+///
+/// let root = AgentId::Root(PeerGroupId::Session);
+/// let task = AgentId::Task("abc-123".to_owned());
+/// assert_ne!(root, task);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum AgentId {
+    /// The parent agent for one [`PeerGroupId`] spawn-tree root.
+    Root(PeerGroupId),
+    /// A spawned sub-agent, keyed by its `task_id`.
+    Task(String),
+}
+
+/// Root identity of one spawn tree. Distinct groups never address each other
+/// (spec `046` US-003).
+///
+/// # Examples
+///
+/// ```rust
+/// use zeph_subagent::peer::PeerGroupId;
+///
+/// let session = PeerGroupId::Session;
+/// let plan = PeerGroupId::Plan("plan-run-42".to_owned());
+/// assert_ne!(session, plan);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum PeerGroupId {
+    /// The interactive session's own root — `/agent run`, `/agent spawn`, `/agent resume`.
+    Session,
+    /// One orchestration plan execution, keyed by a driver-supplied plan run id.
+    Plan(String),
+}
+
+/// A single message sent between two addressable agents (spawner, coordinator, or sibling
+/// sub-agent); delivered in mailbox arrival order, best-effort (FR-011).
+#[derive(Debug, Clone)]
+pub struct PeerMessage {
+    /// The sender's addressable identity.
+    pub sender_id: AgentId,
+    /// The sender's display name, for a human-readable notice.
+    pub sender_name: String,
+    /// The recipient's addressable identity.
+    pub target_id: AgentId,
+    /// The message body. Untrusted content — sanitized on read (NFR-007).
+    pub body: String,
+    /// Wall-clock time the message was sent.
+    pub sent_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// One entry in [`PeerRouter::peers_for`][router::PeerRouter::peers_for]'s result: an
+/// addressable peer the querying agent is authorized to message, and its relation to it
+/// (FR-008).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerDescriptor {
+    /// The peer's addressable identity.
+    pub id: AgentId,
+    /// The peer's display name.
+    pub name: String,
+    /// The peer's relation to the querying agent.
+    pub relation: PeerRelation,
+}
+
+/// Relation of a [`PeerDescriptor`] to the agent that queried
+/// [`PeerRouter::peers_for`][router::PeerRouter::peers_for].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PeerRelation {
+    /// The querying agent's parent (or root).
+    Parent,
+    /// Another sub-agent sharing the same parent as the querying agent.
+    Sibling,
+    /// A descendant of the querying agent.
+    Child,
+}
+
+/// Why a [`PeerRouter::send`][router::PeerRouter::send] was refused.
+///
+/// Kept distinct from a single boolean so the deny branch is assertable in tests and legible
+/// in `tracing` events (NFR-004).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnauthorizedReason {
+    /// Sender and target belong to different spawn-tree roots (US-003).
+    DifferentGroup,
+    /// Same tree, but the target is neither parent, sibling, nor descendant of the sender.
+    NotInScope,
+    /// The sender attempted to address itself.
+    SelfAddress,
+}
+
+/// Failure to deliver a [`PeerMessage`], returned by
+/// [`PeerRouter::send`][router::PeerRouter::send] and
+/// [`SubAgentManager::send_to_subagent`](crate::manager::SubAgentManager::send_to_subagent).
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum DeliveryError {
+    /// No agent is addressable by the given `task_id` or display name.
+    #[error("no agent is addressable as '{0}'")]
+    TargetNotFound(String),
+    /// The target agent's route was deregistered (collected, cancelled, or dropped) before
+    /// delivery.
+    #[error("target agent '{0}' has already terminated")]
+    TargetTerminated(String),
+    /// The sender is not authorized to message the target (US-003, FR-004).
+    #[error("'{sender}' is not authorized to message '{target}': {reason:?}")]
+    Unauthorized {
+        /// The sender's display name.
+        sender: String,
+        /// The target's display name.
+        target: String,
+        /// Why the send was refused.
+        reason: UnauthorizedReason,
+    },
+    /// The target's mailbox is at capacity (FR-005, NFR-002).
+    #[error("target agent '{0}' mailbox is full")]
+    MailboxFull(String),
+    /// The message body exceeds `peer_messaging.max_body_bytes`.
+    #[error("message body exceeds the configured limit ({actual} > {max} bytes)")]
+    BodyTooLarge {
+        /// The body's actual size in bytes.
+        actual: usize,
+        /// The configured maximum.
+        max: usize,
+    },
+    /// The `target` identifier string exceeds the router's internal length cap.
+    #[error("target identifier exceeds the maximum length ({actual} > {max} bytes)")]
+    TargetTooLarge {
+        /// The target string's actual size in bytes.
+        actual: usize,
+        /// The configured maximum.
+        max: usize,
+    },
+    /// Peer messaging is disabled by configuration (`peer_messaging.enabled = false`).
+    #[error("peer messaging is disabled by configuration")]
+    Disabled,
+}

--- a/crates/zeph-subagent/src/peer/router.rs
+++ b/crates/zeph-subagent/src/peer/router.rs
@@ -1,0 +1,883 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! [`PeerRouter`]: the `Arc`-shared node table backing live inter-sub-agent messaging.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+use tokio::sync::mpsc;
+use zeph_config::PeerMessagingConfig;
+use zeph_sanitizer::secret_mask::SecretMaskRegistry;
+
+use super::{
+    AgentId, DeliveryError, PeerDescriptor, PeerGroupId, PeerMessage, PeerRelation,
+    UnauthorizedReason,
+};
+
+/// Maximum length, in bytes, of a `send_peer_message`/`send_to_subagent` `target` argument.
+/// Task IDs are UUIDs (36 bytes) and display names are short; this is a generous cap against
+/// an LLM-supplied string padding allocations or log lines, not a realistic addressing limit.
+const MAX_TARGET_BYTES: usize = 256;
+
+/// One addressable node in the peer graph: a registered agent's routing metadata and the
+/// sender half of its bounded mailbox.
+struct PeerNode {
+    id: AgentId,
+    name: String,
+    /// `None` only for a group root.
+    parent: Option<AgentId>,
+    group: PeerGroupId,
+    mailbox_tx: mpsc::Sender<PeerMessage>,
+}
+
+/// `Arc`-shared node table for live inter-sub-agent messaging (spec
+/// `046-subagent-peer-messaging-parity`).
+///
+/// Shared between [`SubAgentManager`](crate::manager::SubAgentManager) and every spawned
+/// sub-agent's own [`PeerToolExecutor`](super::PeerToolExecutor) — never owned by value by
+/// either side, since a running sub-agent task cannot reach back into the manager. A send is
+/// one brief [`parking_lot::RwLock`] read guard (lookup, authorize, clone the target's
+/// mailbox sender), dropped before the non-blocking `try_send` — there is no `.await` on the
+/// send path at all.
+pub struct PeerRouter {
+    nodes: RwLock<HashMap<AgentId, PeerNode>>,
+    config: PeerMessagingConfig,
+    /// `RwLock`-wrapped (not a plain `Option`) so [`set_secret_registry`][Self::set_secret_registry]
+    /// can be called at any point in bootstrap ordering relative to
+    /// [`SubAgentManager::set_secret_registry`](crate::manager::SubAgentManager::set_secret_registry),
+    /// which mutates the *same* live router rather than requiring one bootstrap call to
+    /// strictly precede the other.
+    secret_registry: RwLock<Option<Arc<SecretMaskRegistry>>>,
+}
+
+/// RAII route registration returned by `PeerRouter::register` (crate-private — only
+/// [`SubAgentManager`](crate::manager::SubAgentManager) constructs routes).
+///
+/// Dropping it deregisters the node, so a [`SubAgentHandle`](crate::manager::SubAgentHandle)
+/// dropped without an explicit `collect()`/`cancel()` cannot leave a dangling addressable
+/// route — mirroring the existing `Drop for SubAgentHandle` cancel-and-revoke safety net.
+pub struct PeerRegistration {
+    id: AgentId,
+    router: Arc<PeerRouter>,
+}
+
+impl PeerRegistration {
+    /// The addressable identity this registration holds a route for.
+    #[must_use]
+    pub fn id(&self) -> &AgentId {
+        &self.id
+    }
+
+    /// The shared router this registration is bound to.
+    #[must_use]
+    pub fn router(&self) -> &Arc<PeerRouter> {
+        &self.router
+    }
+}
+
+impl Drop for PeerRegistration {
+    fn drop(&mut self) {
+        self.router.deregister(&self.id);
+    }
+}
+
+impl std::fmt::Debug for PeerRouter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PeerRouter")
+            .field("nodes_count", &self.nodes.read().len())
+            .field("config", &self.config)
+            .field("secret_registry", &self.secret_registry.read().is_some())
+            .finish()
+    }
+}
+
+impl PeerRouter {
+    /// Construct a new, empty router.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_config::PeerMessagingConfig;
+    /// use zeph_subagent::peer::PeerRouter;
+    ///
+    /// let router = PeerRouter::new(PeerMessagingConfig::default(), None);
+    /// assert_eq!(std::sync::Arc::strong_count(&router), 1);
+    /// ```
+    #[must_use]
+    pub fn new(
+        config: PeerMessagingConfig,
+        secret_registry: Option<Arc<SecretMaskRegistry>>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            nodes: RwLock::new(HashMap::new()),
+            config,
+            secret_registry: RwLock::new(secret_registry),
+        })
+    }
+
+    /// The peer-messaging configuration this router was constructed with.
+    #[must_use]
+    pub fn config(&self) -> &PeerMessagingConfig {
+        &self.config
+    }
+
+    /// Replace the secret-mask registry applied to message bodies at send time.
+    ///
+    /// Callable at any point relative to construction — see the field doc comment on
+    /// [`secret_registry`][Self].
+    pub(crate) fn set_secret_registry(&self, registry: Option<Arc<SecretMaskRegistry>>) {
+        *self.secret_registry.write() = registry;
+    }
+
+    /// Register a node and return its RAII registration plus the receiver half of its
+    /// mailbox (moved into that agent's own [`PeerToolExecutor`](super::PeerToolExecutor)).
+    ///
+    /// Known limitation (review M3): registering an already-live `id` silently overwrites the
+    /// existing node (`HashMap::insert`'s normal replace semantics) rather than erroring. Not
+    /// reachable today — `manager::spawn`'s task ids are freshly minted `Uuid::new_v4`s and
+    /// there is exactly one root per `PeerGroupId` (`Session`, and one `Plan(graph_id)` per
+    /// live plan execution) — but a future caller must not assume `register` is idempotent.
+    #[tracing::instrument(name = "subagent.mailbox.register", skip(self, name), fields(id = ?id))]
+    pub(crate) fn register(
+        self: &Arc<Self>,
+        id: AgentId,
+        name: String,
+        parent: Option<AgentId>,
+        group: PeerGroupId,
+    ) -> (PeerRegistration, mpsc::Receiver<PeerMessage>) {
+        let capacity = self.config.mailbox_capacity.max(1);
+        let (mailbox_tx, mailbox_rx) = mpsc::channel(capacity);
+        let node = PeerNode {
+            id: id.clone(),
+            name,
+            parent,
+            group,
+            mailbox_tx,
+        };
+        self.nodes.write().insert(id.clone(), node);
+        (
+            PeerRegistration {
+                id,
+                router: Arc::clone(self),
+            },
+            mailbox_rx,
+        )
+    }
+
+    /// Remove a node from the table. Called by [`PeerRegistration::drop`].
+    fn deregister(&self, id: &AgentId) {
+        self.nodes.write().remove(id);
+    }
+
+    /// Resolve `target` to a node within `group`: exact `task_id` first, then unique display
+    /// name.
+    ///
+    /// Candidates are filtered to `group` **before** the id/name match (critic round-4 S3) —
+    /// a node in a different spawn-tree root is excluded from the lookup entirely, so it is
+    /// indistinguishable from a nonexistent node (`TargetNotFound`) rather than surfacing as
+    /// an `Unauthorized` rejection, which would let a sender learn a target *exists* in
+    /// another tree (NFR-003, spec §8 "Never... discover"). An ambiguous name (multiple nodes
+    /// in `group` share it) resolves to `None` rather than an arbitrary node.
+    fn resolve_target<'a>(
+        nodes: &'a HashMap<AgentId, PeerNode>,
+        group: &PeerGroupId,
+        target: &str,
+    ) -> Option<&'a PeerNode> {
+        if let Some(node) = nodes
+            .get(&AgentId::Task(target.to_owned()))
+            .filter(|n| &n.group == group)
+        {
+            return Some(node);
+        }
+        let mut matches = nodes
+            .values()
+            .filter(|n| &n.group == group && n.name == target);
+        let first = matches.next()?;
+        if matches.next().is_some() {
+            return None;
+        }
+        Some(first)
+    }
+
+    /// Implements the plan's authorization truth table:
+    /// `root(S) == root(T) AND S != T AND (T == parent(S) | parent(T) == parent(S) | S is an
+    /// ancestor of T)`.
+    ///
+    /// TODO(spec `046-subagent-peer-messaging-parity`, review M6): a grandchild cannot reply
+    /// to an ancestor beyond its direct parent (only `T == parent(S)`, not "T is an ancestor
+    /// of S") — latent until a sub-agent-side spawn tool exists, since every spawn's `parent`
+    /// is a group root today (`manager/spawn.rs`'s own comment at the `spawn()`/`resume()`
+    /// peer-install sites), making every live node's depth exactly 1 and this asymmetry
+    /// unreachable in production. Do not "fix" the truth table without a nested-spawn path to
+    /// verify it against end to end.
+    fn authorize(
+        nodes: &HashMap<AgentId, PeerNode>,
+        from_node: &PeerNode,
+        to_node: &PeerNode,
+    ) -> Result<(), UnauthorizedReason> {
+        if from_node.id == to_node.id {
+            return Err(UnauthorizedReason::SelfAddress);
+        }
+        if from_node.group != to_node.group {
+            return Err(UnauthorizedReason::DifferentGroup);
+        }
+        if from_node.parent.as_ref() == Some(&to_node.id) {
+            return Ok(());
+        }
+        if to_node.parent.is_some() && to_node.parent == from_node.parent {
+            return Ok(());
+        }
+        // S is an ancestor of T: walk T's parent chain looking for S. No visited-set or depth
+        // cap (review LOW finding): a parent cycle would spin forever while holding the
+        // router's read lock, wedging every concurrent send. Unreachable today — every node's
+        // `parent` is either `None` (a root) or a root's own `AgentId` (register()'s only
+        // callers, `manager::spawn`, never nest deeper) — but a future nested-spawn feature
+        // must add a cycle guard here before it can register a node whose ancestry isn't
+        // trivially a root.
+        let mut cursor = to_node.parent.clone();
+        while let Some(ancestor_id) = cursor {
+            if ancestor_id == from_node.id {
+                return Ok(());
+            }
+            cursor = nodes.get(&ancestor_id).and_then(|n| n.parent.clone());
+        }
+        Err(UnauthorizedReason::NotInScope)
+    }
+
+    /// Send a message from `from` to the agent addressable as `target` (FR-001).
+    ///
+    /// Never blocks: one brief read-lock for lookup, authorization, and mailbox-sender
+    /// clone, dropped before the non-blocking `try_send` — there is no `.await` anywhere on
+    /// this path (US-004, NFR-001).
+    ///
+    /// # Errors
+    ///
+    /// See [`DeliveryError`] for every rejection case: peer messaging disabled, the body
+    /// exceeds the configured limit, `from` is not itself a registered/live node (rejected
+    /// the same as an unknown target — never implicitly trusted), `target` does not resolve
+    /// (unknown or ambiguous name), the send is unauthorized (different spawn-tree root, out
+    /// of scope, or self-addressing), the target has already terminated, or the target's
+    /// mailbox is full.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use zeph_config::PeerMessagingConfig;
+    /// use zeph_subagent::peer::{AgentId, DeliveryError, PeerGroupId, PeerRouter};
+    ///
+    /// let router = PeerRouter::new(PeerMessagingConfig::default(), None);
+    /// let from = AgentId::Root(PeerGroupId::Session);
+    ///
+    /// // No node is registered for either side, so the send fails fast rather than
+    /// // blocking or silently dropping the message (US-004, FR-009).
+    /// let err = router.send(&from, "nonexistent", "hello".to_owned()).unwrap_err();
+    /// assert!(matches!(err, DeliveryError::TargetNotFound(_)));
+    /// ```
+    #[tracing::instrument(name = "subagent.mailbox.send", skip(self, body), fields(from = ?from, target))]
+    pub fn send(&self, from: &AgentId, target: &str, body: String) -> Result<(), DeliveryError> {
+        if !self.config.enabled {
+            tracing::warn!("peer message send rejected: peer messaging disabled");
+            return Err(DeliveryError::Disabled);
+        }
+        if body.len() > self.config.max_body_bytes {
+            tracing::warn!(
+                actual = body.len(),
+                max = self.config.max_body_bytes,
+                "peer message send rejected: body too large"
+            );
+            return Err(DeliveryError::BodyTooLarge {
+                actual: body.len(),
+                max: self.config.max_body_bytes,
+            });
+        }
+        // `target` is LLM-supplied (via `send_peer_message`'s tool argument) just like `body`;
+        // cap it too so an unbounded string can't be used to pad allocations or log lines.
+        if target.len() > MAX_TARGET_BYTES {
+            tracing::warn!(
+                actual = target.len(),
+                max = MAX_TARGET_BYTES,
+                "peer message send rejected: target identifier too large"
+            );
+            return Err(DeliveryError::TargetTooLarge {
+                actual: target.len(),
+                max: MAX_TARGET_BYTES,
+            });
+        }
+
+        let (sender_name, target_display, mailbox_tx) = {
+            let nodes = self.nodes.read();
+            // Critic M3: a sender whose own registration was already dropped (e.g.
+            // mid-cancellation) is rejected the same as an unknown target — never
+            // implicitly trusted.
+            let Some(from_node) = nodes.get(from) else {
+                tracing::warn!("peer message send rejected: sender is not a live node");
+                return Err(DeliveryError::TargetNotFound(target.to_owned()));
+            };
+            let Some(to_node) = Self::resolve_target(&nodes, &from_node.group, target) else {
+                tracing::warn!(target, "peer message send rejected: target not found");
+                return Err(DeliveryError::TargetNotFound(target.to_owned()));
+            };
+
+            let authorize_span = tracing::debug_span!("subagent.mailbox.authorize");
+            let auth_result =
+                authorize_span.in_scope(|| Self::authorize(&nodes, from_node, to_node));
+            if let Err(reason) = auth_result {
+                tracing::warn!(
+                    ?reason,
+                    sender = %from_node.name,
+                    target = %to_node.name,
+                    "peer message send rejected: unauthorized"
+                );
+                return Err(DeliveryError::Unauthorized {
+                    sender: from_node.name.clone(),
+                    target: to_node.name.clone(),
+                    reason,
+                });
+            }
+
+            (
+                from_node.name.clone(),
+                to_node.name.clone(),
+                to_node.mailbox_tx.clone(),
+            )
+        };
+
+        let masked_body = match self.secret_registry.read().as_ref() {
+            Some(registry) => registry.mask(&body),
+            None => body,
+        };
+
+        let message = PeerMessage {
+            sender_id: from.clone(),
+            sender_name,
+            target_id: AgentId::Task(target_display),
+            body: masked_body,
+            sent_at: chrono::Utc::now(),
+        };
+
+        match mailbox_tx.try_send(message) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                tracing::warn!(target, "peer message send rejected: mailbox full");
+                Err(DeliveryError::MailboxFull(target.to_owned()))
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                tracing::warn!(target, "peer message send rejected: target terminated");
+                Err(DeliveryError::TargetTerminated(target.to_owned()))
+            }
+        }
+    }
+
+    /// Return every node `from` is authorized to address, with its relation to `from`
+    /// (FR-008). Never leaks a node from another spawn-tree root (NFR-003).
+    #[must_use]
+    pub fn peers_for(&self, from: &AgentId) -> Vec<PeerDescriptor> {
+        let nodes = self.nodes.read();
+        let Some(from_node) = nodes.get(from) else {
+            return Vec::new();
+        };
+        nodes
+            .values()
+            .filter(|n| n.id != from_node.id)
+            .filter_map(|n| {
+                Self::authorize(&nodes, from_node, n).ok()?;
+                let relation = if from_node.parent.as_ref() == Some(&n.id) {
+                    PeerRelation::Parent
+                } else if n.parent == from_node.parent {
+                    PeerRelation::Sibling
+                } else {
+                    PeerRelation::Child
+                };
+                Some(PeerDescriptor {
+                    id: n.id.clone(),
+                    name: n.name.clone(),
+                    relation,
+                })
+            })
+            .collect()
+    }
+
+    /// Current queued (undelivered) message count for `id`'s mailbox, used for the TUI
+    /// unread badge (FR-010). `max_capacity() - capacity()` is O(1) and needs no second
+    /// counter to keep in sync. Returns `0` for an unknown or deregistered id.
+    #[must_use]
+    pub fn mailbox_depth(&self, id: &AgentId) -> usize {
+        self.nodes
+            .read()
+            .get(id)
+            .map_or(0, |n| n.mailbox_tx.max_capacity() - n.mailbox_tx.capacity())
+    }
+
+    /// The spawn-tree root group `id` is registered under, if it is currently a live node.
+    ///
+    /// Used by [`SubAgentManager::send_to_subagent`](crate::manager::SubAgentManager::send_to_subagent)
+    /// to determine which root (`Session` or a specific `Plan`) it must send *as* in order to
+    /// reach `id` — the parent session holds routes for every root it has spawned into, but
+    /// only messaging *as the target's own root* satisfies the ancestor-walk authorization
+    /// clause (critic round-4 S2).
+    #[must_use]
+    pub(crate) fn group_of(&self, id: &AgentId) -> Option<PeerGroupId> {
+        self.nodes.read().get(id).map(|n| n.group.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn router(config: PeerMessagingConfig) -> Arc<PeerRouter> {
+        PeerRouter::new(config, None)
+    }
+
+    fn register_root(router: &Arc<PeerRouter>, group: PeerGroupId, name: &str) -> PeerRegistration {
+        let (reg, rx) = router.register(AgentId::Root(group.clone()), name.to_owned(), None, group);
+        std::mem::forget(rx);
+        reg
+    }
+
+    fn register_task(
+        router: &Arc<PeerRouter>,
+        task_id: &str,
+        name: &str,
+        parent: AgentId,
+        group: PeerGroupId,
+    ) -> (PeerRegistration, mpsc::Receiver<PeerMessage>) {
+        router.register(
+            AgentId::Task(task_id.to_owned()),
+            name.to_owned(),
+            Some(parent),
+            group,
+        )
+    }
+
+    #[test]
+    fn send_to_unknown_target_fails() {
+        let r = router(PeerMessagingConfig::default());
+        let root = register_root(&r, PeerGroupId::Session, "spawner");
+        let err = r.send(root.id(), "nope", "hi".to_owned()).unwrap_err();
+        assert!(matches!(err, DeliveryError::TargetNotFound(_)));
+    }
+
+    #[test]
+    fn send_from_unregistered_sender_is_rejected_like_unknown_target() {
+        // Critic M3: an unknown/dropped sender must never be implicitly trusted.
+        let r = router(PeerMessagingConfig::default());
+        let root = register_root(&r, PeerGroupId::Session, "spawner");
+        let (_child_reg, _rx) = register_task(
+            &r,
+            "child",
+            "child",
+            root.id().clone(),
+            PeerGroupId::Session,
+        );
+        let ghost = AgentId::Task("never-registered".to_owned());
+        let err = r.send(&ghost, "child", "hi".to_owned()).unwrap_err();
+        assert!(matches!(err, DeliveryError::TargetNotFound(_)));
+    }
+
+    #[test]
+    fn sibling_to_sibling_send_succeeds() {
+        let r = router(PeerMessagingConfig::default());
+        let root = register_root(&r, PeerGroupId::Session, "spawner");
+        let (a, _a_rx) = register_task(
+            &r,
+            "a",
+            "researcher",
+            root.id().clone(),
+            PeerGroupId::Session,
+        );
+        let (_b, mut b_rx) = register_task(
+            &r,
+            "b",
+            "implementer",
+            root.id().clone(),
+            PeerGroupId::Session,
+        );
+
+        r.send(a.id(), "b", "redirect".to_owned())
+            .expect("sibling send");
+        let msg = b_rx.try_recv().expect("message delivered");
+        assert_eq!(msg.body, "redirect");
+        assert_eq!(msg.sender_name, "researcher");
+    }
+
+    #[test]
+    fn child_to_parent_send_succeeds() {
+        let r = router(PeerMessagingConfig::default());
+        let mut root_rx = {
+            let (reg, rx) = r.register(
+                AgentId::Root(PeerGroupId::Session),
+                "spawner".to_owned(),
+                None,
+                PeerGroupId::Session,
+            );
+            std::mem::forget(reg);
+            rx
+        };
+        let (child, _rx) = register_task(
+            &r,
+            "child",
+            "child",
+            AgentId::Root(PeerGroupId::Session),
+            PeerGroupId::Session,
+        );
+        r.send(child.id(), "spawner", "question?".to_owned())
+            .expect("child to parent send");
+        let msg = root_rx.try_recv().expect("delivered to root");
+        assert_eq!(msg.body, "question?");
+    }
+
+    #[test]
+    fn parent_to_descendant_send_succeeds() {
+        let r = router(PeerMessagingConfig::default());
+        let root = register_root(&r, PeerGroupId::Session, "spawner");
+        let (child, _child_rx) = register_task(
+            &r,
+            "child",
+            "child",
+            root.id().clone(),
+            PeerGroupId::Session,
+        );
+        let (_grandchild, mut gc_rx) = register_task(
+            &r,
+            "grandchild",
+            "grandchild",
+            child.id().clone(),
+            PeerGroupId::Session,
+        );
+
+        r.send(root.id(), "grandchild", "go".to_owned())
+            .expect("root reaches a grandchild by ancestor walk");
+        let msg = gc_rx.try_recv().expect("delivered");
+        assert_eq!(msg.body, "go");
+    }
+
+    #[test]
+    fn cousin_send_is_denied_not_in_scope() {
+        let r = router(PeerMessagingConfig::default());
+        let root = register_root(&r, PeerGroupId::Session, "spawner");
+        let (parent_a, _a_rx) = register_task(
+            &r,
+            "parent-a",
+            "parent-a",
+            root.id().clone(),
+            PeerGroupId::Session,
+        );
+        let (parent_b, _b_rx) = register_task(
+            &r,
+            "parent-b",
+            "parent-b",
+            root.id().clone(),
+            PeerGroupId::Session,
+        );
+        let (cousin_1, _c1_rx) = register_task(
+            &r,
+            "cousin-1",
+            "cousin-1",
+            parent_a.id().clone(),
+            PeerGroupId::Session,
+        );
+        let (_cousin_2, _c2_rx) = register_task(
+            &r,
+            "cousin-2",
+            "cousin-2",
+            parent_b.id().clone(),
+            PeerGroupId::Session,
+        );
+
+        let err = r
+            .send(cousin_1.id(), "cousin-2", "hi".to_owned())
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            DeliveryError::Unauthorized {
+                reason: UnauthorizedReason::NotInScope,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn cross_group_send_is_denied_as_target_not_found_not_unauthorized() {
+        // Critic round-4 S3: cross-group targets must be indistinguishable from nonexistent
+        // ones (NFR-003) — `resolve_target` filters to the sender's own group before the
+        // id/name match, so this never reaches `authorize`'s `DifferentGroup` branch at all.
+        let r = router(PeerMessagingConfig::default());
+        let session_root = register_root(&r, PeerGroupId::Session, "session-root");
+        let plan_root = register_root(&r, PeerGroupId::Plan("plan-1".to_owned()), "plan-root");
+        let (session_task, _rx1) = register_task(
+            &r,
+            "session-task",
+            "session-task",
+            session_root.id().clone(),
+            PeerGroupId::Session,
+        );
+        let (_plan_task, _rx2) = register_task(
+            &r,
+            "plan-task",
+            "plan-task",
+            plan_root.id().clone(),
+            PeerGroupId::Plan("plan-1".to_owned()),
+        );
+
+        let err = r
+            .send(session_task.id(), "plan-task", "leak?".to_owned())
+            .unwrap_err();
+        assert!(
+            matches!(err, DeliveryError::TargetNotFound(_)),
+            "expected TargetNotFound (no existence oracle across groups), got: {err:?}"
+        );
+        assert_eq!(r.mailbox_depth(&AgentId::Task("plan-task".to_owned())), 0);
+    }
+
+    #[test]
+    fn sequential_plans_produce_distinct_roots() {
+        let r = router(PeerMessagingConfig::default());
+        let (plan1_task, _rx1) = register_task(
+            &r,
+            "p1-task",
+            "p1-task",
+            AgentId::Root(PeerGroupId::Plan("plan-1".to_owned())),
+            PeerGroupId::Plan("plan-1".to_owned()),
+        );
+        let (_plan2_task, _rx2) = register_task(
+            &r,
+            "p2-task",
+            "p2-task",
+            AgentId::Root(PeerGroupId::Plan("plan-2".to_owned())),
+            PeerGroupId::Plan("plan-2".to_owned()),
+        );
+
+        let err = r
+            .send(plan1_task.id(), "p2-task", "straggler".to_owned())
+            .unwrap_err();
+        assert!(matches!(err, DeliveryError::TargetNotFound(_)));
+    }
+
+    #[test]
+    fn self_addressing_is_denied() {
+        let r = router(PeerMessagingConfig::default());
+        let root = register_root(&r, PeerGroupId::Session, "spawner");
+        let err = r.send(root.id(), "spawner", "echo".to_owned()).unwrap_err();
+        assert!(matches!(
+            err,
+            DeliveryError::Unauthorized {
+                reason: UnauthorizedReason::SelfAddress,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn ambiguous_name_resolves_to_target_not_found() {
+        let r = router(PeerMessagingConfig::default());
+        let root = register_root(&r, PeerGroupId::Session, "spawner");
+        let (_a, _a_rx) = register_task(&r, "a", "dup", root.id().clone(), PeerGroupId::Session);
+        let (_b, _b_rx) = register_task(&r, "b", "dup", root.id().clone(), PeerGroupId::Session);
+
+        let err = r.send(root.id(), "dup", "hi".to_owned()).unwrap_err();
+        assert!(matches!(err, DeliveryError::TargetNotFound(_)));
+    }
+
+    #[test]
+    fn task_id_resolution_takes_precedence_over_name() {
+        let r = router(PeerMessagingConfig::default());
+        let root = register_root(&r, PeerGroupId::Session, "spawner");
+        // A node whose display name collides with another node's task_id.
+        let (_a, mut a_rx) = register_task(&r, "a", "b", root.id().clone(), PeerGroupId::Session);
+        let (_b, mut b_rx) =
+            register_task(&r, "b", "b-name", root.id().clone(), PeerGroupId::Session);
+
+        r.send(root.id(), "b", "by-id".to_owned())
+            .expect("send by task_id");
+        assert!(
+            b_rx.try_recv().is_ok(),
+            "task_id match must win over name match"
+        );
+        assert!(a_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn body_too_large_is_rejected_before_lock() {
+        let cfg = PeerMessagingConfig {
+            max_body_bytes: 4,
+            ..PeerMessagingConfig::default()
+        };
+        let r = router(cfg);
+        let root = register_root(&r, PeerGroupId::Session, "spawner");
+        let err = r
+            .send(root.id(), "anyone", "way too long".to_owned())
+            .unwrap_err();
+        assert!(matches!(err, DeliveryError::BodyTooLarge { .. }));
+    }
+
+    #[test]
+    fn disabled_config_rejects_every_send() {
+        let cfg = PeerMessagingConfig {
+            enabled: false,
+            ..PeerMessagingConfig::default()
+        };
+        let r = router(cfg);
+        let root = register_root(&r, PeerGroupId::Session, "spawner");
+        let err = r.send(root.id(), "anyone", "hi".to_owned()).unwrap_err();
+        assert!(matches!(err, DeliveryError::Disabled));
+    }
+
+    #[test]
+    fn mailbox_full_fails_fast_without_awaiting() {
+        let cfg = PeerMessagingConfig {
+            mailbox_capacity: 1,
+            ..PeerMessagingConfig::default()
+        };
+        let r = router(cfg);
+        let root = register_root(&r, PeerGroupId::Session, "spawner");
+        let (_child, _rx) = register_task(
+            &r,
+            "child",
+            "child",
+            root.id().clone(),
+            PeerGroupId::Session,
+        );
+
+        r.send(root.id(), "child", "first".to_owned())
+            .expect("first fits");
+        let err = r.send(root.id(), "child", "second".to_owned()).unwrap_err();
+        assert!(matches!(err, DeliveryError::MailboxFull(_)));
+    }
+
+    #[test]
+    fn dropped_receiver_yields_target_terminated() {
+        let r = router(PeerMessagingConfig::default());
+        let root = register_root(&r, PeerGroupId::Session, "spawner");
+        let (_child, rx) = register_task(
+            &r,
+            "child",
+            "child",
+            root.id().clone(),
+            PeerGroupId::Session,
+        );
+        drop(rx);
+
+        let err = r
+            .send(root.id(), "child", "anyone home?".to_owned())
+            .unwrap_err();
+        assert!(matches!(err, DeliveryError::TargetTerminated(_)));
+    }
+
+    #[test]
+    fn registration_drop_deregisters_and_send_yields_target_not_found() {
+        let r = router(PeerMessagingConfig::default());
+        let root = register_root(&r, PeerGroupId::Session, "spawner");
+        let (child, rx) = register_task(
+            &r,
+            "child",
+            "child",
+            root.id().clone(),
+            PeerGroupId::Session,
+        );
+        drop(rx);
+        drop(child);
+
+        let err = r.send(root.id(), "child", "hi".to_owned()).unwrap_err();
+        assert!(matches!(err, DeliveryError::TargetNotFound(_)));
+    }
+
+    #[test]
+    fn mailbox_depth_tracks_queued_and_drained() {
+        let r = router(PeerMessagingConfig::default());
+        let root = register_root(&r, PeerGroupId::Session, "spawner");
+        let (child, mut rx) = register_task(
+            &r,
+            "child",
+            "child",
+            root.id().clone(),
+            PeerGroupId::Session,
+        );
+
+        assert_eq!(r.mailbox_depth(child.id()), 0);
+        r.send(root.id(), "child", "one".to_owned()).expect("send");
+        r.send(root.id(), "child", "two".to_owned()).expect("send");
+        assert_eq!(r.mailbox_depth(child.id()), 2);
+
+        rx.try_recv().expect("drain one");
+        assert_eq!(r.mailbox_depth(child.id()), 1);
+    }
+
+    #[test]
+    fn peers_for_never_leaks_another_group() {
+        let r = router(PeerMessagingConfig::default());
+        let session_root = register_root(&r, PeerGroupId::Session, "session-root");
+        let plan_root = register_root(&r, PeerGroupId::Plan("p1".to_owned()), "plan-root");
+        let (session_task, _rx1) = register_task(
+            &r,
+            "s-task",
+            "s-task",
+            session_root.id().clone(),
+            PeerGroupId::Session,
+        );
+        let (_plan_task, _rx2) = register_task(
+            &r,
+            "p-task",
+            "p-task",
+            plan_root.id().clone(),
+            PeerGroupId::Plan("p1".to_owned()),
+        );
+
+        let peers = r.peers_for(session_task.id());
+        assert!(
+            peers
+                .iter()
+                .all(|p| p.name != "p-task" && p.name != "plan-root")
+        );
+        assert!(peers.iter().any(|p| p.name == "session-root"));
+    }
+
+    #[test]
+    fn peers_for_labels_parent_sibling_child() {
+        let r = router(PeerMessagingConfig::default());
+        let root = register_root(&r, PeerGroupId::Session, "spawner");
+        let (a, _a_rx) = register_task(&r, "a", "a", root.id().clone(), PeerGroupId::Session);
+        let (_b, _b_rx) = register_task(&r, "b", "b", root.id().clone(), PeerGroupId::Session);
+        let (_c, _c_rx) = register_task(&r, "c", "c", a.id().clone(), PeerGroupId::Session);
+
+        let peers = r.peers_for(a.id());
+        let parent = peers
+            .iter()
+            .find(|p| p.name == "spawner")
+            .expect("parent listed");
+        assert_eq!(parent.relation, PeerRelation::Parent);
+        let sibling = peers
+            .iter()
+            .find(|p| p.name == "b")
+            .expect("sibling listed");
+        assert_eq!(sibling.relation, PeerRelation::Sibling);
+        let child = peers.iter().find(|p| p.name == "c").expect("child listed");
+        assert_eq!(child.relation, PeerRelation::Child);
+    }
+
+    #[test]
+    fn secret_registered_in_mask_registry_is_masked_in_relayed_body() {
+        let registry = Arc::new(SecretMaskRegistry::new());
+        registry.register(
+            "SOME_KEY",
+            "super-secret-value",
+            zeph_sanitizer::secret_mask::SecretCategory::Generic,
+        );
+        let r = PeerRouter::new(PeerMessagingConfig::default(), Some(Arc::clone(&registry)));
+        let root = register_root(&r, PeerGroupId::Session, "spawner");
+        let (_child, mut rx) = register_task(
+            &r,
+            "child",
+            "child",
+            root.id().clone(),
+            PeerGroupId::Session,
+        );
+
+        r.send(root.id(), "child", "value is super-secret-value".to_owned())
+            .expect("send");
+        let msg = rx.try_recv().expect("delivered");
+        assert!(!msg.body.contains("super-secret-value"));
+    }
+}

--- a/crates/zeph-subagent/src/peer/tools.rs
+++ b/crates/zeph-subagent/src/peer/tools.rs
@@ -1,0 +1,916 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! [`PeerToolExecutor`]: the per-spawn tool executor decorator exposing peer messaging to a
+//! sub-agent's own LLM (FR-012).
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::time::Duration;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tokio::sync::{Mutex as AsyncMutex, mpsc};
+use tokio_util::sync::CancellationToken;
+use zeph_common::ToolName;
+use zeph_sanitizer::exfiltration::ExfiltrationGuard;
+use zeph_sanitizer::{ContentSanitizer, ContentSource, ContentSourceKind};
+use zeph_tools::executor::{
+    CheckpointActionResult, CheckpointListResult, ErasedToolExecutor, ToolCall, ToolError,
+    ToolOutput, deserialize_params,
+};
+use zeph_tools::registry::{InvocationHint, ToolDef};
+
+use super::{AgentId, PeerMessage, PeerRouter};
+
+const SEND_PEER_MESSAGE: &str = "send_peer_message";
+const CHECK_MESSAGES: &str = "check_messages";
+const LIST_PEERS: &str = "list_peers";
+
+/// How often `check_messages(wait_ms)`'s wait records a progress heartbeat, well under any
+/// realistic orchestration idle-timeout threshold (critic round-2 S2).
+const PROGRESS_TICK: Duration = Duration::from_secs(5);
+
+#[derive(Deserialize, JsonSchema)]
+struct SendPeerMessageParams {
+    /// `task_id` or unique display name of the recipient.
+    target: String,
+    /// The message body.
+    body: String,
+}
+
+#[derive(Deserialize, JsonSchema)]
+struct CheckMessagesParams {
+    /// Milliseconds to wait for a new message if the mailbox is currently empty. Absent or
+    /// `0` drains and returns immediately. Clamped to the configured `max_wait_ms` ceiling.
+    #[serde(default)]
+    wait_ms: Option<u32>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+struct ListPeersParams {}
+
+#[derive(Serialize)]
+struct MessageView {
+    sender: String,
+    body: String,
+    sent_at: String,
+}
+
+#[derive(Serialize)]
+struct PeerView {
+    id: String,
+    name: String,
+    relation: &'static str,
+}
+
+fn is_peer_tool(tool_id: &str) -> bool {
+    matches!(tool_id, SEND_PEER_MESSAGE | CHECK_MESSAGES | LIST_PEERS)
+}
+
+fn tool_output(tool_id: &str, summary: String) -> ToolOutput {
+    ToolOutput {
+        tool_name: ToolName::new(tool_id),
+        summary,
+        blocks_executed: 1,
+        ..Default::default()
+    }
+}
+
+/// Per-spawn [`ErasedToolExecutor`] decorator exposing `send_peer_message`, `check_messages`,
+/// and `list_peers` to a sub-agent's own LLM (FR-012), modelled structurally on
+/// [`NetworkDenyToolExecutor`](crate::filter::NetworkDenyToolExecutor).
+///
+/// Constructed once per spawn with its own [`AgentId`] baked in — never taken from a tool
+/// argument or `ToolCall.caller_id` — so an LLM cannot spoof its sender identity (critic S2).
+///
+/// # Single-consumer mailbox receiver
+///
+/// [`mailbox_rx`][Self] is held as a [`tokio::sync::Mutex`] (await-aware, not a `std`/
+/// `parking_lot` one) so `execute_tool_call_erased`'s `&self` receiver can still reach it
+/// mutably. This is the **one deliberate hold-across-`.await`** in the whole design (plan.md
+/// §8): the mutex is per-spawn, has exactly one logical consumer — this sub-agent's own
+/// sequential tool calls — and is never acquired by the parent, the manager, or any sibling.
+/// Treat a second consumer of this mutex as a real Await Discipline defect, not a variation
+/// on this documented exception.
+pub struct PeerToolExecutor {
+    inner: Arc<dyn ErasedToolExecutor>,
+    id: AgentId,
+    router: Arc<PeerRouter>,
+    mailbox_rx: AsyncMutex<mpsc::Receiver<PeerMessage>>,
+    cancel: CancellationToken,
+    progress_at: Option<Arc<AtomicU64>>,
+    sanitizer: ContentSanitizer,
+    exfil_guard: ExfiltrationGuard,
+    max_wait_ms: u64,
+}
+
+impl PeerToolExecutor {
+    /// Wrap `inner`, adding the three peer-messaging tools for the agent addressable as `id`.
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        inner: Arc<dyn ErasedToolExecutor>,
+        id: AgentId,
+        router: Arc<PeerRouter>,
+        mailbox_rx: mpsc::Receiver<PeerMessage>,
+        cancel: CancellationToken,
+        progress_at: Option<Arc<AtomicU64>>,
+        sanitizer: ContentSanitizer,
+        exfil_guard: ExfiltrationGuard,
+        max_wait_ms: u64,
+    ) -> Self {
+        Self {
+            inner,
+            id,
+            router,
+            mailbox_rx: AsyncMutex::new(mailbox_rx),
+            cancel,
+            progress_at,
+            sanitizer,
+            exfil_guard,
+            max_wait_ms,
+        }
+    }
+
+    /// Sanitize and exfiltration-scan one message body before it reaches the LLM (NFR-007).
+    fn sanitize_body(&self, sender_name: &str, body: &str) -> String {
+        let source =
+            ContentSource::new(ContentSourceKind::SubagentPeerMessage).with_identifier(sender_name);
+        let sanitized = self.sanitizer.sanitize(body, source);
+        if !sanitized.injection_flags.is_empty() {
+            tracing::warn!(
+                sender = sender_name,
+                flags = sanitized.injection_flags.len(),
+                "injection patterns detected in peer message body"
+            );
+        }
+        let (cleaned, events) = self.exfil_guard.scan_output(&sanitized.body);
+        if !events.is_empty() {
+            tracing::warn!(
+                sender = sender_name,
+                blocked = events.len(),
+                "exfiltration guard blocked content in peer message body"
+            );
+        }
+        cleaned
+    }
+
+    fn drain_ready(rx: &mut mpsc::Receiver<PeerMessage>, out: &mut Vec<PeerMessage>) {
+        while let Ok(msg) = rx.try_recv() {
+            out.push(msg);
+        }
+    }
+
+    #[tracing::instrument(name = "subagent.mailbox.send_tool", skip(self, call), fields(sender = ?self.id))]
+    async fn handle_send_peer_message(
+        &self,
+        call: &ToolCall,
+    ) -> Result<Option<ToolOutput>, ToolError> {
+        let params: SendPeerMessageParams = deserialize_params(&call.params)?;
+        // Critic round-4 item 5: `target` (and `DeliveryError`'s `Display`, which echoes it
+        // verbatim) is LLM-supplied — hand-rolling this as a format string let a `target`
+        // containing `"` produce malformed JSON or inject a spoofed `"delivered":true` key.
+        // `check_messages`/`list_peers` already build their JSON via `serde_json`; this was
+        // the one inconsistent handler.
+        let summary = match self.router.send(&self.id, &params.target, params.body) {
+            Ok(()) => serde_json::json!({"delivered": true}).to_string(),
+            Err(e) => serde_json::json!({"delivered": false, "error": e.to_string()}).to_string(),
+        };
+        Ok(Some(tool_output(SEND_PEER_MESSAGE, summary)))
+    }
+
+    /// `wait_ms` clamped by config and raced against `cancel.cancelled()`. A periodic
+    /// progress tick during the wait keeps orchestration idle-detection from reaping a
+    /// legitimately-waiting sub-agent (critic round-2 S2).
+    #[tracing::instrument(name = "subagent.mailbox.wait", skip(self, call), fields(agent = ?self.id))]
+    async fn handle_check_messages(
+        &self,
+        call: &ToolCall,
+    ) -> Result<Option<ToolOutput>, ToolError> {
+        let params: CheckMessagesParams = deserialize_params(&call.params)?;
+        let wait_ms = u64::from(params.wait_ms.unwrap_or(0)).min(self.max_wait_ms);
+
+        let mut rx = self.mailbox_rx.lock().await;
+        let mut messages = Vec::new();
+        Self::drain_ready(&mut rx, &mut messages);
+
+        if messages.is_empty() && wait_ms > 0 {
+            let mut ticker = tokio::time::interval(PROGRESS_TICK);
+            ticker.tick().await; // first tick fires immediately — consume it before the loop
+            let sleep = tokio::time::sleep(Duration::from_millis(wait_ms));
+            tokio::pin!(sleep);
+            loop {
+                tokio::select! {
+                    biased;
+                    () = self.cancel.cancelled() => break,
+                    recv_result = rx.recv() => {
+                        if let Some(msg) = recv_result {
+                            messages.push(msg);
+                            Self::drain_ready(&mut rx, &mut messages);
+                        }
+                        break;
+                    }
+                    _ = ticker.tick() => {
+                        crate::agent_loop::record_progress(self.progress_at.as_ref());
+                    }
+                    () = &mut sleep => break,
+                }
+            }
+        }
+
+        drop(rx);
+
+        // Critic round-4 M8: a `remaining` count computed here would be structurally always
+        // 0 outside a same-instant race — both `drain_ready` calls above (the initial drain
+        // and, on the wait path, the post-delivery drain) already exhaust the mailbox before
+        // this point, so it would read to the LLM as "call me again" when that's essentially
+        // never true. Dropped rather than shipped as a misleading field.
+        let views: Vec<MessageView> = messages
+            .into_iter()
+            .map(|m| MessageView {
+                body: self.sanitize_body(&m.sender_name, &m.body),
+                sender: m.sender_name,
+                sent_at: m.sent_at.to_rfc3339(),
+            })
+            .collect();
+
+        let summary = serde_json::to_string(&serde_json::json!({ "messages": views }))
+            .unwrap_or_else(|_| "{\"messages\":[]}".to_owned());
+
+        Ok(Some(tool_output(CHECK_MESSAGES, summary)))
+    }
+
+    fn handle_list_peers(&self) -> ToolOutput {
+        let views: Vec<PeerView> = self
+            .router
+            .peers_for(&self.id)
+            .into_iter()
+            .map(|p| PeerView {
+                // Critic round-4 S1: must be the exact string `resolve_target` accepts back
+                // as `send_peer_message`'s `target` argument — `AgentId`'s `{:?}` form (e.g.
+                // `Task("9f2c-...")`) is not parseable and, worse, `resolve_target` would
+                // then fall through to a *name* match, so two sub-agents spawned from the
+                // same definition (sharing a display name) become mutually unaddressable.
+                // `Task`'s payload *is* the task_id `resolve_target` matches first; a `Root`
+                // has no task_id, so its name (already unique — one root per group) is the
+                // only resolvable string for it.
+                id: match &p.id {
+                    AgentId::Task(task_id) => task_id.clone(),
+                    AgentId::Root(_) => p.name.clone(),
+                },
+                name: p.name,
+                relation: match p.relation {
+                    super::PeerRelation::Parent => "parent",
+                    super::PeerRelation::Sibling => "sibling",
+                    super::PeerRelation::Child => "child",
+                },
+            })
+            .collect();
+        let summary = serde_json::to_string(&views).unwrap_or_else(|_| "[]".to_owned());
+        tool_output(LIST_PEERS, summary)
+    }
+
+    async fn dispatch(&self, call: &ToolCall) -> Result<Option<ToolOutput>, ToolError> {
+        match call.tool_id.as_str() {
+            SEND_PEER_MESSAGE => self.handle_send_peer_message(call).await,
+            CHECK_MESSAGES => self.handle_check_messages(call).await,
+            LIST_PEERS => Ok(Some(self.handle_list_peers())),
+            _ => unreachable!("dispatch only called for is_peer_tool ids"),
+        }
+    }
+}
+
+impl ErasedToolExecutor for PeerToolExecutor {
+    fn execute_erased<'a>(
+        &'a self,
+        response: &'a str,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a>,
+    > {
+        self.inner.execute_erased(response)
+    }
+
+    fn execute_confirmed_erased<'a>(
+        &'a self,
+        response: &'a str,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a>,
+    > {
+        self.inner.execute_confirmed_erased(response)
+    }
+
+    fn tool_definitions_erased(&self) -> Vec<ToolDef> {
+        let mut defs = self.inner.tool_definitions_erased();
+        defs.push(ToolDef {
+            id: SEND_PEER_MESSAGE.into(),
+            description: "Send a message to another addressable agent (your spawner or a \
+                          sibling sub-agent) by task_id or display name. Use list_peers to \
+                          discover who you may address. The recipient does not need to \
+                          terminate or be respawned to receive it."
+                .into(),
+            schema: schemars::schema_for!(SendPeerMessageParams),
+            invocation: InvocationHint::ToolCall,
+            output_schema: None,
+            server_id: None,
+        });
+        defs.push(ToolDef {
+            id: CHECK_MESSAGES.into(),
+            description: "Drain your inbound peer-message mailbox. With wait_ms unset or 0, \
+                          returns immediately (empty list if nothing is queued). With wait_ms \
+                          set, parks for up to that many milliseconds for a message to arrive \
+                          before returning, so you can wait for a reply in a single turn."
+                .into(),
+            schema: schemars::schema_for!(CheckMessagesParams),
+            invocation: InvocationHint::ToolCall,
+            output_schema: None,
+            server_id: None,
+        });
+        defs.push(ToolDef {
+            id: LIST_PEERS.into(),
+            description: "List the addressable agents (your spawner and sibling sub-agents) \
+                          you are authorized to message, with their relation to you."
+                .into(),
+            schema: schemars::schema_for!(ListPeersParams),
+            invocation: InvocationHint::ToolCall,
+            output_schema: None,
+            server_id: None,
+        });
+        defs
+    }
+
+    fn execute_tool_call_erased<'a>(
+        &'a self,
+        call: &'a ToolCall,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a>,
+    > {
+        if is_peer_tool(call.tool_id.as_str()) {
+            return Box::pin(self.dispatch(call));
+        }
+        self.inner.execute_tool_call_erased(call)
+    }
+
+    fn execute_tool_call_confirmed_erased<'a>(
+        &'a self,
+        call: &'a ToolCall,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a>,
+    > {
+        if is_peer_tool(call.tool_id.as_str()) {
+            return Box::pin(self.dispatch(call));
+        }
+        self.inner.execute_tool_call_confirmed_erased(call)
+    }
+
+    fn set_skill_env(&self, env: Option<std::collections::HashMap<String, String>>) {
+        self.inner.set_skill_env(env);
+    }
+
+    fn set_effective_trust(&self, level: zeph_tools::SkillTrustLevel) {
+        self.inner.set_effective_trust(level);
+    }
+
+    fn is_tool_retryable_erased(&self, tool_id: &str) -> bool {
+        if is_peer_tool(tool_id) {
+            // send_peer_message is side-effecting; check_messages is a destructive drain —
+            // retrying either could duplicate a send or silently skip messages already
+            // consumed. Neither is safe to retry.
+            return false;
+        }
+        self.inner.is_tool_retryable_erased(tool_id)
+    }
+
+    fn requires_confirmation_erased(&self, call: &ToolCall) -> bool {
+        if is_peer_tool(call.tool_id.as_str()) {
+            return false;
+        }
+        self.inner.requires_confirmation_erased(call)
+    }
+
+    fn checkpoint_undo_erased(&self, n: usize) -> CheckpointActionResult {
+        self.inner.checkpoint_undo_erased(n)
+    }
+
+    fn checkpoint_redo_erased(&self) -> CheckpointActionResult {
+        self.inner.checkpoint_redo_erased()
+    }
+
+    fn checkpoint_list_erased(&self) -> CheckpointListResult {
+        self.inner.checkpoint_list_erased()
+    }
+
+    fn is_tool_speculatable_erased(&self, tool_id: &str) -> bool {
+        if is_peer_tool(tool_id) {
+            return false;
+        }
+        self.inner.is_tool_speculatable_erased(tool_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::Ordering;
+
+    use zeph_config::PeerMessagingConfig;
+    use zeph_sanitizer::ContentIsolationConfig;
+    use zeph_sanitizer::exfiltration::ExfiltrationGuardConfig;
+
+    use super::*;
+    use crate::peer::{PeerGroupId, PeerRouter};
+
+    struct NoopExecutor;
+
+    impl ErasedToolExecutor for NoopExecutor {
+        fn execute_erased<'a>(
+            &'a self,
+            _response: &'a str,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a,
+            >,
+        > {
+            Box::pin(std::future::ready(Ok(None)))
+        }
+
+        fn execute_confirmed_erased<'a>(
+            &'a self,
+            _response: &'a str,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a,
+            >,
+        > {
+            Box::pin(std::future::ready(Ok(None)))
+        }
+
+        fn tool_definitions_erased(&self) -> Vec<ToolDef> {
+            vec![]
+        }
+
+        fn execute_tool_call_erased<'a>(
+            &'a self,
+            _call: &'a ToolCall,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = Result<Option<ToolOutput>, ToolError>> + Send + 'a,
+            >,
+        > {
+            Box::pin(std::future::ready(Ok(None)))
+        }
+
+        fn is_tool_retryable_erased(&self, _tool_id: &str) -> bool {
+            false
+        }
+
+        zeph_tools::erased_tool_executor_no_inner_defaults!();
+    }
+
+    fn call(tool_id: &str, params: serde_json::Value) -> ToolCall {
+        let params = match params {
+            serde_json::Value::Object(map) => map,
+            _ => serde_json::Map::new(),
+        };
+        ToolCall {
+            tool_id: tool_id.into(),
+            params,
+            caller_id: None,
+            context: None,
+            tool_call_id: String::new(),
+            skill_name: None,
+        }
+    }
+
+    fn make_executor(
+        id: AgentId,
+        router: Arc<PeerRouter>,
+        rx: mpsc::Receiver<PeerMessage>,
+        cancel: CancellationToken,
+        progress_at: Option<Arc<AtomicU64>>,
+    ) -> PeerToolExecutor {
+        PeerToolExecutor::new(
+            Arc::new(NoopExecutor),
+            id,
+            router,
+            rx,
+            cancel,
+            progress_at,
+            ContentSanitizer::new(&ContentIsolationConfig::default()),
+            ExfiltrationGuard::new(ExfiltrationGuardConfig::default()),
+            30_000,
+        )
+    }
+
+    #[test]
+    fn tool_definitions_include_the_three_peer_tools_plus_inner() {
+        let router = PeerRouter::new(PeerMessagingConfig::default(), None);
+        let (_reg, rx) = router.register(
+            AgentId::Task("t1".into()),
+            "t1".into(),
+            None,
+            PeerGroupId::Session,
+        );
+        let exec = make_executor(
+            AgentId::Task("t1".into()),
+            router,
+            rx,
+            CancellationToken::new(),
+            None,
+        );
+        let ids: Vec<String> = exec
+            .tool_definitions_erased()
+            .into_iter()
+            .map(|d| d.id.into_owned())
+            .collect();
+        assert!(ids.contains(&SEND_PEER_MESSAGE.to_owned()));
+        assert!(ids.contains(&CHECK_MESSAGES.to_owned()));
+        assert!(ids.contains(&LIST_PEERS.to_owned()));
+    }
+
+    #[tokio::test]
+    async fn non_peer_tool_is_forwarded_to_inner_unchanged() {
+        let router = PeerRouter::new(PeerMessagingConfig::default(), None);
+        let (_reg, rx) = router.register(
+            AgentId::Task("t1".into()),
+            "t1".into(),
+            None,
+            PeerGroupId::Session,
+        );
+        let exec = make_executor(
+            AgentId::Task("t1".into()),
+            router,
+            rx,
+            CancellationToken::new(),
+            None,
+        );
+        let result = exec
+            .execute_tool_call_erased(&call("bash", serde_json::json!({})))
+            .await;
+        assert!(
+            result.unwrap().is_none(),
+            "NoopExecutor always returns None"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_peer_message_reports_delivered_true() {
+        let router = PeerRouter::new(PeerMessagingConfig::default(), None);
+        let (root_reg, root_rx) = router.register(
+            AgentId::Root(PeerGroupId::Session),
+            "spawner".into(),
+            None,
+            PeerGroupId::Session,
+        );
+        drop(root_rx);
+        let (a_reg, a_rx) = router.register(
+            AgentId::Task("a".into()),
+            "a".into(),
+            Some(root_reg.id().clone()),
+            PeerGroupId::Session,
+        );
+        let (_b_reg, b_rx) = router.register(
+            AgentId::Task("b".into()),
+            "b".into(),
+            Some(root_reg.id().clone()),
+            PeerGroupId::Session,
+        );
+        let exec_a = make_executor(
+            AgentId::Task("a".into()),
+            Arc::clone(&router),
+            a_rx,
+            CancellationToken::new(),
+            None,
+        );
+        let _exec_b = make_executor(
+            AgentId::Task("b".into()),
+            router,
+            b_rx,
+            CancellationToken::new(),
+            None,
+        );
+        let out = exec_a
+            .execute_tool_call_erased(&call(
+                SEND_PEER_MESSAGE,
+                serde_json::json!({"target": "b", "body": "hi"}),
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(out.summary.contains("\"delivered\":true"));
+        drop(a_reg);
+    }
+
+    #[tokio::test]
+    async fn send_peer_message_round_trip_addressed_by_list_peers_returned_id() {
+        // Critic round-4 item 8: the only prior US-001 coverage sent via
+        // `router.send(...)` directly with the raw `task_id`, bypassing the decorator
+        // entirely — so S1's `list_peers` Debug-format bug (a value that couldn't be fed
+        // back into `send_peer_message`) went uncaught. This test drives the real
+        // decorator round trip end to end, and deliberately uses two sub-agents that share
+        // the same *display name* (US-001's own "researcher"/"implementer" scenario, both
+        // spawned from one `SubAgentDef`) so a name-based `id` would make them mutually
+        // unaddressable — proving `list_peers` must return the `task_id`, not the name.
+        let router = PeerRouter::new(PeerMessagingConfig::default(), None);
+        let (root_reg, root_rx) = router.register(
+            AgentId::Root(PeerGroupId::Session),
+            "spawner".into(),
+            None,
+            PeerGroupId::Session,
+        );
+        drop(root_rx);
+        let (a_reg, a_rx) = router.register(
+            AgentId::Task("task-a".into()),
+            "shared-name".into(),
+            Some(root_reg.id().clone()),
+            PeerGroupId::Session,
+        );
+        let (_b_reg, b_rx) = router.register(
+            AgentId::Task("task-b".into()),
+            "shared-name".into(),
+            Some(root_reg.id().clone()),
+            PeerGroupId::Session,
+        );
+        let exec_a = make_executor(
+            AgentId::Task("task-a".into()),
+            Arc::clone(&router),
+            a_rx,
+            CancellationToken::new(),
+            None,
+        );
+        let exec_b = make_executor(
+            AgentId::Task("task-b".into()),
+            router,
+            b_rx,
+            CancellationToken::new(),
+            None,
+        );
+
+        // Discover the target through list_peers, exactly as an LLM would.
+        let peers_out = exec_a
+            .execute_tool_call_erased(&call(LIST_PEERS, serde_json::json!({})))
+            .await
+            .unwrap()
+            .unwrap();
+        let peers: serde_json::Value = serde_json::from_str(&peers_out.summary).unwrap();
+        let sibling_id = peers
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|p| p["relation"] == "sibling")
+            .expect("sibling listed")["id"]
+            .as_str()
+            .unwrap()
+            .to_owned();
+        assert_eq!(
+            sibling_id, "task-b",
+            "list_peers must return the resolvable task_id, not a name that collides"
+        );
+
+        let send_out = exec_a
+            .execute_tool_call_erased(&call(
+                SEND_PEER_MESSAGE,
+                serde_json::json!({"target": sibling_id, "body": "redirect"}),
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(send_out.summary.contains("\"delivered\":true"));
+
+        let recv_out = exec_b
+            .execute_tool_call_erased(&call(CHECK_MESSAGES, serde_json::json!({})))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(recv_out.summary.contains("redirect"));
+        drop(a_reg);
+    }
+
+    #[tokio::test]
+    async fn check_messages_empty_drain_returns_empty_list_not_error() {
+        let router = PeerRouter::new(PeerMessagingConfig::default(), None);
+        let (_reg, rx) = router.register(
+            AgentId::Task("t1".into()),
+            "t1".into(),
+            None,
+            PeerGroupId::Session,
+        );
+        let exec = make_executor(
+            AgentId::Task("t1".into()),
+            router,
+            rx,
+            CancellationToken::new(),
+            None,
+        );
+        let out = exec
+            .execute_tool_call_erased(&call(CHECK_MESSAGES, serde_json::json!({})))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(out.summary.contains("\"messages\":[]"));
+    }
+
+    #[tokio::test]
+    async fn check_messages_preserves_arrival_order() {
+        let router = PeerRouter::new(PeerMessagingConfig::default(), None);
+        let (root_reg, root_rx) = router.register(
+            AgentId::Root(PeerGroupId::Session),
+            "spawner".into(),
+            None,
+            PeerGroupId::Session,
+        );
+        let (_child_reg, child_rx) = router.register(
+            AgentId::Task("child".into()),
+            "child".into(),
+            Some(root_reg.id().clone()),
+            PeerGroupId::Session,
+        );
+        drop(root_rx);
+        router
+            .send(root_reg.id(), "child", "first".into())
+            .expect("send 1");
+        router
+            .send(root_reg.id(), "child", "second".into())
+            .expect("send 2");
+
+        let exec = make_executor(
+            AgentId::Task("child".into()),
+            router,
+            child_rx,
+            CancellationToken::new(),
+            None,
+        );
+        let out = exec
+            .execute_tool_call_erased(&call(CHECK_MESSAGES, serde_json::json!({})))
+            .await
+            .unwrap()
+            .unwrap();
+        let first_idx = out.summary.find("first").expect("first present");
+        let second_idx = out.summary.find("second").expect("second present");
+        assert!(first_idx < second_idx, "arrival order must be preserved");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn check_messages_wait_returns_early_on_delivery() {
+        let router = PeerRouter::new(PeerMessagingConfig::default(), None);
+        let (root_reg, root_rx) = router.register(
+            AgentId::Root(PeerGroupId::Session),
+            "spawner".into(),
+            None,
+            PeerGroupId::Session,
+        );
+        let (_child_reg, child_rx) = router.register(
+            AgentId::Task("child".into()),
+            "child".into(),
+            Some(root_reg.id().clone()),
+            PeerGroupId::Session,
+        );
+        drop(root_rx);
+        let exec = make_executor(
+            AgentId::Task("child".into()),
+            Arc::clone(&router),
+            child_rx,
+            CancellationToken::new(),
+            None,
+        );
+
+        let wait = tokio::spawn(async move {
+            exec.execute_tool_call_erased(&call(
+                CHECK_MESSAGES,
+                serde_json::json!({"wait_ms": 30_000}),
+            ))
+            .await
+        });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        router
+            .send(root_reg.id(), "child", "reply".into())
+            .expect("send while waiting");
+
+        let out = tokio::time::timeout(Duration::from_secs(5), wait)
+            .await
+            .expect("must not hit the outer test timeout")
+            .expect("task join")
+            .unwrap()
+            .unwrap();
+        assert!(out.summary.contains("reply"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn check_messages_wait_times_out_to_empty() {
+        let router = PeerRouter::new(PeerMessagingConfig::default(), None);
+        let (_reg, rx) = router.register(
+            AgentId::Task("t1".into()),
+            "t1".into(),
+            None,
+            PeerGroupId::Session,
+        );
+        let exec = make_executor(
+            AgentId::Task("t1".into()),
+            router,
+            rx,
+            CancellationToken::new(),
+            None,
+        );
+        let check_call = call(CHECK_MESSAGES, serde_json::json!({"wait_ms": 200}));
+        let call_fut = exec.execute_tool_call_erased(&check_call);
+        tokio::pin!(call_fut);
+        tokio::time::advance(Duration::from_millis(250)).await;
+        let out = call_fut.await.unwrap().unwrap();
+        assert!(out.summary.contains("\"messages\":[]"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn check_messages_wait_aborts_immediately_on_cancellation() {
+        let router = PeerRouter::new(PeerMessagingConfig::default(), None);
+        let (_reg, rx) = router.register(
+            AgentId::Task("t1".into()),
+            "t1".into(),
+            None,
+            PeerGroupId::Session,
+        );
+        let cancel = CancellationToken::new();
+        let exec = make_executor(AgentId::Task("t1".into()), router, rx, cancel.clone(), None);
+        cancel.cancel();
+        let out = tokio::time::timeout(
+            Duration::from_secs(1),
+            exec.execute_tool_call_erased(&call(
+                CHECK_MESSAGES,
+                serde_json::json!({"wait_ms": 30_000}),
+            )),
+        )
+        .await
+        .expect("cancellation must return immediately, not after the 30s wait");
+        assert!(out.unwrap().unwrap().summary.contains("\"messages\":[]"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn check_messages_wait_records_progress_ticks() {
+        let router = PeerRouter::new(PeerMessagingConfig::default(), None);
+        let (_reg, rx) = router.register(
+            AgentId::Task("t1".into()),
+            "t1".into(),
+            None,
+            PeerGroupId::Session,
+        );
+        // Seed with a sentinel a real `monotonic_millis()` reading can never produce (0 is
+        // not safe here — a paused-clock test executes in well under 1ms of real wall-clock
+        // time, so `record_progress`'s real-time write can legitimately read back as 0 even
+        // though it fired; see `agent_loop::record_progress_tests` for the same pitfall).
+        let progress = Arc::new(AtomicU64::new(u64::MAX));
+        let exec = make_executor(
+            AgentId::Task("t1".into()),
+            router,
+            rx,
+            CancellationToken::new(),
+            Some(Arc::clone(&progress)),
+        );
+        let exec = Arc::new(exec);
+        let exec_for_task = Arc::clone(&exec);
+        let handle = tokio::spawn(async move {
+            let check_call = call(CHECK_MESSAGES, serde_json::json!({"wait_ms": 20_000}));
+            exec_for_task.execute_tool_call_erased(&check_call).await
+        });
+        // `tokio::time::sleep` (unlike a bare `advance`) actually yields to the runtime under
+        // `start_paused = true`, letting the spawned task run far enough to register its
+        // timers before the virtual clock moves.
+        tokio::time::sleep(Duration::from_secs(12)).await;
+        assert_ne!(
+            progress.load(Ordering::Relaxed),
+            u64::MAX,
+            "a progress tick must have fired during the wait"
+        );
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        let _ = handle.await;
+    }
+
+    #[tokio::test]
+    async fn list_peers_returns_only_peers_for_self() {
+        let router = PeerRouter::new(PeerMessagingConfig::default(), None);
+        let (root_reg, root_rx) = router.register(
+            AgentId::Root(PeerGroupId::Session),
+            "spawner".into(),
+            None,
+            PeerGroupId::Session,
+        );
+        let (child_reg, child_rx) = router.register(
+            AgentId::Task("child".into()),
+            "child".into(),
+            Some(root_reg.id().clone()),
+            PeerGroupId::Session,
+        );
+        drop(root_rx);
+        let exec = make_executor(
+            child_reg.id().clone(),
+            router,
+            child_rx,
+            CancellationToken::new(),
+            None,
+        );
+        let out = exec
+            .execute_tool_call_erased(&call(LIST_PEERS, serde_json::json!({})))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(out.summary.contains("spawner"));
+        assert!(out.summary.contains("parent"));
+    }
+}

--- a/crates/zeph-tui/src/widgets/subagents.rs
+++ b/crates/zeph-tui/src/widgets/subagents.rs
@@ -73,6 +73,13 @@ fn build_agent_line(sa: &SubAgentMetrics, tick: u8, selected: bool, ascii: bool)
         "accept_edits" => " [accept_edits]",
         _ => "",
     };
+    // FR-010 (spec 046-subagent-peer-messaging-parity): visible unread-message badge,
+    // cleared once `check_messages` drains the mailbox (mailbox_depth returns to 0).
+    let msg_badge = if sa.unread_messages > 0 {
+        format!(" [msg:{}]", sa.unread_messages)
+    } else {
+        String::new()
+    };
 
     let base_style = if selected {
         Style::default().add_modifier(Modifier::REVERSED)
@@ -83,7 +90,7 @@ fn build_agent_line(sa: &SubAgentMetrics, tick: u8, selected: bool, ascii: bool)
     Line::from(vec![
         Span::styled(format!(" {spinner} "), Style::default().fg(color)),
         Span::styled(
-            format!("{}{}{}", sa.name, bg_marker, perm_badge),
+            format!("{}{}{}{}", sa.name, bg_marker, perm_badge, msg_badge),
             base_style,
         ),
         Span::styled(
@@ -1117,6 +1124,7 @@ mod tests {
                     permission_mode: String::new(),
                     transcript_dir: None,
                     live_transcript: Vec::new(),
+                    unread_messages: 0,
                 },
                 SubAgentMetrics {
                     id: "def456".into(),
@@ -1129,6 +1137,7 @@ mod tests {
                     permission_mode: "dont_ask".into(),
                     transcript_dir: None,
                     live_transcript: Vec::new(),
+                    unread_messages: 0,
                 },
             ],
             ..MetricsSnapshot::default()
@@ -1161,6 +1170,7 @@ mod tests {
                     permission_mode: "plan".into(),
                     transcript_dir: None,
                     live_transcript: Vec::new(),
+                    unread_messages: 0,
                 },
                 SubAgentMetrics {
                     id: "b".into(),
@@ -1173,6 +1183,7 @@ mod tests {
                     permission_mode: "bypass_permissions".into(),
                     transcript_dir: None,
                     live_transcript: Vec::new(),
+                    unread_messages: 0,
                 },
             ],
             ..MetricsSnapshot::default()
@@ -1209,6 +1220,7 @@ mod tests {
                     permission_mode: String::new(),
                     transcript_dir: None,
                     live_transcript: Vec::new(),
+                    unread_messages: 0,
                 },
                 SubAgentMetrics {
                     id: "b".into(),
@@ -1221,6 +1233,7 @@ mod tests {
                     permission_mode: String::new(),
                     transcript_dir: None,
                     live_transcript: Vec::new(),
+                    unread_messages: 0,
                 },
             ],
             ..MetricsSnapshot::default()
@@ -1245,6 +1258,7 @@ mod tests {
                     permission_mode: String::new(),
                     transcript_dir: None,
                     live_transcript: Vec::new(),
+                    unread_messages: 0,
                 })
                 .collect(),
             ..MetricsSnapshot::default()
@@ -1274,6 +1288,7 @@ mod tests {
             permission_mode: String::new(),
             transcript_dir: None,
             live_transcript,
+            unread_messages: 0,
         }
     }
 
@@ -1303,6 +1318,49 @@ mod tests {
         );
         assert!(output.contains("first forwarded turn"));
         assert!(output.contains("second forwarded turn"));
+    }
+
+    #[test]
+    fn build_agent_line_shows_unread_badge_when_nonzero() {
+        let sa = SubAgentMetrics {
+            id: "abc".into(),
+            name: "helper".into(),
+            state: "working".into(),
+            turns_used: 1,
+            max_turns: 5,
+            background: false,
+            elapsed_secs: 1,
+            permission_mode: String::new(),
+            transcript_dir: None,
+            live_transcript: Vec::new(),
+            unread_messages: 2,
+        };
+        let line = super::build_agent_line(&sa, 0, false, true);
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(
+            text.contains("[msg:2]"),
+            "expected unread badge, got: {text:?}"
+        );
+    }
+
+    #[test]
+    fn build_agent_line_omits_unread_badge_when_zero() {
+        let sa = SubAgentMetrics {
+            id: "abc".into(),
+            name: "helper".into(),
+            state: "working".into(),
+            turns_used: 1,
+            max_turns: 5,
+            background: false,
+            elapsed_secs: 1,
+            permission_mode: String::new(),
+            transcript_dir: None,
+            live_transcript: Vec::new(),
+            unread_messages: 0,
+        };
+        let line = super::build_agent_line(&sa, 0, false, true);
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(!text.contains("[msg:"), "no badge expected, got: {text:?}");
     }
 
     #[test]

--- a/src/init/agents.rs
+++ b/src/init/agents.rs
@@ -273,6 +273,14 @@ pub(super) fn step_agents(state: &mut WizardState) -> anyhow::Result<()> {
         .default(false)
         .interact()?;
 
+    state.agents_peer_messaging_enabled = Confirm::new()
+        .with_prompt(
+            "Enable live inter-sub-agent messaging (send_peer_message/check_messages tools, \
+             /agent msg)? See [agents.peer_messaging] in config.toml for capacity/limit knobs.",
+        )
+        .default(true)
+        .interact()?;
+
     println!();
     Ok(())
 }

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -119,6 +119,9 @@ pub(crate) struct WizardState {
     /// Forward each running sub-agent's per-turn text/thinking output to an active consumer
     /// surface (issue #6359). Default `false` (opt-in, matches `SubAgentConfig::default()`).
     pub(crate) agents_forward_transcript: bool,
+    /// Enable live inter-sub-agent messaging (spec `046-subagent-peer-messaging-parity`,
+    /// issue #5871). Default `true`, matching `PeerMessagingConfig::default()`.
+    pub(crate) agents_peer_messaging_enabled: bool,
     /// "regex", "judge", or "model" — defaults to "regex" (no LLM calls).
     pub(crate) detector_mode: Option<String>,
     pub(crate) judge_model: Option<String>,
@@ -453,6 +456,7 @@ impl Default for WizardState {
             agents_user_dir: None,
             agents_default_memory_scope: None,
             agents_forward_transcript: false,
+            agents_peer_messaging_enabled: true,
             detector_mode: None,
             judge_model: None,
             feedback_provider: None,
@@ -1242,6 +1246,7 @@ pub(crate) fn build_config(state: &WizardState) -> Config {
         .clone_from(&state.agents_user_dir);
     config.agents.default_memory_scope = state.agents_default_memory_scope;
     config.agents.forward_transcript = state.agents_forward_transcript;
+    config.agents.peer_messaging.enabled = state.agents_peer_messaging_enabled;
 
     // Worktree isolation for sub-agents (#4656)
     if state.worktree_enabled {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -3311,6 +3311,10 @@ pub(crate) async fn run(mut cli: Cli) -> anyhow::Result<()> {
         // switch — `effective_delegation_mode` folds it in so `SubAgentManager` itself only
         // ever sees the already-resolved value and does not need to re-read `enabled` (FR-002).
         mgr.set_delegation_mode(agents_config.effective_delegation_mode());
+        // Spec 046-subagent-peer-messaging-parity: reconfigure the peer-messaging router from
+        // the resolved config before any spawn (must precede the first `spawn()` call, per
+        // `set_peer_messaging_config`'s own doc comment).
+        mgr.set_peer_messaging_config(agents_config.peer_messaging.clone());
 
         // Bootstrap the worktree subsystem when enabled (hard-fail per spec NEVER #92).
         if agents_config.worktree.enabled && !exec_mode.bare {


### PR DESCRIPTION
## Summary

Adds live, addressable messaging between concurrently spawned sub-agents and their spawner — a gap identified by competitive parity analysis against Claude Code's own Agent Teams feature (spec `046-subagent-peer-messaging-parity`).

- New `send_peer_message`/`check_messages`/`list_peers` tools on every spawned sub-agent, plus `/agent msg`/`/agent inbox` slash commands on the parent.
- Routing lives in a new `Arc`-shared `PeerRouter` (`crates/zeph-subagent/src/peer/`), independent of `SubAgentManager` ownership — a running sub-agent cannot reach `&mut SubAgentManager`, so the router is the addressing plane while the manager remains the ownership plane.
- Authorization is deny-by-default across spawn-tree roots (the interactive session is one root, each orchestration plan execution is another), so a sub-agent cannot address or discover an agent outside its own tree.
- Peer message bodies are sanitized and pass through an exfiltration guard before reaching an LLM; they are never auto-injected into context (explicit tool poll only). Secrets granted to a sub-agent are masked before being relayed to a peer.
- No new `tokio::spawn` call sites — the transport is bounded `mpsc` channels riding on already-supervised agent-loop tasks.
- New `[agents.peer_messaging]` config section, `--init` wizard prompt, `--migrate-config` step, and a TUI unread-message badge.

## Process notes

This went through four adversarial review rounds before merge:
1. Initial plan rejected (`critical`) — the original design put a mailbox on `SubAgentHandle` that a running sub-agent structurally could not reach.
2. Redesigned around the `Arc<PeerRouter>` split; re-reviewed (`minor` then `significant` on a deeper pass) for wiring gaps in secret-registry propagation and exfiltration-guard config plumbing.
3. Implementation reviewed by parallel test/perf/security/adversarial-critic passes, which found 4 real defects in the shipped code: an unusable peer-addressing scheme, a missing authorization root for orchestration-plan sub-agents, a cross-group name/existence leak, and a `resume()`-only config regression.
4. All four fixed and independently re-verified before this PR was opened.

Full spec/plan/tasks package: `.local/specs/046-subagent-peer-messaging-parity/` (local, not committed — referenced here for anyone continuing this work).

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (15487 passed, 0 failed)
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links"`) clean
- [x] `cargo test --doc --workspace` clean
- [x] Async-supervision / blocking-pattern scans unchanged from baseline (67/64, both pre-existing drift on `main`, not introduced by this PR)
- [ ] Live session verification (playbook: `.local/testing/playbooks/subagent-peer-messaging.md`) — not run this session, recommended before/around merge

Closes #5871