### PR TITLE
refactor(llm): consolidate ToolUse/ToolResult orphan-pairing repair into a shared helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `zeph-core`: rendered the `<shared-state>` prompt block as NDJSON instead of
   `"{key}: {value}"` lines, closing a pseudo-row-forging gap for values containing a
   literal newline (#6775, #6779).
+- `zeph-core`: fixed `trim_parent_messages` matching orphaned `ToolUse`/`ToolResult` parts
+  against a global id set instead of adjacency, which could cross-pair an orphan against an
+  unrelated tool call sharing its id under Ollama-style batch-index id reuse (#6770).
 
 ### Added
 
@@ -74,6 +77,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Consolidated five independent `ToolUse`/`ToolResult` orphan-pairing implementations
+  (`zeph-core::agent::subagent_commands::trim_parent_messages`,
+  `zeph-core::agent::shutdown::flush_orphaned_tool_use_on_shutdown`,
+  `zeph-subagent::agent_loop::trim_message_history`,
+  `zeph-agent-persistence::sanitize::sanitize_tool_pairs`, and the Claude request builder) into a
+  shared `zeph_llm::tool_pairing` module, all adjacency-scoped against the immediately
+  preceding/following non-system message rather than a global id set. Also closes a Claude
+  request-builder gap (#6771) where an empty content-block array could be sent to the API on
+  certain orphan/thinking-only user messages, and a trailing unanswered `ToolUse` is now repaired
+  everywhere instead of being exempted only at some call sites. **Breaking**:
+  `zeph_agent_persistence::sanitize::has_meaningful_content` (a `pub fn`) is removed — relocated
+  to `zeph_llm::tool_pairing::has_meaningful_content`, with no re-export.
 - Raised the workspace MSRV to Rust 1.98 and resolved the new `clippy::unused_async_trait_impl` /
   `clippy::chunks_exact_to_as_chunks` lints introduced by it (#6746, #6748).
 - `release.yml`: removed `Swatinem/rust-cache` and `sccache` from the `build-binaries` job.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   literal newline (#6775, #6779).
 - `zeph-core`: fixed `trim_parent_messages` matching orphaned `ToolUse`/`ToolResult` parts
   against a global id set instead of adjacency, which could cross-pair an orphan against an
-  unrelated tool call sharing its id under Ollama-style batch-index id reuse (#6770).
+  unrelated tool call sharing its id under Ollama-style batch-index id reuse (#6770, #6780).
 
 ### Added
 
@@ -88,7 +88,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   certain orphan/thinking-only user messages, and a trailing unanswered `ToolUse` is now repaired
   everywhere instead of being exempted only at some call sites. **Breaking**:
   `zeph_agent_persistence::sanitize::has_meaningful_content` (a `pub fn`) is removed — relocated
-  to `zeph_llm::tool_pairing::has_meaningful_content`, with no re-export.
+  to `zeph_llm::tool_pairing::has_meaningful_content`, with no re-export (#6780).
 - Raised the workspace MSRV to Rust 1.98 and resolved the new `clippy::unused_async_trait_impl` /
   `clippy::chunks_exact_to_as_chunks` lints introduced by it (#6746, #6748).
 - `release.yml`: removed `Swatinem/rust-cache` and `sccache` from the `build-binaries` job.

--- a/crates/zeph-agent-persistence/src/sanitize.rs
+++ b/crates/zeph-agent-persistence/src/sanitize.rs
@@ -1,29 +1,36 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Tool-pair sanitization helpers: remove orphaned `ToolUse`/`ToolResult` messages from
-//! restored conversation history.
+//! Tool-pair sanitization helpers: remove orphaned `ToolUse`/`ToolResult` parts from restored
+//! conversation history.
 //!
 //! These are pure functions operating on `Vec<Message>` slices — no agent state required.
+//! Orphan repair itself delegates to `zeph_llm::tool_pairing` (issue #6771).
+//!
+//! A prior revision of this module also ran a separate duplicate-`ToolResult` sweep after orphan
+//! repair (#5513: a `tool_use_id` that already received a result earlier in the same open call
+//! window, re-appearing later — e.g. from a cancellation-handling defect that wrote more than one
+//! tombstone for the same call). That sweep is now provably unreachable and was removed: after
+//! [`zeph_llm::tool_pairing::repair_tool_pairs`] with [`OrphanAction::Delete`], every surviving
+//! `ToolResult(X)` has, by [`unmatched_tool_result_ids`](zeph_llm::tool_pairing::unmatched_tool_result_ids)'s
+//! own definition, an `Assistant` message carrying `ToolUse(X)` as its immediately preceding
+//! non-system message — so any #5513 shape is already caught by adjacency repair itself, which
+//! never depended on a cross-message "already resolved" id set in the first place (that is
+//! exactly the global-vs-adjacency distinction issue #6770 is about). The `#5513` regression
+//! tests below are kept: they now document that adjacency repair alone handles duplicate/reopened
+//! `tool_use_id`s correctly, without needing a second bookkeeping pass.
 
-use std::collections::HashSet;
+use zeph_llm::provider::Message;
+use zeph_llm::tool_pairing::{self, OrphanAction};
 
-use zeph_llm::provider::{Message, MessagePart, Role};
-
-/// Remove orphaned `ToolUse`/`ToolResult` messages from restored history.
+/// Remove orphaned `ToolUse`/`ToolResult` parts from restored history.
 ///
-/// Four failure modes are handled:
-/// 1. **Trailing orphan**: the last message is an assistant with `ToolUse` parts but no
-///    subsequent user message with `ToolResult` — caused by LIMIT boundary splits or
-///    interrupted sessions.
-/// 2. **Leading orphan**: the first message is a user with `ToolResult` parts but no
-///    preceding assistant message with `ToolUse` — caused by LIMIT boundary cuts.
-/// 3. **Mid-history orphaned `ToolUse`**: an assistant message with `ToolUse` parts is not
-///    followed by a user message with matching `ToolResult` parts. The `ToolUse` parts are
-///    stripped; if no content remains the message is removed.
-/// 4. **Mid-history orphaned `ToolResult`**: a user message has `ToolResult` parts whose
-///    `tool_use_id` is not present in the preceding assistant message. Those `ToolResult` parts
-///    are stripped; if no content remains the message is removed.
+/// Delegates to [`zeph_llm::tool_pairing::repair_tool_pairs`] with [`OrphanAction::Delete`]: a
+/// `ToolUse` part with no matching `ToolResult` in the immediately following non-system message,
+/// or a `ToolResult` part with no matching `ToolUse` in the immediately preceding non-system
+/// message, is deleted. A message left with no parts and no meaningful content is removed
+/// entirely. Repair is part-level — a message that also carries independent text is kept, only
+/// the orphaned part is stripped (spec-078 FR-003).
 ///
 /// Returns `(removed_count, db_ids)` where `removed_count` is the number of messages removed
 /// entirely and `db_ids` contains `metadata.db_id` values of those messages for `SQLite`
@@ -43,365 +50,19 @@ use zeph_llm::provider::{Message, MessagePart, Role};
 /// assert!(ids.is_empty());
 /// ```
 pub fn sanitize_tool_pairs(messages: &mut Vec<Message>) -> (usize, Vec<i64>) {
-    let mut removed = 0;
-    let mut db_ids: Vec<i64> = Vec::new();
-
-    // Remove trailing orphaned tool_use messages (assistant with ToolUse, no following tool_result).
-    while let Some(last) = messages.last()
-        && last.role == Role::Assistant
-        && last
-            .parts
-            .iter()
-            .any(|p| matches!(p, MessagePart::ToolUse { .. }))
-    {
-        let ids: Vec<String> = last
-            .parts
-            .iter()
-            .filter_map(|p| {
-                if let MessagePart::ToolUse { id, .. } = p {
-                    Some(id.clone())
-                } else {
-                    None
-                }
-            })
-            .collect();
-        tracing::warn!(
-            tool_ids = ?ids,
-            "removing orphaned trailing tool_use message from restored history"
-        );
-        if let Some(db_id) = messages.last().and_then(|m| m.metadata.db_id) {
-            db_ids.push(db_id);
-        }
-        messages.pop();
-        removed += 1;
-    }
-
-    // Count leading orphaned tool_result messages (user with ToolResult, no preceding tool_use),
-    // then drain them in a single O(N) pass instead of repeated O(N) remove(0) calls.
-    let skip_count = messages
+    let report = tool_pairing::repair_tool_pairs(messages, OrphanAction::Delete);
+    let db_ids: Vec<i64> = report
+        .removed_messages
         .iter()
-        .take_while(|m| {
-            m.role == Role::User
-                && m.parts
-                    .iter()
-                    .any(|p| matches!(p, MessagePart::ToolResult { .. }))
-        })
-        .count();
-
-    if skip_count > 0 {
-        for m in messages.iter().take(skip_count) {
-            let ids: Vec<String> = m
-                .parts
-                .iter()
-                .filter_map(|p| {
-                    if let MessagePart::ToolResult { tool_use_id, .. } = p {
-                        Some(tool_use_id.clone())
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-            tracing::warn!(
-                tool_use_ids = ?ids,
-                "removing orphaned leading tool_result message from restored history"
-            );
-            if let Some(db_id) = m.metadata.db_id {
-                db_ids.push(db_id);
-            }
-        }
-        messages.drain(0..skip_count);
-        removed += skip_count;
-    }
-
-    let (mid_removed, mid_db_ids) = strip_mid_history_orphans(messages);
-    removed += mid_removed;
-    db_ids.extend(mid_db_ids);
-
-    (removed, db_ids)
-}
-
-/// Returns `true` if `content` contains human-readable text beyond legacy tool bracket markers.
-///
-/// Legacy markers produced by `Message::flatten_parts` are:
-/// - `[tool_use: name(id)]` — assistant `ToolUse`
-/// - `[tool_result: id]\nbody` — user `ToolResult`
-/// - `[tool output: name] body` — `ToolOutput`
-///
-/// A message whose content consists solely of such markers (and whitespace) has no
-/// user-visible text and is a candidate for soft-delete.
-///
-/// # Examples
-///
-/// ```
-/// use zeph_agent_persistence::sanitize::has_meaningful_content;
-///
-/// assert!(has_meaningful_content("hello world"));
-/// assert!(!has_meaningful_content("[tool_use: bash(abc123)]"));
-/// assert!(!has_meaningful_content("   [tool_result: abc]\nsome output"));
-/// ```
-#[must_use]
-pub fn has_meaningful_content(content: &str) -> bool {
-    const PREFIXES: [&str; 3] = ["[tool_use: ", "[tool_result: ", "[tool output: "];
-
-    let mut remaining = content.trim();
-
-    loop {
-        let next = PREFIXES
-            .iter()
-            .filter_map(|prefix| remaining.find(prefix).map(|pos| (pos, *prefix)))
-            .min_by_key(|(pos, _)| *pos);
-
-        let Some((start, prefix)) = next else {
-            break;
-        };
-
-        if !remaining[..start].trim().is_empty() {
-            return true;
-        }
-
-        let after_prefix = &remaining[start + prefix.len()..];
-        let Some(close) = after_prefix.find(']') else {
-            return true; // Malformed tag — treat as meaningful.
-        };
-
-        let tag_end = start + prefix.len() + close + 1;
-
-        if prefix == "[tool_result: " || prefix == "[tool output: " {
-            let body = remaining[tag_end..].trim_start_matches('\n');
-            let next_tag = PREFIXES
-                .iter()
-                .filter_map(|p| body.find(p))
-                .min()
-                .unwrap_or(body.len());
-            remaining = &body[next_tag..];
-        } else {
-            remaining = &remaining[tag_end..];
-        }
-    }
-
-    !remaining.trim().is_empty()
-}
-
-/// Collect `tool_use` IDs from `msg` that have no matching `ToolResult` in `next_msg`.
-fn orphaned_tool_use_ids(msg: &Message, next_msg: Option<&Message>) -> HashSet<String> {
-    let matched: HashSet<String> = next_msg
-        .filter(|n| n.role == Role::User)
-        .map(|n| {
-            msg.parts
-                .iter()
-                .filter_map(|p| if let MessagePart::ToolUse { id, .. } = p { Some(id.clone()) } else { None })
-                .filter(|uid| n.parts.iter().any(|np| matches!(np, MessagePart::ToolResult { tool_use_id, .. } if tool_use_id == uid)))
-                .collect()
-        })
-        .unwrap_or_default();
-    msg.parts
-        .iter()
-        .filter_map(|p| {
-            if let MessagePart::ToolUse { id, .. } = p
-                && !matched.contains(id)
-            {
-                Some(id.clone())
-            } else {
-                None
-            }
-        })
-        .collect()
-}
-
-/// Collect `tool_result` IDs from `msg` that have no matching `ToolUse` in `prev_msg`.
-fn orphaned_tool_result_ids(msg: &Message, prev_msg: Option<&Message>) -> HashSet<String> {
-    let avail: HashSet<&str> = prev_msg
-        .filter(|p| p.role == Role::Assistant)
-        .map(|p| {
-            p.parts
-                .iter()
-                .filter_map(|part| {
-                    if let MessagePart::ToolUse { id, .. } = part {
-                        Some(id.as_str())
-                    } else {
-                        None
-                    }
-                })
-                .collect()
-        })
-        .unwrap_or_default();
-    msg.parts
-        .iter()
-        .filter_map(|p| {
-            if let MessagePart::ToolResult { tool_use_id, .. } = p
-                && !avail.contains(tool_use_id.as_str())
-            {
-                Some(tool_use_id.clone())
-            } else {
-                None
-            }
-        })
-        .collect()
-}
-
-/// Strips orphaned `ToolUse` parts from `messages[i]` (an assistant message) when unmatched by a
-/// `ToolResult` in the next non-system message. Returns `true` if the message was removed
-/// entirely (caller must not advance past `i`).
-fn strip_orphaned_tool_use_at(
-    messages: &mut Vec<Message>,
-    i: usize,
-    db_ids: &mut Vec<i64>,
-) -> bool {
-    let next_non_system = (i + 1..messages.len())
-        .find(|&j| messages[j].role != Role::System)
-        .and_then(|j| messages.get(j));
-    let orphaned_ids = orphaned_tool_use_ids(&messages[i], next_non_system);
-    if orphaned_ids.is_empty() {
-        return false;
-    }
-    tracing::warn!(
-        tool_ids = ?orphaned_ids,
-        index = i,
-        "stripping orphaned mid-history tool_use parts from assistant message"
-    );
-    messages[i]
-        .parts
-        .retain(|p| !matches!(p, MessagePart::ToolUse { id, .. } if orphaned_ids.contains(id)));
-    let is_empty = !has_meaningful_content(&messages[i].content) && messages[i].parts.is_empty();
-    if is_empty {
-        if let Some(db_id) = messages[i].metadata.db_id {
-            db_ids.push(db_id);
-        }
-        messages.remove(i);
-    }
-    is_empty
-}
-
-/// Strips orphaned and duplicate `ToolResult` parts from `messages[i]` (a user message).
-///
-/// A part is orphaned when unmatched by a `ToolUse` in the previous non-system message, or a
-/// **duplicate** (#5513) when its `tool_use_id` is already in `resolved_tool_use_ids` — i.e. a
-/// `tool_use_id` that already received a result (real or tombstone) earlier in history and shows
-/// up again later, e.g. from a cancellation-handling defect that wrote more than one tombstone for
-/// the same call. Either shape would trip the same "`tool_calls` must be followed by tool
-/// messages" provider error, so both are stripped.
-///
-/// Whatever `ToolResult` parts survive are added to `resolved_tool_use_ids`. Returns `true` if the
-/// message was removed entirely (caller must not advance past `i`).
-fn strip_tool_result_orphans_at(
-    messages: &mut Vec<Message>,
-    i: usize,
-    resolved_tool_use_ids: &mut HashSet<String>,
-    db_ids: &mut Vec<i64>,
-) -> bool {
-    let prev_non_system = (0..i)
-        .rev()
-        .find(|&j| messages[j].role != Role::System)
-        .and_then(|j| messages.get(j));
-    let orphaned_ids = orphaned_tool_result_ids(&messages[i], prev_non_system);
-    let duplicate_ids: HashSet<String> = messages[i]
-        .parts
-        .iter()
-        .filter_map(|p| {
-            if let MessagePart::ToolResult { tool_use_id, .. } = p {
-                Some(tool_use_id.clone())
-            } else {
-                None
-            }
-        })
-        .filter(|id| resolved_tool_use_ids.contains(id))
+        .filter_map(|m| m.metadata.db_id)
         .collect();
-    if !duplicate_ids.is_empty() {
-        tracing::warn!(
-            tool_use_ids = ?duplicate_ids,
-            index = i,
-            "stripping duplicate mid-history tool_result parts from user message"
-        );
-    }
-    if !orphaned_ids.is_empty() {
-        tracing::warn!(
-            tool_use_ids = ?orphaned_ids,
-            index = i,
-            "stripping orphaned mid-history tool_result parts from user message"
-        );
-    }
-    let strip_ids: HashSet<&str> = orphaned_ids
-        .iter()
-        .chain(duplicate_ids.iter())
-        .map(String::as_str)
-        .collect();
-    let mut removed = false;
-    if !strip_ids.is_empty() {
-        messages[i].parts.retain(|p| {
-            !matches!(p, MessagePart::ToolResult { tool_use_id, .. } if strip_ids.contains(tool_use_id.as_str()))
-        });
-        let is_empty =
-            !has_meaningful_content(&messages[i].content) && messages[i].parts.is_empty();
-        if is_empty {
-            if let Some(db_id) = messages[i].metadata.db_id {
-                db_ids.push(db_id);
-            }
-            messages.remove(i);
-            removed = true;
-        }
-    }
-    if !removed {
-        for p in &messages[i].parts {
-            if let MessagePart::ToolResult { tool_use_id, .. } = p {
-                resolved_tool_use_ids.insert(tool_use_id.clone());
-            }
-        }
-    }
-    removed
-}
-
-/// Scan all messages and strip orphaned `ToolUse`/`ToolResult` parts from mid-history messages,
-/// as well as **duplicate** `ToolResult` parts (#5513) — see [`strip_tool_result_orphans_at`].
-///
-/// `resolved_tool_use_ids` is scoped to the current open call window: whenever a `ToolUse(id)`
-/// is encountered, `id` is removed from the set first, since it is being re-opened. Some
-/// providers (e.g. Ollama, which assigns `tool_call` ids as `format!("call_{i}")` by batch
-/// index) legitimately reuse the same `tool_use_id` across turns; without this, a later turn's
-/// real `ToolResult` would be misdetected as a duplicate of an earlier turn's and stripped,
-/// orphaning the later turn's `ToolUse`.
-fn strip_mid_history_orphans(messages: &mut Vec<Message>) -> (usize, Vec<i64>) {
-    let mut removed = 0;
-    let mut db_ids: Vec<i64> = Vec::new();
-    let mut resolved_tool_use_ids: HashSet<String> = HashSet::new();
-    let mut i = 0;
-    while i < messages.len() {
-        if messages[i].role == Role::Assistant
-            && messages[i]
-                .parts
-                .iter()
-                .any(|p| matches!(p, MessagePart::ToolUse { .. }))
-        {
-            for p in &messages[i].parts {
-                if let MessagePart::ToolUse { id, .. } = p {
-                    resolved_tool_use_ids.remove(id);
-                }
-            }
-            if strip_orphaned_tool_use_at(messages, i, &mut db_ids) {
-                removed += 1;
-                continue;
-            }
-        }
-
-        if messages[i].role == Role::User
-            && messages[i]
-                .parts
-                .iter()
-                .any(|p| matches!(p, MessagePart::ToolResult { .. }))
-            && strip_tool_result_orphans_at(messages, i, &mut resolved_tool_use_ids, &mut db_ids)
-        {
-            removed += 1;
-            continue;
-        }
-
-        i += 1;
-    }
-    (removed, db_ids)
+    (report.removed_messages.len(), db_ids)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use zeph_llm::provider::MessageMetadata;
+    use zeph_llm::provider::{MessageMetadata, MessagePart, Role};
 
     fn msg(role: Role, content: &str) -> Message {
         Message {
@@ -509,39 +170,103 @@ mod tests {
         assert_eq!(msgs.len(), 3);
     }
 
+    /// Relaxation (spec-078 FR-003 amendment): the shared helper is part-level. A trailing
+    /// assistant message that carries an orphaned `ToolUse` *and* independent text now keeps
+    /// the text instead of being removed wholesale, unlike the old whole-message removal.
     #[test]
-    fn has_meaningful_content_with_text() {
-        assert!(has_meaningful_content("hello world"));
-        assert!(has_meaningful_content(
-            "some text [tool_use: bash(abc)] more text"
-        ));
+    fn trailing_orphan_tool_use_alongside_text_keeps_the_text() {
+        let mut msgs = vec![
+            msg(Role::User, "run something"),
+            msg_with_parts(
+                Role::Assistant,
+                "thinking",
+                vec![
+                    MessagePart::Text {
+                        text: "thinking out loud".to_owned(),
+                    },
+                    MessagePart::ToolUse {
+                        id: "abc".to_owned(),
+                        name: "bash".to_owned(),
+                        input: serde_json::json!({}),
+                    },
+                ],
+            ),
+        ];
+        let (removed, _) = sanitize_tool_pairs(&mut msgs);
+        assert_eq!(removed, 0, "the message survives because text remains");
+        assert_eq!(msgs.len(), 2);
+        assert!(
+            msgs[1]
+                .parts
+                .iter()
+                .any(|p| matches!(p, MessagePart::Text { text } if text == "thinking out loud"))
+        );
+        assert!(
+            !msgs[1]
+                .parts
+                .iter()
+                .any(|p| matches!(p, MessagePart::ToolUse { .. }))
+        );
     }
 
+    /// C2 regression: a partial strip must never touch `content`, not just a fully-empty one.
+    /// A restored assistant message with `parts = [ThinkingBlock, ToolUse(orphan)]` keeps
+    /// `ThinkingBlock` after the orphan is stripped (parts non-empty), but `ThinkingBlock` alone
+    /// flattens to `""` — rebuilding `content` from the surviving parts would silently empty a
+    /// message whose `content` field holds real, independently-authored DB-restored text.
     #[test]
-    fn has_meaningful_content_only_markers() {
-        assert!(!has_meaningful_content("[tool_use: bash(abc123)]"));
-        assert!(!has_meaningful_content("  "));
+    fn partial_strip_never_touches_independently_authored_content() {
+        let mut msgs = vec![
+            msg(Role::User, "run something"),
+            Message {
+                role: Role::Assistant,
+                content: "Independently-authored reasoning text flatten_parts cannot \
+                          reconstruct."
+                    .to_owned(),
+                parts: vec![
+                    MessagePart::ThinkingBlock {
+                        thinking: "internal reasoning".to_owned(),
+                        signature: "sig".to_owned(),
+                    },
+                    MessagePart::ToolUse {
+                        id: "orphan".to_owned(),
+                        name: "bash".to_owned(),
+                        input: serde_json::json!({}),
+                    },
+                ],
+                metadata: MessageMetadata::default(),
+            },
+        ];
+        let content_before = msgs[1].content.clone();
+        let (removed, _) = sanitize_tool_pairs(&mut msgs);
+        assert_eq!(
+            removed, 0,
+            "the message survives because ThinkingBlock keeps parts non-empty"
+        );
+        assert_eq!(msgs.len(), 2);
+        assert!(
+            !msgs[1]
+                .parts
+                .iter()
+                .any(|p| matches!(p, MessagePart::ToolUse { .. })),
+            "the orphaned ToolUse must be stripped"
+        );
+        assert_eq!(
+            msgs[1].content, content_before,
+            "content must never be touched by a partial strip — it may hold independently- \
+             authored text `flatten_parts` cannot reconstruct"
+        );
     }
 
-    #[test]
-    fn has_meaningful_content_empty() {
-        assert!(!has_meaningful_content(""));
-    }
-
-    /// Regression test for #5513 item 6 (turn-scoped, see S1 correction below):
-    /// `strip_mid_history_orphans` must track resolved `tool_use_id`s cumulatively *within one
-    /// open call window*, so a duplicate `ToolResult` several messages downstream of its
-    /// matching `ToolUse` (no intervening re-open) is still caught — see
-    /// `duplicate_tool_result_several_messages_downstream_is_stripped` for that shape.
-    ///
-    /// This test instead documents the corrected boundary: when a *second* `ToolUse` reuses the
-    /// same id (re-opening the call), `resolved_tool_use_ids` forgets the earlier resolution, so
-    /// the following `ToolResult` is evaluated as a fresh pairing, not a duplicate. An earlier
-    /// version of this test asserted the opposite (id reuse via a new `ToolUse` always means
-    /// duplicate) — that assumption was wrong: it is indistinguishable from legitimate
-    /// index-based id reuse (e.g. Ollama's `format!("call_{i}")`, see
-    /// `legitimate_id_reuse_across_turns_ollama_style_must_not_be_stripped`), and stripping it
-    /// unconditionally re-creates the #5513 corruption for those providers.
+    /// Regression test for #5513 item 6: when a *second* `ToolUse` reuses the same id
+    /// (re-opening the call), the second `ToolResult(id)` must pair with the second `ToolUse`,
+    /// not be treated as a duplicate of the first result. Adjacency repair handles this for
+    /// free — each `ToolResult` matches only against its own immediately preceding non-system
+    /// message, never a cross-message "already resolved" id set — so there is nothing here that
+    /// needs id reuse to be distinguished from a genuine duplicate; see
+    /// `duplicate_tool_result_several_messages_downstream_is_stripped` for the shape that *is* a
+    /// genuine duplicate, and the module docs for why a separate dedup sweep was removed as
+    /// provably unreachable after this repair runs.
     #[test]
     fn tool_result_after_id_reopened_by_new_tool_use_is_not_a_duplicate() {
         let tool_use = |id: &str| MessagePart::ToolUse {
@@ -609,10 +334,10 @@ mod tests {
     /// by batch index, so `call_0` legitimately recurs on *every* turn of a multi-turn tool
     /// conversation — unlike OpenAI/Claude/Gemini, which use globally unique per-call ids.
     ///
-    /// `resolved_tool_use_ids` is scoped to the current open call window (S1 fix): a `ToolUse(id)`
-    /// removes `id` from the set, so a later turn's legitimate `ToolUse(call_0) ->
-    /// ToolResult(call_0, real)` pair is evaluated fresh, not flagged as a duplicate of an
-    /// earlier turn's result.
+    /// Adjacency repair (issue #6770/#6771) matches each `ToolResult` only against its own
+    /// immediately preceding non-system message, so a later turn's legitimate
+    /// `ToolUse(call_0) -> ToolResult(call_0, real)` pair is evaluated fresh against its own
+    /// neighbour — never flagged as a duplicate of an earlier, unrelated turn's result.
     #[test]
     fn legitimate_id_reuse_across_turns_ollama_style_must_not_be_stripped() {
         let tool_use = |id: &str| MessagePart::ToolUse {
@@ -736,5 +461,64 @@ mod tests {
             })
             .collect();
         assert_eq!(remaining_results, vec!["real output"]);
+    }
+
+    /// A leading orphaned `ToolResult` whose id recurs later in history must not confuse the
+    /// later, legitimate pair: adjacency repair matches each `ToolResult` only against its own
+    /// immediately preceding non-system message, so the leading orphan (`prev == None`) and the
+    /// later pair (`prev` is the matching `Assistant(ToolUse)`) are judged independently, with
+    /// no cross-message id-set bookkeeping to confuse.
+    #[test]
+    fn leading_orphan_result_id_recurring_later_does_not_confuse_the_later_legitimate_pair() {
+        let tool_use = |id: &str| MessagePart::ToolUse {
+            id: id.to_owned(),
+            name: "bash".to_owned(),
+            input: serde_json::json!({}),
+        };
+        let tool_result = |id: &str, content: &str| MessagePart::ToolResult {
+            tool_use_id: id.to_owned(),
+            content: content.to_owned(),
+            is_error: false,
+        };
+
+        let mut msgs = vec![
+            // Leading orphan: no preceding ToolUse for "dup_id" — will be repaired away first.
+            msg_with_parts(
+                Role::User,
+                "[tool_result: dup_id]",
+                vec![tool_result("dup_id", "boundary-cut orphan")],
+            ),
+            msg(Role::User, "real task"),
+            msg_with_parts(
+                Role::Assistant,
+                "[tool_use: bash(dup_id)]",
+                vec![tool_use("dup_id")],
+            ),
+            msg_with_parts(
+                Role::User,
+                "[tool_result: dup_id]\nreal output",
+                vec![tool_result("dup_id", "real output")],
+            ),
+        ];
+
+        let (removed, _) = sanitize_tool_pairs(&mut msgs);
+
+        assert_eq!(removed, 1, "only the leading orphan must be removed");
+        let remaining_results: Vec<&str> = msgs
+            .iter()
+            .flat_map(|m| m.parts.iter())
+            .filter_map(|p| {
+                if let MessagePart::ToolResult { content, .. } = p {
+                    Some(content.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert_eq!(
+            remaining_results,
+            vec!["real output"],
+            "the legitimate later pair must survive, not be flagged a duplicate of the orphan"
+        );
     }
 }

--- a/crates/zeph-agent-persistence/src/service.rs
+++ b/crates/zeph-agent-persistence/src/service.rs
@@ -106,7 +106,7 @@ impl PersistenceService {
         let mut skipped = 0;
 
         for msg in history {
-            use crate::sanitize::has_meaningful_content;
+            use zeph_llm::tool_pairing::has_meaningful_content;
             if !has_meaningful_content(&msg.content) && msg.parts.is_empty() {
                 tracing::warn!("skipping empty message from history (role: {:?})", msg.role);
                 skipped += 1;

--- a/crates/zeph-agent-persistence/src/session_sink.rs
+++ b/crates/zeph-agent-persistence/src/session_sink.rs
@@ -434,8 +434,9 @@ mod tests {
 
     /// Regression test for #5464: same round-trip as
     /// `session_replay_tool_call_turn_produces_valid_openai_message_array`, but through the
-    /// Claude serializer. Also exercises `compute_matched_tool_ids`'s orphan guard
-    /// (`crates/zeph-llm/src/claude/request.rs`): if the fold still produced a mismatched/merged
+    /// Claude serializer. Also exercises `zeph_llm::tool_pairing`'s orphan guard
+    /// (`unmatched_tool_use_ids`/`unmatched_tool_result_ids`, used by
+    /// `crates/zeph-llm/src/claude/request.rs`): if the fold still produced a mismatched/merged
     /// shape, the guard would silently downgrade the `tool_use`/`tool_result` blocks to plain
     /// text instead of letting the API 400 — so asserting the blocks keep their native
     /// `tool_use`/`tool_result` type is what actually proves the fix here, not just that a

--- a/crates/zeph-core/src/agent/persistence/tests.rs
+++ b/crates/zeph-core/src/agent/persistence/tests.rs
@@ -2018,8 +2018,8 @@ async fn load_history_keeps_tool_only_user_message() {
 }
 
 /// RC2 reverse pass: a user message with a `ToolResult` whose `tool_use_id` has no matching
-/// `ToolUse` in the preceding assistant message must be stripped by
-/// `strip_mid_history_orphans`.
+/// `ToolUse` in the preceding assistant message must be stripped by adjacency repair
+/// (`zeph_llm::tool_pairing::repair_tool_pairs`, via `sanitize_tool_pairs`).
 #[tokio::test]
 async fn strip_orphans_removes_orphaned_tool_result() {
     use zeph_llm::provider::MessagePart;

--- a/crates/zeph-core/src/agent/shutdown.rs
+++ b/crates/zeph-core/src/agent/shutdown.rs
@@ -90,58 +90,53 @@ impl<C: Channel> Agent<C> {
         use zeph_llm::provider::{MessagePart, Role};
 
         // Walk messages in reverse: if the last assistant message (ignoring any trailing
-        // system messages) has ToolUse parts and is NOT immediately followed by a user
-        // message whose ToolResult ids cover those ToolUse ids, persist tombstones.
+        // system messages) has ToolUse parts and is NOT immediately followed (adjacency-scoped,
+        // see zeph_llm::tool_pairing — a global scan across every following message wrongly
+        // cross-pairs an orphan against an unrelated call sharing its id under Ollama-style
+        // call_{i} id reuse, issue #6770) by a user message whose ToolResult ids cover those
+        // ToolUse ids, persist tombstones.
         let msgs = &self.msg.messages;
         // Find last assistant message index.
         let Some(asst_idx) = msgs.iter().rposition(|m| m.role == Role::Assistant) else {
             return;
         };
         let asst_msg = &msgs[asst_idx];
-        let tool_use_ids: Vec<(&str, &str, &serde_json::Value)> = asst_msg
+        if !asst_msg
             .parts
             .iter()
-            .filter_map(|p| {
-                if let MessagePart::ToolUse { id, name, input } = p {
-                    Some((id.as_str(), name.as_str(), input))
-                } else {
-                    None
-                }
-            })
-            .collect();
-        if tool_use_ids.is_empty() {
+            .any(|p| matches!(p, MessagePart::ToolUse { .. }))
+        {
             return;
         }
 
-        // Check whether a following user message already pairs all ToolUse ids.
-        let paired_ids: std::collections::HashSet<&str> = msgs
+        let next_non_system = msgs
             .get(asst_idx + 1..)
             .into_iter()
             .flatten()
-            .filter(|m| m.role == Role::User)
-            .flat_map(|m| m.parts.iter())
+            .find(|m| m.role != Role::System);
+        let unpaired_ids =
+            zeph_llm::tool_pairing::unmatched_tool_use_ids(asst_msg, next_non_system);
+        if unpaired_ids.is_empty() {
+            return;
+        }
+
+        let unpaired: Vec<zeph_llm::provider::ToolUseRequest> = asst_msg
+            .parts
+            .iter()
             .filter_map(|p| {
-                if let MessagePart::ToolResult { tool_use_id, .. } = p {
-                    Some(tool_use_id.as_str())
+                if let MessagePart::ToolUse { id, name, input } = p
+                    && unpaired_ids.contains(id.as_str())
+                {
+                    Some(zeph_llm::provider::ToolUseRequest {
+                        id: id.clone(),
+                        name: name.clone().into(),
+                        input: input.clone(),
+                    })
                 } else {
                     None
                 }
             })
             .collect();
-
-        let unpaired: Vec<zeph_llm::provider::ToolUseRequest> = tool_use_ids
-            .iter()
-            .filter(|(id, _, _)| !paired_ids.contains(*id))
-            .map(|(id, name, input)| zeph_llm::provider::ToolUseRequest {
-                id: (*id).to_owned(),
-                name: (*name).to_owned().into(),
-                input: (*input).clone(),
-            })
-            .collect();
-
-        if unpaired.is_empty() {
-            return;
-        }
 
         tracing::info!(
             count = unpaired.len(),

--- a/crates/zeph-core/src/agent/subagent_commands.rs
+++ b/crates/zeph-core/src/agent/subagent_commands.rs
@@ -1309,26 +1309,47 @@ pub(crate) fn estimate_parts_size(m: &zeph_llm::provider::Message) -> usize {
         .sum()
 }
 
-/// Applies token-budget truncation and orphaned-tool-pair pruning to a parent message slice.
+/// Applies token-budget truncation and orphaned-tool-pair repair to a parent message slice.
 ///
 /// Budget truncation keeps the **most recent** messages that fit within `max_chars`
 /// (a suffix), so the subagent always receives the freshest context.
 ///
-/// Two passes are performed after budget truncation:
+/// After budget truncation, [`zeph_llm::tool_pairing::repair_window`] repairs any
+/// `ToolUse`/`ToolResult` pair left orphaned by the truncation boundary (adjacency-scoped
+/// against the immediately preceding/following non-system message — never a global id set,
+/// which would wrongly cross-pair an orphan against an unrelated call sharing its id under
+/// Ollama-style `call_{i}` id reuse, issue #6770) and drops any leading non-`user` message
+/// (Anthropic requires the first non-system message to have role `user`).
 ///
-/// 1. Remove `ToolResult` parts from user messages whose matching `ToolUse` is no longer in the
-///    slice (truncated away).
-/// 2. Remove `ToolUse` parts from **interior** assistant messages whose matching `ToolResult`
-///    was removed in pass 1 or was already absent. The trailing assistant message is exempt —
-///    its unanswered `ToolUse` calls are not orphaned; the slice just ends before the result.
+/// `OrphanAction::Delete` is the default: this slice is a **terminal snapshot** handed to a
+/// fresh subagent as `initial_messages`, not a live in-progress window, and `Delete` avoids
+/// pushing previously-discarded parent tool output into the subagent's context unsanitized
+/// under `ParentContextPolicy::Inherit`, where `sanitize_parent_messages` never runs.
 ///
-/// Messages that become fully empty after pruning are removed from `msgs`.
-///
-/// `rebuild_content` is called **only** when `retain` actually removed parts — preserving the
-/// existing `content` field (and any `ThinkingBlock` text embedded there) for unmodified
-/// messages.
+/// `Delete`'s leading-role enforcement can annihilate the **entire** window, though: for a
+/// canonical `Assistant(ToolUse)`/`User(ToolResult)`-alternating tool-loop parent history (with
+/// no other plain-text anchor), the constraints "first non-system message is `user`" and "no
+/// orphaned `ToolResult`" are jointly unsatisfiable by deletion alone — repeatedly dropping the
+/// leading non-`user` message re-orphans the next `ToolResult` in turn, all the way down to
+/// empty. This is reachable in practice (`extract_parent_messages` slices by message count, not
+/// role alignment, so roughly half of count-based cuts into a tool-heavy history start on
+/// `Assistant`), and it would silently deliver **zero** parent context for a user-configured
+/// `ParentContextPolicy::Inherit`/`InheritSanitized` — a functional failure, not the graceful
+/// `[System, User(task_prompt)]` degradation `ParentContextPolicy::None` already produces on
+/// purpose. So `Delete` runs first on a scratch copy; if (and only if) it would annihilate a
+/// non-empty window, repair falls back to `DowngradeToText` on the original, un-repaired
+/// messages instead, so the leading orphan survives as a `user`-role text anchor. This fallback
+/// is strictly safer under `ParentContextPolicy::InheritSanitized` than the paired case already
+/// is: `sanitize_parent_messages` runs after this function and sanitizes only
+/// `MessagePart::Text`, so a downgraded orphan gets sanitized where a paired native
+/// `ToolResult` does not. Under `ParentContextPolicy::Inherit` the residual exposure is exactly
+/// one orphaned `ToolResult`'s content — qualitatively identical to every *paired* `ToolResult`
+/// that policy already forwards verbatim; there is no security boundary between "tool output
+/// whose `ToolUse` fell inside the count-based slice" and "tool output whose `ToolUse` fell
+/// outside it".
 pub(crate) fn trim_parent_messages(msgs: &mut Vec<zeph_llm::provider::Message>, max_chars: usize) {
-    use zeph_llm::provider::{MessagePart, Role};
+    use zeph_llm::provider::Role;
+    use zeph_llm::tool_pairing::{OrphanAction, repair_window};
 
     // Token-budget cap: keep the most recent messages that fit within max_chars.
     // We iterate from the end (newest) and drain from the front once the budget is exceeded,
@@ -1346,106 +1367,33 @@ pub(crate) fn trim_parent_messages(msgs: &mut Vec<zeph_llm::provider::Message>, 
         msgs.drain(..drop_before);
     }
 
-    // Pass 1: collect ToolUse IDs emitted by assistant messages; prune orphaned ToolResult
-    // parts from user messages that reference a ToolUse no longer present in the slice.
-    // Use owned Strings to avoid holding immutable borrows across the subsequent mutable loop.
-    let emitted_tool_ids: std::collections::HashSet<String> = msgs
-        .iter()
-        .filter(|m| m.role == Role::Assistant)
-        .flat_map(|m| m.parts.iter())
-        .filter_map(|p| {
-            if let MessagePart::ToolUse { id, .. } = p {
-                Some(id.clone())
-            } else {
-                None
-            }
-        })
-        .collect();
+    let had_content = msgs.iter().any(|m| m.role != Role::System);
+    let mut candidate = msgs.clone();
+    let report = repair_window(&mut candidate, OrphanAction::Delete);
 
-    let mut orphans_removed = 0usize;
-    for m in msgs.iter_mut() {
-        if m.role != Role::User || m.parts.is_empty() {
-            continue;
+    if had_content && !candidate.iter().any(|m| m.role != Role::System) {
+        // Delete annihilated the whole window (pure tool-loop parent history, see the doc
+        // comment above) — fall back to DowngradeToText on the un-repaired original so the
+        // leading orphan survives as a user-role text anchor instead of delivering zero parent
+        // context.
+        let fallback = repair_window(msgs, OrphanAction::DowngradeToText);
+        if fallback.parts_repaired > 0 {
+            tracing::debug!(
+                orphans = fallback.parts_repaired,
+                "[subagent] Delete would have emptied the parent context window; \
+                 downgraded orphaned parts to text anchors instead"
+            );
         }
-        let before = m.parts.len();
-        m.parts.retain(|p| match p {
-            MessagePart::ToolResult { tool_use_id, .. } => {
-                emitted_tool_ids.contains(tool_use_id.as_str())
-            }
-            _ => true,
-        });
-        let dropped = before - m.parts.len();
-        if dropped > 0 {
-            orphans_removed += dropped;
-            if m.parts.is_empty() {
-                m.content.clear();
-            } else {
-                m.rebuild_content();
-            }
-        }
+        return;
     }
 
-    // Pass 2: collect ToolResult IDs present in user messages after pass 1; prune ToolUse
-    // parts from assistant messages whose result is confirmed absent.
-    //
-    // The trailing assistant message is exempt: it may legitimately contain unanswered
-    // ToolUse calls (the slice ends before the result arrives). Only interior assistant
-    // messages — those followed by at least one user message — can have provably orphaned
-    // ToolUse parts (the conversation moved on without answering them).
-    let consumed_tool_ids: std::collections::HashSet<String> = msgs
-        .iter()
-        .filter(|m| m.role == Role::User)
-        .flat_map(|m| m.parts.iter())
-        .filter_map(|p| {
-            if let MessagePart::ToolResult { tool_use_id, .. } = p {
-                Some(tool_use_id.clone())
-            } else {
-                None
-            }
-        })
-        .collect();
-
-    // Index of the last assistant message — exempt from pass 2.
-    let last_assistant_idx = msgs
-        .iter()
-        .enumerate()
-        .rev()
-        .find(|(_, m)| m.role == Role::Assistant)
-        .map(|(i, _)| i);
-
-    for (idx, m) in msgs.iter_mut().enumerate() {
-        if m.role != Role::Assistant || m.parts.is_empty() {
-            continue;
-        }
-        // Skip the trailing assistant message — its unanswered ToolUse calls are not orphaned.
-        if Some(idx) == last_assistant_idx {
-            continue;
-        }
-        let before = m.parts.len();
-        m.parts.retain(|p| match p {
-            MessagePart::ToolUse { id, .. } => consumed_tool_ids.contains(id.as_str()),
-            _ => true,
-        });
-        let dropped = before - m.parts.len();
-        if dropped > 0 {
-            orphans_removed += dropped;
-            if m.parts.is_empty() {
-                m.content.clear();
-            } else {
-                m.rebuild_content();
-            }
-        }
-    }
-
-    // Remove messages that were emptied by orphan pruning.
-    msgs.retain(|m| !m.content.is_empty() || !m.parts.is_empty());
-
-    if orphans_removed > 0 {
+    if report.parts_repaired > 0 {
         tracing::debug!(
-            orphans = orphans_removed,
+            orphans = report.parts_repaired,
             "[subagent] pruned orphaned ToolUse/ToolResult parts from parent context boundary"
         );
     }
+    *msgs = candidate;
 }
 
 /// Sanitize text parts of `msgs` through the IPI pipeline.

--- a/crates/zeph-core/src/agent/tests/flush_orphaned_tests.rs
+++ b/crates/zeph-core/src/agent/tests/flush_orphaned_tests.rs
@@ -315,3 +315,190 @@ async fn flush_orphaned_inserts_tombstone_immediately_after_orphan_not_at_end() 
         "the later message must remain after the tombstone, not before it"
     );
 }
+
+/// FO6 (#6771 site-5 migration, KNOWN GAP — see tester handoff): `flush_orphaned_tool_use_on_shutdown`
+/// itself now computes `unpaired_ids` via `zeph_llm::tool_pairing::unmatched_tool_use_ids`
+/// (adjacency-scoped, immediate-neighbour only) and correctly identifies `call_0` as unpaired in
+/// this shape. But the call is still routed through
+/// `Agent::persist_cancelled_tool_results` (`crates/zeph-core/src/agent/tool_execution/focus.rs`,
+/// untouched by #6771), whose own `already_resolved` idempotency guard scans
+/// `self.msg.messages[turn_start..]` — from the last assistant message to the true end of
+/// history, not just the immediate neighbour. A later, unrelated `ToolResult` reusing `call_0`
+/// still falls inside that wider scan and is treated as "already resolved", silently swallowing
+/// the tombstone. So the #6770 adjacency fix for site 5 is *not* fully closed end-to-end: the
+/// classification predicate was fixed, but the downstream write-path idempotency check was not.
+/// Empirically confirmed to fail against current `focus.rs` (not a regression from this PR —
+/// `persist_cancelled_tool_results` is pre-existing #5513 code the PR does not touch). Left
+/// `#[ignore]` rather than failing the suite; un-ignore once `focus.rs`'s scan is narrowed to
+/// adjacency (or the gap is otherwise accepted and tracked).
+#[ignore = "known gap: persist_cancelled_tool_results's turn-scoped (not adjacency-scoped) \
+            already_resolved check can still swallow the tombstone; see doc comment"]
+#[tokio::test]
+async fn flush_orphaned_writes_tombstone_despite_a_later_unrelated_reuse_of_the_same_id() {
+    use zeph_llm::provider::{Message, MessageMetadata, MessagePart, Role};
+
+    let provider = mock_provider(vec![]);
+    let memory = flush_test_memory().await;
+    let cid = memory.sqlite().create_conversation().await.unwrap();
+
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor).with_memory(
+        std::sync::Arc::new(memory),
+        cid,
+        50,
+        5,
+        100,
+    );
+
+    // Genuinely in-flight ToolUse — the last assistant message.
+    agent.msg.messages.push(Message {
+        role: Role::Assistant,
+        content: "[tool_use]".into(),
+        parts: vec![MessagePart::ToolUse {
+            id: "call_0".into(),
+            name: "shell".into(),
+            input: serde_json::json!({}),
+        }],
+        metadata: MessageMetadata::default(),
+    });
+    // Immediately following: unrelated plain text, not the reply to call_0.
+    agent.msg.messages.push(Message {
+        role: Role::User,
+        content: "an unrelated later message".into(),
+        parts: vec![MessagePart::Text {
+            text: "an unrelated later message".into(),
+        }],
+        metadata: MessageMetadata::default(),
+    });
+    // A ToolResult reusing "call_0" surfaces even later (Ollama-style id reuse from an
+    // unrelated call). Adjacency correctly ignores this — it is not the immediate neighbour.
+    agent.msg.messages.push(Message {
+        role: Role::User,
+        content: "[tool_result]".into(),
+        parts: vec![MessagePart::ToolResult {
+            tool_use_id: "call_0".into(),
+            content: "unrelated reused result".into(),
+            is_error: false,
+        }],
+        metadata: MessageMetadata::default(),
+    });
+
+    agent.flush_orphaned_tool_use_on_shutdown().await;
+
+    let history = agent
+        .services
+        .memory
+        .persistence
+        .memory
+        .as_ref()
+        .unwrap()
+        .sqlite()
+        .load_history(cid, 50)
+        .await
+        .unwrap();
+
+    let tombstone_written = history.iter().any(|m| {
+        m.parts.iter().any(|p| {
+            matches!(
+                p,
+                MessagePart::ToolResult { tool_use_id, is_error, content }
+                    if tool_use_id == "call_0" && *is_error && content == "[Cancelled]"
+            )
+        })
+    });
+    assert!(
+        tombstone_written,
+        "the genuinely in-flight call_0 must get a tombstone, not be silently treated as \
+         paired against an unrelated later reuse of its id"
+    );
+}
+
+/// FO7: adjacency must not be confused by an *earlier* turn reusing the same id. A call that is
+/// directly, immediately paired with its own `ToolResult` must produce no tombstone, even when an
+/// unrelated earlier turn already used and resolved the same `call_0` id (Ollama-style reuse).
+/// `unmatched_tool_use_ids` only ever looks at the immediate neighbour, so it cannot be swayed by
+/// anything earlier in history — this is a direct regression test for that contract.
+#[tokio::test]
+async fn flush_orphaned_noop_when_directly_paired_despite_an_earlier_turn_reusing_the_same_id() {
+    use zeph_llm::provider::{Message, MessageMetadata, MessagePart, Role};
+
+    let provider = mock_provider(vec![]);
+    let memory = flush_test_memory().await;
+    let cid = memory.sqlite().create_conversation().await.unwrap();
+
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::no_tools();
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor).with_memory(
+        std::sync::Arc::new(memory),
+        cid,
+        50,
+        5,
+        100,
+    );
+
+    // Turn 1: call_0 used and legitimately resolved.
+    agent.msg.messages.push(Message {
+        role: Role::Assistant,
+        content: "[tool_use]".into(),
+        parts: vec![MessagePart::ToolUse {
+            id: "call_0".into(),
+            name: "shell".into(),
+            input: serde_json::json!({}),
+        }],
+        metadata: MessageMetadata::default(),
+    });
+    agent.msg.messages.push(Message {
+        role: Role::User,
+        content: "[tool_result]".into(),
+        parts: vec![MessagePart::ToolResult {
+            tool_use_id: "call_0".into(),
+            content: "turn-1 output".into(),
+            is_error: false,
+        }],
+        metadata: MessageMetadata::default(),
+    });
+    // Turn 2: call_0 reused (Ollama batch-index id), immediately and legitimately paired — this
+    // is the last assistant message the function will examine.
+    agent.msg.messages.push(Message {
+        role: Role::Assistant,
+        content: "[tool_use]".into(),
+        parts: vec![MessagePart::ToolUse {
+            id: "call_0".into(),
+            name: "shell".into(),
+            input: serde_json::json!({}),
+        }],
+        metadata: MessageMetadata::default(),
+    });
+    agent.msg.messages.push(Message {
+        role: Role::User,
+        content: "[tool_result]".into(),
+        parts: vec![MessagePart::ToolResult {
+            tool_use_id: "call_0".into(),
+            content: "turn-2 output".into(),
+            is_error: false,
+        }],
+        metadata: MessageMetadata::default(),
+    });
+
+    agent.flush_orphaned_tool_use_on_shutdown().await;
+
+    let history = agent
+        .services
+        .memory
+        .persistence
+        .memory
+        .as_ref()
+        .unwrap()
+        .sqlite()
+        .load_history(cid, 50)
+        .await
+        .unwrap();
+    assert!(
+        history.is_empty(),
+        "no tombstone must be persisted for a call that is directly, immediately paired, \
+         regardless of an earlier turn reusing the same id"
+    );
+}

--- a/crates/zeph-core/src/agent/tests/trim_parent_messages_tests.rs
+++ b/crates/zeph-core/src/agent/tests/trim_parent_messages_tests.rs
@@ -38,44 +38,99 @@ fn tool_result_msg(tool_use_id: &str, content: &str) -> Message {
 }
 
 #[test]
-fn trim_parent_messages_drops_orphaned_tool_results() {
-    // Slice starts with a user ToolResult for "tu_A", but the corresponding ToolUse is NOT
-    // in the slice (it was truncated away).  The orphan must be removed.
-    let mut msgs = vec![
-        tool_result_msg("tu_A", "result-a"),
-        text_msg(Role::Assistant, "ok"),
-    ];
-    trim_parent_messages(&mut msgs, usize::MAX);
-    // The orphaned ToolResult message must be gone; only the text assistant message remains.
-    assert_eq!(msgs.len(), 1, "orphaned ToolResult message must be removed");
-    assert!(
-        msgs[0]
-            .parts
-            .iter()
-            .all(|p| !matches!(p, MessagePart::ToolResult { .. })),
-        "no ToolResult parts must remain"
-    );
-}
-
-#[test]
 fn trim_parent_messages_keeps_matched_tool_pairs() {
-    // Both ToolUse and ToolResult for "tu_B" are in the slice — both must be kept.
+    // Both ToolUse and ToolResult for "tu_B" are in the slice — both must be kept. A leading
+    // User anchor keeps the window's first non-system message role=user, so the D3 leading-role
+    // cascade (see `leading_matched_pair_survives_as_downgraded_anchor`) does not fire here.
     let mut msgs = vec![
+        text_msg(Role::User, "run it"),
         tool_use_msg("tu_B", "shell"),
         tool_result_msg("tu_B", "output-b"),
     ];
     trim_parent_messages(&mut msgs, usize::MAX);
-    assert_eq!(msgs.len(), 2, "matched pair must not be removed");
-    let has_use = msgs[0]
+    assert_eq!(msgs.len(), 3, "matched pair must not be removed");
+    let has_use = msgs[1]
         .parts
         .iter()
         .any(|p| matches!(p, MessagePart::ToolUse { id, .. } if id == "tu_B"));
-    let has_result = msgs[1]
+    let has_result = msgs[2]
         .parts
         .iter()
         .any(|p| matches!(p, MessagePart::ToolResult { tool_use_id, .. } if tool_use_id == "tu_B"));
     assert!(has_use, "ToolUse must be preserved");
     assert!(has_result, "ToolResult must be preserved");
+}
+
+#[test]
+fn leading_matched_pair_survives_as_downgraded_anchor() {
+    // C1 (architect resolution): a leading ToolUse/ToolResult pair with no preceding User
+    // anchor would be destroyed entirely by Delete's leading-role cascade (dropping the leading
+    // Assistant orphans its ToolResult, which is then deleted too — proven unsatisfiable by
+    // deletion alone for this shape). `trim_parent_messages` detects the would-be annihilation
+    // on a scratch copy and falls back to `DowngradeToText` on the original instead: the leading
+    // Assistant(ToolUse) message is still dropped by the leading-role rule, but its result
+    // survives downgraded to a Text anchor rather than the whole window being destroyed.
+    let mut msgs = vec![
+        tool_use_msg("tu_B", "shell"),
+        tool_result_msg("tu_B", "output-b"),
+    ];
+    trim_parent_messages(&mut msgs, usize::MAX);
+    assert_eq!(
+        msgs.len(),
+        1,
+        "the leading Assistant is still dropped, but the result survives as a text anchor"
+    );
+    assert_eq!(msgs[0].role, Role::User);
+    let has_marker = msgs[0].parts.iter().any(
+        |p| matches!(p, MessagePart::Text { text } if text.contains("tu_B") && text.contains("output-b")),
+    );
+    assert!(
+        has_marker,
+        "the downgraded ToolResult content must survive as a marked Text part"
+    );
+    assert!(
+        !msgs[0]
+            .parts
+            .iter()
+            .any(|p| matches!(p, MessagePart::ToolResult { .. })),
+        "no dangling native ToolResult may remain"
+    );
+}
+
+#[test]
+fn non_annihilating_window_still_deletes_not_downgrades() {
+    // S5 preservation (C1 architect handoff #4): the DowngradeToText fallback is a bounded
+    // exception triggered only by would-be annihilation, not a general policy change — a window
+    // where Delete does NOT empty everything must still delete the orphan outright, never
+    // downgrade it to a text marker.
+    let mut msgs = vec![
+        text_msg(Role::User, "hi"),
+        Message::from_parts(
+            Role::User,
+            vec![MessagePart::ToolResult {
+                tool_use_id: "tu_A".to_owned(),
+                content: "result".to_owned(),
+                is_error: false,
+            }],
+        ),
+        text_msg(Role::Assistant, "ok"),
+    ];
+    trim_parent_messages(&mut msgs, usize::MAX);
+    assert_eq!(
+        msgs.len(),
+        2,
+        "the orphaned message is removed outright, the rest survive"
+    );
+    for m in &msgs {
+        assert!(
+            m.parts.iter().all(
+                |p| !matches!(p, MessagePart::Text { text } if text.starts_with("[tool result: "))
+            ),
+            "Delete must not downgrade when the window does not annihilate"
+        );
+    }
+    assert_eq!(msgs[0].content, "hi");
+    assert_eq!(msgs[1].content, "ok");
 }
 
 #[test]
@@ -109,9 +164,14 @@ fn trim_parent_messages_budget_uses_structured_size() {
 }
 
 #[test]
-fn trim_parent_messages_removes_empty_message_after_pruning() {
-    // A user message with only ToolResult parts that are all orphaned becomes empty
-    // and must be removed from the slice entirely.
+fn leading_orphan_only_window_is_downgraded_not_annihilated() {
+    // C1: a leading orphaned ToolResult (no preceding ToolUse) followed only by trailing
+    // Assistant text is the same annihilation shape as
+    // `leading_matched_pair_survives_as_downgraded_anchor` — under plain Delete the orphan is
+    // stripped, emptying the message, which then also gets dropped by the leading-role rule
+    // once the trailing Assistant text becomes the new leading (non-user) message, annihilating
+    // the whole window. The fallback downgrades the orphan to a Text anchor instead, so both
+    // messages survive.
     let mut msgs = vec![
         Message::from_parts(
             Role::User,
@@ -124,20 +184,30 @@ fn trim_parent_messages_removes_empty_message_after_pruning() {
         text_msg(Role::Assistant, "reply"),
     ];
     trim_parent_messages(&mut msgs, usize::MAX);
+    assert_eq!(msgs.len(), 2, "the fallback preserves both messages");
+    assert_eq!(msgs[0].role, Role::User);
+    let has_marker = msgs[0].parts.iter().any(
+        |p| matches!(p, MessagePart::Text { text } if text.contains("tu_orphan") && text.contains("result")),
+    );
     assert!(
-        msgs.iter()
-            .all(|m| m.role != Role::User || !m.parts.is_empty()),
-        "emptied user messages must be removed"
+        has_marker,
+        "the orphan must survive downgraded to a marked Text anchor"
     );
-    let has_orphan = msgs.iter().flat_map(|m| m.parts.iter()).any(
-        |p| matches!(p, MessagePart::ToolResult { tool_use_id, .. } if tool_use_id == "tu_orphan"),
+    assert!(
+        !msgs[0]
+            .parts
+            .iter()
+            .any(|p| matches!(p, MessagePart::ToolResult { .. })),
+        "no dangling native ToolResult may remain"
     );
-    assert!(!has_orphan, "orphaned ToolResult must not survive");
+    assert_eq!(msgs[1].content, "reply");
 }
 
 #[test]
 fn orphan_pruning_preserves_thinking_block() {
-    // Assistant message: [ThinkingBlock, Text, ToolUse(matched)]
+    // Assistant message: [ThinkingBlock, Text, ToolUse(matched)] — preceded by a User anchor so
+    // the window's leading message has role=user (the D3 leading-role cascade, see
+    // `leading_matched_pair_survives_as_downgraded_anchor`, does not fire here).
     // User message:      [ToolResult(matched)]
     // After pruning: ToolUse is matched → nothing removed → rebuild_content NOT called →
     //                ThinkingBlock text in content must be intact.
@@ -163,6 +233,7 @@ fn orphan_pruning_preserves_thinking_block() {
     let content_before = assistant_msg.content.clone();
 
     let mut msgs = vec![
+        text_msg(Role::User, "please investigate"),
         assistant_msg,
         Message::from_parts(
             Role::User,
@@ -175,33 +246,31 @@ fn orphan_pruning_preserves_thinking_block() {
     ];
     trim_parent_messages(&mut msgs, usize::MAX);
 
-    assert_eq!(msgs.len(), 2, "no messages should be removed");
-    assert_eq!(msgs[0].parts.len(), 3, "all 3 assistant parts must survive");
+    assert_eq!(msgs.len(), 3, "no messages should be removed");
+    assert_eq!(msgs[1].parts.len(), 3, "all 3 assistant parts must survive");
     assert_eq!(
-        msgs[0].content, content_before,
+        msgs[1].content, content_before,
         "content must not be modified (ThinkingBlock must not be erased)"
     );
 }
 
 #[test]
-fn trailing_assistant_tool_use_preserved_without_result() {
-    // The slice ends with an assistant ToolUse that has no corresponding ToolResult —
-    // this is the trailing-edge case where the slice ends before the result arrives.
-    // Pass 2 must NOT remove this ToolUse.
+fn trailing_assistant_tool_use_is_stripped_as_orphaned() {
+    // S1 (v2 design, issue #6771): universal Repair applies regardless of position — a trailing,
+    // unanswered ToolUse in the parent-context snapshot handed to a fresh subagent can never be
+    // answered (the subagent has no way to supply the parent's tool result), so it is orphaned
+    // like any other and stripped. This is a behavior change from the old v1 "trailing exemption".
     let mut msgs = vec![
         text_msg(Role::User, "do something"),
         tool_use_msg("tu_trailing", "shell"),
     ];
     trim_parent_messages(&mut msgs, usize::MAX);
-    assert_eq!(msgs.len(), 2, "both messages must be preserved");
-    let has_trailing_use = msgs[1]
-        .parts
-        .iter()
-        .any(|p| matches!(p, MessagePart::ToolUse { id, .. } if id == "tu_trailing"));
-    assert!(
-        has_trailing_use,
-        "trailing unanswered ToolUse must not be pruned"
+    assert_eq!(
+        msgs.len(),
+        1,
+        "the trailing unanswered ToolUse message must be removed"
     );
+    assert_eq!(msgs[0].content, "do something");
 }
 
 #[test]

--- a/crates/zeph-llm/src/claude/request.rs
+++ b/crates/zeph-llm/src/claude/request.rs
@@ -3,9 +3,12 @@
 
 //! Message conversion and request building utilities for the Claude provider.
 
+use std::collections::HashSet;
+
 use base64::{Engine, engine::general_purpose::STANDARD};
 
 use crate::provider::{ChatResponse, Message, MessagePart, Role, ThinkingBlock, ToolUseRequest};
+use crate::tool_pairing::{unmatched_tool_result_ids, unmatched_tool_use_ids};
 
 use super::cache::apply_cache_breakpoint;
 use super::types::{
@@ -92,14 +95,7 @@ pub(in crate::claude) fn split_messages_structured(
         .filter(|m| m.metadata.visibility.is_agent_visible() && m.role != Role::System)
         .collect();
 
-    // Track which tool_use IDs were actually emitted as native AnthropicContentBlock::ToolUse
-    // by the most recent assistant message. When processing the following user message, any
-    // ToolResult block whose tool_use_id is not in this set is downgraded to text — prevents
-    // API 400 caused by orphaned ToolResult referencing a non-existent tool_use (RC1 fix).
-    let mut last_emitted_tool_ids: std::collections::HashSet<String> =
-        std::collections::HashSet::new();
-
-    for (idx, msg) in visible.iter().enumerate() {
+    for (idx, &msg) in visible.iter().enumerate() {
         match msg.role {
             Role::System => {} // already extracted above
             Role::User | Role::Assistant => {
@@ -122,35 +118,37 @@ pub(in crate::claude) fn split_messages_structured(
 
                 if has_structured_parts {
                     let is_assistant = msg.role == Role::Assistant;
-                    // For assistant messages, pre-compute which tool_use IDs are matched by
-                    // the next visible user message. Unmatched IDs are downgraded to text to
-                    // prevent Claude API 400 (tool_use without tool_result).
-                    let matched_tool_ids = if is_assistant {
-                        Some(compute_matched_tool_ids(msg, visible.get(idx + 1)))
+                    // Layer A (zeph_llm::tool_pairing), adjacency-scoped against the immediate
+                    // neighbour in `visible` — never a global id set (#6770). Always an
+                    // explicitly computed set, never `Option`, so a call site cannot silently
+                    // reopen the RC1 400 via a defaulted/empty set.
+                    let orphaned_tool_use: HashSet<&str> = if is_assistant {
+                        unmatched_tool_use_ids(msg, visible.get(idx + 1).copied())
                     } else {
-                        None
+                        HashSet::new()
                     };
-                    // Reset emitted tool IDs at the start of each assistant message so user
-                    // messages can check against the immediately preceding assistant only.
-                    if is_assistant {
-                        last_emitted_tool_ids.clear();
-                    }
+                    let orphaned_tool_result: HashSet<&str> = if is_assistant {
+                        HashSet::new()
+                    } else {
+                        let prev = idx.checked_sub(1).and_then(|i| visible.get(i)).copied();
+                        unmatched_tool_result_ids(msg, prev)
+                    };
                     let blocks = convert_parts_to_blocks(
                         &msg.parts,
                         is_assistant,
-                        matched_tool_ids.as_ref(),
-                        &mut last_emitted_tool_ids,
+                        &orphaned_tool_use,
+                        &orphaned_tool_result,
                     );
-                    chat.push(StructuredApiMessage {
-                        role: role.to_owned(),
-                        content: StructuredContent::Blocks(blocks),
-                    });
-                } else {
-                    // Non-structured user/assistant message: clear emitted tool IDs since
-                    // no tool pairs are possible across a plain text message boundary.
-                    if msg.role == Role::Assistant {
-                        last_emitted_tool_ids.clear();
+                    // D4 (mandatory): never emit a StructuredApiMessage with an empty block
+                    // list — Anthropic rejects an empty content array. Consistent with the
+                    // non-structured branch below, which already skips whitespace-only text.
+                    if !blocks.is_empty() {
+                        chat.push(StructuredApiMessage {
+                            role: role.to_owned(),
+                            content: StructuredContent::Blocks(blocks),
+                        });
                     }
+                } else {
                     let text = msg.to_llm_content();
                     if !text.trim().is_empty() {
                         chat.push(StructuredApiMessage {
@@ -274,18 +272,9 @@ fn push_tool_use_block(
     id: &str,
     name: &str,
     input: &serde_json::Value,
-    matched_tool_ids: Option<&std::collections::HashSet<&str>>,
-    last_emitted_tool_ids: &mut std::collections::HashSet<String>,
+    orphaned_tool_use_ids: &HashSet<&str>,
 ) {
-    let matched = matched_tool_ids.is_some_and(|ids| ids.contains(id));
-    if matched {
-        last_emitted_tool_ids.insert(id.to_owned());
-        blocks.push(AnthropicContentBlock::ToolUse {
-            id: id.to_owned(),
-            name: name.to_owned(),
-            input: input.clone(),
-        });
-    } else {
+    if orphaned_tool_use_ids.contains(id) {
         tracing::warn!(
             tool_use_id = %id,
             tool_name = %name,
@@ -295,6 +284,12 @@ fn push_tool_use_block(
             text: format!("[tool_use: {name}] {input}"),
             cache_control: None,
         });
+    } else {
+        blocks.push(AnthropicContentBlock::ToolUse {
+            id: id.to_owned(),
+            name: name.to_owned(),
+            input: input.clone(),
+        });
     }
 }
 
@@ -303,39 +298,43 @@ fn push_tool_result_block(
     tool_use_id: &str,
     content: &str,
     is_error: bool,
-    last_emitted_tool_ids: &std::collections::HashSet<String>,
+    orphaned_tool_result_ids: &HashSet<&str>,
 ) {
-    if last_emitted_tool_ids.contains(tool_use_id) {
+    if orphaned_tool_result_ids.contains(tool_use_id) {
+        tracing::warn!(
+            tool_use_id = %tool_use_id,
+            "downgrading orphaned tool_result to text in API request"
+        );
+        // D4 (mandatory): guarantee non-empty text even when `content` is empty, so this
+        // message survives as the window's leading `user` anchor rather than being dropped
+        // entirely by the empty-blocks guard.
+        blocks.push(AnthropicContentBlock::Text {
+            text: format!("[tool result: {tool_use_id}] {content}"),
+            cache_control: None,
+        });
+    } else {
         blocks.push(AnthropicContentBlock::ToolResult {
             tool_use_id: tool_use_id.to_owned(),
             content: content.to_owned(),
             is_error,
             cache_control: None,
         });
-    } else {
-        tracing::warn!(
-            tool_use_id = %tool_use_id,
-            "downgrading orphaned tool_result to text in API request"
-        );
-        if !content.trim().is_empty() {
-            blocks.push(AnthropicContentBlock::Text {
-                text: content.to_owned(),
-                cache_control: None,
-            });
-        }
     }
 }
 
 /// Convert message parts into `AnthropicContentBlock`s, respecting tool-use/result pairing rules.
 ///
 /// - `is_assistant`: whether the message is from the assistant role
-/// - `matched_tool_ids`: set of `tool_use` IDs that are matched by the next user message
-/// - `last_emitted_tool_ids`: tracks IDs emitted as native `ToolUse` to detect orphaned results
+/// - `orphaned_tool_use_ids`: `tool_use` IDs from [`crate::tool_pairing::unmatched_tool_use_ids`]
+///   to downgrade to text (empty when `!is_assistant`)
+/// - `orphaned_tool_result_ids`: `tool_result` IDs from
+///   [`crate::tool_pairing::unmatched_tool_result_ids`] to downgrade to text (empty when
+///   `is_assistant`)
 pub(super) fn convert_parts_to_blocks(
     parts: &[MessagePart],
     is_assistant: bool,
-    matched_tool_ids: Option<&std::collections::HashSet<&str>>,
-    last_emitted_tool_ids: &mut std::collections::HashSet<String>,
+    orphaned_tool_use_ids: &HashSet<&str>,
+    orphaned_tool_result_ids: &HashSet<&str>,
 ) -> Vec<AnthropicContentBlock> {
     let mut blocks = Vec::new();
     for part in parts {
@@ -363,14 +362,7 @@ pub(super) fn convert_parts_to_blocks(
             MessagePart::ToolUse { id, name, input } if is_assistant => {
                 // Downgrade to text if the tool_use ID is not matched by the
                 // next user message — prevents API 400 on orphaned tool_use.
-                push_tool_use_block(
-                    &mut blocks,
-                    id,
-                    name,
-                    input,
-                    matched_tool_ids,
-                    last_emitted_tool_ids,
-                );
+                push_tool_use_block(&mut blocks, id, name, input, orphaned_tool_use_ids);
             }
             MessagePart::ToolUse { name, input, .. } => {
                 blocks.push(AnthropicContentBlock::Text {
@@ -383,14 +375,14 @@ pub(super) fn convert_parts_to_blocks(
                 content,
                 is_error,
             } if !is_assistant => {
-                // Downgrade to text if the tool_use_id was not emitted as a
-                // native ToolUse by the preceding assistant message (RC1 fix).
+                // Downgrade to text if the tool_use_id was not matched by the
+                // preceding assistant message (RC1 fix).
                 push_tool_result_block(
                     &mut blocks,
                     tool_use_id,
                     content,
                     *is_error,
-                    last_emitted_tool_ids,
+                    orphaned_tool_result_ids,
                 );
             }
             MessagePart::ToolResult { content, .. } => {
@@ -436,34 +428,6 @@ pub(super) fn convert_parts_to_blocks(
         }
     }
     blocks
-}
-
-pub(super) fn compute_matched_tool_ids<'m>(
-    msg: &'m Message,
-    next: Option<&&'m Message>,
-) -> std::collections::HashSet<&'m str> {
-    msg.parts
-        .iter()
-        .filter_map(|p| {
-            if let MessagePart::ToolUse { id, .. } = p {
-                Some(id.as_str())
-            } else {
-                None
-            }
-        })
-        .filter(|uid| {
-            next.is_some_and(|next_msg| {
-                next_msg.role == Role::User
-                    && next_msg.parts.iter().any(|np| {
-                        matches!(
-                            np,
-                            MessagePart::ToolResult { tool_use_id, .. }
-                                if tool_use_id.as_str() == *uid
-                        )
-                    })
-            })
-        })
-        .collect()
 }
 
 #[cfg(test)]
@@ -1216,6 +1180,136 @@ mod tests {
         assert!(
             !user_json.contains("compaction"),
             "Compaction in user message must be dropped"
+        );
+    }
+
+    /// D4: an orphaned `ToolResult` with empty `content` must not yield a `StructuredApiMessage`
+    /// with an empty block array (Anthropic rejects an empty content array). The kept marker
+    /// guarantees non-empty text, so the message survives as the leading `user` anchor instead
+    /// of being skipped by the empty-blocks guard.
+    #[test]
+    fn d4_empty_content_orphaned_tool_result_survives_as_non_empty_text_anchor() {
+        let messages = vec![Message::from_parts(
+            Role::User,
+            vec![MessagePart::ToolResult {
+                tool_use_id: "orphan".into(),
+                content: String::new(),
+                is_error: false,
+            }],
+        )];
+        let (_, chat) = split_messages_structured(&messages, false, None);
+        assert_eq!(
+            chat.len(),
+            1,
+            "the orphan-only message must survive, not be skipped"
+        );
+        assert_eq!(chat[0].role, "user");
+        match &chat[0].content {
+            StructuredContent::Blocks(blocks) => {
+                assert!(!blocks.is_empty(), "no empty block array may be emitted");
+            }
+            StructuredContent::Text(_) => panic!("expected Blocks content"),
+        }
+    }
+
+    /// D4: a user message whose only part is a `ThinkingBlock`/`Compaction`/`RedactedThinkingBlock`
+    /// produces zero blocks (those variants are silently dropped for the user role) — the
+    /// mandatory empty-blocks guard must skip emitting the message entirely rather than pushing
+    /// an empty `Blocks(vec![])`.
+    ///
+    /// N2 (impl-critic C4): the guard fixes the empty-`Blocks([])` 400, but does not by itself
+    /// guarantee the first *emitted* message has `role: "user"` — skipping a leading message can
+    /// promote a following `Assistant` message to `chat[0]`, which Anthropic also rejects. This
+    /// is a **pre-existing, un-widened gap**: `split_messages_structured` has never enforced a
+    /// leading-role invariant on its own (a message list beginning with `Assistant` and no
+    /// structured parts at all would hit exactly this today, empty-blocks guard or not) — it
+    /// relies entirely on upstream repair (`zeph_llm::tool_pairing::repair_window`,
+    /// `adjust_compact_end_for_tool_pairs`) to never hand it such a list. This PR does not close
+    /// that gap; it is tracked as a follow-up (enforcing a leading-role invariant inside
+    /// `split_messages_structured` itself is out of scope here — see the module's callers for
+    /// where that invariant is actually maintained today).
+    #[test]
+    fn d4_empty_blocks_skip_can_promote_a_leading_assistant_message() {
+        let messages = vec![
+            Message::from_parts(
+                Role::User,
+                vec![MessagePart::ThinkingBlock {
+                    thinking: "stray".into(),
+                    signature: "sig".into(),
+                }],
+            ),
+            Message::from_legacy(Role::Assistant, "hello"),
+        ];
+        let (_, chat) = split_messages_structured(&messages, false, None);
+        assert_eq!(chat.len(), 1, "the empty-blocks message must be skipped");
+        assert_eq!(
+            chat[0].role, "assistant",
+            "known gap (N2, not closed by this PR): the skip can promote a leading Assistant \
+             message to chat[0], which Anthropic also rejects — see the doc comment above"
+        );
+    }
+
+    /// The empty-blocks skip does not disturb a *following* leading `user` message when one
+    /// exists — this passes because the second message happens to be `User`, not because the
+    /// guard enforces the leading-role invariant in general (see
+    /// `d4_empty_blocks_skip_can_promote_a_leading_assistant_message` for the case where it
+    /// doesn't hold).
+    #[test]
+    fn d4_leading_skip_does_not_disturb_a_following_user_message() {
+        let messages = vec![
+            Message::from_parts(
+                Role::User,
+                vec![MessagePart::Compaction {
+                    summary: "dropped for user role".into(),
+                }],
+            ),
+            Message::from_legacy(Role::User, "real question"),
+            Message::from_legacy(Role::Assistant, "reply"),
+        ];
+        let (_, chat) = split_messages_structured(&messages, false, None);
+        assert_eq!(chat[0].role, "user");
+        assert!(matches!(&chat[0].content, StructuredContent::Text(t) if t == "real question"));
+    }
+
+    /// New (v2 test strategy item 7): adjacency is stricter than the old threaded
+    /// `last_emitted_tool_ids` state, which was not cleared by an intervening plain-text user
+    /// message. `Assistant(ToolUse a) / User(text) / User(ToolResult a)` — under adjacency,
+    /// `ToolResult a`'s immediate predecessor is the plain-text `User` message, not the
+    /// `Assistant`, so it is downgraded rather than wrongly emitted as a native `ToolResult`.
+    #[test]
+    fn adjacency_is_stricter_than_the_old_threaded_state_across_a_text_message() {
+        let messages = vec![
+            Message::from_parts(
+                Role::Assistant,
+                vec![MessagePart::ToolUse {
+                    id: "a".into(),
+                    name: "bash".into(),
+                    input: serde_json::json!({}),
+                }],
+            ),
+            Message::from_legacy(Role::User, "unrelated text"),
+            Message::from_parts(
+                Role::User,
+                vec![MessagePart::ToolResult {
+                    tool_use_id: "a".into(),
+                    content: "late result".into(),
+                    is_error: false,
+                }],
+            ),
+        ];
+        let (_, chat) = split_messages_structured(&messages, false, None);
+        assert_eq!(chat.len(), 3);
+        // The ToolUse itself has no immediately-following User(ToolResult) either — the text
+        // message intervenes — so it is downgraded too.
+        let assistant_json = serde_json::to_string(&chat[0]).unwrap();
+        assert!(
+            !assistant_json.contains("\"type\":\"tool_use\""),
+            "the ToolUse's immediate neighbour is plain text, not a matching ToolResult: {assistant_json}"
+        );
+        let last_json = serde_json::to_string(&chat[2]).unwrap();
+        assert!(
+            !last_json.contains("\"type\":\"tool_result\""),
+            "the ToolResult's immediate predecessor is plain text, not the ToolUse: {last_json}"
         );
     }
 }

--- a/crates/zeph-llm/src/lib.rs
+++ b/crates/zeph-llm/src/lib.rs
@@ -113,6 +113,7 @@ pub mod stt;
 #[cfg(test)]
 pub mod testing;
 pub(crate) mod tool_desc;
+pub mod tool_pairing;
 pub(crate) mod usage;
 pub mod whisper;
 
@@ -127,4 +128,8 @@ pub use provider_dyn::LlmProviderDyn;
 pub use router::aware::RouterAware;
 pub use router::coe::{CoeConfig, CoeMetrics, CoeRouter};
 pub use stt::{SpeechToText, Transcription};
+pub use tool_pairing::{
+    OrphanAction, RepairReport, has_meaningful_content, repair_tool_pairs, repair_window,
+    unmatched_tool_result_ids, unmatched_tool_use_ids,
+};
 pub use zeph_config::{CacheTtl, GeminiThinkingLevel, ThinkingConfig, ThinkingEffort};

--- a/crates/zeph-llm/src/provider.rs
+++ b/crates/zeph-llm/src/provider.rs
@@ -713,7 +713,7 @@ impl Message {
         }
     }
 
-    fn flatten_parts(parts: &[MessagePart]) -> String {
+    pub(crate) fn flatten_parts(parts: &[MessagePart]) -> String {
         use std::fmt::Write;
         let mut out = String::new();
         for part in parts {

--- a/crates/zeph-llm/src/tool_pairing.rs
+++ b/crates/zeph-llm/src/tool_pairing.rs
@@ -1,0 +1,902 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shared `ToolUse`/`ToolResult` pairing and repair, used by every history-mutating call site
+//! and by the Claude request builder's per-request hot path (issue #6771).
+//!
+//! # Adjacency, not global id sets
+//!
+//! A pair is valid only when the `ToolResult` is in the message **immediately following** (across
+//! `Role::System` messages, which are skipped) the `ToolUse`'s message, and vice versa. Matching
+//! against a global id set across the whole history is wrong: some providers (e.g. Ollama, which
+//! mints ids as `format!("call_{i}")` by batch index — `crates/zeph-llm/src/ollama.rs`) legitimately
+//! reuse the same id across unrelated turns, so a global set cross-pairs an orphan left by a trim
+//! or restore boundary against an unrelated call that happens to share its id (issue #6770). Every
+//! function in this module is adjacency-scoped for this reason.
+//!
+//! # Two layers
+//!
+//! - **Layer A** — [`unmatched_tool_use_ids`] / [`unmatched_tool_result_ids`]: pure classification,
+//!   the single definition of "orphaned" in this codebase. They take already-resolved neighbour
+//!   messages, so they work whether the caller holds `Vec<Message>` (history-mutating call sites)
+//!   or `Vec<&Message>` (the Claude request builder's per-request hot path, which lowers parts into
+//!   wire blocks without cloning history).
+//! - **Layer B** — [`repair_tool_pairs`] / [`repair_window`]: mutating repair, built strictly on top
+//!   of Layer A. Layer B never re-implements the pairing predicate — it calls Layer A, collects the
+//!   returned ids into an owned `HashSet<String>`, then mutates. This is visible directly in the
+//!   source of [`repair_tool_pairs`] below: every orphan decision is a call to
+//!   [`unmatched_tool_use_ids`] or [`unmatched_tool_result_ids`], and neither of those functions
+//!   themselves has a caller inside Layer B other than each other's opposite pass. A reviewer
+//!   verifies this by reading the two pass loops, not by grepping for a pattern — a
+//!   `MessagePart::ToolUse`/`MessagePart::ToolResult` match alone does not distinguish correct
+//!   Layer B code (which must match those variants to mutate `parts`) from a duplicated predicate.
+//!
+//! # Orphaned `ToolUse` is always deleted
+//!
+//! Unlike an orphaned `ToolResult` (which already carries content and can be downgraded to a
+//! non-empty `Text` part, see [`OrphanAction::DowngradeToText`]), an orphaned `ToolUse` has no safe
+//! text form worth preserving as conversation content — every call site already deletes it
+//! unconditionally, so [`repair_tool_pairs`] does the same regardless of `action`.
+//!
+//! # Divergent markers (defensive, not currently exercised)
+//!
+//! [`has_meaningful_content`] recognizes the legacy `[tool_use: `/`[tool_result: `/`[tool output: `
+//! markers produced by `Message::flatten_parts` (underscore, no space before the colon).
+//! [`OrphanAction::DowngradeToText`]'s marker is deliberately `[tool result: {id}] {content}`
+//! (space, no underscore) so a downgraded `ToolResult` always reads as "meaningful" and is never
+//! mistaken for empty, marker-only content — an orphan downgraded specifically to survive as a
+//! window's leading `user` anchor must not then be treated as removable. **If a future caller ever
+//! passes `DowngradeToText` to a site whose surviving text is later checked with
+//! [`has_meaningful_content`], the two markers must stay divergent for that invariant to hold.**
+//! No current caller does this: the only [`has_meaningful_content`] consumer
+//! (`zeph_agent_persistence::sanitize::sanitize_tool_pairs`) uses [`OrphanAction::Delete`], so the
+//! downgrade marker is never actually evaluated against it today.
+//!
+//! # Content resync is exact, not a per-caller policy (issue #6771, R1)
+//!
+//! Both [`repair_tool_pairs`] and [`repair_window`] mutate a message's `content` after stripping
+//! or downgrading a part **only when that message's `content` was already an exact
+//! `flatten_parts` of its (pre-mutation) `parts`** — captured immediately before the mutation, per
+//! message. A DB-restored message can hold independently-authored text `flatten_parts` cannot
+//! reconstruct (e.g. `"Let me list the directory. [tool_use: shell(x)]"` with only a `ToolUse`
+//! part); rebuilding such a message's `content` would silently destroy that text. An earlier
+//! revision instead rebuilt unconditionally in [`repair_window`] on the (false) assumption that
+//! every caller of that function builds messages via `Message::from_parts` — `trim_parent_messages`
+//! (`zeph-core`) actually clones DB-restored parent messages, so this fired on every subagent
+//! spawn under `ParentContextPolicy::Inherit`/`InheritSanitized`, not just on genuine boundary
+//! damage. The per-message, pre-mutation check is exact regardless of caller: a `from_parts`-built
+//! message is always `content == flatten_parts(parts)`, so nothing that needed resyncing before is
+//! now missed, and nothing with divergent content is ever touched.
+//!
+//! One refinement on top of the exact check: a mutated message is also resynced when its stale
+//! `content` had no [`has_meaningful_content`] text (empty or whitespace-only), even though it
+//! wasn't flatten-derived. Without this, [`OrphanAction::DowngradeToText`]'s non-empty-anchor
+//! guarantee (the #6762 N5 fix) could be silently defeated: the orphan survives as a `Text` part
+//! in `parts`, but a stale empty/whitespace `content` is what request builders that read
+//! `to_llm_content()` directly actually see. This is still lossless with respect to the rule
+//! above — a stale content with nothing meaningful to preserve is, by definition, safe to
+//! overwrite in either `OrphanAction` arm.
+//!
+//! # Pass ordering is closed under both `OrphanAction` values
+//!
+//! [`repair_tool_pairs`] runs pass 1 (repair orphaned `ToolResult`s in `User` messages) fully
+//! before pass 2 (strip orphaned `ToolUse`s from `Assistant` messages) — a single ordered sweep,
+//! not a fixed-point loop. This is sufficient: a `ToolResult` that pass 1 validates as matched
+//! against assistant `A` implies `A` holds the matching `ToolUse`, which pass 2 therefore always
+//! keeps — pass 2 can never remove the anchor pass 1 relied on. Iteration is required only for
+//! [`repair_window`]'s leading-message-drop cascade: dropping a leading `Assistant` message can
+//! newly orphan a `ToolResult` that `repair_tool_pairs` correctly kept intact (the pair was
+//! well-formed before the drop), so `repair_window` loops `repair_tool_pairs` and the leading-drop
+//! together to a joint fixed point. Termination is guaranteed because every non-final iteration
+//! strictly decreases `(#ToolUse parts + #ToolResult parts) + (#messages)`: a delete removes a
+//! part, a downgrade converts a `ToolResult` into a `Text` part (never re-examined by either pass),
+//! and a leading-drop removes a message — no combination can increase the measure, so no ping-pong.
+
+use std::collections::HashSet;
+
+use crate::provider::{Message, MessagePart, Role};
+
+/// Collect `tool_use` ids from `msg` that have no matching `ToolResult` in `next`.
+///
+/// `next` must resolve to the message immediately following `msg` in the caller's window,
+/// skipping any `Role::System` messages — this function does not walk `Vec<Message>` itself, so
+/// it works identically whether the caller holds owned messages or borrowed references (the
+/// Claude request builder's hot path holds `Vec<&Message>`). A match requires `next.role ==
+/// Role::User`; any other role (including `None`, e.g. `msg` is the last message in the window)
+/// means every `ToolUse` id in `msg` is unmatched.
+///
+/// `msg`'s own role is not checked — the caller decides whether `msg` is eligible (only an
+/// `Assistant` message can meaningfully carry an unmatched `ToolUse`).
+///
+/// # Examples
+///
+/// ```
+/// use zeph_llm::provider::{Message, MessagePart, Role};
+/// use zeph_llm::tool_pairing::unmatched_tool_use_ids;
+///
+/// let asst = Message::from_parts(Role::Assistant, vec![MessagePart::ToolUse {
+///     id: "t1".into(),
+///     name: "bash".into(),
+///     input: serde_json::json!({}),
+/// }]);
+///
+/// // No next message at all: the ToolUse is unmatched.
+/// assert_eq!(unmatched_tool_use_ids(&asst, None), ["t1"].into_iter().collect());
+///
+/// // A following User message with the matching ToolResult clears it.
+/// let user = Message::from_parts(Role::User, vec![MessagePart::ToolResult {
+///     tool_use_id: "t1".into(),
+///     content: "ok".into(),
+///     is_error: false,
+/// }]);
+/// assert!(unmatched_tool_use_ids(&asst, Some(&user)).is_empty());
+/// ```
+#[must_use]
+pub fn unmatched_tool_use_ids<'a>(msg: &'a Message, next: Option<&Message>) -> HashSet<&'a str> {
+    let matched: HashSet<&str> = next.filter(|n| n.role == Role::User).map_or_default(|n| {
+        n.parts
+            .iter()
+            .filter_map(|p| match p {
+                MessagePart::ToolResult { tool_use_id, .. } => Some(tool_use_id.as_str()),
+                _ => None,
+            })
+            .collect()
+    });
+
+    msg.parts
+        .iter()
+        .filter_map(|p| match p {
+            MessagePart::ToolUse { id, .. } if !matched.contains(id.as_str()) => Some(id.as_str()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Collect `tool_result` ids from `msg` that have no matching `ToolUse` in `prev`.
+///
+/// `prev` must resolve to the message immediately preceding `msg`, skipping `Role::System`
+/// messages. A match requires `prev.role == Role::Assistant`; any other role (including `None`,
+/// e.g. `msg` is the first message in the window) means every `ToolResult` id in `msg` is
+/// unmatched.
+///
+/// `msg`'s own role is not checked — the caller decides whether `msg` is eligible.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_llm::provider::{Message, MessagePart, Role};
+/// use zeph_llm::tool_pairing::unmatched_tool_result_ids;
+///
+/// let user = Message::from_parts(Role::User, vec![MessagePart::ToolResult {
+///     tool_use_id: "t1".into(),
+///     content: "ok".into(),
+///     is_error: false,
+/// }]);
+///
+/// // No preceding message: the ToolResult is unmatched.
+/// assert_eq!(unmatched_tool_result_ids(&user, None), ["t1"].into_iter().collect());
+///
+/// // A preceding Assistant message with the matching ToolUse clears it.
+/// let asst = Message::from_parts(Role::Assistant, vec![MessagePart::ToolUse {
+///     id: "t1".into(),
+///     name: "bash".into(),
+///     input: serde_json::json!({}),
+/// }]);
+/// assert!(unmatched_tool_result_ids(&user, Some(&asst)).is_empty());
+/// ```
+#[must_use]
+pub fn unmatched_tool_result_ids<'a>(msg: &'a Message, prev: Option<&Message>) -> HashSet<&'a str> {
+    let available: HashSet<&str> = prev
+        .filter(|p| p.role == Role::Assistant)
+        .map_or_default(|p| {
+            p.parts
+                .iter()
+                .filter_map(|part| match part {
+                    MessagePart::ToolUse { id, .. } => Some(id.as_str()),
+                    _ => None,
+                })
+                .collect()
+        });
+
+    msg.parts
+        .iter()
+        .filter_map(|p| match p {
+            MessagePart::ToolResult { tool_use_id, .. }
+                if !available.contains(tool_use_id.as_str()) =>
+            {
+                Some(tool_use_id.as_str())
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+/// How [`repair_tool_pairs`] and [`repair_window`] handle an orphaned `ToolResult` part.
+///
+/// Only `ToolResult` orphans are configurable — orphaned `ToolUse` parts are always deleted (see
+/// the module docs). Choose `Delete` for terminal, DB-restored, or otherwise final snapshots where
+/// the orphan carries no further use; choose `DowngradeToText` for a live in-progress window where
+/// the orphaned `ToolResult` may be the only message available to anchor the window on a `user`
+/// role (deleting it there can cascade into removing the window's only conversational content).
+///
+/// # Examples
+///
+/// ```
+/// use zeph_llm::tool_pairing::OrphanAction;
+///
+/// let terminal_snapshot = OrphanAction::Delete;
+/// let live_window = OrphanAction::DowngradeToText;
+///
+/// let describes_deletion = matches!(terminal_snapshot, OrphanAction::Delete);
+/// assert!(describes_deletion);
+/// assert_ne!(terminal_snapshot, live_window);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrphanAction {
+    /// Remove the orphaned `ToolResult` part entirely.
+    Delete,
+    /// Replace the orphaned `ToolResult` part with a `MessagePart::Text` carrying the same
+    /// content, marked `[tool result: {id}] {content}` — guaranteed non-empty even when
+    /// `content` is empty, so the message survives as a valid, non-empty anchor.
+    DowngradeToText,
+}
+
+/// Outcome of a [`repair_tool_pairs`] or [`repair_window`] call.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_llm::provider::{Message, MessagePart, Role};
+/// use zeph_llm::tool_pairing::{repair_tool_pairs, OrphanAction};
+///
+/// let mut messages = vec![Message::from_parts(Role::Assistant, vec![MessagePart::ToolUse {
+///     id: "t1".into(),
+///     name: "bash".into(),
+///     input: serde_json::json!({}),
+/// }])];
+/// let report = repair_tool_pairs(&mut messages, OrphanAction::Delete);
+///
+/// assert_eq!(report.parts_repaired, 1, "the orphaned ToolUse was stripped");
+/// assert_eq!(report.removed_messages.len(), 1, "the now-empty message was removed");
+/// ```
+pub struct RepairReport {
+    /// Number of `ToolUse`/`ToolResult` parts deleted or downgraded.
+    pub parts_repaired: usize,
+    /// Messages removed entirely because repair left them with no parts and no content.
+    /// Moved (not cloned) so a caller can recover `metadata.db_id` for soft-delete without a
+    /// separate lookup pass.
+    pub removed_messages: Vec<Message>,
+}
+
+/// One ordered sweep repairing orphaned `ToolUse`/`ToolResult` parts in `messages`.
+///
+/// Pass 1 repairs orphaned `ToolResult` parts in `User` messages per `action` (adjacency against
+/// the immediately preceding non-system message). Pass 2 then strips orphaned `ToolUse` parts from
+/// `Assistant` messages (adjacency against the immediately following non-system message, which by
+/// this point reflects pass 1's mutations) — always deleted, regardless of `action`. A message
+/// left with empty `parts` and no [`has_meaningful_content`] text after either pass is removed,
+/// **except** `Role::System` messages, which are never removed. `content` itself is never
+/// mutated by this function (see the inline notes on why). See the module docs for why one
+/// ordered sweep (not a fixed-point loop) is sufficient here.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_llm::provider::{Message, MessagePart, Role};
+/// use zeph_llm::tool_pairing::{repair_tool_pairs, OrphanAction};
+///
+/// // A trailing, unanswered ToolUse is orphaned and stripped, regardless of position.
+/// let mut messages = vec![
+///     Message::from_legacy(Role::System, "sys"),
+///     Message::from_parts(Role::Assistant, vec![MessagePart::ToolUse {
+///         id: "t1".into(),
+///         name: "bash".into(),
+///         input: serde_json::json!({}),
+///     }]),
+/// ];
+/// let report = repair_tool_pairs(&mut messages, OrphanAction::Delete);
+/// assert_eq!(report.parts_repaired, 1);
+/// // The now-empty assistant message was removed; only the system message survives.
+/// assert_eq!(messages.len(), 1);
+/// assert_eq!(messages[0].role, Role::System);
+/// ```
+#[must_use]
+pub fn repair_tool_pairs(messages: &mut Vec<Message>, action: OrphanAction) -> RepairReport {
+    let mut parts_repaired = 0usize;
+
+    // Pass 1: repair orphaned ToolResult parts in User messages.
+    for i in 0..messages.len() {
+        if messages[i].role != Role::User || messages[i].parts.is_empty() {
+            continue;
+        }
+        let orphaned: HashSet<String> = {
+            let prev = (0..i)
+                .rev()
+                .find(|&j| messages[j].role != Role::System)
+                .map(|j| &messages[j]);
+            unmatched_tool_result_ids(&messages[i], prev)
+                .into_iter()
+                .map(str::to_owned)
+                .collect()
+        };
+        if orphaned.is_empty() {
+            continue;
+        }
+
+        // Captured BEFORE mutating `parts`: only a message whose `content` was already an exact
+        // flatten of its (pre-repair) `parts` is safe to re-flatten afterward. A DB-restored
+        // message can hold independently-authored text beyond what `flatten_parts` produces —
+        // rebuilding unconditionally would silently clobber it (R1 regression, issue #6771). This
+        // is exact per message, not a per-caller policy: a from_parts-built message is always
+        // `was_derived`, so this never under-syncs the in-memory callers either.
+        let was_derived = messages[i].content == Message::flatten_parts(&messages[i].parts);
+
+        let mut changed = 0usize;
+        match action {
+            OrphanAction::Delete => {
+                let before = messages[i].parts.len();
+                messages[i].parts.retain(|p| {
+                    !matches!(p, MessagePart::ToolResult { tool_use_id, .. } if orphaned.contains(tool_use_id.as_str()))
+                });
+                changed = before - messages[i].parts.len();
+            }
+            OrphanAction::DowngradeToText => {
+                for part in &mut messages[i].parts {
+                    if let MessagePart::ToolResult {
+                        tool_use_id,
+                        content,
+                        ..
+                    } = part
+                        && orphaned.contains(tool_use_id.as_str())
+                    {
+                        let text = format!("[tool result: {tool_use_id}] {content}");
+                        *part = MessagePart::Text { text };
+                        changed += 1;
+                    }
+                }
+            }
+        }
+
+        if changed > 0 {
+            parts_repaired += changed;
+            // E1 hardening: also rebuild when the stale `content` had nothing worth preserving
+            // (empty/whitespace) — under `Delete` this is a no-op (parts are now empty, see
+            // `Message::rebuild_content`'s own contract); under `DowngradeToText` it restores the
+            // downgrade's non-empty-anchor guarantee (#6762 N5) instead of leaving a message
+            // whose surviving `Text` part is invisible to `to_llm_content()` because `content`
+            // was never synced. Lossless in both arms: a *meaningful* stale content is still
+            // never touched, which is R1's entire point.
+            if was_derived || !has_meaningful_content(&messages[i].content) {
+                messages[i].rebuild_content();
+            }
+        }
+    }
+
+    // Pass 2: strip orphaned ToolUse parts from Assistant messages — always deleted.
+    for i in 0..messages.len() {
+        if messages[i].role != Role::Assistant || messages[i].parts.is_empty() {
+            continue;
+        }
+        let orphaned: HashSet<String> = {
+            let next = (i + 1..messages.len())
+                .find(|&j| messages[j].role != Role::System)
+                .map(|j| &messages[j]);
+            unmatched_tool_use_ids(&messages[i], next)
+                .into_iter()
+                .map(str::to_owned)
+                .collect()
+        };
+        if orphaned.is_empty() {
+            continue;
+        }
+
+        // See the matching note in pass 1 — the same exact, per-message guard applies here.
+        let was_derived = messages[i].content == Message::flatten_parts(&messages[i].parts);
+
+        let before = messages[i].parts.len();
+        messages[i].parts.retain(
+            |p| !matches!(p, MessagePart::ToolUse { id, .. } if orphaned.contains(id.as_str())),
+        );
+        let changed = before - messages[i].parts.len();
+        if changed > 0 {
+            parts_repaired += changed;
+            // See the matching note in pass 1 — same E1 hardening applies here (though pass 2
+            // always deletes, so `rebuild_content` no-ops on the now-empty `parts` regardless).
+            if was_derived || !has_meaningful_content(&messages[i].content) {
+                messages[i].rebuild_content();
+            }
+        }
+    }
+
+    // Unconditional — not gated on `parts_repaired > 0`. A message that was already empty
+    // (parts and meaningful content both absent) before this call is removed too, matching the
+    // pre-#6771 per-site behavior (site 1's old unconditional `retain`, site 3's `service.rs`
+    // pre-filter) rather than making removal a side effect of an unrelated repair elsewhere in
+    // the same call. This also converges site 3's two callers: `service.rs` pre-filters on the
+    // identical predicate before calling this function, `hydrate.rs` does not — with an
+    // unconditional sweep both now get the same cleanup regardless of that difference.
+    let mut removed_messages = Vec::new();
+    let mut idx = 0;
+    while idx < messages.len() {
+        // `has_meaningful_content` (not a plain `content.is_empty()` check) because a message
+        // that was not `was_derived` above never got its `content` rebuilt from the (now empty)
+        // `parts` — it can still carry independently-authored text after its last structured
+        // part is gone.
+        let empty = messages[idx].role != Role::System
+            && messages[idx].parts.is_empty()
+            && !has_meaningful_content(&messages[idx].content);
+        if empty {
+            removed_messages.push(messages.remove(idx));
+        } else {
+            idx += 1;
+        }
+    }
+
+    RepairReport {
+        parts_repaired,
+        removed_messages,
+    }
+}
+
+/// Drops the first non-system message in `messages` if its role is not `Role::User`.
+fn drop_leading_non_user_message(messages: &mut Vec<Message>) -> Option<Message> {
+    let idx = messages.iter().position(|m| m.role != Role::System)?;
+    if messages[idx].role == Role::User {
+        return None;
+    }
+    Some(messages.remove(idx))
+}
+
+/// [`repair_tool_pairs`] plus a leading-role invariant: the first non-system message in
+/// `messages` must have `Role::User` (required by the Anthropic API and not enforced by
+/// `repair_tool_pairs` alone). The two are looped to a joint fixed point because dropping a
+/// leading non-`user` message can newly orphan a pair that `repair_tool_pairs` had correctly
+/// kept intact — see the module docs for the counter-example and termination argument.
+///
+/// `content` handling is identical to `repair_tool_pairs` (each mutated message is resynced only
+/// if its `content` was already an exact flatten of its parts before that mutation — see
+/// `repair_tool_pairs`'s doc comment) — `repair_window`'s extra leading-drop pass introduces no
+/// separate content-handling rule of its own.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_llm::provider::{Message, MessagePart, Role};
+/// use zeph_llm::tool_pairing::{repair_window, OrphanAction};
+///
+/// // A well-formed pair leads the window — repair_tool_pairs alone would keep it, but the
+/// // leading-role invariant requires a leading Assistant message to be dropped, which then
+/// // orphans the ToolResult it left behind. repair_window catches this second-order effect.
+/// let mut messages = vec![
+///     Message::from_parts(Role::Assistant, vec![MessagePart::ToolUse {
+///         id: "t1".into(),
+///         name: "bash".into(),
+///         input: serde_json::json!({}),
+///     }]),
+///     Message::from_parts(Role::User, vec![MessagePart::ToolResult {
+///         tool_use_id: "t1".into(),
+///         content: "ok".into(),
+///         is_error: false,
+///     }]),
+/// ];
+/// repair_window(&mut messages, OrphanAction::Delete);
+/// assert!(messages.is_empty(), "the leading-drop cascade must remove the whole window");
+/// ```
+#[must_use]
+pub fn repair_window(messages: &mut Vec<Message>, action: OrphanAction) -> RepairReport {
+    let mut parts_repaired = 0usize;
+    let mut removed_messages = Vec::new();
+
+    loop {
+        let report = repair_tool_pairs(messages, action);
+        parts_repaired += report.parts_repaired;
+        removed_messages.extend(report.removed_messages);
+
+        let dropped = drop_leading_non_user_message(messages);
+        let dropped_any = dropped.is_some();
+        removed_messages.extend(dropped);
+
+        if report.parts_repaired == 0 && !dropped_any {
+            break;
+        }
+    }
+
+    RepairReport {
+        parts_repaired,
+        removed_messages,
+    }
+}
+
+/// Returns `true` if `content` contains human-readable text beyond legacy tool bracket markers.
+///
+/// Moved from `zeph_agent_persistence::sanitize` (issue #6771) — it decodes markers produced by
+/// [`Message::flatten_parts`](crate::provider::Message), which lives in this crate. Legacy
+/// markers are:
+/// - `[tool_use: name(id)]` — assistant `ToolUse`
+/// - `[tool_result: id]\nbody` — user `ToolResult`
+/// - `[tool output: name] body` — `ToolOutput`
+///
+/// A message whose content consists solely of such markers (and whitespace) has no user-visible
+/// text and is a candidate for soft-delete. See the module docs for why this deliberately does
+/// *not* recognize [`OrphanAction::DowngradeToText`]'s `[tool result: ` (space) marker.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_llm::tool_pairing::has_meaningful_content;
+///
+/// assert!(has_meaningful_content("hello world"));
+/// assert!(!has_meaningful_content("[tool_use: bash(abc123)]"));
+/// assert!(!has_meaningful_content("   [tool_result: abc]\nsome output"));
+/// ```
+#[must_use]
+pub fn has_meaningful_content(content: &str) -> bool {
+    const PREFIXES: [&str; 3] = ["[tool_use: ", "[tool_result: ", "[tool output: "];
+
+    let mut remaining = content.trim();
+
+    loop {
+        let next = PREFIXES
+            .iter()
+            .filter_map(|prefix| remaining.find(prefix).map(|pos| (pos, *prefix)))
+            .min_by_key(|(pos, _)| *pos);
+
+        let Some((start, prefix)) = next else {
+            break;
+        };
+
+        if !remaining[..start].trim().is_empty() {
+            return true;
+        }
+
+        let after_prefix = &remaining[start + prefix.len()..];
+        let Some(close) = after_prefix.find(']') else {
+            return true; // Malformed tag — treat as meaningful.
+        };
+
+        let tag_end = start + prefix.len() + close + 1;
+
+        if prefix == "[tool_result: " || prefix == "[tool output: " {
+            let body = remaining[tag_end..].trim_start_matches('\n');
+            let next_tag = PREFIXES
+                .iter()
+                .filter_map(|p| body.find(p))
+                .min()
+                .unwrap_or(body.len());
+            remaining = &body[next_tag..];
+        } else {
+            remaining = &remaining[tag_end..];
+        }
+    }
+
+    !remaining.trim().is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tool_use(id: &str) -> MessagePart {
+        MessagePart::ToolUse {
+            id: id.to_owned(),
+            name: "bash".to_owned(),
+            input: serde_json::json!({}),
+        }
+    }
+
+    fn tool_result(id: &str, content: &str) -> MessagePart {
+        MessagePart::ToolResult {
+            tool_use_id: id.to_owned(),
+            content: content.to_owned(),
+            is_error: false,
+        }
+    }
+
+    fn has_tool_use(m: &Message, id: &str) -> bool {
+        m.parts
+            .iter()
+            .any(|p| matches!(p, MessagePart::ToolUse { id: tid, .. } if tid == id))
+    }
+
+    fn has_tool_result(m: &Message, id: &str) -> bool {
+        m.parts
+            .iter()
+            .any(|p| matches!(p, MessagePart::ToolResult { tool_use_id, .. } if tool_use_id == id))
+    }
+
+    #[test]
+    fn adjacency_scoping_ignores_id_reuse_across_unrelated_turns() {
+        // #6770: a global id set would wrongly pair a leading orphan against an unrelated,
+        // later call sharing its id (Ollama-style `call_0` reuse).
+        let mut messages = vec![
+            Message::from_parts(Role::User, vec![tool_result("call_0", "orphaned")]),
+            Message::from_legacy(Role::Assistant, "unrelated text turn"),
+            Message::from_parts(Role::Assistant, vec![tool_use("call_0")]),
+            Message::from_parts(Role::User, vec![tool_result("call_0", "turn-2 output")]),
+        ];
+        let report = repair_tool_pairs(&mut messages, OrphanAction::Delete);
+        assert_eq!(report.parts_repaired, 1);
+        assert_eq!(report.removed_messages.len(), 1);
+        assert!(messages.iter().any(|m| has_tool_use(m, "call_0")));
+        let remaining_results: Vec<&str> = messages
+            .iter()
+            .flat_map(|m| m.parts.iter())
+            .filter_map(|p| match p {
+                MessagePart::ToolResult { content, .. } => Some(content.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(remaining_results, vec!["turn-2 output"]);
+    }
+
+    #[test]
+    fn trailing_orphaned_tool_use_is_repaired_not_exempted() {
+        // S1: TrailingToolUse::Exempt was deleted — Repair is universal, including the trailing
+        // message of the window.
+        let mut messages = vec![Message::from_parts(Role::Assistant, vec![tool_use("t1")])];
+        let report = repair_tool_pairs(&mut messages, OrphanAction::Delete);
+        assert_eq!(report.parts_repaired, 1);
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn intact_pair_survives_a_single_sweep() {
+        // S2: pass 1 keeps a validated ToolResult, so pass 2 (reading the same, unmutated
+        // message) never removes the ToolUse anchor it relied on.
+        let mut messages = vec![
+            Message::from_parts(Role::Assistant, vec![tool_use("t1")]),
+            Message::from_parts(Role::User, vec![tool_result("t1", "ok")]),
+        ];
+        let report = repair_tool_pairs(&mut messages, OrphanAction::Delete);
+        assert_eq!(report.parts_repaired, 0);
+        assert!(has_tool_use(&messages[0], "t1"));
+        assert!(has_tool_result(&messages[1], "t1"));
+    }
+
+    #[test]
+    fn downgrade_produces_non_empty_marker_even_for_empty_content() {
+        let mut messages = vec![
+            Message::from_legacy(Role::System, "sys"),
+            Message::from_parts(Role::User, vec![tool_result("t1", "")]),
+        ];
+        let report = repair_tool_pairs(&mut messages, OrphanAction::DowngradeToText);
+        assert_eq!(report.parts_repaired, 1);
+        assert_eq!(
+            messages.len(),
+            2,
+            "the downgraded message must survive, not be removed"
+        );
+        let text = messages[1]
+            .parts
+            .iter()
+            .find_map(|p| match p {
+                MessagePart::Text { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .expect("orphan must survive downgraded to Text");
+        assert!(!text.trim().is_empty());
+    }
+
+    #[test]
+    fn repair_window_cascades_leading_drop_into_a_newly_orphaned_pair() {
+        // S2's counter-example: repair_tool_pairs alone keeps this pair intact, but the
+        // leading-role invariant drops the leading Assistant message, which then orphans the
+        // ToolResult it left behind — requiring a second pairing pass.
+        let mut messages = vec![
+            Message::from_parts(Role::Assistant, vec![tool_use("t1")]),
+            Message::from_parts(Role::User, vec![tool_result("t1", "ok")]),
+        ];
+        let report = repair_window(&mut messages, OrphanAction::Delete);
+        assert!(messages.is_empty());
+        assert_eq!(report.removed_messages.len(), 2);
+    }
+
+    #[test]
+    fn system_messages_are_never_removed() {
+        let mut messages = vec![
+            Message::from_legacy(Role::System, String::new()),
+            Message::from_parts(Role::User, vec![tool_result("t1", "orphaned")]),
+        ];
+        let report = repair_tool_pairs(&mut messages, OrphanAction::Delete);
+        assert_eq!(report.parts_repaired, 1);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].role, Role::System);
+    }
+
+    #[test]
+    fn adjacency_skips_over_an_intervening_system_message() {
+        // The module docs promise adjacency is scoped to the immediately preceding/following
+        // *non-system* message. A Role::System message spliced between a ToolUse and its
+        // ToolResult (e.g. a focus checkpoint or utility hint pushed mid-turn, per the impl
+        // critic's verified S6 trace) must not break the pairing.
+        let mut messages = vec![
+            Message::from_parts(Role::Assistant, vec![tool_use("t1")]),
+            Message::from_legacy(Role::System, "focus checkpoint"),
+            Message::from_parts(Role::User, vec![tool_result("t1", "ok")]),
+        ];
+        let report = repair_tool_pairs(&mut messages, OrphanAction::Delete);
+        assert_eq!(
+            report.parts_repaired, 0,
+            "the pair is adjacent across the System message"
+        );
+        assert!(has_tool_use(&messages[0], "t1"));
+        assert_eq!(messages[1].role, Role::System);
+        assert!(has_tool_result(&messages[2], "t1"));
+    }
+
+    #[test]
+    fn multiple_consecutive_orphaned_tool_use_ids_in_one_message_are_all_stripped() {
+        let mut messages = vec![Message::from_parts(
+            Role::Assistant,
+            vec![tool_use("t1"), tool_use("t2"), tool_use("t3")],
+        )];
+        let report = repair_tool_pairs(&mut messages, OrphanAction::Delete);
+        assert_eq!(report.parts_repaired, 3);
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn all_orphan_window_is_fully_repaired_in_one_sweep() {
+        let mut messages = vec![
+            Message::from_parts(Role::User, vec![tool_result("a", "orphan-a")]),
+            Message::from_parts(Role::Assistant, vec![tool_use("b")]),
+            Message::from_parts(Role::User, vec![tool_result("c", "orphan-c")]),
+        ];
+        let report = repair_tool_pairs(&mut messages, OrphanAction::Delete);
+        assert_eq!(report.parts_repaired, 3);
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn repair_window_on_a_system_only_window_is_a_noop() {
+        let mut messages = vec![Message::from_legacy(Role::System, "sys")];
+        let report = repair_window(&mut messages, OrphanAction::Delete);
+        assert_eq!(report.parts_repaired, 0);
+        assert!(report.removed_messages.is_empty());
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].role, Role::System);
+    }
+
+    #[test]
+    fn repair_tool_pairs_never_touches_content_on_a_partial_strip() {
+        // C2: a message that keeps some parts after a strip must have its `content` left
+        // untouched when that `content` was not an exact flatten of its parts to begin with — a
+        // DB-restored message can hold independently-authored text (`ThinkingBlock` alone
+        // flattens to "") that `flatten_parts` of the surviving parts cannot reconstruct. The
+        // `was_derived` check (captured before this strip) is false here, so no resync happens.
+        let mut messages = vec![Message {
+            role: Role::Assistant,
+            content: "Independently-authored reasoning flatten_parts cannot reconstruct."
+                .to_owned(),
+            parts: vec![
+                MessagePart::ThinkingBlock {
+                    thinking: "internal reasoning".to_owned(),
+                    signature: "sig".to_owned(),
+                },
+                tool_use("orphan"),
+            ],
+            metadata: crate::provider::MessageMetadata::default(),
+        }];
+        let content_before = messages[0].content.clone();
+        let report = repair_tool_pairs(&mut messages, OrphanAction::Delete);
+        assert_eq!(
+            report.parts_repaired, 1,
+            "the orphaned ToolUse must be stripped"
+        );
+        assert_eq!(messages.len(), 1, "ThinkingBlock keeps parts non-empty");
+        assert!(!has_tool_use(&messages[0], "orphan"));
+        assert_eq!(
+            messages[0].content, content_before,
+            "content must never be touched by repair_tool_pairs, even on a partial strip"
+        );
+    }
+
+    #[test]
+    fn repair_window_resyncs_content_when_it_was_flatten_derived() {
+        // A from_parts-built message always has content == flatten_parts(parts), so the
+        // `was_derived` check is true here and the resync proceeds normally.
+        // A leading User anchor keeps the leading-role rule from also dropping the Assistant
+        // message under test (out of scope here — that behavior is covered elsewhere).
+        let mut messages = vec![
+            Message::from_parts(
+                Role::User,
+                vec![MessagePart::Text {
+                    text: "please investigate".to_owned(),
+                }],
+            ),
+            Message::from_parts(
+                Role::Assistant,
+                vec![
+                    MessagePart::Text {
+                        text: "thinking out loud".to_owned(),
+                    },
+                    tool_use("orphan"),
+                ],
+            ),
+        ];
+        let report = repair_window(&mut messages, OrphanAction::Delete);
+        assert_eq!(report.parts_repaired, 1);
+        assert_eq!(messages.len(), 2);
+        assert!(
+            messages[1].content.contains("thinking out loud"),
+            "repair_window must rebuild content to reflect the surviving Text part"
+        );
+        assert!(!messages[1].content.contains("tool_use"));
+    }
+
+    #[test]
+    fn repair_window_never_touches_divergent_content_when_nothing_needs_repair() {
+        // R1 regression (issue #6771): a DB-restored message can hold content richer than
+        // flatten_parts(parts) even when its ToolUse/ToolResult pair is fully matched and
+        // nothing needs repairing anywhere in the window. An earlier revision's unconditional
+        // bulk `for m in messages { m.rebuild_content() }` pass fired on every message with
+        // non-empty parts regardless of whether it was touched, silently destroying this exact
+        // case on every subagent spawn under ParentContextPolicy::Inherit. A leading User anchor
+        // keeps the leading-role rule from dropping the Assistant message under test.
+        let mut messages = vec![
+            Message::from_parts(
+                Role::User,
+                vec![MessagePart::Text {
+                    text: "please investigate".to_owned(),
+                }],
+            ),
+            Message {
+                role: Role::Assistant,
+                content: "Let me list the directory. [tool_use: shell(x)]".to_owned(),
+                parts: vec![tool_use("x")],
+                metadata: crate::provider::MessageMetadata::default(),
+            },
+            Message::from_parts(Role::User, vec![tool_result("x", "file1.rs")]),
+        ];
+        let content_before = messages[1].content.clone();
+        let report = repair_window(&mut messages, OrphanAction::Delete);
+        assert_eq!(
+            report.parts_repaired, 0,
+            "the pair is fully matched, nothing to repair"
+        );
+        assert_eq!(messages.len(), 3);
+        assert_eq!(
+            messages[1].content, content_before,
+            "content must survive untouched when nothing needed repair"
+        );
+    }
+
+    #[test]
+    fn e1_downgrade_still_restores_the_anchor_when_stale_content_was_not_meaningful() {
+        // E1 (impl-critic, non-blocking hardening): a message whose `content` is empty or
+        // whitespace-only and NOT flatten-derived (`was_derived == false`) must still get
+        // `content` resynced after a DowngradeToText repair — otherwise the downgrade's own
+        // non-empty-anchor guarantee (#6762 N5) is defeated at request-build time, since
+        // `to_llm_content()` reads `content` directly and a whitespace-only `content` is dropped
+        // by non-structured request-building branches. Rebuilding here is lossless: the stale
+        // content had nothing meaningful to preserve, so overwriting it with the flattened
+        // downgrade marker restores the anchor without reopening R1 (a *meaningful* stale
+        // content, R1's whole concern, is never touched by this path).
+        let mut messages = vec![Message {
+            role: Role::User,
+            content: "   ".to_owned(),
+            parts: vec![tool_result("orphan", "something")],
+            metadata: crate::provider::MessageMetadata::default(),
+        }];
+        let report = repair_tool_pairs(&mut messages, OrphanAction::DowngradeToText);
+        assert_eq!(report.parts_repaired, 1);
+        assert_eq!(
+            messages.len(),
+            1,
+            "the downgraded message must survive as the anchor"
+        );
+        let text_part = messages[0]
+            .parts
+            .iter()
+            .find_map(|p| match p {
+                MessagePart::Text { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .expect("orphan must survive downgraded to Text");
+        assert!(!text_part.trim().is_empty());
+        assert!(
+            messages[0].content.contains(text_part),
+            "content must be resynced to the downgraded anchor text, not left as stale whitespace"
+        );
+    }
+}

--- a/crates/zeph-subagent/src/agent_loop.rs
+++ b/crates/zeph-subagent/src/agent_loop.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, PoisonError};
 use std::time::Instant;
@@ -1055,13 +1055,13 @@ async fn handle_tool_step(
 ///
 /// A FIFO cutoff can land in the middle of a `ToolUse`/`ToolResult` pair, leaving an orphaned
 /// half in the retained window — a provider 400/422 on the next request (see
-/// `specs/002-agent-loop/spec.md`). [`repair_tool_pairing`] repairs the orphaned half after the
-/// drain so the retained window is always well-formed. The drain boundary is also nudged
-/// forward to the next `Role::User` message when possible (at most one extra message beyond
-/// `excess`, in the normal Assistant/User-alternating shape) — this is what lets a canonical
-/// subagent tool loop (pure `Assistant(ToolUse)`/`User(ToolResult)` alternation with no other
-/// plain-text anchor) land on a valid `user`-first window without relying on
-/// [`repair_tool_pairing`]'s leading-role cascade at all.
+/// `specs/002-agent-loop/spec.md`). [`zeph_llm::tool_pairing::repair_window`] repairs the
+/// orphaned half after the drain so the retained window is always well-formed. The drain
+/// boundary is also nudged forward to the next `Role::User` message when possible (at most one
+/// extra message beyond `excess`, in the normal Assistant/User-alternating shape) — this is what
+/// lets a canonical subagent tool loop (pure `Assistant(ToolUse)`/`User(ToolResult)` alternation
+/// with no other plain-text anchor) land on a valid `user`-first window without relying on
+/// `repair_window`'s leading-role cascade at all.
 ///
 /// `max_history_messages` is a plain user-authored per-subagent field with no lower bound —
 /// at a pathologically small `limit` (e.g. 1), the drain alone can leave zero non-system
@@ -1071,9 +1071,9 @@ async fn handle_tool_step(
 /// non-conversational — leaving `messages` over `limit` for this call rather than emitting a
 /// guaranteed-invalid request. The loop retries the trim every turn, so this self-heals once the
 /// message shape changes. This is a backstop, not the common path: for the shapes this crate
-/// actually produces, the boundary nudge plus [`repair_tool_pairing`]'s downgrade-not-delete
-/// handling of orphaned `ToolResult`s (see `strip_orphaned_tool_parts`) means the trim almost
-/// always succeeds instead of being skipped (issue #6762 review discussion, R1).
+/// actually produces, the boundary nudge plus `repair_window`'s downgrade-not-delete handling of
+/// orphaned `ToolResult`s means the trim almost always succeeds instead of being skipped (issue
+/// #6762 review discussion, R1).
 fn trim_message_history(messages: &mut Vec<Message>, limit: usize) {
     if limit == 0 || messages.len() <= limit {
         return;
@@ -1084,15 +1084,18 @@ fn trim_message_history(messages: &mut Vec<Message>, limit: usize) {
     let start = usize::from(has_system);
     let mut drain_end = (start + excess).min(messages.len());
     // Prefer a boundary that starts the retained window on a `User` message so it never needs
-    // `repair_tool_pairing`'s leading-role cascade in the first place — in the canonical
-    // alternating shape this costs at most one extra dropped message.
+    // `repair_window`'s leading-role cascade in the first place — in the canonical alternating
+    // shape this costs at most one extra dropped message.
     while drain_end < messages.len() && messages[drain_end].role != Role::User {
         drain_end += 1;
     }
 
     let mut candidate = messages.clone();
     candidate.drain(start..drain_end);
-    repair_tool_pairing(&mut candidate);
+    let report = zeph_llm::tool_pairing::repair_window(
+        &mut candidate,
+        zeph_llm::tool_pairing::OrphanAction::DowngradeToText,
+    );
 
     if candidate.iter().all(|m| m.role == Role::System) {
         tracing::warn!(
@@ -1103,180 +1106,18 @@ fn trim_message_history(messages: &mut Vec<Message>, limit: usize) {
         return;
     }
 
+    if report.parts_repaired > 0 {
+        tracing::debug!(
+            orphans = report.parts_repaired,
+            "repaired orphaned ToolUse/ToolResult parts from subagent history trim boundary"
+        );
+    }
     tracing::debug!(
         dropped = messages.len() - candidate.len(),
         remaining = candidate.len(),
         "trimming subagent message history"
     );
     *messages = candidate;
-}
-
-/// Repairs `ToolUse`/`ToolResult` parts left orphaned by a FIFO trim boundary (downgrading an
-/// orphaned `ToolResult` to text, stripping an orphaned `ToolUse`), and drops any leading
-/// non-system message that is not `Role::User`.
-///
-/// Pairing is adjacency-scoped — matched against the immediately preceding/following
-/// non-system message, never a global id set — because providers such as Ollama mint tool-call
-/// ids by batch index (`call_0`, `call_1`, ...; see `crates/zeph-llm/src/ollama.rs`), so the
-/// same id recurs across unrelated turns. A global set would wrongly pair an orphan left by the
-/// drain against an unrelated call sharing its id. This mirrors the adjacency scoping in
-/// `zeph_agent_persistence::sanitize::sanitize_tool_pairs`, adapted for a FIFO count-based
-/// cutoff instead of DB-restored history (`crates/zeph-core/src/agent/subagent_commands.rs`'s
-/// `trim_parent_messages` has the same global-set gap; see issue #6762 discussion).
-///
-/// Anthropic requires the first non-system message in a request to have role `user`, and
-/// nothing downstream normalizes this (`crates/zeph-llm/src/claude/request.rs` passes roles
-/// through verbatim) — a FIFO cutoff can leave a *correctly paired* `ToolUse`/`ToolResult` at
-/// the front whose assistant message is not itself orphaned, so pairing repair alone would not
-/// catch it. Dropping that leading assistant message can newly orphan whatever followed it, so
-/// pairing repair and the leading-role check run to a fixed point.
-///
-/// Messages left empty by pruning are removed; the system message (if any) is always kept.
-fn repair_tool_pairing(messages: &mut Vec<Message>) {
-    let mut orphans_repaired = 0usize;
-    loop {
-        let stripped = strip_orphaned_tool_parts(messages);
-        orphans_repaired += stripped;
-        let dropped_leading = drop_leading_non_user_message(messages);
-        if stripped == 0 && !dropped_leading {
-            break;
-        }
-    }
-    if orphans_repaired > 0 {
-        tracing::debug!(
-            orphans = orphans_repaired,
-            "repaired orphaned ToolUse/ToolResult parts from subagent history trim boundary"
-        );
-    }
-}
-
-/// One adjacency-scoped sweep over `messages`:
-///
-/// 1. Downgrade `ToolResult` parts in user messages whose matching `ToolUse` is not present in
-///    the immediately preceding non-system message to a plain `MessagePart::Text` carrying the
-///    same content — mirrors the non-destructive orphan repair `zeph-llm`'s Claude request
-///    builder already does at request-build time (`crates/zeph-llm/src/claude/request.rs`,
-///    `push_tool_result_block`). Downgrading rather than deleting keeps the message non-empty
-///    and `Role::User`, which matters: a canonical subagent tool loop is pure
-///    `Assistant(ToolUse)`/`User(ToolResult)` alternation, so this orphaned `ToolResult` is
-///    often the *only* message available to serve as the window's leading `user` anchor —
-///    deleting it here previously fed [`drop_leading_non_user_message`] a cascade that could
-///    annihilate the entire window down to just the system message (issue #6762 review
-///    discussion, R1).
-/// 2. Strip `ToolUse` parts from assistant messages whose matching `ToolResult` is not present
-///    in the immediately following non-system message. The very last message in `messages` is
-///    exempt — its unanswered `ToolUse` calls are not orphaned; the window just ends before the
-///    result. Deletion (not downgrade) is safe here: unlike pass 1, an assistant message losing
-///    its only part does not change what row would anchor the window, since role alone (not
-///    content) decides whether [`drop_leading_non_user_message`] fires.
-///
-/// Messages left empty by pass 2 are removed, except the system message (index 0, if present),
-/// which is always kept regardless of content.
-///
-/// Returns the number of parts stripped or downgraded.
-fn strip_orphaned_tool_parts(messages: &mut Vec<Message>) -> usize {
-    let mut dropped_total = 0usize;
-
-    for i in 0..messages.len() {
-        if messages[i].role != Role::User || messages[i].parts.is_empty() {
-            continue;
-        }
-        let prev_idx = (0..i).rev().find(|&j| messages[j].role != Role::System);
-        let available_tool_ids: HashSet<String> = prev_idx
-            .filter(|&j| messages[j].role == Role::Assistant)
-            .map(|j| {
-                messages[j]
-                    .parts
-                    .iter()
-                    .filter_map(|p| match p {
-                        MessagePart::ToolUse { id, .. } => Some(id.clone()),
-                        _ => None,
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
-
-        let mut downgraded = 0usize;
-        for part in &mut messages[i].parts {
-            if let MessagePart::ToolResult {
-                tool_use_id,
-                content,
-                ..
-            } = part
-                && !available_tool_ids.contains(tool_use_id.as_str())
-            {
-                // Marker mirrors `push_tool_use_block`'s `[tool_use: {name}] {input}` style and,
-                // critically, guarantees non-empty text even when `content` is empty (e.g. a
-                // no-output tool result, `handle_tool_step`'s `Ok(None)` arm) — a bare empty
-                // string here would be dropped entirely by `claude/request.rs`'s plain-text
-                // branch (`if !text.trim().is_empty()`), silently losing this message as the
-                // window's leading `user` anchor at request-build time (#6762 review, N5).
-                let text = format!("[tool result: {tool_use_id}] {content}");
-                *part = MessagePart::Text { text };
-                downgraded += 1;
-            }
-        }
-        if downgraded > 0 {
-            dropped_total += downgraded;
-            messages[i].rebuild_content();
-        }
-    }
-
-    let last_idx = messages.len().saturating_sub(1);
-    for i in 0..messages.len() {
-        if messages[i].role != Role::Assistant || messages[i].parts.is_empty() || i == last_idx {
-            continue;
-        }
-        let next_idx = (i + 1..messages.len()).find(|&j| messages[j].role != Role::System);
-        let consumed_tool_ids: HashSet<String> = next_idx
-            .filter(|&j| messages[j].role == Role::User)
-            .map(|j| {
-                messages[j]
-                    .parts
-                    .iter()
-                    .filter_map(|p| match p {
-                        MessagePart::ToolResult { tool_use_id, .. } => Some(tool_use_id.clone()),
-                        _ => None,
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
-
-        let before = messages[i].parts.len();
-        messages[i].parts.retain(|p| match p {
-            MessagePart::ToolUse { id, .. } => consumed_tool_ids.contains(id.as_str()),
-            _ => true,
-        });
-        let dropped = before - messages[i].parts.len();
-        if dropped > 0 {
-            dropped_total += dropped;
-            if messages[i].parts.is_empty() {
-                messages[i].content.clear();
-            } else {
-                messages[i].rebuild_content();
-            }
-        }
-    }
-
-    if dropped_total > 0 {
-        messages.retain(|m| m.role == Role::System || !m.content.is_empty() || !m.parts.is_empty());
-    }
-
-    dropped_total
-}
-
-/// Drops the first non-system message in `messages` if its role is not `Role::User`.
-///
-/// Returns `true` if a message was dropped.
-fn drop_leading_non_user_message(messages: &mut Vec<Message>) -> bool {
-    let Some(idx) = messages.iter().position(|m| m.role != Role::System) else {
-        return false;
-    };
-    if messages[idx].role == Role::User {
-        return false;
-    }
-    messages.remove(idx);
-    true
 }
 
 #[tracing::instrument(name = "subagent.agent_loop.run", skip_all, fields(task_id = %args.task_id, agent_name = %args.agent_name))]
@@ -1605,9 +1446,12 @@ mod trim_message_history_tests {
     }
 
     #[test]
-    fn trailing_unanswered_tool_use_is_not_treated_as_orphan() {
-        // The trailing assistant ToolUse has no result yet (the loop just hasn't dispatched it) —
-        // it must survive the trim, not be pruned as if it were orphaned.
+    fn trailing_unanswered_tool_use_is_now_repaired_not_exempted() {
+        // S1 (v2 design, issue #6771): the v1 `TrailingToolUse::Exempt` policy was deleted —
+        // `Repair` is now universal, including the trailing message of the retained window. A
+        // trailing `ToolUse` has no possible following `ToolResult` in this window, so it is
+        // orphaned like any other and stripped; since it carried nothing else, the now-empty
+        // assistant message is also removed.
         let mut msgs = vec![
             sys("sys"),
             usr("u1"),
@@ -1616,7 +1460,12 @@ mod trim_message_history_tests {
             asst_tool_use("t1"),
         ];
         trim_message_history(&mut msgs, 4);
-        assert!(msgs.iter().any(|m| has_tool_use(m, "t1")));
+        assert!(
+            !msgs.iter().any(|m| has_tool_use(m, "t1")),
+            "the trailing ToolUse must now be repaired, not exempted"
+        );
+        assert_eq!(msgs[0].role, Role::System);
+        assert_eq!(msgs[1].content, "u2");
     }
 
     #[test]
@@ -1732,7 +1581,7 @@ mod trim_message_history_tests {
         // orphaned ToolResult("call_0") — its ToolUse was trimmed away — must not be kept just
         // because a later, unrelated ToolUse("call_0") exists in the window; and that later,
         // legitimate pair must survive untouched. Constructed as a post-drain state directly
-        // (adjacency scoping is exercised by `repair_tool_pairing`, not `trim_message_history`'s
+        // (adjacency scoping is exercised by `repair_window`, not `trim_message_history`'s
         // arithmetic).
         let mut msgs = vec![
             sys("sys"),
@@ -1749,7 +1598,10 @@ mod trim_message_history_tests {
             ),
         ];
 
-        repair_tool_pairing(&mut msgs);
+        let _ = zeph_llm::tool_pairing::repair_window(
+            &mut msgs,
+            zeph_llm::tool_pairing::OrphanAction::DowngradeToText,
+        );
 
         let remaining_results: Vec<&str> = msgs
             .iter()
@@ -1786,7 +1638,10 @@ mod trim_message_history_tests {
             asst("a2"),
             usr("u3"),
         ];
-        repair_tool_pairing(&mut msgs);
+        let _ = zeph_llm::tool_pairing::repair_window(
+            &mut msgs,
+            zeph_llm::tool_pairing::OrphanAction::DowngradeToText,
+        );
         assert!(
             !msgs.iter().any(|m| has_tool_use(m, "t1")),
             "pass 2 must strip the unanswered interior ToolUse"
@@ -1813,7 +1668,10 @@ mod trim_message_history_tests {
             asst("a2"),
             usr("u3"),
         ];
-        repair_tool_pairing(&mut msgs);
+        let _ = zeph_llm::tool_pairing::repair_window(
+            &mut msgs,
+            zeph_llm::tool_pairing::OrphanAction::DowngradeToText,
+        );
         let asst_msg = &msgs[2];
         assert!(!has_tool_use(asst_msg, "t1"));
         assert!(
@@ -1845,7 +1703,10 @@ mod trim_message_history_tests {
             asst("a2"),
             usr("u3"),
         ];
-        repair_tool_pairing(&mut msgs);
+        let _ = zeph_llm::tool_pairing::repair_window(
+            &mut msgs,
+            zeph_llm::tool_pairing::OrphanAction::DowngradeToText,
+        );
         assert!(has_tool_use(&msgs[2], "t1"), "answered call must survive");
         assert!(
             !has_tool_use(&msgs[2], "t2"),
@@ -1866,7 +1727,10 @@ mod trim_message_history_tests {
             usr_tool_result("t1"),
             usr("u2"),
         ];
-        repair_tool_pairing(&mut msgs);
+        let _ = zeph_llm::tool_pairing::repair_window(
+            &mut msgs,
+            zeph_llm::tool_pairing::OrphanAction::DowngradeToText,
+        );
         assert_eq!(
             msgs.first().map(|m| m.role),
             Some(Role::System),

--- a/specs/002-agent-loop/spec.md
+++ b/specs/002-agent-loop/spec.md
@@ -228,31 +228,46 @@ Provider preference per channel is persisted to SQLite (#3308, #3385):
 - TUI: `context_gauge` widget (color-coded: green < 70%, yellow 70–90%, red > 90%); hidden when `context_max_tokens == 0`
 - TUI: `compaction_badge` widget shows `"{before}k→{after}k (-{saved}k) {elapsed}"`; hidden until first compaction this session
 
-## Hard Compaction Post-Processing: Orphaned `tool_result` Strip
+## Hard Compaction Boundary: Tool-Pair Prevention, Not Post-Hoc Strip (#6771 amendment)
 
-After hard compaction the message list is drained and rebuilt. A `tool_result` message
-references a prior `tool_use` by id. When the drain removes the originating `tool_use`
-(e.g., the turn that produced it was summarized or evicted) the `tool_result` becomes
-**orphaned** — its reference id points to a message no longer in the list. Sending an
-orphaned `tool_result` to any provider causes a request validation error (Claude: 400,
-OpenAI: 422).
+A `tool_result` message references a prior `tool_use` by id. If hard compaction's drain
+boundary landed inside a `ToolUse`/`ToolResult` pair, the surviving half becomes **orphaned** —
+its reference id points to a message no longer in the list. Sending an orphaned `tool_result` to
+any provider causes a request validation error (Claude: 400, OpenAI: 422).
 
-Fix (#3256): after `apply_hard_compaction()` and after any `apply_deferred_summaries()`
-step, run `strip_orphaned_tool_results(messages)`:
+The originally specified fix (#3256), `strip_orphaned_tool_results(messages)` with a
+**global** tool_use-id-set match, does not exist in the codebase under that name and its
+algorithm is exactly the adjacency-vs-global-set defect fixed by issue #6770 (a global set
+wrongly cross-pairs an orphan against an unrelated call sharing its id under provider-side id
+reuse, e.g. Ollama's `format!("call_{i}")`). The mechanism actually implemented is
+**prevention, not repair**: `crates/zeph-agent-context/src/summarization/compaction.rs`'s
+`adjust_compact_end_for_tool_pairs` walks the compaction boundary backward off any assistant
+message carrying a `ToolUse` part, so the drain never splits a pair in the first place. This
+runs after `apply_deferred_summaries`, so the boundary adjustment sees the final message list
+including any messages deferred summaries just inserted.
 
-```
-strip_orphaned_tool_results(messages: &mut Vec<Message>)
-    collect_set of all tool_use ids present in messages
-    remove any message where role == tool_result AND tool_use_id NOT IN that set
-```
+Residual gap (tracked, not implemented): deferred-summary **hiding**
+(`metadata.deferred_summary`/`MessageVisibility`) removes a message from the request without
+moving the compaction boundary, so it can still orphan a pair at request-build time. Today this
+is caught only by the Claude request builder's Layer-A downgrade
+(`zeph_llm::tool_pairing::unmatched_tool_use_ids`/`unmatched_tool_result_ids` in
+`claude/request.rs`) — OpenAI/compatible/Ollama have no equivalent request-build-time repair (see
+`specs/003-llm-providers/spec.md`'s Tool-Pair Repair section; follow-up issue filed for the
+OpenAI-compatible gap).
 
 ### Key Invariants
 
-- `strip_orphaned_tool_results` runs after EVERY hard compaction event — no exceptions
-- The strip runs AFTER `apply_deferred_summaries` (deferred insertions may add new tool_use messages)
-- Removing an orphaned `tool_result` is silent (no WARN) unless `--debug-dump` is active
-- This is a correctness invariant, not a heuristic — a single orphaned `tool_result` causes a provider 400/422 error
-- NEVER send a `tool_result` whose `tool_use_id` is absent from the message list
+- The compaction boundary MUST be adjusted off any `ToolUse`-bearing assistant message before the
+  drain executes — no exceptions
+- Boundary adjustment runs AFTER `apply_deferred_summaries` (deferred insertions can shift indices
+  and add new `tool_use`-bearing messages, so adjustment must see the final message list, not the
+  pre-insertion one)
+- This is a correctness invariant, not a heuristic — a single orphaned `tool_result` causes a
+  provider 400/422 error
+- NEVER send a `tool_result` whose `tool_use_id` is absent from the message list — enforced at
+  the compaction boundary by prevention here, and at request-build time by
+  `zeph_llm::tool_pairing` (see `specs/003-llm-providers/spec.md`) as defense-in-depth for the
+  residual deferred-summary-hiding gap
 
 ---
 

--- a/specs/003-llm-providers/spec.md
+++ b/specs/003-llm-providers/spec.md
@@ -308,6 +308,53 @@ accordingly.
 - `effective_embedding_model` and `stable_skill_embedding_model` live in `LlmConfig` — NEVER re-add them to `provider_factory`
 - `LlmConfig::default()` must round-trip through empty TOML — NEVER implement `Default` by hand
 
+## Tool-Pair Repair (`zeph_llm::tool_pairing`) (#6771, #6770, #6769, #6762)
+
+`crates/zeph-llm/src/tool_pairing.rs` is the single, shared definition of "orphaned"
+`ToolUse`/`ToolResult` pairing and repair, used by the Claude request builder's per-request hot
+path (`claude/request.rs`) and by every history-mutating call site that previously implemented
+its own copy: `zeph-core::agent::subagent_commands::trim_parent_messages`,
+`zeph-core::agent::shutdown::flush_orphaned_tool_use_on_shutdown`,
+`zeph-subagent::agent_loop::trim_message_history`, and
+`zeph-agent-persistence::sanitize::sanitize_tool_pairs`. Prior to this consolidation each site
+independently reimplemented pairing, and one (`trim_parent_messages`, issue #6770) matched
+against a **global** id set rather than adjacency, cross-pairing an orphan against an unrelated
+call sharing its id under Ollama-style `format!("call_{i}")` id reuse.
+
+Two layers:
+
+- **Layer A** — `unmatched_tool_use_ids(msg, next)` / `unmatched_tool_result_ids(msg, prev)`:
+  pure classification, adjacency-scoped against an already-resolved neighbour message (works for
+  both `Vec<Message>` and `Vec<&Message>` callers).
+- **Layer B** — `repair_tool_pairs` / `repair_window`: mutating repair built strictly on top of
+  Layer A, parameterized by `OrphanAction` (`Delete` or `DowngradeToText`) for orphaned
+  `ToolResult` handling; orphaned `ToolUse` is always deleted regardless of `action`.
+  `repair_window` additionally enforces that the first non-system message has role `user`
+  (required by the Anthropic API), looping the pairing repair and the leading-role drop to a
+  joint fixed point since dropping a leading non-user message can newly orphan a pair that was
+  otherwise well-formed.
+
+### Key Invariants
+
+- Pairing is always adjacency-scoped (immediately preceding/following non-system message) — a
+  global id set across the whole history is NEVER an acceptable match, since it produces the
+  #6770 cross-pair defect under any provider that reuses `tool_use_id`s across turns
+- Layer B MUST call Layer A for every orphan decision — no second, independent pairing predicate
+  may exist anywhere in the module (this is a reviewer-verified property of the source, not a
+  grep-checkable pattern)
+- An orphaned `ToolUse` part is always deleted, never downgraded — it has no safe text form
+  worth preserving as conversation content
+- `Role::System` messages are never removed by repair, regardless of content or parts state
+- The Claude request builder's `StructuredApiMessage` list must never contain an entry with an
+  empty block array — Anthropic rejects an empty content array. This applies to every producer of
+  an empty block list (an orphaned empty-content `ToolResult`, or a message whose only parts are
+  `ThinkingBlock`/`RedactedThinkingBlock`/`Compaction`/whitespace-only `Text` on the user role),
+  not only the tool-pairing case
+- The `[tool result: {id}] {content}` downgrade marker (space, no underscore) MUST stay
+  distinguishable from `has_meaningful_content`'s recognized `[tool_result: ` marker (underscore)
+  — a downgraded orphan must always read as "meaningful" content so it is never later mistaken
+  for empty, marker-only text and dropped as the window's leading anchor
+
 ## Key Invariants
 
 - Provider methods are always `&self` — immutable, concurrent-safe. This scopes to **request/inference** methods (`chat`, `chat_stream`, `chat_with_tools`, …). In-place `&mut self` config setters applied only at turn boundaries between requests (e.g. `set_reasoning_effort`, and the runtime `set_thinking`/`set_thinking_budget`/`set_thinking_level`/`apply_reasoning_effort` setters from `[[specs/070-runtime-thinking-controls/spec]]`) are exempt — request methods remain `&self`.

--- a/specs/078-agent-persistence/spec.md
+++ b/specs/078-agent-persistence/spec.md
@@ -155,7 +155,7 @@ AND values are available to the metrics subsystem for Prometheus export
 |----|------------|----------|
 | FR-001 | WHEN `LoadHistoryParams` is populated with memory, conversation ID, and mutable buffers THEN `load_history()` SHALL fetch up to 50 agent-visible messages (`agent_visible=true`) from SQLite | must |
 | FR-002 | WHEN loaded messages include empty or orphaned messages THEN they SHALL be skipped and counted in the outcome | must |
-| FR-003 | WHEN `sanitize_tool_pairs()` receives a message buffer THEN it SHALL remove: (1) trailing assistant ToolUse without matching ToolResult, (2) leading user ToolResult without preceding ToolUse, (3) mid-history orphaned ToolUse/ToolResult, and (4) unmatched ToolResult parts | must |
+| FR-003 | WHEN `sanitize_tool_pairs()` receives a message buffer THEN it SHALL delegate orphan repair to `zeph_llm::tool_pairing::repair_tool_pairs` (`OrphanAction::Delete`), which strips — at the individual-part level, not whole-message — any `ToolUse` part with no matching `ToolResult` in the immediately following non-system message and any `ToolResult` part with no matching `ToolUse` in the immediately preceding non-system message (adjacency-scoped, not a global id set, per issue #6770); a message left with no parts and no meaningful content is then removed entirely. There is no separate duplicate-`ToolResult` sweep: the #5513 shape (a stale duplicate result for an already-resolved `tool_use_id`) is provably always caught by adjacency repair itself, since any surviving `ToolResult` is by construction paired with its own immediately preceding `ToolUse` — a dedicated sweep that existed in an earlier revision was removed as unreachable dead code | must |
 | FR-004 | WHEN orphaned messages are removed THEN their SQLite `db_id` values SHALL be collected and returned for soft-delete | must |
 | FR-005 | WHEN `persist_message()` is called with memory disabled (None) THEN the operation SHALL return early with zero-filled outcome | must |
 | FR-006 | WHEN message parts cannot be serialized to JSON THEN persistence SHALL fail gracefully, log an error, and return `None` to avoid creating orphaned tool-pair records | must |
@@ -165,7 +165,7 @@ AND values are available to the metrics subsystem for Prometheus export
 | FR-010 | WHEN `last_persisted_message_id` is set THEN subsequent history loads SHALL fetch only newer messages (LIMIT-based pagination) | must |
 | FR-011 | WHEN a `PersistenceService` method encounters a database error THEN it SHALL log at ERROR level and return an error or `None`, never panic | must |
 | FR-012 | WHEN `serialize_parts_json()` is called THEN it SHALL serde-serialize parts to a flat JSON array; empty parts returns `"[]"` | must |
-| FR-013 | WHEN `has_meaningful_content()` evaluates a message THEN it SHALL identify legacy tool bracket markers and strip them; content with only markers is considered empty | must |
+| FR-013 | WHEN `has_meaningful_content()` evaluates a message THEN it SHALL identify legacy tool bracket markers and strip them; content with only markers is considered empty. Relocated to `zeph_llm::tool_pairing` (issue #6771) since it decodes markers produced by `zeph_llm::provider::Message::flatten_parts`, which lives in that crate; `zeph-agent-persistence` calls it via `zeph_llm::tool_pairing::has_meaningful_content` | must |
 | FR-014 | WHEN metrics are updated via `MetricsView` THEN `sqlite_message_count`, `embeddings_generated`, and `exfiltration_memory_guards` counters SHALL be incremented atomically | must |
 
 ---


### PR DESCRIPTION
## Summary

- Extracts a single adjacency-scoped orphan-pairing repair module (`zeph_llm::tool_pairing`, Layer A pure classification + Layer B mutating repair) replacing five independent implementations that had drifted apart at the edges (delete vs. downgrade-to-text, trailing-`ToolUse` handling): `zeph-core::subagent_commands::trim_parent_messages`, `zeph-core::shutdown::flush_orphaned_tool_use_on_shutdown`, `zeph-subagent::agent_loop::trim_message_history`, `zeph-agent-persistence::sanitize::sanitize_tool_pairs`, and the Claude request builder (`zeph-llm::claude::request`).
- Fixes #6770: `trim_parent_messages` matched orphaned tool-call ids against a global, order-blind set instead of adjacency, so an orphaned `ToolResult` could be wrongly cross-paired with an unrelated later `ToolUse` sharing its id under Ollama's batch-index id reuse (`call_0`, `call_1`, ...).
- Fixes a latent leading-role gap at the same call site: a count-based parent-context slice had no leading-role normalization at all and could start on `Assistant`, which Anthropic rejects. The fix required a design iteration beyond a naive port of the subagent-side boundary nudge — for a pure `Assistant(ToolUse)`/`User(ToolResult)` window, "first non-system message is user" and "no orphaned `ToolResult`" are jointly unsatisfiable by deletion alone, so `trim_parent_messages` now falls back to downgrade-to-text only when the default delete policy would otherwise annihilate the entire window.
- Fixes a Claude request-builder gap where a user message whose only content was an orphaned, empty-content `ToolResult` (or a `ThinkingBlock`/`Compaction`-only message) could serialize to an empty content-block array, which Anthropic rejects.
- **Breaking**: `zeph_agent_persistence::sanitize::has_meaningful_content` (public) is removed — relocated to `zeph_llm::tool_pairing::has_meaningful_content`, no re-export (pre-1.0).

## Design process

This went through two architecture-critique rounds (one significant revision cutting the design down to a single-field policy enum) and three implementation-critique rounds, each surfacing a real regression before merge: a content-clobber bug on DB-restored messages where `content` diverges from `flatten_parts(parts)`, a window-annihilation defect in the leading-role fix (resolved by the delete/downgrade fallback described above), and a follow-up regression in the first fix for the content-clobber bug. All are covered by dedicated regression tests.

## Known, deliberately out-of-scope gaps (documented in code, follow-up issues to be filed)

- The Claude request builder's empty-content-block guard can still promote a non-`user` message to be first in the request in one narrow case (leading-role enforcement was never in scope for this call site); left as an explicit, undeniable gap with a dedicated test documenting it.
- `zeph-core::agent::tool_execution::focus::persist_cancelled_tool_results` has its own turn-scoped (not adjacency-scoped) idempotency scan that can still swallow a tombstone under id reuse; left as an `#[ignore]`d regression test with a clear doc comment.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` — 15510 passed, 0 failed
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links"`) and `cargo test --doc --workspace`
- [x] `gitleaks protect --staged`
- [x] Spec amendments applied (`specs/002-agent-loop`, `specs/003-llm-providers`, `specs/078-agent-persistence`)
- [x] `.local/testing/playbooks/tool-pairing-consolidation-6771.md` and `.local/testing/coverage-status.md` updated
- [ ] Live Claude round-trip: request reached the Anthropic API and was rejected with `400 Your credit balance is too low` (known account-exhaustion constraint, not a payload defect) — the serialized request was well-formed enough to be evaluated. A full 200 end-to-end round-trip is not yet confirmed; re-run once credits are available.

Closes #6771
Closes #6770