### PR TITLE
fix(llm,core): close orphaned tool-pairing gaps in OpenAI builder and shutdown tombstone flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `zeph-core`: fixed `trim_parent_messages` matching orphaned `ToolUse`/`ToolResult` parts
   against a global id set instead of adjacency, which could cross-pair an orphan against an
   unrelated tool call sharing its id under Ollama-style batch-index id reuse (#6770, #6780).
+- `zeph-llm`: added a request-build-time orphaned `ToolUse`/`ToolResult` repair pass to the
+  OpenAI/OpenAI-compatible request builder (`convert_messages_structured`), mirroring the
+  Claude request builder's downgrade-to-text pattern — previously only Claude had this
+  backstop, so an orphan surviving upstream trim/sanitize passes could reach OpenAI or an
+  OpenAI-compatible/Ollama endpoint unrepaired and produce a 400/422 (#6781).
+- `zeph-core`: made `persist_cancelled_tool_results`'s idempotency guard adjacency-scoped
+  instead of scanning the whole turn tail, closing a gap where an unrelated later
+  `ToolResult` reusing an orphaned call's id (Ollama-style batch-index id reuse) could make
+  the guard wrongly treat the orphan as already resolved and silently skip its shutdown
+  tombstone write (#6783). Also fixed `shutdown.rs`'s `flush_orphaned_tool_use_on_shutdown`
+  to reuse the shared `zeph_llm::tool_pairing::next_non_system` adjacency helper instead of
+  a duplicate hand-rolled scan, and hardened the same idempotency guard against a missing
+  assistant message in history (previously fell back to an arbitrary index instead of
+  resolving nothing).
 
 ### Added
 

--- a/crates/zeph-core/src/agent/shutdown.rs
+++ b/crates/zeph-core/src/agent/shutdown.rs
@@ -109,13 +109,8 @@ impl<C: Channel> Agent<C> {
             return;
         }
 
-        let next_non_system = msgs
-            .get(asst_idx + 1..)
-            .into_iter()
-            .flatten()
-            .find(|m| m.role != Role::System);
-        let unpaired_ids =
-            zeph_llm::tool_pairing::unmatched_tool_use_ids(asst_msg, next_non_system);
+        let next_msg = zeph_llm::tool_pairing::next_non_system(msgs, asst_idx);
+        let unpaired_ids = zeph_llm::tool_pairing::unmatched_tool_use_ids(asst_msg, next_msg);
         if unpaired_ids.is_empty() {
             return;
         }

--- a/crates/zeph-core/src/agent/tests/flush_orphaned_tests.rs
+++ b/crates/zeph-core/src/agent/tests/flush_orphaned_tests.rs
@@ -316,23 +316,14 @@ async fn flush_orphaned_inserts_tombstone_immediately_after_orphan_not_at_end() 
     );
 }
 
-/// FO6 (#6771 site-5 migration, KNOWN GAP — see tester handoff): `flush_orphaned_tool_use_on_shutdown`
-/// itself now computes `unpaired_ids` via `zeph_llm::tool_pairing::unmatched_tool_use_ids`
-/// (adjacency-scoped, immediate-neighbour only) and correctly identifies `call_0` as unpaired in
-/// this shape. But the call is still routed through
-/// `Agent::persist_cancelled_tool_results` (`crates/zeph-core/src/agent/tool_execution/focus.rs`,
-/// untouched by #6771), whose own `already_resolved` idempotency guard scans
-/// `self.msg.messages[turn_start..]` — from the last assistant message to the true end of
-/// history, not just the immediate neighbour. A later, unrelated `ToolResult` reusing `call_0`
-/// still falls inside that wider scan and is treated as "already resolved", silently swallowing
-/// the tombstone. So the #6770 adjacency fix for site 5 is *not* fully closed end-to-end: the
-/// classification predicate was fixed, but the downstream write-path idempotency check was not.
-/// Empirically confirmed to fail against current `focus.rs` (not a regression from this PR —
-/// `persist_cancelled_tool_results` is pre-existing #5513 code the PR does not touch). Left
-/// `#[ignore]` rather than failing the suite; un-ignore once `focus.rs`'s scan is narrowed to
-/// adjacency (or the gap is otherwise accepted and tracked).
-#[ignore = "known gap: persist_cancelled_tool_results's turn-scoped (not adjacency-scoped) \
-            already_resolved check can still swallow the tombstone; see doc comment"]
+/// FO6 (#6783 fix): `flush_orphaned_tool_use_on_shutdown` computes `unpaired_ids` via
+/// `zeph_llm::tool_pairing::unmatched_tool_use_ids` (adjacency-scoped, immediate-neighbour only)
+/// and correctly identifies `call_0` as unpaired in this shape. `Agent::persist_cancelled_tool_results`
+/// (`crates/zeph-core/src/agent/tool_execution/focus.rs`) now uses the same adjacency-scoped
+/// `zeph_llm::tool_pairing::resolved_tool_result_ids` for its own idempotency guard instead of
+/// scanning `self.msg.messages[turn_start..]` to the true end of history, so a later, unrelated
+/// `ToolResult` reusing `call_0` no longer falls inside the scan and can no longer be treated as
+/// "already resolved" to silently swallow the tombstone.
 #[tokio::test]
 async fn flush_orphaned_writes_tombstone_despite_a_later_unrelated_reuse_of_the_same_id() {
     use zeph_llm::provider::{Message, MessageMetadata, MessagePart, Role};

--- a/crates/zeph-core/src/agent/tool_execution/focus.rs
+++ b/crates/zeph-core/src/agent/tool_execution/focus.rs
@@ -371,17 +371,30 @@ impl<C: Channel> Agent<C> {
     /// persisted but the matching user `ToolResult` message was not yet written. Without this, the
     /// DB contains an orphaned `ToolUse` that will trigger a Claude API 400 on the next session.
     ///
-    /// Idempotency guard (#5513): skips any `tool_use_id` that already has a `ToolResult` (real or
-    /// tombstone) earlier in the *current turn*, so a caller that (mistakenly, or via a future
-    /// defect) invokes this more than once for the same batch cannot write duplicate/contradicting
-    /// results.
+    /// Idempotency guard (#5513): skips any `tool_use_id` that already has a matching `ToolResult`
+    /// (real or tombstone), so a caller that (mistakenly, or via a future defect) invokes this
+    /// more than once for the same batch cannot write duplicate/contradicting results.
     ///
-    /// The scan is scoped to messages from the current turn's assistant `ToolUse` message onward
+    /// The guard is adjacency-scoped (#6783), via [`zeph_llm::tool_pairing::resolved_tool_result_ids`]
+    /// against the message immediately following the current turn's assistant `ToolUse` message
     /// (found as the most recent `Role::Assistant` message, mirroring
-    /// `shutdown::flush_orphaned_tool_use_on_shutdown`), not the whole history. Some providers
-    /// (e.g. Ollama, which assigns `tool_call` ids as `format!("call_{i}")` by batch index) reuse
-    /// the same `tool_use_id` across turns; scanning full history would treat an earlier turn's
-    /// legitimate result as covering this turn's call and wrongly skip its tombstone.
+    /// `shutdown::flush_orphaned_tool_use_on_shutdown`, whose own adjacency-scoped `unpaired_ids`
+    /// computation this mirrors) — not a scan of every message in the turn. A turn-wide scan can
+    /// be fooled by an unrelated *later* `ToolResult` in the same turn that reuses the orphaned
+    /// call's id (Ollama-style `format!("call_{i}")` batch-index id reuse, see the
+    /// `zeph_llm::tool_pairing` module docs for the general hazard): it would wrongly treat the
+    /// genuinely orphaned call as already resolved and silently skip its tombstone, even when
+    /// `shutdown::flush_orphaned_tool_use_on_shutdown` already correctly identified it as unpaired
+    /// before calling in here.
+    ///
+    /// `resolved_tool_result_ids` (not [`zeph_llm::tool_pairing::unmatched_tool_use_ids`]) is used
+    /// because `tool_calls` here is an arbitrary caller-supplied batch, not necessarily identical
+    /// to the current turn's assistant message's own `ToolUse` parts — `resolved_tool_result_ids`
+    /// only needs the adjacent message, not a `Message` to read `ToolUse` ids from. When no
+    /// `Role::Assistant` message exists in history at all (there is no turn boundary to be
+    /// adjacent to), the guard treats every id as unresolved rather than guessing a boundary —
+    /// every `tool_calls` entry gets tombstoned, which is the safe direction for an idempotency
+    /// guard to fail in (a spurious duplicate tombstone, never a silently dropped one).
     ///
     /// `insert_at` places the tombstone at a specific index instead of the true end of history —
     /// required by `flush_orphaned_tool_use_on_shutdown`, which can run after a later turn's
@@ -400,23 +413,21 @@ impl<C: Channel> Agent<C> {
         tool_calls: &[zeph_llm::provider::ToolUseRequest],
         insert_at: Option<usize>,
     ) {
-        let turn_start = self
+        // No fallback to index 0 on a missing assistant message: `resolved_tool_result_ids`
+        // needs a real turn boundary to identify "the adjacent message" — guessing one would
+        // silently narrow the scan to an arbitrary slice instead of "no assistant ⇒ no
+        // adjacency, nothing can be resolved yet" (review finding, #6783 follow-up).
+        let already_resolved = self
             .msg
             .messages
             .iter()
             .rposition(|m| m.role == Role::Assistant)
-            .unwrap_or(0);
-        let already_resolved: std::collections::HashSet<&str> = self.msg.messages[turn_start..]
-            .iter()
-            .flat_map(|m| m.parts.iter())
-            .filter_map(|p| {
-                if let MessagePart::ToolResult { tool_use_id, .. } = p {
-                    Some(tool_use_id.as_str())
-                } else {
-                    None
-                }
+            .map(|turn_start| {
+                zeph_llm::tool_pairing::resolved_tool_result_ids(
+                    zeph_llm::tool_pairing::next_non_system(&self.msg.messages, turn_start),
+                )
             })
-            .collect();
+            .unwrap_or_default();
 
         let result_parts: Vec<MessagePart> = tool_calls
             .iter()

--- a/crates/zeph-core/src/agent/tool_execution/tests/focus_tests.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tests/focus_tests.rs
@@ -116,6 +116,23 @@ fn tool_use_request(id: &str) -> ToolUseRequest {
     }
 }
 
+fn push_assistant_tool_use(agent: &mut Agent<MockChannel>, ids: &[&str]) {
+    let parts: Vec<MessagePart> = ids
+        .iter()
+        .map(|id| MessagePart::ToolUse {
+            id: (*id).to_owned(),
+            name: "bash".to_owned(),
+            input: serde_json::json!({}),
+        })
+        .collect();
+    agent.msg.messages.push(Message {
+        role: Role::Assistant,
+        content: "[tool_use]".to_owned(),
+        parts,
+        metadata: MessageMetadata::default(),
+    });
+}
+
 fn push_tool_result(agent: &mut Agent<MockChannel>, id: &str, content: &str, is_error: bool) {
     let part = MessagePart::ToolResult {
         tool_use_id: id.to_owned(),
@@ -148,6 +165,9 @@ fn tool_result_count(agent: &Agent<MockChannel>, id: &str) -> usize {
 #[tokio::test]
 async fn persist_cancelled_tool_results_is_noop_when_all_ids_already_resolved() {
     let mut agent = make_agent();
+    // An assistant ToolUse message must anchor the adjacency scan (#6783 follow-up) — without
+    // one, "already resolved" can no longer be inferred and every id is tombstoned instead.
+    push_assistant_tool_use(&mut agent, &["call-1"]);
     push_tool_result(&mut agent, "call-1", "real output", false);
     let message_count_before = agent.msg.messages.len();
 
@@ -172,6 +192,9 @@ async fn persist_cancelled_tool_results_is_noop_when_all_ids_already_resolved() 
 #[tokio::test]
 async fn persist_cancelled_tool_results_only_tombstones_unresolved_ids() {
     let mut agent = make_agent();
+    // An assistant ToolUse message must anchor the adjacency scan (#6783 follow-up) — without
+    // one, "already resolved" can no longer be inferred and every id is tombstoned instead.
+    push_assistant_tool_use(&mut agent, &["call-1", "call-2"]);
     push_tool_result(&mut agent, "call-1", "real output", false);
 
     agent
@@ -221,6 +244,31 @@ async fn persist_cancelled_tool_results_tombstones_all_ids_when_none_resolved() 
 
     assert_eq!(tool_result_count(&agent, "call-1"), 1);
     assert_eq!(tool_result_count(&agent, "call-2"), 1);
+}
+
+/// Review finding (#6783 follow-up): with **no** `Role::Assistant` message anywhere in history,
+/// there is no turn boundary for the adjacency scan to anchor on, so the guard must never guess
+/// one — every id must be treated as unresolved (tombstoned), not silently "resolved" by
+/// whatever non-system message happens to sit at a fallback index. Before this fix, a fallback
+/// of `turn_start = 0` made `next_non_system` inspect `messages[1]`, which could coincidentally
+/// be a real `ToolResult` for `call-1` and wrongly skip its tombstone.
+#[tokio::test]
+async fn persist_cancelled_tool_results_tombstones_everything_when_no_assistant_message_exists() {
+    let mut agent = make_agent();
+    // No assistant ToolUse message at all — just an unrelated ToolResult sitting at the
+    // position a naive `unwrap_or(0)` fallback would have inspected as "the adjacent message".
+    push_tool_result(&mut agent, "call-1", "real output", false);
+
+    agent
+        .persist_cancelled_tool_results(&[tool_use_request("call-1")], None)
+        .await;
+
+    assert_eq!(
+        tool_result_count(&agent, "call-1"),
+        2,
+        "with no assistant message to anchor adjacency, call-1 must be tombstoned even though \
+         an unrelated ToolResult for the same id exists elsewhere in history"
+    );
 }
 
 /// Regression test for the Ollama id-reuse finding (impl-critic, verified against

--- a/crates/zeph-llm/src/openai/mod.rs
+++ b/crates/zeph-llm/src/openai/mod.rs
@@ -30,9 +30,13 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt;
+use std::fmt::Write as _;
 
 use crate::error::LlmError;
 use crate::tool_desc::build_tool_description;
+use crate::tool_pairing::{
+    next_non_system, prev_non_system, unmatched_tool_result_ids, unmatched_tool_use_ids,
+};
 use base64::{Engine, engine::general_purpose::STANDARD};
 use serde::{Deserialize, Serialize};
 
@@ -1598,10 +1602,120 @@ where
     Ok(Option::<String>::deserialize(deserializer)?.unwrap_or_default())
 }
 
+/// Convert an assistant message's parts into a single `StructuredApiMessage`, downgrading any
+/// `ToolUse` part whose id is in `orphaned_tool_use` to a text marker instead of a `tool_calls`
+/// entry (issue #6781 — mirrors the Claude request builder's `push_tool_use_block`). A single
+/// ordered pass over `msg.parts` preserves relative order between downgraded-orphan text and
+/// genuine text content.
+fn convert_assistant_tool_message(
+    msg: &Message,
+    orphaned_tool_use: &HashSet<&str>,
+) -> StructuredApiMessage {
+    let mut text_content = String::new();
+    let mut tool_calls: Vec<OpenAiToolCallOut> = Vec::new();
+    for part in &msg.parts {
+        match part {
+            MessagePart::ToolUse { id, name, input } if orphaned_tool_use.contains(id.as_str()) => {
+                tracing::warn!(
+                    tool_use_id = %id,
+                    tool_name = %name,
+                    "downgrading unmatched tool_use to text in OpenAI request"
+                );
+                let _ = write!(text_content, "[tool_use: {name}] {input}");
+            }
+            MessagePart::ToolUse { id, name, input } => {
+                tool_calls.push(OpenAiToolCallOut {
+                    id: id.clone(),
+                    r#type: "function".to_owned(),
+                    function: OpenAiFunctionCall {
+                        name: name.clone(),
+                        arguments: serde_json::to_string(input).unwrap_or_else(|_| "{}".to_owned()),
+                    },
+                });
+            }
+            other => {
+                if let Some(text) = other.as_plain_text() {
+                    text_content.push_str(text);
+                }
+            }
+        }
+    }
+
+    StructuredApiMessage {
+        role: "assistant".to_owned(),
+        content: if text_content.is_empty() {
+            None
+        } else {
+            Some(text_content)
+        },
+        tool_calls: if tool_calls.is_empty() {
+            None
+        } else {
+            Some(tool_calls)
+        },
+        tool_call_id: None,
+    }
+}
+
+/// Convert a user message's parts into zero or more `StructuredApiMessage` entries pushed onto
+/// `result`: each `ToolResult` becomes a `role: "tool"` message unless its id is in
+/// `orphaned_tool_result`, in which case it is downgraded to a plain `role: "user"` text message
+/// (issue #6781 — mirrors the Claude request builder's `push_tool_result_block`) instead of a
+/// `tool_call_id` the API can never resolve. Non-tool text parts pass through as `"user"`
+/// messages, matching the pre-#6781 behaviour.
+fn push_user_tool_messages(
+    result: &mut Vec<StructuredApiMessage>,
+    msg: &Message,
+    orphaned_tool_result: &HashSet<&str>,
+) {
+    for part in &msg.parts {
+        match part {
+            MessagePart::ToolResult {
+                tool_use_id,
+                content,
+                ..
+            } if orphaned_tool_result.contains(tool_use_id.as_str()) => {
+                tracing::warn!(
+                    tool_use_id = %tool_use_id,
+                    "downgrading orphaned tool_result to text in OpenAI request"
+                );
+                result.push(StructuredApiMessage {
+                    role: "user".to_owned(),
+                    content: Some(format!("[tool result: {tool_use_id}] {content}")),
+                    tool_calls: None,
+                    tool_call_id: None,
+                });
+            }
+            MessagePart::ToolResult {
+                tool_use_id,
+                content,
+                ..
+            } => {
+                result.push(StructuredApiMessage {
+                    role: "tool".to_owned(),
+                    content: Some(content.clone()),
+                    tool_calls: None,
+                    tool_call_id: Some(tool_use_id.clone()),
+                });
+            }
+            other => {
+                if let Some(text) = other.as_plain_text().filter(|t| !t.is_empty()) {
+                    result.push(StructuredApiMessage {
+                        role: "user".to_owned(),
+                        content: Some(text.to_owned()),
+                        tool_calls: None,
+                        tool_call_id: None,
+                    });
+                }
+            }
+        }
+    }
+}
+
 fn convert_messages_structured(messages: &[Message]) -> Vec<StructuredApiMessage> {
     let mut result = Vec::new();
 
-    for msg in messages {
+    for (i, msg) in messages.iter().enumerate() {
         let has_tool_parts = msg.parts.iter().any(|p| {
             matches!(
                 p,
@@ -1610,74 +1724,28 @@ fn convert_messages_structured(messages: &[Message]) -> Vec<StructuredApiMessage
         });
 
         if has_tool_parts {
-            // Assistant messages with ToolUse parts → tool_calls field
+            // Layer A (zeph_llm::tool_pairing), adjacency-scoped against the immediate
+            // neighbour in `messages` — never a global id set (issue #6781, matching the
+            // Claude request builder's #6770 fix). `messages` here is not pre-filtered to
+            // agent-visible non-system messages the way Claude's `visible` slice is, so
+            // adjacency is computed directly over `messages` via the shared
+            // `next_non_system`/`prev_non_system` helpers rather than a raw `idx + 1`/`idx - 1`.
+            // This also means classification is not filtered by `metadata.visibility` the way
+            // Claude's is — self-consistent only because this builder also emits
+            // agent-invisible messages; a future change that filters emission without also
+            // filtering classification input would misclassify pairs straddling a hidden
+            // message as orphaned.
             if msg.role == Role::Assistant {
-                let text_content: String = msg
-                    .parts
-                    .iter()
-                    .filter_map(|p| p.as_plain_text())
-                    .collect::<Vec<_>>()
-                    .join("");
-
-                let tool_calls: Vec<OpenAiToolCallOut> = msg
-                    .parts
-                    .iter()
-                    .filter_map(|p| match p {
-                        MessagePart::ToolUse { id, name, input } => Some(OpenAiToolCallOut {
-                            id: id.clone(),
-                            r#type: "function".to_owned(),
-                            function: OpenAiFunctionCall {
-                                name: name.clone(),
-                                arguments: serde_json::to_string(input)
-                                    .unwrap_or_else(|_| "{}".to_owned()),
-                            },
-                        }),
-                        _ => None,
-                    })
-                    .collect();
-
-                result.push(StructuredApiMessage {
-                    role: "assistant".to_owned(),
-                    content: if text_content.is_empty() {
-                        None
-                    } else {
-                        Some(text_content)
-                    },
-                    tool_calls: if tool_calls.is_empty() {
-                        None
-                    } else {
-                        Some(tool_calls)
-                    },
-                    tool_call_id: None,
-                });
+                result.push(convert_assistant_tool_message(
+                    msg,
+                    &unmatched_tool_use_ids(msg, next_non_system(messages, i)),
+                ));
             } else {
-                // User messages with ToolResult parts → role: "tool" messages
-                for part in &msg.parts {
-                    match part {
-                        MessagePart::ToolResult {
-                            tool_use_id,
-                            content,
-                            ..
-                        } => {
-                            result.push(StructuredApiMessage {
-                                role: "tool".to_owned(),
-                                content: Some(content.clone()),
-                                tool_calls: None,
-                                tool_call_id: Some(tool_use_id.clone()),
-                            });
-                        }
-                        other => {
-                            if let Some(text) = other.as_plain_text().filter(|t| !t.is_empty()) {
-                                result.push(StructuredApiMessage {
-                                    role: "user".to_owned(),
-                                    content: Some(text.to_owned()),
-                                    tool_calls: None,
-                                    tool_call_id: None,
-                                });
-                            }
-                        }
-                    }
-                }
+                push_user_tool_messages(
+                    &mut result,
+                    msg,
+                    &unmatched_tool_result_ids(msg, prev_non_system(messages, i)),
+                );
             }
         } else {
             let role = match msg.role {

--- a/crates/zeph-llm/src/openai/tests.rs
+++ b/crates/zeph-llm/src/openai/tests.rs
@@ -1187,7 +1187,43 @@ fn convert_messages_structured_plain_messages() {
 #[test]
 fn convert_messages_structured_assistant_tool_only_content_is_none() {
     // When assistant message has tool_calls but no text, content must be None (not "")
-    // OpenAI API rejects "content": "" combined with "tool_calls" with HTTP 400
+    // OpenAI API rejects "content": "" combined with "tool_calls" with HTTP 400.
+    // A following ToolResult message keeps the pair matched so the orphan-repair pass
+    // (issue #6781) does not downgrade it — see the trailing-unanswered test below for
+    // that case.
+    let messages = vec![
+        Message::from_parts(
+            Role::Assistant,
+            vec![MessagePart::ToolUse {
+                id: "call_1".into(),
+                name: "bash".into(),
+                input: serde_json::json!({"command": "ls"}),
+            }],
+        ),
+        Message::from_parts(
+            Role::User,
+            vec![MessagePart::ToolResult {
+                tool_use_id: "call_1".into(),
+                content: "file1.rs".into(),
+                is_error: false,
+            }],
+        ),
+    ];
+    let result = convert_messages_structured(&messages);
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0].role, "assistant");
+    assert!(
+        result[0].content.is_none(),
+        "content must be None (not \"\") for tool-only assistant messages"
+    );
+    assert!(result[0].tool_calls.is_some());
+}
+
+#[test]
+fn convert_messages_structured_trailing_unanswered_tool_use_is_downgraded_to_text() {
+    // #6781: a trailing ToolUse with no following ToolResult is orphaned — matching the
+    // Claude request builder's repair (#6770/#6771), it is downgraded to text instead of
+    // being sent as a dangling tool_calls entry the API can never resolve.
     let messages = vec![Message::from_parts(
         Role::Assistant,
         vec![MessagePart::ToolUse {
@@ -1200,10 +1236,85 @@ fn convert_messages_structured_assistant_tool_only_content_is_none() {
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].role, "assistant");
     assert!(
-        result[0].content.is_none(),
-        "content must be None (not \"\") for tool-only assistant messages"
+        result[0].tool_calls.is_none(),
+        "the orphaned call must not survive as tool_calls"
     );
-    assert!(result[0].tool_calls.is_some());
+    let content = result[0]
+        .content
+        .as_deref()
+        .expect("downgraded marker must survive as text");
+    assert!(
+        content.contains("bash"),
+        "downgrade marker must name the tool"
+    );
+}
+
+#[test]
+fn convert_messages_structured_leading_unmatched_tool_result_is_downgraded_to_text() {
+    // #6781: a ToolResult with no preceding matching ToolUse (e.g. after a trim boundary)
+    // must not be sent as a "tool" role message — OpenAI rejects a tool_call_id with no
+    // corresponding tool_calls entry earlier in the request.
+    let messages = vec![Message::from_parts(
+        Role::User,
+        vec![MessagePart::ToolResult {
+            tool_use_id: "call_orphan".into(),
+            content: "leftover output".into(),
+            is_error: false,
+        }],
+    )];
+    let result = convert_messages_structured(&messages);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].role, "user");
+    assert!(
+        result[0].tool_call_id.is_none(),
+        "the orphaned result must not survive as a tool-role message"
+    );
+    let content = result[0]
+        .content
+        .as_deref()
+        .expect("downgraded marker must survive as text");
+    assert!(content.contains("leftover output"));
+}
+
+#[test]
+fn convert_messages_structured_multiple_orphaned_tool_use_ids_in_one_message_are_all_downgraded() {
+    // Parity with tool_pairing's own
+    // multiple_consecutive_orphaned_tool_use_ids_in_one_message_are_all_stripped: a trailing
+    // assistant message with several ToolUse parts and no following ToolResult message must
+    // have every one of them downgraded, not just the first.
+    let messages = vec![Message::from_parts(
+        Role::Assistant,
+        vec![
+            MessagePart::ToolUse {
+                id: "call_1".into(),
+                name: "bash".into(),
+                input: serde_json::json!({}),
+            },
+            MessagePart::ToolUse {
+                id: "call_2".into(),
+                name: "read_file".into(),
+                input: serde_json::json!({}),
+            },
+            MessagePart::ToolUse {
+                id: "call_3".into(),
+                name: "grep".into(),
+                input: serde_json::json!({}),
+            },
+        ],
+    )];
+    let result = convert_messages_structured(&messages);
+    assert_eq!(result.len(), 1);
+    assert!(
+        result[0].tool_calls.is_none(),
+        "none of the three orphaned calls may survive as tool_calls"
+    );
+    let content = result[0]
+        .content
+        .as_deref()
+        .expect("all three downgraded markers must survive as text");
+    assert!(content.contains("bash"));
+    assert!(content.contains("read_file"));
+    assert!(content.contains("grep"));
 }
 
 #[test]

--- a/crates/zeph-llm/src/tool_pairing.rs
+++ b/crates/zeph-llm/src/tool_pairing.rs
@@ -96,6 +96,66 @@ use std::collections::HashSet;
 
 use crate::provider::{Message, MessagePart, Role};
 
+/// Nearest `Role`-eligible neighbour immediately following index `at` in `messages`, skipping
+/// any `Role::System` messages in between.
+///
+/// This is the single definition of "next adjacent message" used by every orphan-detection call
+/// site — [`repair_tool_pairs`]'s own pass 2 scan, and non-Claude request builders (`OpenAI`/
+/// `OpenAI`-compatible, issue #6781) that classify orphans against `&[Message]` directly rather
+/// than a pre-filtered `visible` slice (contrast `zeph_llm::claude::request::split_messages_structured`,
+/// which pre-filters agent-visible non-system messages and therefore indexes that slice instead).
+///
+/// # Examples
+///
+/// ```
+/// use zeph_llm::provider::{Message, Role};
+/// use zeph_llm::tool_pairing::next_non_system;
+///
+/// let messages = vec![
+///     Message::from_legacy(Role::Assistant, "a"),
+///     Message::from_legacy(Role::System, "sys"),
+///     Message::from_legacy(Role::User, "b"),
+/// ];
+/// let next = next_non_system(&messages, 0).expect("skips the System message");
+/// assert_eq!(next.role, Role::User);
+/// assert!(next_non_system(&messages, 2).is_none(), "no message follows index 2");
+/// ```
+#[must_use]
+pub fn next_non_system(messages: &[Message], at: usize) -> Option<&Message> {
+    messages
+        .get(at + 1..)?
+        .iter()
+        .find(|m| m.role != Role::System)
+}
+
+/// Nearest `Role`-eligible neighbour immediately preceding index `at` in `messages`, skipping
+/// any `Role::System` messages in between. See [`next_non_system`] for the forward direction and
+/// why this shared definition exists.
+///
+/// # Examples
+///
+/// ```
+/// use zeph_llm::provider::{Message, Role};
+/// use zeph_llm::tool_pairing::prev_non_system;
+///
+/// let messages = vec![
+///     Message::from_legacy(Role::Assistant, "a"),
+///     Message::from_legacy(Role::System, "sys"),
+///     Message::from_legacy(Role::User, "b"),
+/// ];
+/// let prev = prev_non_system(&messages, 2).expect("skips the System message");
+/// assert_eq!(prev.role, Role::Assistant);
+/// assert!(prev_non_system(&messages, 0).is_none(), "no message precedes index 0");
+/// ```
+#[must_use]
+pub fn prev_non_system(messages: &[Message], at: usize) -> Option<&Message> {
+    messages
+        .get(..at)?
+        .iter()
+        .rev()
+        .find(|m| m.role != Role::System)
+}
+
 /// Collect `tool_use` ids from `msg` that have no matching `ToolResult` in `next`.
 ///
 /// `next` must resolve to the message immediately following `msg` in the caller's window,
@@ -133,15 +193,7 @@ use crate::provider::{Message, MessagePart, Role};
 /// ```
 #[must_use]
 pub fn unmatched_tool_use_ids<'a>(msg: &'a Message, next: Option<&Message>) -> HashSet<&'a str> {
-    let matched: HashSet<&str> = next.filter(|n| n.role == Role::User).map_or_default(|n| {
-        n.parts
-            .iter()
-            .filter_map(|p| match p {
-                MessagePart::ToolResult { tool_use_id, .. } => Some(tool_use_id.as_str()),
-                _ => None,
-            })
-            .collect()
-    });
+    let matched = resolved_tool_result_ids(next);
 
     msg.parts
         .iter()
@@ -150,6 +202,46 @@ pub fn unmatched_tool_use_ids<'a>(msg: &'a Message, next: Option<&Message>) -> H
             _ => None,
         })
         .collect()
+}
+
+/// Collect the `tool_use_id`s of every `ToolResult` part in `next`, if `next` is eligible to
+/// resolve a preceding `ToolUse` (`next.role == Role::User`; `None`, or any other role, yields
+/// an empty set).
+///
+/// This is the "matched" half of [`unmatched_tool_use_ids`]'s definition, factored out so a
+/// caller that needs to test *arbitrary candidate ids* against the same adjacency-scoped
+/// resolution set — not necessarily ids drawn from a `Message`'s own `parts`, as
+/// [`unmatched_tool_use_ids`] requires — does not re-implement the pairing predicate (issue
+/// #6783: `zeph-core`'s `Agent::persist_cancelled_tool_results` idempotency guard checks a
+/// `&[ToolUseRequest]` parameter against this resolution set, and that parameter is not
+/// guaranteed to equal the current turn's assistant message's own `ToolUse` parts in every
+/// caller — see its doc comment).
+///
+/// # Examples
+///
+/// ```
+/// use zeph_llm::provider::{Message, MessagePart, Role};
+/// use zeph_llm::tool_pairing::resolved_tool_result_ids;
+///
+/// let next = Message::from_parts(Role::User, vec![MessagePart::ToolResult {
+///     tool_use_id: "t1".into(),
+///     content: "ok".into(),
+///     is_error: false,
+/// }]);
+/// assert!(resolved_tool_result_ids(Some(&next)).contains("t1"));
+/// assert!(resolved_tool_result_ids(None).is_empty());
+/// ```
+#[must_use]
+pub fn resolved_tool_result_ids(next: Option<&Message>) -> HashSet<&str> {
+    next.filter(|n| n.role == Role::User).map_or_default(|n| {
+        n.parts
+            .iter()
+            .filter_map(|p| match p {
+                MessagePart::ToolResult { tool_use_id, .. } => Some(tool_use_id.as_str()),
+                _ => None,
+            })
+            .collect()
+    })
 }
 
 /// Collect `tool_result` ids from `msg` that have no matching `ToolUse` in `prev`.
@@ -310,10 +402,7 @@ pub fn repair_tool_pairs(messages: &mut Vec<Message>, action: OrphanAction) -> R
             continue;
         }
         let orphaned: HashSet<String> = {
-            let prev = (0..i)
-                .rev()
-                .find(|&j| messages[j].role != Role::System)
-                .map(|j| &messages[j]);
+            let prev = prev_non_system(messages, i);
             unmatched_tool_result_ids(&messages[i], prev)
                 .into_iter()
                 .map(str::to_owned)
@@ -378,9 +467,7 @@ pub fn repair_tool_pairs(messages: &mut Vec<Message>, action: OrphanAction) -> R
             continue;
         }
         let orphaned: HashSet<String> = {
-            let next = (i + 1..messages.len())
-                .find(|&j| messages[j].role != Role::System)
-                .map(|j| &messages[j]);
+            let next = next_non_system(messages, i);
             unmatched_tool_use_ids(&messages[i], next)
                 .into_iter()
                 .map(str::to_owned)
@@ -602,6 +689,74 @@ mod tests {
         m.parts
             .iter()
             .any(|p| matches!(p, MessagePart::ToolResult { tool_use_id, .. } if tool_use_id == id))
+    }
+
+    #[test]
+    fn next_non_system_skips_a_run_of_system_messages() {
+        let messages = vec![
+            Message::from_legacy(Role::Assistant, "a"),
+            Message::from_legacy(Role::System, "sys1"),
+            Message::from_legacy(Role::System, "sys2"),
+            Message::from_legacy(Role::User, "b"),
+        ];
+        let next = next_non_system(&messages, 0).expect("skips both System messages");
+        assert_eq!(next.role, Role::User);
+    }
+
+    #[test]
+    fn next_non_system_is_none_at_the_last_index() {
+        let messages = vec![Message::from_legacy(Role::Assistant, "a")];
+        assert!(next_non_system(&messages, 0).is_none());
+    }
+
+    #[test]
+    fn next_non_system_is_none_when_only_system_messages_follow() {
+        let messages = vec![
+            Message::from_legacy(Role::Assistant, "a"),
+            Message::from_legacy(Role::System, "sys"),
+        ];
+        assert!(next_non_system(&messages, 0).is_none());
+    }
+
+    #[test]
+    fn prev_non_system_skips_a_run_of_system_messages() {
+        let messages = vec![
+            Message::from_legacy(Role::Assistant, "a"),
+            Message::from_legacy(Role::System, "sys1"),
+            Message::from_legacy(Role::System, "sys2"),
+            Message::from_legacy(Role::User, "b"),
+        ];
+        let prev = prev_non_system(&messages, 3).expect("skips both System messages");
+        assert_eq!(prev.role, Role::Assistant);
+    }
+
+    #[test]
+    fn prev_non_system_is_none_at_index_zero() {
+        let messages = vec![Message::from_legacy(Role::User, "a")];
+        assert!(prev_non_system(&messages, 0).is_none());
+    }
+
+    #[test]
+    fn resolved_tool_result_ids_is_empty_for_non_user_role() {
+        let next = Message::from_parts(Role::Assistant, vec![tool_result("t1", "ok")]);
+        assert!(resolved_tool_result_ids(Some(&next)).is_empty());
+    }
+
+    #[test]
+    fn resolved_tool_result_ids_collects_multiple_results_in_one_message() {
+        let next = Message::from_parts(
+            Role::User,
+            vec![tool_result("t1", "ok"), tool_result("t2", "ok")],
+        );
+        let resolved = resolved_tool_result_ids(Some(&next));
+        assert!(resolved.contains("t1"));
+        assert!(resolved.contains("t2"));
+        assert_eq!(resolved.len(), 2);
+    }
+
+    #[test]
+    fn resolved_tool_result_ids_is_empty_for_none() {
+        assert!(resolved_tool_result_ids(None).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two follow-ups from #6771/PR #6780, which introduced the shared `zeph_llm::tool_pairing` module for orphaned `ToolUse`/`ToolResult` repair (Layer A classification: `unmatched_tool_use_ids`/`unmatched_tool_result_ids`).

- Closes #6781: adds a request-build-time orphan repair pass to the OpenAI/OpenAI-compatible request builder (`convert_messages_structured`), mirroring the Claude request builder's downgrade-to-text pattern. Previously only Claude had this backstop; an orphan surviving upstream trim/sanitize passes could reach OpenAI or an OpenAI-compatible/Ollama endpoint unrepaired and produce a 400/422. `CompatibleProvider` fully delegates to `OpenaiProvider`, so this covers Ollama traffic configured as `type = "compatible"` too; Ollama's native (non-OpenAI-compatible) path carries no wire-level tool-call ids and has nothing to orphan-pair.
- Closes #6783: makes `persist_cancelled_tool_results`'s idempotency guard (`crates/zeph-core/src/agent/tool_execution/focus.rs`) adjacency-scoped instead of scanning the whole turn tail, via a new `zeph_llm::tool_pairing::resolved_tool_result_ids` helper. Closes a gap where an unrelated later `ToolResult` reusing an orphaned call's id (Ollama-style batch-index id reuse) could make the guard wrongly treat the orphan as already resolved and silently skip its shutdown tombstone write. Also removes a duplicate hand-rolled adjacency scan in `shutdown.rs` in favor of the shared `next_non_system` helper, and hardens the guard against a missing assistant message in history (previously fell back to an arbitrary index instead of resolving nothing — the un-ignored `flush_orphaned_writes_tombstone_despite_a_later_unrelated_reuse_of_the_same_id` regression test from PR #6780 now passes).

## Review notes

Full team-develop bug-fix chain (developer → tester + impl-critic in parallel → reviewer → fix cycle → re-review approved). Reviewer flagged and developer fixed 3 Important findings before approval:
1. A doc comment naming the wrong helper function.
2. `shutdown.rs` still hand-rolling the adjacency scan this PR extracted into a shared helper (DRY, sibling half of the #6783 fix).
3. An unguarded `unwrap_or(0)` fallback in the idempotency guard that made its own regression test pass only by coincidence of fixture shape; fixed to fail safe (resolve nothing) when no assistant message exists, with a fixture correction and a new targeted test.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (15554 passed, 0 failed)
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --features "desktop,ide,server,chat,pdf,scheduler"`)
- [x] `cargo test --doc -p zeph-llm` (44 passed)
- [x] `gitleaks protect --staged`
- [x] Un-ignored `flush_orphaned_writes_tombstone_despite_a_later_unrelated_reuse_of_the_same_id` regression test, verified passing and unweakened
- [x] New/updated regression tests for the OpenAI orphan repair path and the shutdown-guard fallback

Closes #6781
Closes #6783