### PR TITLE
fix(core): reset BudgetHint remaining_tool_calls per turn instead of stale carry-over

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   a duplicate hand-rolled scan, and hardened the same idempotency guard against a missing
   assistant message in history (previously fell back to an arbitrary index instead of
   resolving nothing).
+- `zeph-core`: `BudgetHint.remaining_tool_calls` no longer leaked the previous turn's last
+  tool-loop iteration count into a new turn's system prompt; removed the dead per-iteration
+  counter and set `remaining_tool_calls` directly to the full `max_tool_calls` budget at the
+  once-per-turn seam that reads it (#6765).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `zeph-core`: `BudgetHint.remaining_tool_calls` no longer leaked the previous turn's last
   tool-loop iteration count into a new turn's system prompt; removed the dead per-iteration
   counter and set `remaining_tool_calls` directly to the full `max_tool_calls` budget at the
-  once-per-turn seam that reads it (#6765).
+  once-per-turn seam that reads it (#6787).
 
 ### Added
 

--- a/crates/zeph-core/src/agent/context/assembly.rs
+++ b/crates/zeph-core/src/agent/context/assembly.rs
@@ -1172,9 +1172,10 @@ impl<C: Channel> Agent<C> {
                 let max = ct.max_daily_cents();
                 if max > 0.0 { Some(max) } else { None }
             });
+            // `rebuild_system_prompt` runs once per turn, before the tool loop starts, so the
+            // full budget is always what should be advertised here (#6765).
             let max_tool_calls = self.tool_orchestrator.max_iterations;
-            let remaining_tool_calls =
-                max_tool_calls.saturating_sub(self.services.tool_state.current_tool_iteration);
+            let remaining_tool_calls = max_tool_calls;
             let hint = BudgetHint {
                 remaining_cost_cents,
                 total_budget_cents,

--- a/crates/zeph-core/src/agent/state/mod.rs
+++ b/crates/zeph-core/src/agent/state/mod.rs
@@ -930,8 +930,6 @@ pub(crate) struct ToolState {
     pub(crate) dependency_always_on: HashSet<String>,
     /// Tool IDs that completed successfully in the current session.
     pub(crate) completed_tool_ids: HashSet<String>,
-    /// Current tool loop iteration index within the active user turn.
-    pub(crate) current_tool_iteration: usize,
     /// PASTE pattern store for tool invocation history and prediction (#3642).
     ///
     /// `Some` only when `config.tools.speculative.mode` is `Pattern` or `Both`.
@@ -960,7 +958,6 @@ impl Default for ToolState {
             dependency_graph: None,
             dependency_always_on: HashSet::new(),
             completed_tool_ids: HashSet::new(),
-            current_tool_iteration: 0,
             pattern_store: None,
             tool_to_skill: HashMap::new(),
             last_tool_per_skill: HashMap::new(),

--- a/crates/zeph-core/src/agent/tests/budget_hint_reset_tests.rs
+++ b/crates/zeph-core/src/agent/tests/budget_hint_reset_tests.rs
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2026 Andrei G <bug-ops>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Regression coverage for #6765: `BudgetHint.remaining_tool_calls`, injected into the system
+//! prompt by `rebuild_system_prompt` (`crate::agent::context::assembly`), used to be computed
+//! from `ToolState::current_tool_iteration` — a counter that was written per tool-loop
+//! iteration (`tier_loop.rs`) but never reset at turn start. A new turn therefore inherited the
+//! previous turn's last iteration value and reported a shrunk budget instead of the full
+//! `max_tool_calls` allowance. Since `rebuild_system_prompt` only ever runs once per turn,
+//! before the tool loop starts, the fix removed the dead per-iteration counter entirely:
+//! `remaining_tool_calls` is now set directly to `max_tool_calls` at that once-per-turn seam.
+
+use zeph_llm::any::AnyProvider;
+use zeph_llm::mock::MockProvider;
+use zeph_llm::provider::{ChatResponse, ToolUseRequest};
+use zeph_tools::executor::ToolOutput;
+
+use crate::agent::Agent;
+use crate::agent::agent_tests::{MockChannel, MockToolExecutor, create_test_registry};
+
+fn tool_output(name: &str, summary: &str) -> ToolOutput {
+    ToolOutput {
+        tool_name: name.into(),
+        summary: summary.to_owned(),
+        blocks_executed: 1,
+        filter_stats: None,
+        diff: None,
+        streamed: false,
+        terminal_id: None,
+        locations: None,
+        raw_response: None,
+        claim_source: None,
+        ..Default::default()
+    }
+}
+
+fn tool_use_batch(n: usize) -> ChatResponse {
+    ChatResponse::ToolUse {
+        text: None,
+        tool_calls: (0..n)
+            .map(|i| ToolUseRequest {
+                id: format!("call-{i}"),
+                name: format!("tool_{i}").into(),
+                input: serde_json::json!({"arg": i}),
+            })
+            .collect(),
+        thinking_blocks: vec![],
+    }
+}
+
+/// Extracts the `<remaining_tool_calls>N</remaining_tool_calls>` value from the agent's current
+/// system prompt. `rebuild_system_prompt` overwrites `messages[0].content` (the system message)
+/// in place every turn, so this reads exactly what the LLM would see for the most recent turn.
+fn remaining_tool_calls_in_system_prompt(agent: &Agent<MockChannel>) -> usize {
+    let prompt = &agent.msg.messages[0].content;
+    let tag_start = "<remaining_tool_calls>";
+    let tag_end = "</remaining_tool_calls>";
+    let start = prompt
+        .find(tag_start)
+        .expect("BudgetHint must be injected into the system prompt (max_tool_calls > 0)")
+        + tag_start.len();
+    let end = start
+        + prompt[start..]
+            .find(tag_end)
+            .expect("closing tag must follow");
+    prompt[start..end]
+        .parse()
+        .expect("remaining_tool_calls must be a valid integer")
+}
+
+/// AC (root cause, #6765): a turn that consumes tool-loop iterations must not leak a stale
+/// iteration count into the *next* turn's `BudgetHint`. Turn 2's system prompt must always
+/// advertise the full, fresh `max_tool_calls` budget, regardless of how many iterations turn 1
+/// consumed.
+#[tokio::test]
+async fn budget_hint_shows_full_budget_after_prior_turn_consumed_iterations() {
+    let (mock, _counter) = MockProvider::default().with_tool_use(vec![
+        tool_use_batch(1),
+        ChatResponse::Text("first turn done".into()),
+        ChatResponse::Text("second turn done".into()),
+    ]);
+    let provider = AnyProvider::Mock(mock);
+    let channel = MockChannel::new(vec![]);
+    let registry = create_test_registry();
+    let executor = MockToolExecutor::new(vec![Ok(Some(tool_output("tool_0", "r0")))]);
+
+    let mut agent = Agent::new(provider, channel, registry, None, 5, executor);
+    let max_tool_calls = agent.tool_orchestrator.max_iterations;
+
+    agent
+        .process_user_message("first: run one tool".to_owned(), vec![])
+        .await
+        .unwrap();
+
+    agent
+        .process_user_message("second: no tools".to_owned(), vec![])
+        .await
+        .unwrap();
+
+    assert_eq!(
+        remaining_tool_calls_in_system_prompt(&agent),
+        max_tool_calls,
+        "turn 2's BudgetHint must show the full budget, not max_tool_calls minus turn 1's stale \
+         iteration count"
+    );
+}

--- a/crates/zeph-core/src/agent/tests/mod.rs
+++ b/crates/zeph-core/src/agent/tests/mod.rs
@@ -8,6 +8,8 @@ mod bare_mode_shutdown_tests;
 #[cfg(test)]
 mod bg_metrics_tick_race_tests;
 #[cfg(test)]
+mod budget_hint_reset_tests;
+#[cfg(test)]
 mod commands_rs_drift_tests;
 #[cfg(test)]
 mod compaction_e2e;

--- a/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
+++ b/crates/zeph-core/src/agent/tool_execution/tier_loop.rs
@@ -2375,8 +2375,6 @@ impl<C: Channel> Agent<C> {
         // Clear the per-turn replay flag; it is set below when the LLM step is replayed.
         self.services.session.durable_turn_replayed = false;
 
-        // Track iteration for BudgetHint injection (#2267).
-        self.services.tool_state.current_tool_iteration = iteration;
         self.channel.send_typing().await?;
 
         if let Some(ref budget) = self.context_manager.budget {

--- a/specs/086-skill-execution-state/spec.md
+++ b/specs/086-skill-execution-state/spec.md
@@ -63,12 +63,12 @@ related:
 | `crates/zeph-skills/src/generator.rs:412,448` | Self-learning re-emission of whole SKILL.md text; `metadata` feeds re-emission |
 | `crates/zeph-skills/src/merge_prompts.rs:18` | `MERGE_SYSTEM_PROMPT` — must preserve `state:` block on skill merge |
 | `crates/zeph-core/src/agent/state/mod.rs:83-168` | `SkillState` — new state field lives here |
-| `crates/zeph-core/src/agent/state/mod.rs:907-953` | `ToolState` — gains `last_batch_tool_call_ids`; sibling of `current_tool_iteration` (which has the never-reset-per-turn defect, M2) |
+| `crates/zeph-core/src/agent/state/mod.rs:907-953` | `ToolState` — gains `last_batch_tool_call_ids`; the former `current_tool_iteration` field that sat alongside it was removed entirely by #6765 (M2 fixed), not just reset |
 | `crates/zeph-core/src/agent/state/mod.rs:1038` | `durable_agent_turns_config: Option<DurableConfig>` — session-stable gate predicate for D1 |
 | `crates/zeph-core/src/agent/context/assembly.rs:908` | `active_skill_names` assignment site — where skill-state activation is resolved, turn-start only |
 | `crates/zeph-core/src/agent/context/assembly.rs:1058` | Cache-stable system-prompt prefix seal — state must never enter here |
 | `crates/zeph-core/src/agent/context/assembly.rs:1106-1107` | Volatile system-prompt region ("never cached") |
-| `crates/zeph-core/src/agent/context/assembly.rs:1177` | `BudgetHint` reads `current_tool_iteration` once per turn (evidence for D4, M2) |
+| `crates/zeph-core/src/agent/context/assembly.rs:1177` | `BudgetHint.remaining_tool_calls` now set directly to `max_tool_calls` at this once-per-turn seam, post-#6765 (evidence for D4; M2 fixed) |
 | `crates/zeph-core/src/agent/tool_execution/tier_loop.rs:2331` | `call_llm_durable` fingerprint construction (`fp_input`) — D1's hazard |
 | `crates/zeph-core/src/agent/tool_execution/tier_loop.rs:2466-2474` | `handle_native_tool_calls` → clearing pass insertion point → `maybe_summarize_tool_pair` → `prune_stale_tool_outputs` |
 | `crates/zeph-core/src/agent/llm_dispatch.rs:92-113` | Rolling-tail rendering precedent (`remove_lsp_messages` → `push_message` → `recompute_prompt_tokens`) — D4's seam |
@@ -275,7 +275,7 @@ THEN no `<skill_state>` block is rendered, no clearing pass runs, and a `tracing
 | `SkillExecutionState` | `zeph-skills` | The live, bounded state object for the active state-declaring skill — **in-memory only**, no persistence in this spec |
 | `StatePatch` | `zeph-skills` | A validated, dictionary-merge patch with null-deletion semantics — rejected before merge on any validation failure, never partially applied |
 | `NestedMode` | `zeph-skills::loader` | `enum { Collect, Skip }` — replaces `parse_frontmatter`'s `bool in_metadata`; `Collect` for `metadata:` (unchanged behavior), `Skip` for any other empty-valued top-level key (fixes the pre-existing `extensions:` leak, and covers the new `state:` block) |
-| `ToolState.last_batch_tool_call_ids` | `crates/zeph-core/src/agent/state/mod.rs`, sibling of `current_tool_iteration` (`:924`) | `Vec<String>` — the `tool_use_id`s of the tool batch a validated patch in the current iteration may absorb; **must** be cleared at turn start or gated on `iteration > 0` (FR-009) |
+| `ToolState.last_batch_tool_call_ids` | `crates/zeph-core/src/agent/state/mod.rs` | `Vec<String>` — the `tool_use_id`s of the tool batch a validated patch in the current iteration may absorb; **must** be cleared at turn start or gated on `iteration > 0` (FR-009) |
 | `clear_absorbed_tool_results` | `zeph-context::microcompact` (new, pure) | `fn(messages: &mut [Message], tool_use_ids: &[String], sentinel: &str, now_ts: i64) -> usize` — signature mirrors `sweep_stale_tool_outputs` (slice in, sentinel/`now_ts` supplied by caller, count returned); no `LOW_VALUE_TOOLS` gate, no `keep_recent` cutoff — targets exactly the given ids |
 | `find_preceding_tool_use_id` | `zeph-context::microcompact` (new) | Sibling of `find_preceding_tool_use_name` — walks back to the nearest preceding `ToolUse` id for a `ToolOutput` part (which carries no `tool_use_id` itself) |
 | `skill_state_patch` | Built-in tool, `zeph-core` | Registered only when a state-declaring skill is active; JSON input schema derived from `SkillStateSchema` |
@@ -417,11 +417,15 @@ sentinel-prefixed or with `compacted_at.is_some()`. Never removing a part and ne
 
 The original design's rendering seam (a `<skill_state>` block at the once-per-turn
 system-prompt/`inject_active_goal` seam, `assembly.rs:2228-2270`, rebuilt once per turn at
-`mod.rs:1761`) is **superseded**. Direct evidence it mis-serves per-iteration state: the existing
-`current_tool_iteration` field is written every iteration (`tier_loop.rs:2379`) but its only
-reader, `BudgetHint` in `rebuild_system_prompt`, runs once before the loop
-(`assembly.rs:1177`) — `remaining_tool_calls` shown to the model carries over from the previous
-turn's last iteration (M2, a separate pre-existing P3 defect, not fixed by this spec).
+`mod.rs:1761`) is **superseded**. Direct evidence it mis-serves per-iteration state (pre-#6765):
+the `current_tool_iteration` field used to be written every iteration (`tier_loop.rs:2379`) but
+its only reader, `BudgetHint` in `rebuild_system_prompt`, ran once before the loop
+(`assembly.rs:1177`) — `remaining_tool_calls` shown to the model carried over from the previous
+turn's last iteration (M2, a separate pre-existing P3 defect). #6765 fixed M2 by removing the
+dead per-iteration counter outright rather than merely resetting it: `remaining_tool_calls` is
+now set directly to `max_tool_calls` at the once-per-turn seam. That resolution sharpens rather
+than undermines this section's point — the once-per-turn seam structurally cannot reflect
+per-iteration state, so it was simplified to stop pretending to.
 
 **Decision**: render at the rolling-tail seam in `llm_dispatch.rs:96-113`, the verified precedent
 for mid-turn `messages[0]`-adjacent mutation: `remove_lsp_messages()` → `push_message(Message::


### PR DESCRIPTION
## Summary

`BudgetHint.remaining_tool_calls` was derived from `ToolState::current_tool_iteration`, a counter written every tool-loop iteration but read only once per turn by `rebuild_system_prompt`, before the loop starts. The counter was never reset at turn start, so a new turn's system prompt always advertised the previous turn's last iteration count instead of the fresh turn's full budget.

Since `rebuild_system_prompt` only ever runs once per turn, before any iteration, this PR removes the dead per-iteration counter entirely rather than just resetting it: `remaining_tool_calls` is now set directly to `max_tool_calls` at that once-per-turn seam. This is a minimal, targeted fix — the alternative of re-rendering `BudgetHint` at each iteration would require a mid-loop rendering seam (recompute prompt tokens at O(history) per iteration), which is more scope than this bug warrants. That work is tracked separately in #6786.

- Removed `ToolState::current_tool_iteration` (field, `Default` init, per-iteration write in `tier_loop.rs`)
- `assembly.rs`: `remaining_tool_calls` set directly to `max_tool_calls`
- Added regression test driving two real agent turns and asserting on the rendered `<remaining_tool_calls>` system-prompt content
- Updated `specs/086-skill-execution-state/spec.md` citations that referenced this defect as evidence for design decision D4
- Updated `CHANGELOG.md`

Closes #6765

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --profile ci --workspace --all-targets --features "desktop,ide,server,chat,pdf,scheduler,testing" -- -D warnings`
- [x] `cargo nextest run --config-file .github/nextest.toml -p zeph-core --lib --bins` (2134 passed)
- [x] `cargo nextest run --config-file .github/nextest.toml --workspace --features "desktop,ide,server,chat,pdf,scheduler" --lib --bins` (2408 passed)
- [x] Rustdoc gate (`RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace ...`)
- [x] `gitleaks protect --staged`
- [x] New regression test verified to fail without the fix and pass with it